### PR TITLE
Adding info about the order of event firings

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -868,7 +868,11 @@ To totally disable date mutations, simply return an empty array from the `getDat
 <a name="model-events"></a>
 ## Model Events
 
-Eloquent models fire several events, allowing you to hook into various points in the model's lifecycle using the following methods: `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`. If `false` is returned from the `creating`, `updating`, or `saving` events, the action will be cancelled:
+Eloquent models fire several events, allowing you to hook into various points in the model's lifecycle using the following methods: `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`.
+
+Whenever a new item is saved for the first time, the `creating` and `created` events will fire. If an item is not new and the `save()` method is called, the `updating`/`updated` events will fire. In either case, the `saving`/`saved` events will fire.
+
+If `false` is returned from the `creating`, `updating`, `saving`, or `deleting` events, the action will be cancelled:
 
 **Cancelling Save Operations Via Events**
 


### PR DESCRIPTION
I also added the `deleting` event to the things whose actions can be cancelled by returning false (see: https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/Model.php#L698)
