### PR TITLE
Pagination count of current page

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -48,6 +48,7 @@ You may also access additional pagination information via the following methods:
 - `getTotal`
 - `getFrom`
 - `getTo`
+- `count` (gets the number of recoreds on the current page)
 
 Sometimes you may wish to create a pagination instance manually, passing it an array of items. You may do so using the `Paginator::make` method:
 


### PR DESCRIPTION
Added the count option to the aditional options for the pagination. 

I was wondering how to get the number of records on the current page, dug in to the source and found there was an option, think it would be usefull to put in the docs.
