### PR TITLE
Fix relative link to ssh task runner.

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -32,7 +32,7 @@ Homestead is currently built and tested using Vagrant 1.6.
 - Redis
 - Memcached
 - Beanstalkd
-- [Laravel Envoy](/docs/ssh#envoy-task-runner)
+- [Laravel Envoy](ssh.md#envoy-task-runner)
 - Fabric + HipChat Extension
 
 <a name="installation-and-setup"></a>


### PR DESCRIPTION
The previous link had an extra /docs/ in the url.
