### PR TITLE
Added note about artisan key:generate to the installation instructions

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -29,7 +29,7 @@ The Laravel framework has a few system requirements:
 
 Laravel needs almost no configuration out of the box. You are free to get started developing! However, you may wish to review the `app/config/app.php` file and its documentation. It contains several options such as `timezone` and `locale` that you may wish to change according to your application.
 
-> **Note:** One configuration option you should be sure to set is the `key` option within `app/config/app.php`. This value should be set to a 32 character, random string. This key is used when encrypting values, and encrypted values will not be safe until it is properly set. You can set this value quickly by using the following artisan command "php artisan key:generate".
+> **Note:** One configuration option you should be sure to set is the `key` option within `app/config/app.php`. This value should be set to a 32 character, random string. This key is used when encrypting values, and encrypted values will not be safe until it is properly set. You can set this value quickly by using the following artisan command `php artisan key:generate`.
 
 <a name="pretty-urls"></a>
 ## Pretty URLs


### PR DESCRIPTION
There was a note on the first page of laravel 4 docs about setting the encryption key, the note did not seem complete without mentioning the artisan command to generate a key.
