### PR TITLE
Corrects use of --create in migrations doc

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -30,7 +30,7 @@ The `--table` and `--create` options may also be used to indicate the name of th
 
 	php artisan migrate:make add_votes_to_user_table --table=users
 
-	php artisan migrate:make create_users_table --create=users
+	php artisan migrate:make create_users_table --create --table=users
 
 <a name="running-migrations"></a>
 ## Running Migrations


### PR DESCRIPTION
`--create` doesn't accept a value, doc updated to correct usage using `--table` as well
