### PR TITLE
Example variable name mismatch

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -32,7 +32,7 @@ Multiple rules may be delimited using either a "pipe" character, or as separate 
 
 Once the a `Validator` instance has been created, the `fails` (or `passes`) method may be used to perform the validation.
 
-	if ($validation->fails())
+	if ($validator->fails())
 	{
 		// The given data did not pass validation
 	}


### PR DESCRIPTION
Variable set in previous examples was $validator however success and failure example used the variable $validation
