### PR TITLE
Added example of elseif in templating docs

### DIFF
--- a/templates.md
+++ b/templates.md
@@ -80,8 +80,10 @@ To escape the output, you may use the triple curly brace syntax:
 
 **If Statements**
 
-	@if (count($records) > 0)
-		I have records!
+	@if (count($records) === 1)
+		I have one record!
+	@elseif (count($records) > 1)
+		I have multiple records!
 	@else
 		I don't have any records!
 	@endif


### PR DESCRIPTION
If statements are shown under control structures in the templating documentation, however the example does not include elseif. This pull request changes the if-else example to an if-elseif-else example.
