### PR TITLE
Updates to View::composer()

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -143,7 +143,7 @@ You may also attach a view composer to multiple views at once:
         $view->with('count', User::count());
     });
     
-> **Note:** If all views are using the same layout, instead of giving all pages as an array, you can also give the `layout` they are extending.
+> **Note:** If all the views in array are extending the same layout, you can pass the `layout` they are extending instead of passing all the child views.
 
 If you would rather use a class based composer, which will provide the benefits of being resolved through the application [IoC Container](/docs/ioc), you may do so:
 


### PR DESCRIPTION
It's a common thing to bind the `layout` view instead of giving an array of child views. It's a better usage on most cases.

For example, if `dashboard, profile, update, messages, wall` etc. sub views are all extending the `layouts.account_layout` layout, you can pass `layouts.account_layout` to composer instead of all the pages.

Page specific things has to be binded using `with` method, so it fits the logic of using View Composers. 

Anyway, it would be good if this use is mentioned there as a text, or a note. There may be issues with my sentence, so I would be glad if any native English speaker can check and confirm it.
