### PR TITLE
Documentation for bury() method on Beanstalkd queues

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -114,7 +114,7 @@ _Beanstalkd_ can temporarily set a job aside for you to review and take action. 
 	if ($job->attempts() > 3)
 	{
 		Log::info('Buried job: ' . $job->getJobId());
-		job->bury();
+		$job->bury();
 	}
 
 


### PR DESCRIPTION
When added the bury() method forgot to document properly. Think it is worth mentioning it.
