### PR TITLE
Specify where auth.basic can be configured

### DIFF
--- a/security.md
+++ b/security.md
@@ -176,9 +176,12 @@ HTTP Basic Authentication provides a quick way to authenticate users of your app
 		// Only authenticated users may enter...
 	}));
 
-By default, the `basic` filter will use the `email` column on the user record when authenticating. If you wish to use another column you may pass the column name as the first parameter to the `basic` method:
+By default, the `basic` filter will use the `email` column on the user record when authenticating. If you wish to use another column you may pass the column name as the first parameter to the `basic` method in `app/filters.php`:
 
-	return Auth::basic('username');
+	Route::filter('auth.basic', function()
+	{
+		return Auth::basic('username');
+	});
 
 You may also use HTTP Basic Authentication without setting a user identifier cookie in the session, which is particularly useful for API authentication. To do so, define a filter that returns the `onceBasic` method:
 


### PR DESCRIPTION
While reading this part of the docs for the first time,
it is not obvious where that line is, especially if
someone skipped straight to HTTP Basic Authentication.
