### PR TITLE
Added to database transaction description.

### DIFF
--- a/database.md
+++ b/database.md
@@ -89,6 +89,20 @@ To run a set of operations within a database transaction, you may use the `trans
 		DB::table('posts')->delete();
 	});
 
+> **Note:** Any exception thrown within the `transaction` closure will cause the transaction to be rolled back automatically.
+
+Sometimes you may need to begin a transaction yourself:
+
+	DB::beginTransaction();
+
+You can rollback a transaction via the `rollback` method:
+
+	DB::rollback();
+
+Lastly, you can commit a transaction via the `commit` method:
+
+	DB::commit();
+
 <a name="accessing-connections"></a>
 ## Accessing Connections
 


### PR DESCRIPTION
I've added to the [database transaction](http://laravel.com/docs/database#database-transactions) description in order to note two important things:
1. The behavior of transactions when exceptions are thrown (giving developers the knowledge of how to cause a rollback in their code, as it is not specified)
2. Added information about the availability of the `beginTransaction`, `commit` and `rollback` methods, which developers may have use for if they need to both catch an exception AND be able to rollback/commit a transaction (And probably other use cases I can't think of at the moment).
