### PR TITLE
Replace the word 'two' with 'some'

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -7,7 +7,7 @@
 <a name="laravel-5.0"></a>
 ## Laravel 5.0
 
-Laravel 5.0 introduces a fresh application structure to the default Laravel project. This new structure serves as a better foundation for building robust application in Laravel, as well as embraces new auto-loading standards (PSR-4) throughout the application. First, let's examine two of the major changes:
+Laravel 5.0 introduces a fresh application structure to the default Laravel project. This new structure serves as a better foundation for building robust application in Laravel, as well as embraces new auto-loading standards (PSR-4) throughout the application. First, let's examine some of the major changes:
 
 ### New Folder Structure
 


### PR DESCRIPTION
There are more than two major changes listed below the statement 'First, let's examine two of the major changes'. In place of 'two' a more appropriate word is 'some'.