### PR TITLE
PHP >= 5.4.0 required

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -35,7 +35,7 @@ If you want to update the Laravel framework, you may issue the `php composer.pha
 
 The Laravel framework has a few system requirements:
 
-- PHP >= 5.3.7
+- PHP >= 5.4.0
 - MCrypt PHP Extension
 
 As of PHP 5.5, some OS distributions may require you to manually install the PHP JSON extension. When using Ubuntu, this can be done via `apt-get install php5-json`.


### PR DESCRIPTION
Laravel core packages (support, http, eloquent etc.) make use of traits which aren't available < PHP 5.4.0, updated the installation guide to require PHP 5.4.0 instead of PHP 5.3.7.
