### PR TITLE
Add more clarification on the index naming convention

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -186,7 +186,7 @@ To drop a foreign key, you may use the `dropForeign` method. A similar naming co
 <a name="dropping-indexes"></a>
 ## Dropping Indexes
 
-To drop an index you must specify the index's name. Laravel assigns a reasonable name to the indexes by default. Simply concatenate the table name, the names of the column in the index, and the index type. Index names are in small caps, occurrences of `-` and `.` are replaced by the `_` character, and the table names and column names are joined with the `_` character. Here are some examples:
+To drop an index you must specify the index's name. Laravel assigns a reasonable name to the indexes by default. Simply concatenate the table name, the names of the column in the index, and the index type. Index names are in small caps, occurrences of `-` and `.` in the table name are replaced by the `_` character, and the table names and column names are joined with the `_` character. Here are some examples:
 
 Command  | Description
 ------------- | -------------


### PR DESCRIPTION
Currently there is no way to the index names generated by Laravel other than by checking the DB directly or by going into the Laravel source code to check the method used to generate the index names. The docs should make the naming convention clearer.
