### PR TITLE
added note about using urls to determine environment

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -40,7 +40,7 @@ Simply create a folder within the `config` directory that matches your environme
 
 Notice that you do not have to specify _every_ option that is in the base configuration file, but only the options you wish to override. The environment configuration files will "cascade" over the base files.
 
-Next, we need to instruct the framework how to determine which environment it is running in. The default environment is always `production`. However, you may setup other environments within the `bootstrap/start.php` file at the root of your installation. In this file you will find an `$app->detectEnvironment` call. The array passed to this method is used to determine the current environment. You may add other environments using machine names or unix style URL patterns to the array as needed.
+Next, we need to instruct the framework how to determine which environment it is running in. The default environment is always `production`. However, you may setup other environments within the `bootstrap/start.php` file at the root of your installation. In this file you will find an `$app->detectEnvironment` call. The array passed to this method is used to determine the current environment. You may add other environments by adding machine names or unix style URL patterns to the array as needed.
 
     <?php
 
@@ -49,6 +49,8 @@ Next, we need to instruct the framework how to determine which environment it is
         'local' => array('your-machine-name', '*.local'),
 
     ));
+
+Note that artisan cannot match against URLs to determine environments.
 
 You may also pass a `Closure` to the `detectEnvironment` method, allowing you to implement your own environment detection:
 


### PR DESCRIPTION
Explicitly stated that you can use unix style pattern matching to determine environment.

Laravel 3's docs had this, but it's suspiciously missing from 4's...
