### PR TITLE
Inability to use objects for Closure queueing

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -129,6 +129,8 @@ You may also push a Closure onto the queue. This is very convenient for quick, s
 
 When using Iron.io [push queues](#push-queues), you should take extra precaution queueing Closures. The end-point that receives your queue messages should check for a token to verify that the request is actually from Iron.io. For example, your push queue end-point should be something like: `https://yourapp.com/queue/receive?token=SecretToken`. You may then check the value of the secret token in your application before marshaling the queue request.
 
+> **Note:** Be sure not to `use` any objects (including Eloquent models) from outside of the Closure, as they will be lost in the serialization process. In the case of Eloquent models, you could pass the primary key so you can reassemble the model object when the job is being processed.
+
 <a name="running-the-queue-listener"></a>
 ## Running The Queue Listener
 


### PR DESCRIPTION
Added a note explaining that instance objects should not be imported into the scope of a Closure when queueing as they will be lost in serialisation with Super Closure.
