### PR TITLE
changed the framing for the 'resourceful controllers' at the end to 'rou...

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -289,6 +289,6 @@ More information on handling 404 exceptions and using custom responses for these
 <a name="routing-to-controllers"></a>
 ## Routing to Controllers
 
-There are many things that you can do with controller classes including routing to controller actions and creating "resource controllers" which make it easier to build RESTful controllers around resources.
+There are many things that you can do with controller classes including routing to controller actions and creating "resource controllers", which make it easier to build RESTful controllers around resources.
 
 See the documentation on [Controllers](/docs/controllers) for more information.


### PR DESCRIPTION
...ting to controllers' with new copy

The goal with this change is to give the user a clear path to know how to route to controllers, not just to identify that resource controllers exist.
