### PR TITLE
[Addition] Quick note to clear a Facade mock

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -111,6 +111,11 @@ We can mock the call to the `Event` class by using the `shouldReceive` method on
 		$this->call('GET', '/');
 	}
 
+To clear the mock for later use you can use the method `clearResolvedInstances`
+
+	Event::clearResolvedInstances();
+
+
 > **Note:** You should not mock the `Request` facade. Instead, pass the input you desire into the `call` method when running your test.
 
 <a name="framework-assertions"></a>


### PR DESCRIPTION
instance. I had to mock a facade in two places of my unit test, and if I did not do this, I ended up getting the state of the first facade overwriting the state of my last facade.