### PR TITLE
Update change in Set Mutator syntax

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -530,7 +530,7 @@ Mutators are declared in a similar fashion:
 
 		public function setFirstName($value)
 		{
-			return strtolower($value);
+			$this->attributes['first_name'] = strtolower($value);
 		}
 
 	}


### PR DESCRIPTION
As per this commit and its discussion https://github.com/illuminate/database/commit/be7246d44f4667e27a196cbf91225f758b862004#L0R916 and then this issue, https://github.com/illuminate/database/issues/107 the syntax for mutators has changed.
