### PR TITLE
added missing cookies variable for call method

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -52,7 +52,7 @@ You may easily call one of your routes for a test using the `call` method:
 
 	$response = $this->call('GET', 'user/profile');
 
-	$response = $this->call($method, $uri, $parameters, $files, $server, $content);
+	$response = $this->call($method, $uri, $parameters, $cookies, $files, $server, $content);
 
 You may then inspect the `Illuminate\Http\Response` object:
 


### PR DESCRIPTION
The application's [call](https://github.com/laravel/framework/blob/5.0/src/Illuminate/Foundation/Testing/ApplicationTrait.php#L54) method has a `$cookies` variable before the `$files`, `$server` and `$content` arguments.