### PR TITLE
Edited explanation of associate method

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -678,11 +678,13 @@ In this example, the `post_id` field will automatically be set on the inserted c
 
 When updating a `belongsTo` relationship, you may use the `associate` method. This method will set the foreign key on the child model:
 
-	$account = Account::find(10);
+	$user = User::find(10);
 
-	$user->account()->associate($account);
+	$phone->user()->associate($user);
 
-	$user->save();
+	$phone->save();
+	
+In this example, the user_id foreign key field in the phones table will be set to the id of the retrieved $user object. 
 
 ### Inserting Related Models (Many To Many)
 


### PR DESCRIPTION
Just a minor suggested edit to the explanation of the belongsTo associate() method to make it clearer that the method needs to be chained to the model with the belongsTo relationship - and used the $user -> $phone relationship example from further up in the docs - the Account/User example was not quite as clear as to which was the belongsTo and which was the hasOne Model. 

The existing example may not be quite as clear as possible given the likes of this question - http://stackoverflow.com/questions/19868838/call-to-undefined-method-illuminate-database-query-builderassociate/19993027#19993027 - but that may just be me - and I may not be 100% correct in my understanding - so no major if you think it should stay as is.
