### PR TITLE
Corrected characters amount for password validation.

### DIFF
--- a/security.md
+++ b/security.md
@@ -272,7 +272,7 @@ By default, the `Password::reset` method will verify that the passwords match an
 
 	Password::validator(function($credentials)
 	{
-		return strlen($credentials['password']) >= 8;
+		return strlen($credentials['password']) >= 6;
 	});
 
 > **Note:** By default, password reset tokens expire after one hour. You may change this via the `reminder.expire` option of your `app/config/auth.php` file.


### PR DESCRIPTION
```
protected function validatePasswordWithDefaults(array $credentials)
{
    $matches = $credentials['password'] == $credentials['password_confirmation'];

    return $matches && $credentials['password'] && strlen($credentials['password']) >= 6;
}
```
