### PR TITLE
Fixed filter() sample code.

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -968,10 +968,7 @@ When filtering collections, the callback provided will be used as callback for [
 
 	$users = $users->filter(function($user)
 	{
-		if($user->isAdmin())
-		{
-			return $user;
-		}
+		return $user->isAdmin();
 	});
 
 > **Note:** When filtering a collection and converting it to JSON, try calling the `values` function first to reset the array's keys.


### PR DESCRIPTION
The filter() method callback should return true/false, not the actual object.  The existing code technically worked, but was misleading and not ideal.
