### PR TITLE
Fix wording in extending.md

### DIFF
--- a/extending.md
+++ b/extending.md
@@ -85,7 +85,7 @@ Extending Laravel with a custom session driver is just as easy as extending the 
 
 ### Where To Extend The Session
 
-Session extensions need to be registered differently than other extensions like Cache and Auth. Since sessions are started very early in the request-lifecycle, registering the extensions in a `start` file will happen be too late. Instead, a [service provider](/docs/ioc#service-providers) will be needed. You should place your session extension code in the `register` method of your service provider, and the provider should be placed **below** the default `Illuminate\Session\SessionServiceProvider` in the `providers` configuration array.
+Session extensions need to be registered differently than other extensions like Cache and Auth. Since sessions are started very early in the request-lifecycle, registering the extensions in a `start` file will happen too late. Instead, a [service provider](/docs/ioc#service-providers) will be needed. You should place your session extension code in the `register` method of your service provider, and the provider should be placed **below** the default `Illuminate\Session\SessionServiceProvider` in the `providers` configuration array.
 
 ### Writing The Session Extension
 


### PR DESCRIPTION
The second sentence read: '...registering the extensions in a start file will happen be too late'. I removed the 'be' from the sentence.
