### PR TITLE
Added HTTPException documentation to Responses section

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -1,6 +1,7 @@
 # Errors & Logging
 
 - [Error Detail](#error-detail)
+- [HTTP Exceptions](#http-exceptions)
 - [Handling Errors](#handling-errors)
 - [Handling 404 Errors](#handling-404-errors)
 - [Logging](#logging)
@@ -33,6 +34,21 @@ If an exception handler returns a response, that response will be sent to the br
 
 		return 'Sorry! Something is wrong with this account!';
 	});
+
+<a name="http-exceptions"></a>
+## HTTP Exceptions
+Exceptions in respect to HTTP, refer to errors that may occur during a client request. This may be a page
+not found error (404), an authorized error (401) or even a generated 500 error. In order to return such a response, use the following:
+
+	App::abort(404, 'Page not found');
+
+The first argument, is the HTTP status code, with the following being a custom message you'd like to show with the error.
+
+In order to raise a 401 Unauthorized exception, just do the following:
+
+	App::abort(401, 'You are not authorized.');
+
+These exceptions can be executed at any time during the request's lifecycle.
 
 <a name="handling-404-errors"></a>
 ## Handling 404 Errors

--- a/responses.md
+++ b/responses.md
@@ -4,7 +4,6 @@
 - [Redirects](#redirects)
 - [Views](#views)
 - [View Composers](#view-composers)
-- [HTTP Exceptions](#http-exceptions)
 - [Special Responses](#special-responses)
 
 <a name="basic-responses"></a>
@@ -143,21 +142,6 @@ A view composer class should be defined like so:
 	}
 
 Note that there is no convention on where composer classes may be stored. You are free to store them anywhere as long as they can be autoloaded using the directives in your `composer.json` file.
-
-<a name="http-exceptions"></a>
-## HTTP Exceptions
-Exceptions in respect to HTTP, refer to errors that may occur during a client request. This may be a page
-not found error (404), an authorized error (401) or even a generated 500 error. In order to return such a response, use the following:
-
-	App::abort(404, 'Page not found');
-
-The first argument, is the HTTP status code, with the following being a custom message you'd like to show with the error.
-
-In order to raise a 401 Unauthorized exception, just do the following:
-
-	App::abort(401, 'You are not authorized.');
-
-These exceptions can be executed at any time during the request's lifecycle.
 
 <a name="special-responses"></a>
 ## Special Responses


### PR DESCRIPTION
Tbh, I'm not entirely sure if this is the correct spot for it - happy to move it to another file if it makes more sense? Just figured it may work here, as I ended up having to do something very similar as part of a response (which is when I think most devs would use this feature).
