### PR TITLE
Added installation instructions for "Forms & HTML"

### DIFF
--- a/html.md
+++ b/html.md
@@ -1,5 +1,8 @@
 # Forms & HTML
 
+> **Warning:** The Form helper was removed from Laravel 5, and is now being maintained by Laravel Collective. For further information, please refer to the [Laravel Collective](http://laravelcollective.com/docs/5.0/html) documentation.
+
+- [Installation](#installation)
 - [Opening A Form](#opening-a-form)
 - [CSRF Protection](#csrf-protection)
 - [Form Model Binding](#form-model-binding)
@@ -12,6 +15,40 @@
 - [Buttons](#buttons)
 - [Custom Macros](#custom-macros)
 - [Generating URLs](#generating-urls)
+
+<a name="installation"></a>
+## Installation
+
+Begin by installing this package through Composer. Edit your project's `composer.json` file to require `laravelcollective/html`.
+
+    "require": {
+        "laravelcollective/html": "~5.0"
+    }
+
+Next, update Composer from the Terminal:
+
+    composer update
+
+Next, add your new provider to the `providers` array of `config/app.php`:
+
+```php
+  'providers' => [
+    // ...
+    'Collective\Html\HtmlServiceProvider',
+    // ...
+  ],
+```
+
+Finally, add two class aliases to the `aliases` array of `config/app.php`:
+
+```php
+  'aliases' => [
+    // ...
+      'Form' => 'Collective\Html\FormFacade',
+      'Html' => 'Collective\Html\HtmlFacade',
+    // ...
+  ],
+```
 
 <a name="opening-a-form"></a>
 ## Opening A Form

--- a/html.md
+++ b/html.md
@@ -1,7 +1,5 @@
 # Forms & HTML
 
-> **Warning:** The Form helper was removed from Laravel 5, and is now being maintained by Laravel Collective. For further information, please refer to the [Laravel Collective](http://laravelcollective.com/docs/5.0/html) documentation.
-
 - [Installation](#installation)
 - [Opening A Form](#opening-a-form)
 - [CSRF Protection](#csrf-protection)
@@ -19,33 +17,25 @@
 <a name="installation"></a>
 ## Installation
 
-Begin by installing this package through Composer. Edit your project's `composer.json` file to require `laravelcollective/html`.
+The Forms & HTML helpers are no longer bundled with Laravel core. 
+
+You can install this package through Composer. Edit your project's `composer.json` file to require `laravel/html`.
 
     "require": {
-        "laravelcollective/html": "~5.0"
+        "laravel/html": "~5.0"
     }
 
 Next, update Composer from the Terminal:
 
     composer update
 
-Next, add your new provider to the `providers` array of `config/app.php`:
-
-```php
-  'providers' => [
-    // ...
-    'Collective\Html\HtmlServiceProvider',
-    // ...
-  ],
-```
-
-Finally, add two class aliases to the `aliases` array of `config/app.php`:
+Finally, add the class aliases to the `aliases` array of `config/app.php`:
 
 ```php
   'aliases' => [
     // ...
-      'Form' => 'Collective\Html\FormFacade',
-      'Html' => 'Collective\Html\HtmlFacade',
+    'Form' => 'Illuminate\Support\Facades\Form',
+    'Html' => 'Illuminate\Support\Facades\Form',
     // ...
   ],
 ```


### PR DESCRIPTION
The Forms/Html helpers are no longer bundled in the core, but shipped in a separate package.
The installation instructions for this package are missing, as well as the information that the helpers are no longer bundled in the core.