### PR TITLE
[4.2] Don't need to mention that there is a SessionHandlerInterface stub for PHP 5.3

### DIFF
--- a/extending.md
+++ b/extending.md
@@ -89,7 +89,7 @@ Session extensions need to be registered differently than other extensions like 
 
 ### Writing The Session Extension
 
-Note that our custom session driver should implement the `SessionHandlerInterface`. This interface is included in the PHP 5.4+ core. If you are using PHP 5.3, the interface will be defined for you by Laravel so you have forward-compatibility. This interface contains just a few simple methods we need to implement. A stubbed MongoDB implementation would look something like this:
+Note that our custom session driver should implement the `SessionHandlerInterface`. This interface is included in the PHP 5.4+ core. This interface contains just a few simple methods we need to implement. A stubbed MongoDB implementation would look something like this:
 
 	class MongoHandler implements SessionHandlerInterface {
 


### PR DESCRIPTION
As PHP 5.3 isn't supported anyway.

[*](https://github.com/laravel/docs/pull/1012#issuecomment-69023347)