### PR TITLE
Added details about extra queue that is needed

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -20,6 +20,12 @@ Add a new `cipher` option in your `app/config/app.php` configuration file. The v
 
 This setting may be used to control the default cipher used by the Laravel encryption facilities.
 
+### Queue Configuration
+
+#### Iron.io
+
+Add a new `encrypt` option into the `iron` array in your `app/config/queue.php` configuration file. The value of this option is a `boolean` and in new laravel installations it defaults to `true`.
+
 ### Soft Deleting Models Now Use Traits
 
 If you are using soft deleting models, the `softDeletes` property has been removed. You should now use the `SoftDeletingTrait` like so:


### PR DESCRIPTION
The Iron driver throws errors if this new key isn't present in the configuration, so it should be noted in the upgrade documentation. I'm unsure about other queue drivers as I don't use them, but I believe some have had new configuration options too...
