### PR TITLE
Document versioning of multiple files in Elixir

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -193,6 +193,18 @@ Within your views, you may use the `elixir()` function to load the appropriately
 
 Behind the scenes, the `elixir()` function will determine the name of the hashed file that should be included. Don't you feel the weight lifting off your shoulders already?
 
+#### Version / Hash Multiple files
+
+```javascript
+elixir(function(mix) {
+    mix.version([
+        "css/all.css",
+        "js/scripts.js"
+    ]);
+});
+```
+If you wish to version multiple files, they must be specified in an array.
+
 #### Copy a File to a New Location
 
 ```javascript


### PR DESCRIPTION
It was not clear to me that elixir's .version() must be called with an array in order to version multiple files.  I tried doing multiple .version() calls, which only outputs the last call.  This adds documentation of proper usage just below the single file version.