### PR TITLE
Removed double-quotes from example, which throws an exception.

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -23,7 +23,7 @@ To create a new command, you may use the `command:make` Artisan command, which w
 
 By default, generated commands will be stored in the `app/commands` directory; however, you may specify custom path or namespace:
 
-	php artisan command:make FooCommand --path="app/classes" --namespace="Classes"
+	php artisan command:make FooCommand --path=app/classes --namespace=Classes
 
 ### Writing The Command
 


### PR DESCRIPTION
 Reason: Options and arguments are passed without.
