### PR TITLE
Fixed typo referencing route filters

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -16,7 +16,7 @@ There are several middleware included in the Laravel framework, including middle
 <a name="defining-middleware"></a>
 ## Defining Middleware
 
-To create a new route filter, use the `make:middleware` Artisan command:
+To create a new middleware, use the `make:middleware` Artisan command:
 
 	php artisan make:middleware OldMiddleware
 


### PR DESCRIPTION
I assume this was copy-pasted from the L4 route filters docs but this reference was missed.