### PR TITLE
Make sentence about queue daemons make sense

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -188,7 +188,7 @@ As you can see, the `queue:work` command supports most of the same options avail
 
 ### Deploying With Daemon Queue Workers
 
-The simplest way to deploy an application using daemon queue workers is to put the application in maintenance mode at the beginning of your deploymnet. This can be done using the `php artisan down` command. Once the application is in maintenance mode, Laravel will now accept any new jobs off of the queue, but will continue to process existing jobs. Once enough time has passed for all of your existing jobs to execute (usually no longer than 30-60 seconds), you may stop the worker and continue your deployment process.
+The simplest way to deploy an application using daemon queue workers is to put the application in maintenance mode at the beginning of your deploymnet. This can be done using the `php artisan down` command. Once the application is in maintenance mode, Laravel will not accept any new jobs off of the queue, but will continue to process existing jobs. Once enough time has passed for all of your existing jobs to execute (usually no longer than 30-60 seconds), you may stop the worker and continue your deployment process.
 
 If you are using Supervisor or Laravel Forge, which utilizes Supervisor, you may typically stop a worker with a command like the following:
 


### PR DESCRIPTION
Previous:

> Once the application is in maintenance mode, Laravel will now accept any new jobs off of the queue, but will continue to process existing jobs.

New:

> Once the application is in maintenance mode, Laravel will **not** accept any new jobs off of the queue, but will continue to process existing jobs.

I think this is correct - sentence didn't make sense otherwise.
