### PR TITLE
Add note about hiding relationships using method name instead of accessor

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -991,6 +991,20 @@ Sometimes you may wish to limit the attributes that are included in your model's
 
 	}
 
+To hide relationships, add the method name of the relationship accessor to the `hidden` property, rather than the accessor name.
+
+	class Comment extends Eloquent {
+
+		// Hide both the foreign key field and the relationship
+		protected $hidden = array('authored_by_id', 'authoredBy');
+
+		public function authoredBy()
+		{
+			return $this->belongsTo('User');
+		}
+
+	}
+
 Alternatively, you may use the `visible` property to define a white-list:
 
 	protected $visible = array('first_name', 'last_name');


### PR DESCRIPTION
Caught me out for a bit.

In `toArray()` the relationship will be under the `authored_by` key, however to hide it we need to add `authoredBy` to `$hidden` instead (method name, instead of accessor).

See laravel/framework#373
