### PR TITLE
edits to upgrading from 4.0 to 4.1

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -150,7 +150,7 @@ If `app/controllers/BaseController.php` has a `use` statement at the top, change
 
 ### Password Reminders Updates
 
-Password reminders have been overhauled for greater flexibility. You may examine the new stub controller by running the `php artisan auth:reminders-controller` Artisan command. You may also browse the [updated documentation](/docs/security#password-reminders-and-reset) and update your application accordingly.
+Password reminders have been overhauled for greater flexibility. You may examine the new stub controller by running the `php artisan auth:reminders-controller` Artisan command (only run this command after completing the changes below). You may also browse the [updated documentation](/docs/security#password-reminders-and-reset) and update your application accordingly.
 
 Update your `app/lang/en/reminders.php` language file to match [this updated file](https://github.com/laravel/laravel/blob/master/app/lang/en/reminders.php).
 
@@ -174,7 +174,7 @@ The current route is now accessed via `Route::current()` instead of `Route::getC
 
 ### Composer Update
 
-Once you have completed the changes above, you can run the `composer update` function to update your core application files! If you receive class load errors, try running the `update` command with the `--no-scripts` option enabled like so: `composer update --no-scripts`.
+Once you have completed the changes above, you can run the `composer update` function to update your core application files! If you receive class load errors, try running the `update` command with the `--no-scripts` option enabled like so: `composer update --no-scripts`. (You may have to run `sudo composer update` if you are getting Permission denied)
 
 ### Wildcard Event Listeners
 


### PR DESCRIPTION
I updated one of my projects from 4.0 to 4.1. In reading the documentation, I instantly `ran php artisan auth:reminders-controller` to create my reminders. That resulted in an error because I hadn't run `composer update` yet. I thought that it would be nice to let others know not to run that until they are done upgrading.

Also, when I ran `composer update`, I saw some "Permission Denied" errors. I re-ran `composer update` this time with sudo and it all went fine.

Ravi.
