### PR TITLE
Added firstByAttributes() example

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -61,6 +61,16 @@ Once a model is defined, you are ready to start retrieving and creating records 
 
 > **Note:** All methods available on the [query builder](/docs/queries) are also available when querying Eloquent models.
 
+#### Retrieving A Record By Non-Primary Attributes
+
+	$attributes = ['external_id' => '123456', 'status' => 'active'];
+	
+	// Return the model if it can be retrieved
+	$user = User::firstByAttributes($attributes);
+	
+	// Guarantee the model will be returned
+	$user = User::firstOrCreate($attributes);
+
 #### Retrieving A Model By Primary Key Or Throw An Exception
 
 Sometimes you may wish to throw an exception if a model is not found, allowing you to catch the exceptions using an `App::error` handler and display a 404 page.


### PR DESCRIPTION
Whether these convenience methods that wrap the underlying methods, are worthy of the main documentation, is up for argument. I think firstByAttributes() is a common-enough requirement to have a place here, and give newbies an example of slightly more abstracted access methods than WHERE clauses. See what you think.