### PR TITLE
Corrected anchor name attribute.

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -13,7 +13,7 @@
 
 All of the configuration files for the Laravel framework are stored in the `config` directory. Each option is documented, so feel free to look through the files and get familiar with the options available to you.
 
-<a name="configuration"></a>
+<a name="after-installation"></a>
 ## After Installation
 
 ### Naming Your Application


### PR DESCRIPTION
Corrected anchor name to (name="after-installation"), as it was (name="configuration").