### PR TITLE
Remove unused menu item 'queues'

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -18,7 +18,6 @@
     - [Mail](/docs/mail)
     - [Package Development](/docs/packages)
     - [Pagination](/docs/pagination)
-    - [Queues](#)
     - [Security](/docs/security)
     - [Session](/docs/session)
     - [Templates](/docs/templates)


### PR DESCRIPTION
Menu item isn't used and there isn't a documentation page for.
