### PR TITLE
Added note about relationship column when eager loading with callback

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -877,6 +877,8 @@ Of course, eager loading Closures aren't limited to "constraints". You may also 
 
 	}))->get();
 
+> **Note:** When specifying columns using the eager loading callback, it's important that the constraining column is included or it won't be linked to the original model.
+
 ### Lazy Eager Loading
 
 It is also possible to eagerly load related models directly from an already existing model collection. This may be useful when dynamically deciding whether to load related models or not, or in combination with caching.


### PR DESCRIPTION
With many ORM's eager loading is done with a join so doesn't necessarily require the columns for the foreign key relationship in the select statement.  Due to the efficient method Eloquent uses, it does require that that particular column be included, which might not be immediately obvious.

Alternatively to modifying the doc, the getEager method could check the eager query columns to see if it's a wildcard or the particular foreign key relation is included, and if not, automatically add it to the query if not.