### PR TITLE
Added default argument value for $paramaters on missingMethod to an empty array

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -204,7 +204,7 @@ A catch-all method may be defined which will be called when no other matching me
 
 **Defining A Catch-All Method**
 
-	public function missingMethod($method, $parameters)
+	public function missingMethod($method, $parameters = array())
 	{
 		//
 	}


### PR DESCRIPTION
If the missingMethod method doesn't have an empty array as the default value, an error is thrown:

Declaration of MyController::missingMethod() should be compatible with Illuminate\Routing\Controller::missingMethod($method, $parameters = Array)

The example should have an empty array set as the default argument to save any confusion with this error.
