### PR TITLE
getting executed sql queries from the QueryLog

### DIFF
--- a/database.md
+++ b/database.md
@@ -84,3 +84,8 @@ Sometimes you may need to reconnect to a given database:
 By default, Laravel keeps a log in memory of all queries that have been run for the current request. However, in some cases, such as when inserting a large number of rows, this can cause the application to use excess memory. To disable the log, you may use the `disableQueryLog` method:
 
 	DB::connection()->disableQueryLog();
+	
+To get the executed queries from the log, it is possible to do so
+       
+       $queries = DB::getQueryLog();
+       $last_query = end($queries);


### PR DESCRIPTION
pointed to a neat way of geting your raw sql queries from the query log
$queries = DB::getQueryLog();
$last_query = end($queries);
