### PR TITLE
Correct format for latest added sentence

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -37,8 +37,8 @@ If an exception handler returns a response, that response will be sent to the br
 
 <a name="http-exceptions"></a>
 ## HTTP Exceptions
-Exceptions in respect to HTTP, refer to errors that may occur during a client request. This may be a page
-not found error (404), an authorized error (401) or even a generated 500 error. In order to return such a response, use the following:
+
+Exceptions in respect to HTTP, refer to errors that may occur during a client request. This may be a page not found error (404), an authorized error (401) or even a generated 500 error. In order to return such a response, use the following:
 
 	App::abort(404, 'Page not found');
 


### PR DESCRIPTION
No empty line under header line. A sentence was divided to two lines. So correct them.

Signed-off-by: Hirohisa Kawase hirokws@gmail.com
