### PR TITLE
Document $user parameter on callback to remind method

### DIFF
--- a/security.md
+++ b/security.md
@@ -204,9 +204,9 @@ Note that the arguments passed to the `remind` method are similar to the `Auth::
 
 You may modify the message instance that is sent to the user by passing a Closure as the second argument to the `remind` method:
 
-	return Password::remind($credentials, function($m, User $user)
+	return Password::remind($credentials, function($message, User $user)
 	{
-		$m->subject('Hey {$user->first_name}, here is your password reminder');
+		$message->subject('Hey {$user->first_name}, here is your password reminder');
 	});
 
 You may also have noticed that we are returning the results of the `remind` method directly from a route. By default, the `remind` method will return a `Redirect` to the current URI. If an error occurred while attempting to reset the password, an `error` variable will be flashed to the session, as well as a `reason`, which can be used to extract a language line from the `reminders` language file. So, your password reset form view could look something like this:


### PR DESCRIPTION
I don't think that much people know they can access the retrieved user in this way to (for example) personalise the e-mail subject.
