### PR TITLE
Add a hint that @yield supports a default value

### DIFF
--- a/templates.md
+++ b/templates.md
@@ -44,7 +44,7 @@ Blade is a simple, yet powerful templating engine provided with Laravel. Unlike 
 			@show
 
 			<div class="container">
-				@yield('content')
+				@yield('content', 'Some default content')
 			</div>
 		</body>
 	</html>


### PR DESCRIPTION
Today I found out that blade's `@yield()` supports a default value.

I think this pretty helpful and should definitely be added to the docs.
