### PR TITLE
Updating a typo(?) in the configuration docs.

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -48,7 +48,7 @@ Simply create a folder within the `config` directory that matches your environme
 
 Notice that you do not have to specify _every_ option that is in the base configuration file, but only the options you wish to override. The environment configuration files will "cascade" over the base files.
 
-Next, we need to instruct the framework how to determine which environment it is running in. The default environment is always `production`. However, you may setup other environments within the `bootstrap/environment.php` file at the root of your installation. In this file you will find an `$app->detectEnvironment` call. The array passed to this method is used to determine the current environment. You may add other environments and machine names to the array as needed.
+Next, we need to instruct the framework how to determine which environment it is running in. The default environment is always `production`. However, you may setup other environments within the `bootstrap/start.php` file at the root of your installation. In this file you will find an `$app->detectEnvironment` call. The array passed to this method is used to determine the current environment. You may add other environments and machine names to the array as needed.
 
     <?php
 


### PR DESCRIPTION
The documentation is referring to the file `bootstrap/environment.php`. This file does not exist.

The call being referred to is in `bootstrap/start.php`.

Updated the docs accordingly.
