### PR TITLE
fixed a typo

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -49,7 +49,7 @@ The `--table` and `--create` options may also be used to indicate the name of th
 
 ### Forcing Migrations In Production
 
-Some migration operations are destructive, meaning they may cause you to lose data. In order to protect you from running these commands against your production database, you will prompted for confirmation before these commands are executed. To force thse commands to run without a prompt, use the `--force` flag:
+Some migration operations are destructive, meaning they may cause you to lose data. In order to protect you from running these commands against your production database, you will prompted for confirmation before these commands are executed. To force the commands to run without a prompt, use the `--force` flag:
 
 	php artisan migrate --force
 


### PR DESCRIPTION
Fixed a typo in the migration documentation
