### PR TITLE
Update validation.md boolean rule section placement

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -238,6 +238,11 @@ The field under validation must be a value preceding the given date. The dates w
 
 The field under validation must have a size between the given _min_ and _max_. Strings, numerics, and files are evaluated in the same fashion as the `size` rule.
 
+<a name="rule-boolean"></a>
+#### boolean
+
+The field under validation must be able to be cast as a boolean. Accepted input are `true`, `false`, `1`, `0`, `"1"` and `"0"`.
+
 <a name="rule-confirmed"></a>
 #### confirmed
 
@@ -267,11 +272,6 @@ The field under validation must be _numeric_ and must have an exact length of _v
 #### digits_between:_min_,_max_
 
 The field under validation must have a length between the given _min_ and _max_.
-
-<a name="rule-boolean"></a>
-#### boolean
-
-The field under validation must be able to be cast as a boolean. Accepted input are `true`, `false`, `1`, `0`, `"1"` and `"0"`.
 
 <a name="rule-email"></a>
 #### email


### PR DESCRIPTION
The `boolean` rule section is situated between the `digits_between` and `email` sections, which is out of its alphabetical place. This commit puts it in it's rightful place between the `between` and `confirmed` sections.
