### PR TITLE
Fixed subscribe method

### DIFF
--- a/events.md
+++ b/events.md
@@ -136,7 +136,7 @@ Event subscribers are classes that may subscribe to multiple events from within 
 		 * @param  Illuminate\Events\Dispatcher  $events
 		 * @return array
 		 */
-		public static function subscribe($events)
+		public function subscribe($events)
 		{
 			$events->listen('user.login', 'UserEventHandler@onUserLogin');
 


### PR DESCRIPTION
Subscribe method of a handler should not be static.

See: https://github.com/laravel/framework/blob/master/src/Illuminate/Events/Dispatcher.php#L117
