### PR TITLE
Update Eloquent table name convention

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -37,7 +37,7 @@ To get started, create an Eloquent model. Models typically live in the `app/mode
 
 	class User extends Eloquent {}
 
-Note that we did not tell Eloquent which table to use for our `User` model. The lower-case, plural name of the class will be used as the table name unless another name is explicitly specified. So, in this case, Eloquent will assume the `User` model stores records in the `users` table. You may specify a custom table by defining a `table` property on your model:
+Note that we did not tell Eloquent which table to use for our `User` model. The lower-case, plural name of the class, separated with underscores in case of multiple words, will be used as the table name unless another name is explicitly specified. So, in this case, Eloquent will assume the `User` model stores records in the `users` table. You may specify a custom table by defining a `table` property on your model:
 
 	class User extends Eloquent {
 


### PR DESCRIPTION
Add information that Laravel would add underscores to the name of the table if the model name consists of multiple words *and* no table name is explicitly specified within the model.

Eg: For a model named ContentType, Eloquent would automatically assume that this model stores its content within a DB table called content_types