### PR TITLE
Updated example of View Composer : Correction

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -119,18 +119,18 @@ View composers are callbacks or class methods that are called when a view is cre
 
 **Defining A View Composer**
 
-	View::composer('profile', function($event)
+	View::composer('profile', function($view)
 	{
-		$event->view->with('count', User::count());
+		$view->with('count', User::count());
 	});
 
 Now each time the `profile` view is created, the `count` data will be bound to the view.
 
 You may also attach a view composer to multiple views at once:
 
-    View::composer(array('profile','dashboard'), function($event)
+    View::composer(array('profile','dashboard'), function($view)
     {
-        $event->view->with('count', User::count());
+        $view->with('count', User::count());
     });
 
 If you would rather use a class based composer, which will provide the benefits of being resolved through the application [IoC container](/docs/ioc), you may do so:
@@ -141,9 +141,9 @@ A view composer class should be defined like so:
 
 	class ProfileComposer {
 
-		public function compose($event)
+		public function compose($view)
 		{
-			$event->view->with('count', User::count());
+			$view->with('count', User::count());
 		}
 
 	}


### PR DESCRIPTION
The current example throws an exception as it is no longer an event object and right now the callback is given the view object.
