### PR TITLE
Adding dropForeign() example, under the dropping indexes section

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -190,6 +190,7 @@ Command  | Description
 `$table->dropPrimary('users_id_primary');`  |  Dropping a primary key from the "users" table
 `$table->dropUnique('users_email_unique');`  |  Dropping a unique index from the "users" table
 `$table->dropIndex('geo_state_index');`  |  Dropping a basic index from the "geo" table
+`$table->dropForeign('employees_department_id_foreign');`  |  Dropping a foreign key from the "employees" table
 
 <a name="storage-engines"></a>
 ## Storage Engines


### PR DESCRIPTION
dropForeign() is already mentioned in the previous section however by
adding it to the examples we clarify that it is completely parallel to
the other indexes - 'Simply concatenate the table name, the names of
the column in the index, and the index type.'

I think this adds further clarity than just having the statement - 'A
similar naming convention is used for foreign keys as is used for other
indexes' that is in an earlier section.
