### PR TITLE
Resource routes after other routes

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -197,6 +197,18 @@ By default, all resource controller actions have a route name; however, you can 
 	Route::resource('photo', 'PhotoController',
 					array('names' => array('create' => 'photo.build')));
 
+Sometimes, you may want to specify additional routes within the same URI path as a resource route. For example, you might want to create a route at `photo/{id}/comment` to display comments associated with a particular photo. Any such additional routes must be declared *before* the `Route::resource` call:
+
+	// This must come first:
+	Route::get('photo/{id}/comment', function($id)
+	{
+		//
+	});
+	
+	// This must come second:
+	Route::resource('photo', 'PhotoController');
+	
+
 <a name="handling-missing-methods"></a>
 ## Handling Missing Methods
 


### PR DESCRIPTION
Resource routes have to be declared after any other routes applying to the same path or a subpath of it. This behavior doesn't seem to be documented anywhere. I'm not sure if this is how it's supposed to work, but if so, I've written a brief explanation with an example.
