### PR TITLE
Update security.md

### DIFF
--- a/security.md
+++ b/security.md
@@ -216,7 +216,7 @@ Next, a table must be created to store the password reset tokens. To generate a 
 
 **Generating The Reminder Table Migration**
 
-	php artisan auth:reminders
+	php artisan auth:reminders-table
 
 	php artisan migrate
 


### PR DESCRIPTION
`php artisan auth:reminders` gives the following error:

```
[InvalidArgumentException]
  Command "auth:reminders" is ambiguous (auth:reminders-table, auth:reminders
  -controller).
```

The intended command is:

```
php artisan auth:reminders-table
```
