### PR TITLE
HTTP Basic Authentication workaround under Apache FastCGI

### DIFF
--- a/security.md
+++ b/security.md
@@ -159,6 +159,11 @@ Laravel provides an easy method of protecting your application from cross-site r
 
 HTTP Basic Authentication provides a quick way to authenticate users of your application without setting up a dedicated "login" page. To get started, attach the `auth.basic` filter to your route:
 
+> **Note:** php-cgi under Apache does not pass HTTP Basic user/pass to PHP by default, for this workaround to work, add these lines to your .htaccess file:
+
+	RewriteCond %{HTTP:Authorization} ^(.+)$
+	RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
 **Protecting A Route With HTTP Basic**
 
 	Route::get('profile', array('before' => 'auth.basic', function()


### PR DESCRIPTION
HTTP Basic Authentication under Apache with CGI/FastCGI doesn't work.
This is a workaround to get it working.

Source : 
https://github.com/symfony/symfony/issues/1813
