### PR TITLE
Documenting how to restart Queue workers with APCu

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -198,6 +198,8 @@ The easiest way to restart your workers is to include the following command in y
 
 This command will instruct all queue workers to restart after they finish processing their current job.
 
+> **Note:** This command relies on the cache system to schedule the restart. By default, APCu does not work for CLI commands. If you are using APCu, add `apc.enable_cli=1` to your APCu configuration.
+
 ### Coding For Daemon Queue Workers
 
 Daemon queue workers do not restart the framework before processing each job. Therefore, you should be careful to free any heavy resources before your job finishes. For example, if you are doing image manipulation with the GD library, you should free the memory with `imagedestroy` when you are done.


### PR DESCRIPTION
By default, APCu does not work with CLI applications. The `queue:restart` command relies on the cache system, and does not work if APCu is used as the cache driver, unless APCu is configured.
