### PR TITLE
Change "of" to "in" in authentication.

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -282,7 +282,7 @@ Your user will receive an e-mail with a link that points to the `getReset` metho
 
 	protected $redirectTo = '/dashboard';
 
-> **Note:** By default, password reset tokens expire after one hour. You may change this via the `reminder.expire` option of your `config/auth.php` file.
+> **Note:** By default, password reset tokens expire after one hour. You may change this via the `reminder.expire` option in your `config/auth.php` file.
 
 <a name="social-authentication"></a>
 ## Social Authentication


### PR DESCRIPTION
The part "You may have this via the `reminder.expire` option of your `config/auth.php` file." sounds rather weird, changing it to "[...] option in your `config/auth.php` file." sounds a bit better.