### PR TITLE
[Queues] Remove obsolete note

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -127,8 +127,6 @@ You may also push a Closure onto the queue. This is very convenient for quick, s
 		$job->delete();
 	});
 
-> **Note:** When pushing Closures onto the queue, the `__FILE__` constant should not be used.
-
 When using Iron.io [push queues](#push-queues), you should take extra precaution queueing Closures. The end-point that receives your queue messages should check for a token to verify that the request is actually from Iron.io. For example, your push queue end-point should be something like: `https://yourapp.com/queue/receive?token=SecretToken`. You may then check the value of the secret token in your application before marshaling the queue request.
 
 <a name="running-the-queue-listener"></a>


### PR DESCRIPTION
`__DIR__` [is supported](https://github.com/jeremeamia/super_closure/issues/16) by the super_closure library, so this can be removed.

I tested this and indeed it seemed to be working fine.
