### PR TITLE
Exclude @handle from the registering event example

### DIFF
--- a/events.md
+++ b/events.md
@@ -24,7 +24,7 @@ The `EventServiceProvider` included with your Laravel application provides a con
 	 */
 	protected $listen = [
 		'App\Events\PodcastWasPurchased' => [
-			'App\Handlers\Events\EmailPurchaseConfirmation@handle',
+			'App\Handlers\Events\EmailPurchaseConfirmation',
 		],
 	];
 


### PR DESCRIPTION
 The current example of registering event handlers has a @handle after the name of the handler class ('App\Handlers\Events\EmailPurchaseConfirmation@handle'). If you put this in the EventServiceProvider file and run the 'event:generate' artisan command you actually get a file named 'EmailPurchaseConfirmation@handle.php' in the Handlers/Events directory with a class with the same name (which cannot happen).

 Everything is fixed if you remove the @handle. Tried it on a clean laravel project, fired the event in artisan's tinker and the event was correctly handled by the @handle method that was created automatically.