### PR TITLE
 `object` cast types are also useful handling stored serialized JSON.

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1211,7 +1211,7 @@ If you have some attributes that you want to always convert to another data-type
 
 Now the `is_admin` attribute will always be cast to a boolean when you access it, even if the underlying value is stored in the database as an integer. Other supported cast types are: `integer`, `real`, `float`, `double`, `string`, `boolean`, `object` and `array`.
 
-The `array` cast is particularly useful for working with columns that are stored as serialized JSON. For example, if your database has a TEXT type field that contains serialized JSON, adding the `array` cast to that attribute will automatically deserialize the attribute to a PHP array when you access it on your Eloquent model:
+The `object` and `array` cast types are particularly useful for working with columns that are stored as serialized JSON. For example, if your database has a TEXT type field that contains serialized JSON, adding the `array` cast to that attribute will automatically deserialize the attribute to a PHP array when you access it on your Eloquent model:
 
 	/**
 	 * The attributes that should be casted to native types.


### PR DESCRIPTION
Leaving it can maybe confuse readers that the `array` cast type is the
only viable one dealing with serialized JSON.