### PR TITLE
updated composer create-project command

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -22,7 +22,7 @@ First, download the [Laravel installer PHAR archive](http://laravel.com/laravel.
 
 You may also install Laravel by issuing the Composer `create-project` command in your terminal:
 
-	composer create-project laravel/laravel --prefer-dist
+	composer create-project laravel/laravel:dev-develop --prefer-dist
 
 ### Via Download
 


### PR DESCRIPTION
Now that the online docs have a version switcher the composer create-project should command should be changed in the 4.1 version, so that it install the latest development branch and not master (4.0.*).
