### PR TITLE
Add example for Form::open() with route parameters

### DIFF
--- a/html.md
+++ b/html.md
@@ -32,6 +32,12 @@ You may also open forms that point to named routes or controller actions:
 
 	echo Form::open(array('action' => 'Controller@method'))
 
+You may pass in route parameters as well:
+
+	echo Form::open(array('route' => array('route.name', $user->id)))
+
+	echo Form::open(array('action' => array('Controller@method', $user->id)))
+
 If your form is going to accept file uploads, add a `files` option to your array:
 
 	echo Form::open(array('url' => 'foo/bar', 'files' => true))


### PR DESCRIPTION
By answering a question on the forums, I just realized that route parameters are only used once (on the `Form Model Binding` section) and not even mentioned at `Forms & HTML`.

I've added examples for named routes and controller action routes to the `Opening A Form` section to make it easier to find.
