### PR TITLE
Fixed array_forget() example.

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -102,7 +102,9 @@ The `array_forget` method will remove a given key / value pair from a deeply nes
 
 	$array = array('names' => array('joe' => array('programmer')));
 
-	$array = array_forget($array, 'names.joe');
+	array_forget($array, 'names.joe');
+
+	// array('names' => array())
 
 ### array_get
 


### PR DESCRIPTION
```
$array = array_forget($array, 'names.joe');
```

Documentation is mistakenly assuming that the `array_forget()` returns the modified data...
