### PR TITLE
Update IronMQ dependency

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -27,7 +27,7 @@ The following dependencies are needed for the listed queue drivers:
 
 - Amazon SQS: `aws/aws-sdk-php`
 - Beanstalkd: `pda/pheanstalk ~3.0`
-- IronMQ: `iron-io/iron_mq`
+- IronMQ: `iron-io/iron_mq ~1.0`
 - Redis: `predis/predis ~1.0`
 
 <a name="basic-usage"></a>


### PR DESCRIPTION
According to ironmq's docs :

Use branch 1.* - laravel-compatible, php-5.2-compatible version. No namespaces. Using default IronMQ servers.