### PR TITLE
Indicate that the update method needs to have a user id param

### DIFF
--- a/html.md
+++ b/html.md
@@ -59,7 +59,7 @@ Often, you will want to populate a form based on the contents of a model. To do 
 
 **Opening A Model Form**
 
-	echo Form::model($user, array('route' => 'user.update'))
+	echo Form::model($user, array('route' => array('user.update', $user->id)))
 
 Now, when you generate a form element, like a text input, the model's value matching the field's name will automatically be set as the field value. So, for example, for a text input named `email`, the user model's `email` attribute would be set as the value. However, there's more! If there is an item in the Session flash data matching the input name, that will take precedence over the model's value. So, the priority looks like this:
 


### PR DESCRIPTION
I was a bit confused because I thought the form model binder inserted the ID parameter from the user model automatically. This isn't the case as Taylor indicated in laravel/framework#1415. That's why I think it's better to add this explicitly in the docs that the user still needs to manually add the ID param to prevent further confusion.
