### PR TITLE
Added inline radio examples

### DIFF
--- a/html.md
+++ b/html.md
@@ -106,18 +106,14 @@ This allows you to quickly build forms that not only bind to model values, but e
 
 **Generating A Checkbox Or Radio Input**
 
-	// Checkbox
 	echo Form::checkbox('name', 'value');
 	
-	// Radio
 	echo Form::radio('name', 'value');
 
 **Generating A Checkbox Or Radio Input That Is Checked**
 
-	// Checkbox
 	echo Form::checkbox('name', 'value', true);
 	
-	// Radio
 	echo Form::radio('name', 'value', true);
 
 <a name="file-input"></a>


### PR DESCRIPTION
Previously users would need to look through both checkbox examples before being told that the radio method is the same as the checkbox method. Inline examples added to allow readers to quickly see the radio method without having to read a footnote on the section.
