### PR TITLE
Add str_slug description to Helpers.md

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -304,6 +304,18 @@ Generate a random string of the given length.
 Convert a string to its singular form (English only).
 
 	$singular = str_singular('cars');
+	
+### str_slug
+
+Generate a URL friendly "slug" from a given string.
+
+	str_slug($title, $separator);
+
+Example:
+	
+	$title = str_slug("Laravel 5 Framework", "-");
+	
+	// laravel-5-framework
 
 ### studly_case
 


### PR DESCRIPTION
Hello.

I think this helper doc should have `str_slug` in it because it's very useful when you don't want to use the `Str` facade. 

I've also add an example.