### PR TITLE
Update laravel website repository url.

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -26,7 +26,7 @@ The Laravel source code is managed on Github, and there are repositories for eac
 - [Laravel Envoy](https://github.com/laravel/envoy)
 - [Laravel Homestead](https://github.com/laravel/homestead)
 - [Laravel Homestead Build Scripts](https://github.com/laravel/settler)
-- [Laravel Website](https://github.com/laravel/website)
+- [Laravel Website](https://github.com/laravel/laravel.com)
 - [Laravel Art](https://github.com/laravel/art)
 
 <a name="core-development-discussion"></a>


### PR DESCRIPTION
Old laravel website repository address gets a 404 error page on github.
