### PR TITLE
Pagination: correct zurb presenter example markup

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -123,7 +123,7 @@ Extend the `Illuminate\Pagination\Presenter` class and implement its abstract me
 
         public function getDisabledTextWrapper($text)
         {
-            return '<li class="unavailable">'.$text.'</li>';
+            return '<li class="unavailable"><a href="">'.$text.'</a></li>';
         }
 
         public function getPageLinkWrapper($url, $page, $rel = null)


### PR DESCRIPTION
The markup used in the [ZurbPresenter example](http://laravel.com/docs/pagination#custom-presenters) doesn't completely match that shown in the foundation [documentation](http://foundation.zurb.com/docs/components/pagination.html). This patch updates the example to implement the correct markup. 
