### PR TITLE
Add nginx documentation for pretty URLs

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -67,5 +67,5 @@ If the `.htaccess` file that ships with Laravel does not work with your Apache i
 If you are using nginx to serve your Laravel application, the following is required inside a `server` block for pretty URLs:
 
 	location / {
-		try_files $uri /index.php;
+		try_files $uri /index.php?$query_string;
 	}


### PR DESCRIPTION
Apache is pretty popular as a webserver, but it's not the only one in existence, so I added nginx documentation for installation. This is the bare minimum actually needed to support pretty URLs.

As a note, you could really use `try_files $uri $uri/ /index.php` instead (if you wanted directory listing through nginx), but this is just the bare minimum.
