### PR TITLE
4.1 

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -195,7 +195,7 @@ And, you may also specify a subset of actions to handle on the route:
 By default, all resource controller actions have a route name; however, you can override these names by passing a `names` array with your options:
 
 	Route::resource('photo', 'PhotoController',
-					array('names' => array('create' => 'photo.build'));
+					array('names' => array('create' => 'photo.build')));
 
 <a name="handling-missing-methods"></a>
 ## Handling Missing Methods


### PR DESCRIPTION
A small mistake in Laravel 4.1 Routing Documentation
Link : http://laravel.com/docs/routing#route-parameters
There is a missing semi-colon(;) at the end of "Passing An Array Of Wheres" example .
Correct Code :
`Route::get('user/{id}/{name}', function($id, $name)
{
    //
})
->where(array('id' => '[0-9]+', 'name' => '[a-z]+'));`
Just mentioning a small mistake which needs to be fixed :D

Also thank you for this amazing framework.
