### PR TITLE
example not working

### DIFF
--- a/templates.md
+++ b/templates.md
@@ -151,7 +151,7 @@ The following example creates a `@datetime($var)` directive which simply calls `
 
 	Blade::extend(function($view, $compiler)
 	{
-		$pattern = $compiler->createMatcher('datetime');
+		$pattern = $compiler->createOpenMatcher('datetime');
 
-		return preg_replace($pattern, '$1<?php echo $2->format(\'m/d/Y H:i\'); ?>', $view);
+		return preg_replace($pattern, '$1<?php echo $2->format(\'m/d/Y H:i\')); ?>', $view);
 	});


### PR DESCRIPTION
pattern from createMatcher() leads to: echo ($var)->format('m/d/Y H:i') -> not working
pattern from createOpenMatcher() with the additional brace leads to: echo ($var->format('m/d/Y H:i'))