### PR TITLE
Clarify the Launch of homestead

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -123,7 +123,7 @@ To add Bash aliases to your Homestead box, simply add to the `aliases` file in t
 
 ### Launch The Vagrant Box
 
-Once you have edited the `Homestead.yaml` to your liking, run the `vagrant up` command from your Homestead directory.
+Once you have edited the `Homestead.yaml` to your liking, run the `homestead up` command from your Homestead directory.
 
 Vagrant will boot the virtual machine, and configure your shared folders and Nginx sites automatically! To destroy the machine, you may use the `vagrant destroy --force` command.
 


### PR DESCRIPTION
Launching the homestead vagrant box via vagrant up will only work if you had homestead create a vagrant file for you first.
However homestead init will not do so.
So instead of using vagrant up you should use homestead up, which will first create the vagrantfile and only then run vagrant up.
Once the vagrantfile is there you can of course  run vagrant up instead, just not at this point in the install.


This is true for all versions of this documentation. I submitted this pull request to the 5.0 branch as that is the most recent version with the error inside.
The fix should probably be applied to the documentation for all Laravel versions, though.