### PR TITLE
Update Server Requirements

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -45,6 +45,7 @@ The Laravel framework has a few system requirements:
 - Mcrypt PHP Extension
 - OpenSSL PHP Extension
 - Mbstring PHP Extension
+- Tokenizer PHP Extension
 
 As of PHP 5.5, some OS distributions may require you to manually install the PHP JSON extension. When using Ubuntu, this can be done via `apt-get install php5-json`.
 


### PR DESCRIPTION
Laravel 5 requires `Psy/Psych`. 

`Psy/Psych` requires `Nikic/Php-Parser`

`Nikic/Php-Parser` requires the PHP Exteniosn `tonkenizer` to be installed.

Therefore Laravel 5 requires this extension, otherwise composer will fail to install Laravel 5. Issue was discovered on this SO thread: http://stackoverflow.com/q/28914789/1317935