### PR TITLE
add directory defaults section

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -241,6 +241,20 @@ Now that you've told Elixir which tasks to execute, you only need to trigger Gul
 
 > **Note:** All tasks will assume a development environment, and will exclude minification. For production, use `gulp --production`.
 
+<a name="defaults"></a>
+## Directory Defaults
+
+Elixir assumes a default directory for each component, listed below. While you are free to override the directory, these provide some sensible defaults.
+
+Component    | Directory
+:------------|:--------------------------
+Less         | `resources/assets/less`
+Sass         | `resources/assets/sass`
+CoffeeScript | `resources/assets/coffee`
+CSS          | `resources/css`
+Javascript   | `resources/js`
+
+
 <a name="extensions"></a>
 ## Extensions
 


### PR DESCRIPTION
There was a header titled 'Directory Defaults', but it didn't link anywhere. I added the link, and created a table to show the default directory that Elixir assumes for each component.