### PR TITLE
Add note of special treatment of .env.php in production environment.

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -117,7 +117,7 @@ Be sure to add the `.env.local.php` file to your `.gitignore` file. This will al
 
 Now, on your production server, create a `.env.php` file in your project root that contains the corresponding values for your production environment. Like the `.env.local.php` file, the production `.env.php` file should never be included in source control.
 
-> **Note:** You may create a file for each environment supported by your application. For example, the `development` environment will load the `.env.development.php` file if it exists.
+> **Note:** You may create a file for each environment supported by your application. For example, the `development` environment will load the `.env.development.php` file if it exists. In the `production` environment, only use a `.env.php` file. If you include an `.env.production.php` file, it will be ignored.
 
 <a name="maintenance-mode"></a>
 ## Maintenance Mode


### PR DESCRIPTION
Adds warning that a user should not expect a .env.production.php configuration file to be read over a .env.php file.
