### PR TITLE
Add note about mix.sass() calls

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -74,6 +74,7 @@ elixir(function(mix) {
 ```
 
 This assumes that your Sass files are stored in `resources/assets/sass`.
+> **Note:** mix.sass() can only be called once. If compiling multiple files pass them as an array.
 
 #### Compile CoffeeScript
 


### PR DESCRIPTION
mix.sass() can only be called once and causes a bit of a confusion as all the others can be called multiple times and documentation doesn't make any reference to it.
https://laracasts.com/discuss/channels/general-discussion/problem-with-mixsass