### PR TITLE
Nginx has a special variable for url arguments

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -81,7 +81,7 @@ If the `.htaccess` file that ships with Laravel does not work with your Apache i
 On Nginx, the following directive in your site configuration will allow "pretty" URLs:
 
     location / {
-        try_files $uri $uri/ /index.php?$query_string;
+        try_files $uri $uri/ /index.php$is_args$args;
     }
 
 Of course, when using [Homestead](/docs/5.0/homestead), pretty URLs will be configured automatically.


### PR DESCRIPTION
`$is_args` is set to "?" or an empty string based on the availability of query params