### PR TITLE
Make mention of the vendor\bin location on Windows

### DIFF
--- a/quick.md
+++ b/quick.md
@@ -18,7 +18,7 @@ First, download the Laravel installer using Composer.
 
 	composer global require "laravel/installer=~1.1"
 
-Make sure to place the `~/.composer/vendor/bin` directory in your PATH so the `laravel` executable is found when you run the `laravel` command in your terminal.
+Make sure to place the `~/.composer/vendor/bin` directory in your PATH (or `C:\%HOMEPATH%\AppData\Roaming\Composer\vendor\bin` if working with Windows) so the `laravel` executable is found when you run the `laravel` command in your terminal.
 
 Once installed, the simple `laravel new` command will create a fresh Laravel installation in the directory you specify. For instance, `laravel new blog` would create a directory named `blog` containing a fresh Laravel installation with all dependencies installed. This method of installation is much faster than installing via Composer.
 


### PR DESCRIPTION
Not sure if this was more appropriate for only the stable or also future releases, but it would be very helpful for new users if the site mentioned the AppData directory that is meant to parallel `~/.composer`.