### PR TITLE
Fixed the example for creating macros

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -160,9 +160,9 @@ For example, from a [service provider's](/docs/5.0/providers) `boot` method:
 		 */
 		public function boot()
 		{
-			Response::('caps', function($value) use ($response)
+			Response::macro('caps', function($value)
 			{
-				return $response->make(strtoupper($value));
+				return Response::make(strtoupper($value));
 			});
 		}
 


### PR DESCRIPTION
Added missing macro() method and replaced the use statement with the Response facade.