### PR TITLE
Added mention of class change Eloquent > Eloquent\Model

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -81,6 +81,8 @@ Feel free to create a new `app/Models` directory to house your Eloquent models. 
 
 Update any models using `SoftDeletingTrait` to use `Illuminate\Database\Eloquent\SoftDeletes`.
 
+If your models extends the Eloquent or Illuminate\Database\Eloquent class, update this to extend the class Illuminate\Database\Eloquent\Model.
+
 #### Eloquent Caching
 
 Eloquent no longer provides the `remember` method for caching queries. You now are responsible for caching your queries manually using the `Cache::remember` function. For more information on caching, consult the [full documentation](/docs/5.0/cache).


### PR DESCRIPTION
When migration a small app I found this missing in the upgrade guide. Fixed it with help from the Laracasts forum: https://laracasts.com/discuss/channels/general-discussion/laravel-50-eloquent-not-found

Added it to the docs to prevent the next users from finding out what happend.