### PR TITLE
Update extending.md

### DIFF
--- a/extending.md
+++ b/extending.md
@@ -171,12 +171,12 @@ For example, the `HashServiceProvider` binds a `hash` key into the service conta
 
 		public function boot()
 		{
+			parent::boot();
+					
 			$this->app->bindShared('hash', function()
 			{
 				return new \Snappy\Hashing\ScryptHasher;
 			});
-
-			parent::boot();
 		}
 
 	}


### PR DESCRIPTION
Running parent::boot() afterwards overwrites custom binding. Custom bindings should come after parent::boot()