### PR TITLE
Updated section on Adding Additional Sites

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -110,7 +110,7 @@ To connect to your MySQL or Postgres database from your main machine via Navicat
 
 ### Adding Additional Sites
 
-Once your Homestead environment is provisioned and running, you may want to add additional Nginx sites for your Laravel applications. You can run as many Laravel installation as you wish on a single Homestead environment. There are two ways to do this. First, you may simply add the sites to your `Homestead.yaml` file, `vagrant destroy` the box, and then `vagrant up` again.
+Once your Homestead environment is provisioned and running, you may want to add additional Nginx sites for your Laravel applications. You can run as many Laravel installation as you wish on a single Homestead environment. There are two ways to do this. First, you may simply add the sites to your `Homestead.yaml` file and then run `vagrant provision`.
 
 Alternatively, you may use the `serve` script that is available on your Homestead environment. To use the `serve` script, SSH into your Homestead environment and run the following command:
 


### PR DESCRIPTION
Running `vagrant destroy` and then `vagrant up` is not the best way to do this. It deletes the entire VM and requires a full download when running `vagrant up` again - this is painful for those of us on slower connections. It is much faster to simply run `vagrant provision` to add the new sites to the nginx config.
