### PR TITLE
Fix for example for routes with regex conditions.

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -69,7 +69,13 @@ Most of the routes for your application will be defined in the `app/routes.php` 
 	{
 		//
 	})
-	->where('name', 'A-Za-z');
+	->where('name', '[A-Za-z]+');
+
+	Route::get('user/{id}', function($id)
+	{
+		//
+	})
+	->where('id', '[0-9]+');
 
 <a name="route-filters"></a>
 ## Route Filters


### PR DESCRIPTION
I tried to use the routing example as provided in the documentation and it didn't work. I fixed the regex in the example so it did, and also added a second example for another common use-case.
