### PR TITLE
Added a noun and added a serial (AKA Oxford) comma

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -13,7 +13,7 @@ Laravel strives to make the entire PHP development experience delightful, includ
 
 Laravel Homestead is an official, pre-packaged Vagrant "box" that provides you a wonderful development environment without requiring you to install PHP, HHVM, a web server, and any other server software on your local machine. No more worrying about messing up your operating system! Vagrant boxes are completely disposable. If something goes wrong, you can destroy and re-create the box in minutes!
 
-Homestead runs on any Windows, Mac, and Linux, and includes the Nginx web server, PHP 5.6, MySQL, Postgres, Redis, Memcached and all of the other goodies you need to develop amazing Laravel applications.
+Homestead runs on any Windows, Mac, or Linux system, and includes the Nginx web server, PHP 5.6, MySQL, Postgres, Redis, Memcached, and all of the other goodies you need to develop amazing Laravel applications.
 
 > **Note:** If you are using Windows, you may need to enable hardware virtualization (VT-x). It can usually be enabled via your BIOS.
 


### PR DESCRIPTION
Nitpicky grammar stuff, but every little thing counts. I realize that the sentence could technically by correct as 

> Homestead runs on any Windows, Mac, [...]

by using the OS names as the nouns, and implying it works on any version, but the conjunction should then be "or," not "and." In either case, I think 

> Homestead runs on any Windows, Mac, or Linux system [...]

rolls better. 

The serial comma just brings it into line with the rest of the documentation (no other files lack a serial comma).
