### PR TITLE
Add directory defaults section from original elixir readme

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -4,6 +4,7 @@
 - [Installation & Setup](#installation)
 - [Usage](#usage)
 - [Gulp](#gulp)
+- [Directory Defaults](#defaults)
 - [Extensions](#extensions)
 
 <a name="introduction"></a>
@@ -291,6 +292,27 @@ Now that you've told Elixir which tasks to execute, you only need to trigger Gul
     gulp tdd
 
 > **Note:** All tasks will assume a development environment, and will exclude minification. For production, use `gulp --production`.
+
+<a name="defaults"></a>
+## Directory Defaults
+
+While Elixir will assume the default Laravel 5 directory structure, it's possible that you'd prefer to put your assets, styles, and scripts within a different location. No problem!
+
+Create a `elixir.json` file within the root of your project, and update the necessary paths as needed.
+
+```json
+{
+    "assetsDir": "app/assets/",
+
+    "cssOutput": "public/css/",
+
+    "jsOutput": "public/js/"
+}
+```
+
+- **`assetsDir`**: The path to the base directory for Sass, Less, CoffeeScript, etc.
+- **`cssOutput`**: The path to where compiled CSS should be saved.
+- **`jsOutput`**: The path to where compiled JavaScript should be saved.
 
 <a name="extensions"></a>
 ## Extensions


### PR DESCRIPTION
When having changed folder structure (for example on shared server with public_html folder) or for custom export directories, elixir should know about that and having elixir.json makes things little easier than having to use parameters in sass or coffee tasks. 

I find this useful and some users don't know where to look in source for this.