### PR TITLE
Changed all user.* events to auth.* events (now for 4.1)

### DIFF
--- a/events.md
+++ b/events.md
@@ -13,35 +13,35 @@ The Laravel `Event` class provides a simple observer implementation, allowing yo
 
 #### Subscribing To An Event
 
-	Event::listen('user.login', function($user)
-	{
-		$user->last_login = new DateTime;
+    Event::listen('auth.login', function($user)
+    {
+        $user->last_login = new DateTime;
 
-		$user->save();
-	});
+        $user->save();
+    });
 
 #### Firing An Event
 
-	$event = Event::fire('user.login', array($user));
+    $event = Event::fire('auth.login', array($user));
 
 You may also specify a priority when subscribing to events. Listeners with higher priority will be run first, while listeners that have the same priority will be run in order of subscription.
 
 #### Subscribing To Events With Priority
 
-	Event::listen('user.login', 'LoginHandler', 10);
+    Event::listen('auth.login', 'LoginHandler', 10);
 
-	Event::listen('user.login', 'OtherHandler', 5);
+    Event::listen('auth.login', 'OtherHandler', 5);
 
 Sometimes, you may wish to stop the propagation of an event to other listeners. You may do so using by returning `false` from your listener:
 
 #### Stopping The Propagation Of An Event
 
-	Event::listen('user.login', function($event)
-	{
-		// Handle the event...
+    Event::listen('auth.login', function($event)
+    {
+        // Handle the event...
 
-		return false;
-	});
+        return false;
+    });
 
 ### Where To Register Events
 
@@ -56,22 +56,22 @@ When registering an event listener, you may use asterisks to specify wildcard li
 
 #### Registering Wildcard Event Listeners
 
-	Event::listen('foo.*', function($param)
-	{
-		// Handle the event...
-	});
+    Event::listen('foo.*', function($param)
+    {
+        // Handle the event...
+    });
 
 This listener will handle all events that begin with `foo.`.
 
 You may use the `Event::firing` method to determine exactly which event was fired:
 
-	Event::listen('foo.*', function($param)
-	{
-		if (Event::firing() == 'foo.bar')
-		{
-			//
-		}
-	});
+    Event::listen('foo.*', function($param)
+    {
+        if (Event::firing() == 'foo.bar')
+        {
+            //
+        }
+    });
 
 <a name="using-classes-as-listeners"></a>
 ## Using Classes As Listeners
@@ -80,26 +80,26 @@ In some cases, you may wish to use a class to handle an event rather than a Clos
 
 #### Registering A Class Listener
 
-	Event::listen('user.login', 'LoginHandler');
+    Event::listen('auth.login', 'LoginHandler');
 
 By default, the `handle` method on the `LoginHandler` class will be called:
 
 #### Defining An Event Listener Class
 
-	class LoginHandler {
+    class LoginHandler {
 
-		public function handle($data)
-		{
-			//
-		}
+        public function handle($data)
+        {
+            //
+        }
 
-	}
+    }
 
 If you do not wish to use the default `handle` method, you may specify the method that should be subscribed:
 
 #### Specifying Which Method To Subscribe
 
-	Event::listen('user.login', 'LoginHandler@onLogin');
+    Event::listen('auth.login', 'LoginHandler@onLogin');
 
 <a name="queued-events"></a>
 ## Queued Events
@@ -108,18 +108,18 @@ Using the `queue` and `flush` methods, you may "queue" an event for firing, but 
 
 #### Registering A Queued Event
 
-	Event::queue('foo', array($user));
+    Event::queue('foo', array($user));
 
 #### Registering An Event Flusher
 
-	Event::flusher('foo', function($user)
-	{
-		//
-	});
+    Event::flusher('foo', function($user)
+    {
+        //
+    });
 
 Finally, you may run the "flusher" and flush all queued events using the `flush` method:
 
-	Event::flush('foo');
+    Event::flush('foo');
 
 <a name="event-subscribers"></a>
 ## Event Subscribers
@@ -128,43 +128,43 @@ Event subscribers are classes that may subscribe to multiple events from within 
 
 #### Defining An Event Subscriber
 
-	class UserEventHandler {
+    class UserEventHandler {
 
-		/**
-		 * Handle user login events.
-		 */
-		public function onUserLogin($event)
-		{
-			//
-		}
+        /**
+         * Handle user login events.
+         */
+        public function onUserLogin($event)
+        {
+            //
+        }
 
-		/**
-		 * Handle user logout events.
-		 */
-		public function onUserLogout($event)
-		{
-			//
-		}
+        /**
+         * Handle user logout events.
+         */
+        public function onUserLogout($event)
+        {
+            //
+        }
 
-		/**
-		 * Register the listeners for the subscriber.
-		 *
-		 * @param  Illuminate\Events\Dispatcher  $events
-		 * @return array
-		 */
-		public function subscribe($events)
-		{
-			$events->listen('user.login', 'UserEventHandler@onUserLogin');
+        /**
+         * Register the listeners for the subscriber.
+         *
+         * @param  Illuminate\Events\Dispatcher  $events
+         * @return array
+         */
+        public function subscribe($events)
+        {
+            $events->listen('auth.login', 'UserEventHandler@onUserLogin');
 
-			$events->listen('user.logout', 'UserEventHandler@onUserLogout');
-		}
+            $events->listen('auth.logout', 'UserEventHandler@onUserLogout');
+        }
 
-	}
+    }
 
 Once the subscriber has been defined, it may be registered with the `Event` class.
 
 #### Registering An Event Subscriber
 
-	$subscriber = new UserEventHandler;
+    $subscriber = new UserEventHandler;
 
-	Event::subscribe($subscriber);
+    Event::subscribe($subscriber);


### PR DESCRIPTION
Changed the event names user.login and user.logout to the appropriate and used event names in Laravel. Because this was confusing to me when using the events.
