### PR TITLE
Added a missing * to make "View creators" bold

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -164,7 +164,7 @@ Note that there is no convention on where composer classes may be stored. You ar
 
 ### View Creators
 
-View **creators* work almost exactly like view composers; however, they are fired immediately when the view is instantiated. To register a view creator, simple use the `creator` method:
+View **creators** work almost exactly like view composers; however, they are fired immediately when the view is instantiated. To register a view creator, simple use the `creator` method:
 
 	View::creator('profile', function($view)
 	{


### PR DESCRIPTION
![laraveldocs](https://f.cloud.github.com/assets/4924995/1138350/525b6310-1c74-11e3-9717-8c3e86936b27.png)
Added the missing *.

However, I'm not sure if it shouldn't be `creators` instead of **creators**.
