### PR TITLE
Add GET method to the note about HTML supported form action methods 

### DIFF
--- a/html.md
+++ b/html.md
@@ -24,7 +24,7 @@ By default, a `POST` method will be assumed; however, you are free to specify an
 
 	echo Form::open(array('url' => 'foo/bar', 'method' => 'put'))
 
-> **Note:** Since HTML forms only support `POST`, `PUT` and `DELETE` methods will be spoofed by automatically adding a `_method` hidden field to your form.
+> **Note:** Since HTML forms only support `POST` and `GET`, `PUT` and `DELETE` methods will be spoofed by automatically adding a `_method` hidden field to your form.
 
 You may also open forms that point to named routes or controller actions:
 


### PR DESCRIPTION
Note area mentions that HTML forms only support POST method and left out the GET method for some reason. I'm not sure if the original author intended to indicate the supported method in the Form object (is that even true?) or general HTML forms, but given the context, an addition of GET seems to be appropriate for the statement to be technically correct.
