### PR TITLE
Missing semicolon

### DIFF
--- a/ioc.md
+++ b/ioc.md
@@ -142,7 +142,7 @@ To create a service provider, simply extend the `Illuminate\Support\ServiceProvi
 			$this->app->bind('foo', function()
 			{
 				return new Foo;
-			})
+			});
 		}
 
 	}


### PR DESCRIPTION
Added missing semicolon to the ServiceProvider example in the IoC Container page
