### PR TITLE
Replaced . with :

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -140,4 +140,4 @@ Sometimes you may wish to call other commands from your command. You may do so u
 
 **Calling Another Command**
 
-	$this->call('command.name', array('argument' => 'foo', '--option' => 'bar'));
+	$this->call('command:name', array('argument' => 'foo', '--option' => 'bar'));


### PR DESCRIPTION
Atleast on my Windows machine (not tested on Linux) it's $this->call('command:nameofcommand'). Or it will fail not finding the command.
