### PR TITLE
Small fix for Route::group() under sub-domain matching.

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -187,7 +187,7 @@ Laravel routes are also able to handle wildcard sub-domains, and pass you wildca
 
 **Registering Sub-Domain Routes**
 
-	Route::group(array('domain' => '{account}.myapp.com', function()
+	Route::group(array('domain' => '{account}.myapp.com'), function()
 	{
 
 		Route::get('user/{id}', function($account, $id)
@@ -195,7 +195,7 @@ Laravel routes are also able to handle wildcard sub-domains, and pass you wildca
 			//
 		});
 
-	}));
+	});
 
 <a name="throwing-404-errors"></a>
 ## Throwing 404 Errors


### PR DESCRIPTION
Route::group() in the docs uses one argument while it actually takes two.
