### PR TITLE
Clarifying the use of $job when queueing closures

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -94,7 +94,7 @@ You may also push a Closure onto the queue. This is very convenient for quick, s
 	Queue::push(function($job) use ($id)
 	{
 		Account::delete($id);
-                $job->delete();
+        $job->delete();
 	});
 
 > **Note:** When pushing Closures onto the queue, the `__DIR__` and `__FILE__` constants should not be used.


### PR DESCRIPTION
I feel the most common use case for queues in Laravel 4 would be to defer processing of a job like queueing e-mail for later. For most cases, you will want to delete the job off the queue after you're finished with it, however the documentation defaults to showing closure queueing without $job as a parameter. Maybe I'm dumb, but it took me quite a while to figure out you could do that (or how to do it) with closures.
