### PR TITLE
Better SSH key comment

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -60,7 +60,7 @@ Next, you should edit the `Homestead.yaml` file included in the repository. In t
 
 Don't have an SSH key? On Mac and Linux, you can generally create an SSH key pair using the following command:
 
-	ssh-keygen -t rsa -C "your@email.com"
+	ssh-keygen -t rsa -C "you@homestead"
 
 On Windows, you may install [Git](http://git-scm.com/) and use the `Git Bash` shell included with Git to issue the command above. Alternatively, you may use [PuTTY](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html) and [PuTTYgen](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html).
 


### PR DESCRIPTION
SSH key comments are not usually emails, they are only emails if they are used for a website where identification is done using email and not using a username. So for example, a website like Github where every user pushes as git@ is something where an email would make sense.

Usually the comments on SSH keys are user@hostname, since the homestead box has no particular hostname other than localhost @homestead is a good replacement here. The naming is more conventional this way and teaches practice right away that you should use different keys for different hosts.

Minor detail. Not like comments matter for anything at all.
