### PR TITLE
Added --class option to database seeding examples.

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -97,6 +97,10 @@ To seed your database, you may use the `db:seed` command on the Artisan CLI:
 
 	php artisan db:seed
 
+By default, the `php artisan db:seed` command fires a class named `DatabaseSeeder,` which as mentioned, is usually used to run calls to all seed classes as needed. In this example, `UserTableSeeder` is passed which can be used to seed one specific table:
+
+	php artisan db:seed --class="UserTableSeeder"
+
 You may also seed your database using the `migrate:refresh` command, which will also rollback and re-run all of your migrations:
 
 	php artisan migrate:refresh --seed


### PR DESCRIPTION
Added `--class` option to database seeding examples in migrations.md.

I found myself having to figure this out when I created another table to an already existing database. Saw the documentation in `--help,` but not online and wanted to word it to show it a bit more explicitly to users such that they can see an example of how to seed one specific class (and therefore, table.)
