### PR TITLE
Add Config::get default value in case the configuration value does not exist

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -14,7 +14,12 @@ Sometimes you may need to access configuration values at run-time. You may do so
 
 	Config::get('app.timezone');
 
-Notice that "dot" style syntax may be used to access values in the various files. You may also set configuration values at run-time:
+Notice that "dot" style syntax may be used to access values in the various files.
+Also you can specify a default value for a configuration value in case it is not defined:
+
+	Config::get('myfile.rows_per_page',25)
+
+You may also set configuration values at run-time:
 
 **Setting A Configuration Value**
 


### PR DESCRIPTION
It wasn't documented but actually if a configuration is not found in the config file you can set a default value (just like a nice fallback 

Ex:

<code>Config::get('myfile.rows_per_page',25);</code>

In this case if I don't have myfile.php in the configuration directory or the rows_per_page array key define in it Config::get will still return 25 
