### PR TITLE
Minor view content re-arrangement to improve readability

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -93,7 +93,7 @@ The second argument passed to `View::make` is an array of data that should be ma
 
 **Passing Data To Views**
 
-Arrays can be passed as arguments to a views and the associative keys will be extracted into variables accessible by the view. In the example below the variable `$name` would be accessible from the view, and would contain `Steve`.
+Arrays can be passed as arguments to a view and the associative keys will be extracted into variables. In the example below the variable `$name` would be accessible from the view, and would contain `Steve`.
 
 	$view = View::make('greeting', array('name' => 'Steve'));
 


### PR DESCRIPTION
Verbiage that states 

> In the example above the variable `$name`..." 

There are actually two examples, and the statement is only referring to the second one. The first example is not relevant in the context and does not add value to the section. Should be removed for clarity of new users.

Removing `$view = View::make('greeting', $data);`
