### PR TITLE
Update facades.md

### DIFF
--- a/facades.md
+++ b/facades.md
@@ -147,7 +147,7 @@ Redis  |  [Illuminate\Redis\Database](http://laravel.com/api/4.1/Illuminate/Redi
 Request  |  [Illuminate\Http\Request](http://laravel.com/api/4.1/Illuminate/Http/Request.html)  |  `request`
 Response  |  [Illuminate\Support\Facades\Response](http://laravel.com/api/4.1/Illuminate/Support/Facades/Response.html)  |
 Route  |  [Illuminate\Routing\Router](http://laravel.com/api/4.1/Illuminate/Routing/Router.html)  |  `router`
-Schema  |  [Illuminate\Database\Schema\Blueprint](http://laravel.com/api/4.1/Illuminate/Database/Schema/Blueprint.html)  |
+Schema  |  [Illuminate\Database\Schema\Builder](http://laravel.com/api/4.1/Illuminate/Database/Schema/Builder.html)  |
 Session  |  [Illuminate\Session\SessionManager](http://laravel.com/api/4.1/Illuminate/Session/SessionManager.html)  |  `session`
 Session (Instance)  |  [Illuminate\Session\Store](http://laravel.com/api/4.1/Illuminate/Session/Store.html)  |
 SSH  |  [Illuminate\Remote\RemoteManager](http://laravel.com/api/4.1/Illuminate/Remote/RemoteManager.html)  |  `remote`


### PR DESCRIPTION
The Schema Facade references "Illuminate\Database\Schema\Builder" and not "Illuminate\Database\Schema\Blueprint". Blueprint references the $table variable you pass through the closure when creating or updating table columns but not the Schema Facade.
