### PR TITLE
Update ssh.md

### DIFF
--- a/ssh.md
+++ b/ssh.md
@@ -68,7 +68,7 @@ The `SSH` class also includes a simple way to upload files, or even strings, to 
 
 	SSH::into('staging')->put($localFile, $remotePath);
 
-	SSH::into('staging')->putString('Foo', $remotePath);
+	SSH::into('staging')->putString($remotePath, 'Foo');
 
 <a name="tailing-remote-logs"></a>
 ## Tailing Remote Logs


### PR DESCRIPTION
The documentation of the putString method used the wrong order of the required arguments($content, $remotepath) instead of the correct one ($remotepath, $content).

I changed that part.
