### PR TITLE
Correct 'typo' in Migraitons Introduction (scheme => schema)

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -9,7 +9,7 @@
 <a name="introduction"></a>
 ## Introduction
 
-Migrations are a type of version control for your database. They allow a team to modify the database schema and stay up to date on the current schema state. Migrations are typically paired with the [Schema Builder](/docs/schema) to easily manage your application's scheme.
+Migrations are a type of version control for your database. They allow a team to modify the database schema and stay up to date on the current schema state. Migrations are typically paired with the [Schema Builder](/docs/schema) to easily manage your application's schema.
 
 <a name="creating-migrations"></a>
 ## Creating Migrations


### PR DESCRIPTION
The final sentence in the introduction ended with 'manage your applications' scheme' however 'schema' was intended.
