### PR TITLE
Update homestead.md

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -76,7 +76,7 @@ The `Homestead.yaml` file will be placed in your `~/.homestead` directory.
 
 Once the box has been added to your Vagrant installation, you are ready to install the Homestead CLI tool using the Composer `global` command:
 
-	composer global require "laravel/homestead=~2.0"
+	composer global require "laravel/homestead=dev-master"
 
 Make sure to place the `~/.composer/vendor/bin` directory in your PATH so the `homestead` executable is found when you run the `homestead` command in your terminal.
 

--- a/homestead.md
+++ b/homestead.md
@@ -90,7 +90,7 @@ The `Homestead.yaml` file will be placed in the `~/.homestead` directory. If you
 
 ### Configure Your Provider
 
-The `provider` key in your `Homestead.yaml` file indicates which Vagrant provider should be used: `virtualbox` or `vmware_fusion`. You may set this to whichever provider you prefer.
+The `provider` key in your `Homestead.yaml` file indicates which Vagrant provider should be used: `virtualbox` or `vmware_fusion` / `wmware_workstation`. You may set this to whichever provider you prefer.
 
 	provider: virtualbox
 

--- a/homestead.md
+++ b/homestead.md
@@ -90,7 +90,7 @@ The `Homestead.yaml` file will be placed in the `~/.homestead` directory. If you
 
 ### Configure Your Provider
 
-The `provider` key in your `Homestead.yaml` file indicates which Vagrant provider should be used: `virtualbox` or `vmware_fusion` / `wmware_workstation`. You may set this to whichever provider you prefer.
+The `provider` key in your `Homestead.yaml` file indicates which Vagrant provider should be used: `virtualbox` or `vmware_fusion` / `vmware_workstation`. You may set this to whichever provider you prefer.
 
 	provider: virtualbox
 


### PR DESCRIPTION
My homestead was stuck at v2.0.13 and I couldn't get this new snippet of code:

```
    # Configure A Few VMware Settings
    ["vmware_fusion", "vmware_workstation"].each do |vmware|
      config.vm.provider vmware do |v|
        v.vmx["displayName"] = "homestead"
        v.vmx["memsize"] = settings["memory"] ||= 2048
        v.vmx["numvcpus"] = settings["cpus"] ||= 1
        v.vmx["guestOS"] = "ubuntu-64"
      end
    end
```

I still had this one... which doesn't work well with workstation
```
    config.vm.provider "vmware_fusion" do |v|
      v.name = 'homestead'
      v.memory = settings["memory"] ||= "2048"
      v.cpus = settings["cpus"] ||= "1"
    end
```