### PR TITLE
Specifying twitter bootstrap version compatiblity

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -9,7 +9,7 @@
 
 In other frameworks, pagination can be very painful. Laravel makes it a breeze. There is a single configuration option in the `app/config/view.php` file. The `pagination` option specifies which view should be used to create pagination links. By default, Laravel includes two views.
 
-The `pagination::slider` view will show an intelligent "range" of links based on the current page, while the `pagination::simple` view will simply show "previous" and "next" buttons. **Both views are compatible with Twitter Bootstrap out of the box.**
+The `pagination::slider` view will show an intelligent "range" of links based on the current page, while the `pagination::simple` view will simply show "previous" and "next" buttons. **Both views are compatible with Twitter Bootstrap 2.0 out of the box.**
 
 <a name="usage"></a>
 ## Usage


### PR DESCRIPTION
Twitter bootstrap 3.0 has been released. For the pagination the class "pagination" should be applied to the `<ul>` not the `<div>` so the views are no longer compatible out of the box with Twitter Bootstrap.

But I don't feel like this is worded well as it's compatible with version 1.0-2.3 anyone want to suggest a further edit?
