### PR TITLE
reminding users they need to set 'files' => true

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -97,6 +97,8 @@ Since you often will want to flash input in association with a redirect to the p
 <a name="files"></a>
 ## Files
 
+> **Note:** You will also need to add 'files' => true when [opening a form](/docs/html#opening-a-form)
+
 #### Retrieving An Uploaded File
 
 	$file = Input::file('photo');


### PR DESCRIPTION
Minor change which lets users know that they need to add  'files' => true when opening a form, otherwise Input::file() will return null.

Although this is mentioned in html#file-input it's not mentioned in the dedicated section about file uploads. Spent a good 30 minutes fighting the framework because this section on files doesn't mention the form requirements :)
