### PR TITLE
Incorrectly used "custom cache driver"

### DIFF
--- a/extending.md
+++ b/extending.md
@@ -89,7 +89,7 @@ Session extensions need to be registered differently than other extensions like 
 
 ### Writing The Session Extension
 
-Note that our custom cache driver should implement the `SessionHandlerInterface`. This interface is included in the PHP 5.4+ core. If you are using PHP 5.3, the interface will be defined for you by Laravel so you have forward-compatibility. This interface contains just a few simple methods we need to implement. A stubbed MongoDB implementation would look something like this:
+Note that our custom session driver should implement the `SessionHandlerInterface`. This interface is included in the PHP 5.4+ core. If you are using PHP 5.3, the interface will be defined for you by Laravel so you have forward-compatibility. This interface contains just a few simple methods we need to implement. A stubbed MongoDB implementation would look something like this:
 
 	class MongoHandler implements SessionHandlerInterface {
 


### PR DESCRIPTION
Used "custom cache driver" instead of "custom session driver/extension" in the "Writing The Session Extension" section.
