### PR TITLE
make clear the path helpers are functions

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -158,6 +158,8 @@ Return the last element in the array. Useful for method chaining.
 <a name="paths"></a>
 ## Paths
 
+These are functions that return the relevant value, For example `$app_path = app_path();`.
+
 ### app_path
 
 Get the fully qualified path to the `app` directory.


### PR DESCRIPTION
It wasn't clear to me from reading the docs how to actually use the path helpers. Just adding a line that states they are functions.
