### PR TITLE
Adjustments on headings/descriptions for Route::controller and Route::resource methods

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -2,8 +2,8 @@
 
 - [Basic Controllers](#basic-controllers)
 - [Controller Filters](#controller-filters)
-- [RESTful Controllers](#restful-controllers)
-- [Resource Controllers](#resource-controllers)
+- [Implicit Controllers](#implicit-controllers)
+- [RESTful Resource Controllers](#resftul-resource-controllers)
 - [Handling Missing Methods](#handling-missing-methods)
 
 <a name="basic-controllers"></a>
@@ -120,10 +120,10 @@ If you would like to use another method on the controller as a filter, you may u
 
 	}
 
-<a name="restful-controllers"></a>
-## RESTful Controllers
+<a name="implicit-controllers"></a>
+## Implicit Controllers
 
-Laravel allows you to easily define a single route to handle every action in a controller using simple, REST naming conventions. First, define the route using the `Route::controller` method:
+Laravel allows you to easily define a single route to handle every action in a controller. First, define the route using the `Route::controller` method:
 
 	Route::controller('users', 'UserController');
 
@@ -154,8 +154,8 @@ If your controller action contains multiple words, you may access the action usi
 
 	public function getAdminProfile() {}
 
-<a name="resource-controllers"></a>
-## Resource Controllers
+<a name="restful-resource-controllers"></a>
+## RESTful Resource Controllers
 
 Resource controllers make it easier to build RESTful controllers around resources. For example, you may wish to create a controller that manages "photos" stored by your application. Using the `controller:make` command via the Artisan CLI and the `Route::resource` method, we can quickly create such a controller.
 


### PR DESCRIPTION
Suggest not describing the `Route::controller` method as RESTful or listing it under the _RESTful Controllers_ heading.

REST generally has the following criteria:
- You have a standard set of URLs to perform basic CRUD operations on a Resource of your application.
- Every Resource has a unique ID.

None of those things are being enforced when using `Route::controller`.

A more appropriate name for this heading might be _Implicit Routing_; you're mapping routes to a Controller without explicitly defining those routes. There's nothing RESTful about this.

The method that comes after, `Route::resource`, falls more into the category of RESTful routing. So perhaps that heading might become `RESTful Resource Controllers`.
