### PR TITLE
Changed code example for custom 404 error pages

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -64,7 +64,8 @@ You may register an error handler that handles all "404 Not Found" errors in you
 
 	App::missing(function($exception)
 	{
-		return View::make('errors.missing');
+		$content = View::make('errors.missing');
+		return Response::make($content, 404);
 	});
 
 <a name="logging"></a>


### PR DESCRIPTION
Return the correct HTTP status code on custom 404 error pages. See issue #141.
