### PR TITLE
Add memcached cache config tips and examples, including Unix sockets. Link to Redis config section.

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -17,12 +17,16 @@ The cache configuration file also contains various other options, which are docu
 Requires the [Memcached PECL package](http://pecl.php.net/package/memcached) to be installed.
 
 The default configuration uses TCP/IP
+
 	'memcached' => array(
 		array('host' => '127.0.0.1', 'port' => 11211, 'weight' => 100),
+	),
+
 For better performance, consider start Memcached as a UNIX socket and then set `host` to a socket file path and `port` is `0`
+
 	'memcached' => array(
 		array('host' => '/var/run/memcached/memcached.sock', 'port' => 0, 'weight' => 100),
-
+	),
 
 <a name="cache-usage"></a>
 ## Cache Usage

--- a/cache.md
+++ b/cache.md
@@ -28,6 +28,9 @@ For better performance, consider start Memcached as a UNIX socket and then set `
 		array('host' => '/var/run/memcached/memcached.sock', 'port' => 0, 'weight' => 100),
 	),
 
+#### Redis
+See [Redis Configuration](/docs/redis#configuration)
+
 <a name="cache-usage"></a>
 ## Cache Usage
 

--- a/cache.md
+++ b/cache.md
@@ -13,6 +13,17 @@ Laravel provides a unified API for various caching systems. The cache configurat
 
 The cache configuration file also contains various other options, which are documented within the file, so make sure to read over these options. By default, Laravel is configured to use the `file` cache driver, which stores the serialized, cached objects in the filesystem. For larger applications, it is recommended that you use an in-memory cache such as Memcached or APC.
 
+#### Memcached
+Requires the [Memcached PECL package](http://pecl.php.net/package/memcached) to be installed.
+
+The default configuration uses TCP/IP
+	'memcached' => array(
+		array('host' => '127.0.0.1', 'port' => 11211, 'weight' => 100),
+For better performance, consider start Memcached as a UNIX socket and then set `host` to a socket file path and `port` is `0`
+	'memcached' => array(
+		array('host' => '/var/run/memcached/memcached.sock', 'port' => 0, 'weight' => 100),
+
+
 <a name="cache-usage"></a>
 ## Cache Usage
 

--- a/cache.md
+++ b/cache.md
@@ -16,13 +16,13 @@ The cache configuration file also contains various other options, which are docu
 #### Memcached
 Requires the [Memcached PECL package](http://pecl.php.net/package/memcached) to be installed.
 
-The default configuration uses TCP/IP
+The default configuration uses TCP/IP based on [Memcached::addServer](http://php.net/manual/en/memcached.addserver.php)
 
 	'memcached' => array(
 		array('host' => '127.0.0.1', 'port' => 11211, 'weight' => 100),
 	),
 
-For better performance, consider start Memcached as a UNIX socket and then set `host` to a socket file path and `port` is `0`
+For better performance, start Memcached as a UNIX socket, and then set `host` to a socket file path and `port` to `0`
 
 	'memcached' => array(
 		array('host' => '/var/run/memcached/memcached.sock', 'port' => 0, 'weight' => 100),


### PR DESCRIPTION
[A previous pull request](https://github.com/laravel/laravel/pull/3008) explained the background.

[OT suggested putting this info in the docs](https://github.com/laravel/laravel/pull/3008#issuecomment-55362861), instead of the config.php comments, so here it is.