### PR TITLE
Homestead MySQL Username correction (root)

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -102,7 +102,7 @@ If you want even more convenience, it can be helpful to add the following alias 
 
 A `homestead` database is configured for both MySQL and Postgres out of the box. For even more convenience, Laravel's `local` database configuration is set to use this database by default.
 
-To connect to your MySQL or Postgres database from your main machine via Navicat or Sequel Pro, you should connect to `127.0.0.1` and port 33060 (MySQL) or 54320 (Postgres). The username and password for both databases is `homestead` / `secret`.
+To connect to your MySQL or Postgres database from your main machine via Navicat or Sequel Pro, you should connect to `127.0.0.1` and port 33060 (MySQL) or 54320 (Postgres). The username and password for both databases is `root` / `secret`.
 
 > **Note:** You should only use these non-standard ports when connecting to the databases from your main machine. You will use the default 3306 and 5432 ports in your Laravel database configuration file since Laravel is running _within_ the Virtual Machine.
 


### PR DESCRIPTION
Username `homestead` works fine for me when connecting remotely, however internally (ie. from Laravel/MySQL via SSH) it does not connect. Using the username `root` instead (with password `secret`), works.

**I'm not familiar with Postgres, so haven't checked with that, though.**
