### PR TITLE
Update which classes have to be implemented for password resets

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -266,7 +266,7 @@ If you are using PHP FastCGI, HTTP Basic authentication may not work correctly o
 
 Most web applications provide a way for users to reset their forgotten passwords. Rather than forcing you to re-implement this on each application, Laravel provides convenient methods for sending password reminders and performing password resets.
 
-To get started, verify that your `User` model implements the `Illuminate\Contracts\Auth\Remindable` contract. Of course, the `User` model included with the framework already implements this interface, and uses the `Illuminate\Auth\Reminders\Remindable` trait to include the methods needed to implement the interface.
+To get started, verify that your `User` model implements the `Illuminate\Contracts\Auth\CanResetPassword` contract. Of course, the `User` model included with the framework already implements this interface, and uses the `Illuminate\Auth\Passwords\CanResetPassword` trait to include the methods needed to implement the interface.
 
 #### Generating The Reminder Table Migration
 


### PR DESCRIPTION
These classes have changed in Laravel 5:

`Illuminate\Contracts\Auth\Remindable` is now `Illuminate\Contracts\Auth\CanResetPassword`
`Illuminate\Auth\Reminders\Remindable` is now `Illuminate\Auth\Passwords\CanResetPassword`