### PR TITLE
Rename from "Unit Testing" to "Testing"

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -1,4 +1,4 @@
-# Unit Testing
+# Testing
 
 - [Introduction](#introduction)
 - [Defining & Running Tests](#defining-and-running-tests)


### PR DESCRIPTION
The lines between different kinds of testing can sometimes be fuzzy, but very little of this doc is applicable to Unit Testing specifically. It may be more accurate to just call the page Testing.
