### PR TITLE
Method Specific View Composer

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -185,6 +185,7 @@ You may use the `composers` method to register a group of composers at the same 
 	View::composers(array(
 		'AdminComposer' => array('admin.index', 'admin.profile'),
 		'UserComposer' => 'user',
+		'ProductComposer@create' => 'product' 
 	));
 
 > **Note:** There is no convention on where composer classes may be stored. You are free to store them anywhere as long as they can be autoloaded using the directives in your `composer.json` file.


### PR DESCRIPTION
When defining multiple view composers it is important to point out that you can be method/action specific.
