### PR TITLE
correct variable name, and update reject callback

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -14,7 +14,7 @@ The `Illuminate\Support\Collection` class provides a fluent, convenient wrapper 
 	})
 	->reject(function($name)
 	{
-		return is_null($value);
+		return empty($name);
 	});
 
 


### PR DESCRIPTION
Wrong variable name inside the callback, and replaced is_null with empty function because strtoupper function applied before returned an empty string when applied to null values, therefore is_null wont reject after strtoupper.