### PR TITLE
For missing classes, only dump-autoload is needed.

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -45,7 +45,7 @@ The `--table` and `--create` options may also be used to indicate the name of th
 
 	php artisan migrate --package=vendor/package
 
-> **Note:** If you receive a "class not found" error when running migrations, try running the `composer update` command.
+> **Note:** If you receive a "class not found" error when running migrations, try running the `composer dump-autoload` command.
 
 <a name="rolling-back-migrations"></a>
 ## Rolling Back Migrations


### PR DESCRIPTION
Even though `composer update` also calls `dump-autoload`, there's no need for it.

At times, `composer update` can take quite a while, and in this case is completely unnecessary.
