### PR TITLE
Add wildcard options to 'styles' and 'scripts' ingredients

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -144,6 +144,15 @@ elixir(function(mix) {
 });
 ```
 
+#### Combine All Styles in a Directory Using a Wildcard
+
+```javascript
+elixir(function(mix) {
+    mix.styles("public/css/*.css");
+});
+```
+
+
 #### Combine Scripts
 
 ```javascript
@@ -162,6 +171,14 @@ Again, this assumes all paths are relative to the `resources/js` directory.
 ```javascript
 elixir(function(mix) {
     mix.scriptsIn("public/js/some/directory");
+});
+```
+
+#### Combine All Scripts in a Directory Using a Wildcard
+
+```javascript
+elixir(function(mix) {
+    mix.scripts("public/js/some/*.js");
 });
 ```
 


### PR DESCRIPTION
 Since elixir currently has an issue of not being able to concatenate a file generated by elixir (https://github.com/laravel/framework/issues/7565) one workaround is to use wildcards to concatenate every file in a folder. I think this should be in the docs since it is very useful and it is implemented in pure gulp.js.