### PR TITLE
Add note regarding Artisan's CLI directory.

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -11,6 +11,8 @@ Artisan is the name of the command-line interface included with Laravel. It prov
 <a name="usage"></a>
 ## Usage
 
+> **Note:** To use Artisan, first make sure your CLI's current working directoy is in the root Laravel directory (where your `app`, `public`, and other folders reside), or you provide the full path to the Artisan shell script.
+
 To view a list of all available Artisan commands, you may use the `list` command:
 
 **Listing All Available Commands**


### PR DESCRIPTION
I had a blonde moment and forgot that, to access a shell script, one needs to be in its directory, or provide the full path. I'm sure others not as familiar as me will have the same hiccup at some point, so a note is nice to have.

I'm not 100% sure if the wording is best for "beginners" or what have you, but I figure a lot of Laravel isn't geared towards them in the first place, so I didn't rack my brain over it. Suggestions are welcome.
