### PR TITLE
Add note about PSR-4 Packages

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -88,6 +88,8 @@ There is not a "default location" for service provider classes. You may put them
 If you have changed the location of your package's resources, such as configuration files or views, you should pass a third argument to the `package` method which specifies the location of your resources:
 
 	$this->package('vendor/package', null, '/path/to/resources');
+	
+> **Note**: If your package uses PSR-4 for autoloading, you will need to pass the path to your resources to the `package` method.
 
 <a name="deferred-providers"></a>
 ## Deferred Providers


### PR DESCRIPTION
The docs were not clear (since PSR-4 is included in "composer's autoloading facilities") that a package that uses PSR-4 requires extra thought.