### PR TITLE
Fix inline code formatting.

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -88,7 +88,7 @@ You may also pass arguments to the `environment` method to check if the environm
 <a name="provider-configuration"></a>
 ### Provider Configuration
 
-When using environment configuration, you may want to "append" environment [service providers](/docs/ioc#service-providers) to your primary `app` configuration file. However, if you try this, you will notice the environment `app providers are overriding the providers in your primary `app` configuration file. To force the providers to be appended, use the `append_config` helper method in your environment `app` configuration file:
+When using environment configuration, you may want to "append" environment [service providers](/docs/ioc#service-providers) to your primary `app` configuration file. However, if you try this, you will notice the environment `app` providers are overriding the providers in your primary `app` configuration file. To force the providers to be appended, use the `append_config` helper method in your environment `app` configuration file:
 
 	'providers' => append_config(array(
 		'LocalOnlyServiceProvider',


### PR DESCRIPTION
A missing “ ` ” is inverting the formatting of all of the text after it till the end of the paragraph.
