### PR TITLE
Change 'secret' to 'plaintext_password' in security docs

### DIFF
--- a/security.md
+++ b/security.md
@@ -28,11 +28,11 @@ The Laravel `Hash` class provides secure Bcrypt hashing:
 
 #### Hashing A Password Using Bcrypt
 
-	$password = Hash::make('secret');
+	$password = Hash::make('plaintext_password');
 
 #### Verifying A Password Against A Hash
 
-	if (Hash::check('secret', $hashedPassword))
+	if (Hash::check('plaintext_password', $hashedPassword))
 	{
 		// The passwords match...
 	}
@@ -41,7 +41,7 @@ The Laravel `Hash` class provides secure Bcrypt hashing:
 
 	if (Hash::needsRehash($hashed))
 	{
-		$hashed = Hash::make('secret');
+		$hashed = Hash::make('plaintext_password');
 	}
 
 <a name="authenticating-users"></a>


### PR DESCRIPTION
I propose to change 'secret' to 'plaintext_password' (or maybe something else, tell me) to more clearly express that Hash::* accept plaintext password (and not salt or any other kind of secret) as its argument. Not everybody yet knows that bcrypt used by Hash doesn't require any additional salt, so this could be misleading. It actually was in my case, which is the reason I created this pull request.

There is also an instance of 'secret' in Crypt:: example, but I'm not quite sure that 'plaintext_password' should go in its place. Please comment if you think it should also be changed.