### PR TITLE
added fallback update option for serviceprovider error

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -69,3 +69,5 @@ The current route is now accessed via `Route::current()` instead of `Route::getC
 ### Composer Update
 
 Once you have completed the changes above, you can run the `composer update` function to update your core application files!
+
+If you are running into a *ConsoleSupportServiceProvider not found* error while trying to update the packages you should run `composer update --no-scripts` once.


### PR DESCRIPTION
There is a possibility that an "Class 'Illuminate\Foundation\Providers\ConsoleSupportServiceProvider'
 not found" error occures when upgrading to 4.1. If someone runs the command in the updated docs it correctly upgrades the system.

Tried it out my self and it solved it for me as well.

Credits to jjoel http://forums.laravel.io/viewtopic.php?pid=64885
