### PR TITLE
Fix typo 'deploymnent' -> 'deployment'

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -190,7 +190,7 @@ As you can see, the `queue:work` command supports most of the same options avail
 
 ### Deploying With Daemon Queue Workers
 
-The simplest way to deploy an application using daemon queue workers is to put the application in maintenance mode at the beginning of your deploymnet. This can be done using the `php artisan down` command. Once the application is in maintenance mode, Laravel will not accept any new jobs off of the queue, but will continue to process existing jobs.
+The simplest way to deploy an application using daemon queue workers is to put the application in maintenance mode at the beginning of your deployment. This can be done using the `php artisan down` command. Once the application is in maintenance mode, Laravel will not accept any new jobs off of the queue, but will continue to process existing jobs.
 
 The easiest way to restart your workers is to include the following command in your deployment script:
 


### PR DESCRIPTION
Fix typo in 4.2 docs: 'deploymnent' -> 'deployment'
