### PR TITLE
Remove $table->dateTime() and correct $table->date()

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -68,8 +68,7 @@ Command  | Description
 `$table->float('amount');`  |  FLOAT equivalent to the table
 `$table->decimal('amount', 5, 2);`  |  DECIMAL equivalent with a precision and scale
 `$table->boolean('confirmed');`  |  BOOLEAN equivalent to the table
-`$table->date('created_at');`  |  DATE equivalent to the table
-`$table->dateTime('created_at');`  |  DATETIME equivalent to the table
+`$table->date('created_at');`  |  DATETIME equivalent to the table
 `$table->time('sunrise');`  |  TIME equivalent to the table
 `$table->timestamp('added_on');`  |  TIMESTAMP equivalent to the table
 `$table->timestamps();`  |  Adds **created\_at** and **updated\_at** columns


### PR DESCRIPTION
Remove $table->dateTime() and modify $table->date() to reflect its creation of a DATETIME equivalent.

$table->dateTime() doesn't exist in laravel 4, yet the source reveals that date() returns a DATETIME equivalent. Is datetime() to be added? What about fields that require a DATE equivalent?

For now, this change correctly reflects behaviour of laravel 4.0
