### PR TITLE
Added Hash::make() when saving the user from Password::reset()

### DIFF
--- a/security.md
+++ b/security.md
@@ -204,7 +204,7 @@ Again, notice we are using the `Session` to display any errors that may be detec
 
 		return Password::reset($credentials, function($user, $password)
 		{
-			$user->password = $password;
+			$user->password = Hash::make($password);
 
 			$user->save();
 


### PR DESCRIPTION
This page: http://four.laravel.com/docs/security#password-reminders-and-reset

When using the example from `Password::reset`, a `Hash::make` call is missing: 

``` php
Route::post('password/reset', function()
{
    $credentials = array('email' => Input::get('email'));

    return Password::reset($credentials, function($user, $password)
    {
        $user->password = $password;

        $user->save();

        return Redirect::to('home');
    });
});
```
