### PR TITLE
Removing Flusher(), never implemented

### DIFF
--- a/events.md
+++ b/events.md
@@ -110,14 +110,9 @@ Using the `queue` and `flush` methods, you may "queue" an event for firing, but 
 
 	Event::queue('foo', array($user));
 
-#### Registering An Event Flusher
+#### Flush A Queued Event
 
-	Event::flusher('foo', function($user)
-	{
-		//
-	});
-
-Finally, you may run the "flusher" and flush all queued events using the `flush` method:
+Flush queued events using the `flush` method:
 
 	Event::flush('foo');
 


### PR DESCRIPTION
There is not a Flusher method within the Dispatcher, removing to avoid
misleading info in docs.

reference https://github.com/laravel/framework/issues/4729
