### PR TITLE
Stop recommending `and`/`or` over `&&`/`||`

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -28,5 +28,4 @@ Laravel follows the [PSR-0](https://github.com/php-fig/fig-standards/blob/master
 - Namespace declarations should be on the same line as `<?php`.
 - Class opening `{` should be on the same line as the class name.
 - Function and control structure opening `{` should be on a separate line.
-- Always use `and` and `or`. Never use `&&` or `||`.
 - Interface names are suffixed with `Interface` (`FooInterface`)


### PR DESCRIPTION
The coding guidelines suggest using `and` and `or` over `&&`
and `||`. Frankly I don't think this is a good idea. The
precedence rules for `and` and `or` are so weird, they will
cause lots of confusion and edge cases.

To illustrate this, look at the following example ([from logical
operators](http://php.net/manual/en/language.operators.logical.php)):

```
$x = false or true;
```

What do you expect the value of `$x` to be? It's `false`, because
`or` has lower precedence than `=`. So while you expected the
expression to be:

```
$x = (false or true);
```

It is in fact:

```
($x = false) or true;
```

Stop using `and`/`or` as logical operators. They were designed
for flow control.
