### PR TITLE
Update quickstart for proper database default

### DIFF
--- a/quick.md
+++ b/quick.md
@@ -73,7 +73,7 @@ Wonderful! Now you have setup a simple view that extends a layout. Next, let's s
 
 To create a table to hold our data, we'll use the Laravel migration system. Migrations let you expressively define modifications to your database, and easily share them with the rest of your team.
 
-First, let's configure a database connection. You may configure all of your database connections from the `app/config/database.php` file. By default, Laravel is configured to use SQLite, and an SQLite database is included in the `app/database` directory. If you wish, you may change the `driver` option to `mysql` and configure the `mysql` connection credentials within the database configuration file.
+First, let's configure a database connection. You may configure all of your database connections from the `app/config/database.php` file. By default, Laravel is configured to use mySQL, and you will need to supply connection credentials within the database configuration file. If you wish, you may change the `driver` option to `sqlite` and it will use the SQLite database included in the `app/database` directory.
 
 Next, to create the migration, we'll use the [Artisan CLI](/docs/artisan). From the root of your project, run the following from your terminal:
 


### PR DESCRIPTION
As I worked through the quickstart, I saw a disconnect between the docs sayin SQLite is the default and what I was seeing in `app/config/database.php` where mySQL is the default.
