### PR TITLE
Added note about aliased typehints failing to autoload

### DIFF
--- a/facades.md
+++ b/facades.md
@@ -95,7 +95,7 @@ Finally, if we wish, we can add an alias for our facade to the `aliases` array i
 
 	Payment::process();
 
-> **Note:** Classes in the `aliases` array are not available in some instances because [PHP will not attempt to autoload undefined type-hinted classes](https://bugs.php.net/bug.php?id=39003). If `\ServiceWrapper\ApiTimeoutException` is aliased to `ApiTimeoutException`, a `catch(ApiTimeoutException)` outside of the namespace `\ServiceWrapper` will never catch the exception, even if one is thrown. A similar problem is found in Models which have type hints to aliased classes. The only workaround is to forego aliasing and `use` the classes you wish to type hint at the top of each file, which requires them.
+> **Note:** Classes in the `aliases` array are not available in some instances because [PHP will not attempt to autoload undefined type-hinted classes](https://bugs.php.net/bug.php?id=39003). If `\ServiceWrapper\ApiTimeoutException` is aliased to `ApiTimeoutException`, a `catch(ApiTimeoutException $e)` outside of the namespace `\ServiceWrapper` will never catch the exception, even if one is thrown. A similar problem is found in Models which have type hints to aliased classes. The only workaround is to forego aliasing and `use` the classes you wish to type hint at the top of each file which requires them.
 
 <a name="mocking-facades"></a>
 ## Mocking Facades


### PR DESCRIPTION
Related [laravel/framework issue #1861](https://github.com/laravel/framework/issues/1861): Although PHP's reasoning for not autoloading undefined type-hinted classes is solid (undefined classes clearly can't have instances and therefore the type hint raises an error), it's not intuitive in the context of Laravel's IoC. It seems like Laravel should be able to alias all typehints, but since it can't, I think it is important to note that in the docs with the short bit about aliases.
