### PR TITLE
Update quick.md

### DIFF
--- a/quick.md
+++ b/quick.md
@@ -20,7 +20,7 @@ The Laravel framework utilizes [Composer](http://getcomposer.org) for installati
 
 Now you can install Laravel by issuing the following command from your terminal:
 
-	composer create-project laravel/laravel your-project-name --prefer-dist
+	composer create-project laravel/laravel=4.1.* your-project-name --prefer-dist
 
 This command will download and install a fresh copy of Laravel in a new `your-project-name` folder within your current directory.
 


### PR DESCRIPTION
composer create-project laravel/laravel --prefer-dist will install 4.2 by default (at this point). 
This pull request will ensure those who are looking at a specific version of Laravel's documentation and fire up the corresponded version of Laravel.

Reference:
http://stackoverflow.com/questions/23754260/installing-specific-laravel-version-via-composer-create-project
