### PR TITLE
Provision instead of destroy after adding sites

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -110,7 +110,7 @@ To connect to your MySQL or Postgres database from your main machine via Navicat
 
 ### Adding Additional Sites
 
-Once your Homestead environment is provisioned and running, you may want to add additional Nginx sites for your Laravel applications. You can run as many Laravel installation as you wish on a single Homestead environment. There are two ways to do this. First, you may simply add the sites to your `Homestead.yaml` file, `vagrant destroy` the box, and then `vagrant up` again.
+Once your Homestead environment is provisioned and running, you may want to add additional Nginx sites for your Laravel applications. You can run as many Laravel installation as you wish on a single Homestead environment. There are two ways to do this. First, you may simply add the sites to your `Homestead.yaml` file and `vagrant provision` the box.
 
 Alternatively, you may use the `serve` script that is available on your Homestead environment. To use the `serve` script, SSH into your Homestead environment and run the following command:
 


### PR DESCRIPTION
Destroying the box is - in my eyes - not the best way of doing this. It will also delete all user's changes (like installing phpunit, phpmyadmin, setting git config). 
`vagrant provision` does the trick of adding the new sites, without destroying all changes.
