### PR TITLE
Update ssh.md

### DIFF
--- a/ssh.md
+++ b/ssh.md
@@ -260,4 +260,4 @@ To update Envoy, simply run the `self-update` command:
 
 If your Envoy installation is in `/usr/local/bin`, you may need to use `sudo`:
 
-	sudo envoy self-update
+	composer global update


### PR DESCRIPTION
Envoy update information is outdated, needs to be : "composer global update" as new documentation.
Self-update does not work on current version.
