### PR TITLE
adding info for installing homestead on ubuntu

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -48,6 +48,10 @@ Once VirtualBox and Vagrant have been installed, you should add the `laravel/hom
 
 	vagrant box add laravel/homestead
 
+If this fails, you may have an older version of vagrant that requires the url of the box. The following should work:
+
+	vagrant box add laravel/homestead https://atlas.hashicorp.com/laravel/boxes/homestead
+
 ### Installing Homestead
 
 #### With Composer + PHP Tool


### PR DESCRIPTION
Ubuntu LTS 14.04 users who install vagrant via `apt-get` will get [Vagrant 1.4.3-1](http://packages.ubuntu.com/trusty/vagrant):
```
➜  ~  vagrant box add laravel/homestead
This command was not invoked properly. The help for this command is
available below.

Usage: vagrant box add <name> <url> [--provider provider] [-h]

        --checksum VALUE             Checksum
        --checksum-type VALUE        Checksum type
    -c, --clean                      Remove old temporary download if it exists.
    -f, --force                      Overwrite an existing box if it exists.
        --insecure                   If set, SSL certs will not be validated.
        --cacert certfile            CA certificate
        --cert certfile              The client SSL cert
        --provider provider          The provider that backs the box.
    -h, --help                       Print this help
```

[Upgrading vagrant](http://laravel.io/forum/05-21-2014-problem-adding-laravel-homestead-box?page=1#reply-8752) also works, but it seemed simpler to just add the command that would resolve the issue immediately.