### PR TITLE
Pass an array for more than one file in elixir mix.less

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -54,6 +54,17 @@ elixir(function(mix) {
 
 In the example above, Elixir assumes that your Less files are stored in `resources/assets/less`.
 
+#### Pass an array for more than one file
+
+```javascript
+elixir(function(mix) {
+    mix.less([
+        'app.less',
+        'something-else.less'
+    ]);
+});
+```
+
 #### Compile Sass
 
 ```javascript


### PR DESCRIPTION
I've had lots of trouble with elixir and gulp where essentially, calling mix.less twice produces some unstable results.

The documentation didn't say I could pass an array and since i'm new to gulp (and grunt). I had to inspect the elixir source code to find out.