### PR TITLE
Tweaked docs about Blackfire

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -205,10 +205,10 @@ If you wish, you may forward additional ports to the Vagrant box, as well as spe
 
 [Blackfire Profiler](https://blackfire.io) by SensioLabs automatically gathers data about your code's execution, such as RAM, CPU time, and disk I/O. Homestead makes it a breeze to use this profiler for your own applications.
 
-All of the proper packages have already been installed on your Homestead box, you simply need to set a Blackfire Server ID and token in your `Homestead.yaml` file:
+All of the proper packages have already been installed on your Homestead box, you simply need to set a Blackfire **Server** ID and token in your `Homestead.yaml` file:
 
 	blackfire:
-	    - id: your-id
-	      token: your-token
+	    - id: your-server-id
+	      token: your-server-token
 
 Once you have configured your Blackfire credentials, re-provision the box using `homestead provision` or `vagrant provision`. Of course, be sure to review the [Blackfire documentation](https://blackfire.io/getting-started) to learn how to install the Blackfire companion extension for your web browser.


### PR DESCRIPTION
Blackfire has two sets of credentials: client and server. For homestead, we need the server credentials. Even if it is already mentioned in the docs, people are confused. So, this PR tries to make things a little clearer.

Also, what do you think about renaming the YAML `id` and `token` keys to `server-id` and `server-token` respectively? I can make the needed changes and PRs.