### PR TITLE
File not found Service Provider

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -38,7 +38,7 @@ Once the `workbench` command has been executed, your package will be available w
 
 Once the provider has been registered, you are ready to start developing your package! However, before diving in, you may wish to review the sections below to get more familiar with the package structure and development workflow.
 
-> **Note:** If your ServiceProvider cannot be found, run `composer dump-autoload` and `composer update` inside your package directory.
+> **Note:** If your ServiceProvider cannot be found, run `composer dump-autoload` inside your package directory.
 
 <a name="package-structure"></a>
 ## Package Structure


### PR DESCRIPTION
When creating a new Package and namespacing the ServiceProvider sometimes it cannot be found even after running `composer dump`, `composer update` and `artisan dump-autoload`. This note in the docs would help people out, as I am not the only one who has experienced this ("Borob" in #laravel)
