### PR TITLE
Section "Extending Blade" is wrong

### DIFF
--- a/templates.md
+++ b/templates.md
@@ -176,5 +176,5 @@ The following example creates a `@datetime($var)` directive which simply calls `
 	{
 		$pattern = $compiler->createMatcher('datetime');
 
-		return preg_replace($pattern, '$1<?php echo $2->format('m/d/Y H:i'); ?>', $view);
+		return preg_replace($pattern, '$1<?php echo $2->format(\'m/d/Y H:i\'); ?>', $view);
 	});


### PR DESCRIPTION
This is wrong:

```
The following example creates a `@datetime($var)` directive which simply calls `->format()` on `$var`:

    Blade::extend(function($view, $compiler)
    {
        $pattern = $compiler->createMatcher('datetime');

        return preg_replace($pattern, '$1<?php echo $2->format('m/d/Y H:i'); ?>', $view);
    });

```

This has 2 errors in it:
1. `'m/d/Y H:i'` isn't properly escaped.
2. `@datetime($var)` becomes `($var)->format()` and crashes instead of `$var->format()`

Previous discussion: https://github.com/laravel/framework/issues/4770 and https://github.com/laravel/docs/pull/835
