### PR TITLE
Added blade example for displaying errors

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -118,6 +118,10 @@ So, after redirection, you may utilize the automatically bound `$errors` variabl
 
 	<?php echo $errors->first('email'); ?>
 
+Or if you're using blade templates
+
+	{{{ $errors->first('email') }}}
+
 <a name="available-validation-rules"></a>
 ## Available Validation Rules
 


### PR DESCRIPTION
Mostly to remind people to use tripple curly brackets, but also to point out you don't need to use raw php for error displays to work.
