### PR TITLE
Add section to Eager Loading about the `$with` model variable

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -818,6 +818,15 @@ It is also possible to eagerly load related models directly from an already exis
 
 	$books->load('author', 'publisher');
 
+### Always Eager Load
+
+If you are always eager loading related models, you may add a `$with` variable to your model.
+
+        class Books extends Eloquent 
+        {
+        	protected $with = array('author', 'publisher');
+        }
+
 <a name="inserting-related-models"></a>
 ## Inserting Related Models
 


### PR DESCRIPTION
This is from a stack overflow entry:

http://stackoverflow.com/questions/15823344/eager-loading-from-the-model-in-laravel-4 (Not Mine)

It doesn't look like any proposed change made it in.  I don't see a more obvious place to put it.
