### PR TITLE
Standarize indentation to tabs instead of mixture.

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -70,10 +70,10 @@ The `intended` redirect function will redirect the user to the URL they were att
 
 You also may add extra conditions to the authentication query:
 
-    if (Auth::attempt(['email' => $email, 'password' => $password, 'active' => 1]))
-    {
-        // The user is active, not suspended, and exists.
-    }
+	if (Auth::attempt(['email' => $email, 'password' => $password, 'active' => 1]))
+	{
+		// The user is active, not suspended, and exists.
+	}
 
 #### Determining If A User Is Authenticated
 

--- a/configuration.md
+++ b/configuration.md
@@ -139,8 +139,8 @@ If the `.htaccess` file that ships with Laravel does not work with your Apache i
 
 On Nginx, the following directive in your site configuration will allow "pretty" URLs:
 
-    location / {
-        try_files $uri $uri/ /index.php?$query_string;
-    }
+	location / {
+		try_files $uri $uri/ /index.php?$query_string;
+	}
 
 Of course, when using [Homestead](/docs/5.0/homestead), pretty URLs will be configured automatically.

--- a/elixir.md
+++ b/elixir.md
@@ -37,7 +37,7 @@ Next, you'll want to pull in [Gulp](http://gulpjs.com) as a global NPM package l
 
 The only remaining step is to install Elixir! With a new install of Laravel, you'll find a `package.json` file in the root. Think of this like your `composer.json` file, except it defines Node dependencies instead of PHP. You may install the dependencies it references by running:
 
-    npm install
+	npm install
 
 <a name="usage"></a>
 ## Usage
@@ -48,7 +48,7 @@ Now that you've installed Elixir, you'll be compiling and concatenating in no ti
 
 ```javascript
 elixir(function(mix) {
-    mix.less("app.less");
+	mix.less("app.less");
 });
 ```
 
@@ -58,10 +58,10 @@ In the example above, Elixir assumes that your Less files are stored in `resourc
 
 ```javascript
 elixir(function(mix) {
-    mix.less([
-        'app.less',
-        'something-else.less'
-    ]);
+	mix.less([
+		'app.less',
+		'something-else.less'
+	]);
 });
 ```
 
@@ -69,7 +69,7 @@ elixir(function(mix) {
 
 ```javascript
 elixir(function(mix) {
-    mix.sass("app.sass");
+	mix.sass("app.sass");
 });
 ```
 
@@ -79,7 +79,7 @@ By default, Elixir, underneath the hood, uses the LibSass library for compilatio
 
 ```javascript
 elixir(function(mix) {
-    mix.rubySass("app.sass");
+	mix.rubySass("app.sass");
 });
 ```
 
@@ -89,7 +89,7 @@ elixir(function(mix) {
 elixir.config.sourcemaps = false;
 
 elixir(function(mix) {
-    mix.sass("app.scss");
+	mix.sass("app.scss");
 });
 ```
 
@@ -99,7 +99,7 @@ Source maps are enabled out of the box. As such, for each file that is compiled,
 
 ```javascript
 elixir(function(mix) {
-    mix.coffee();
+	mix.coffee();
 });
 ```
 
@@ -118,7 +118,7 @@ elixir(function(mix) {
 
 ```javascript
 elixir(function(mix) {
-    mix.phpUnit();
+	mix.phpUnit();
 });
 ```
 
@@ -126,7 +126,7 @@ elixir(function(mix) {
 
 ```javascript
 elixir(function(mix) {
-    mix.phpSpec();
+	mix.phpSpec();
 });
 ```
 
@@ -134,10 +134,10 @@ elixir(function(mix) {
 
 ```javascript
 elixir(function(mix) {
-    mix.styles([
-        "normalize.css",
-        "main.css"
-    ]);
+	mix.styles([
+		"normalize.css",
+		"main.css"
+	]);
 });
 ```
 
@@ -147,10 +147,10 @@ Paths passed to this method are relative to the `resources/css` directory.
 
 ```javascript
 elixir(function(mix) {
-    mix.styles([
-        "normalize.css",
-        "main.css"
-    ], 'public/build/css/everything.css');
+	mix.styles([
+		"normalize.css",
+		"main.css"
+	], 'public/build/css/everything.css');
 });
 ```
 
@@ -158,10 +158,10 @@ elixir(function(mix) {
 
 ```javascript
 elixir(function(mix) {
-    mix.styles([
-        "normalize.css",
-        "main.css"
-    ], 'public/build/css/everything.css', 'public/css');
+	mix.styles([
+		"normalize.css",
+		"main.css"
+	], 'public/build/css/everything.css', 'public/css');
 });
 ```
 
@@ -171,7 +171,7 @@ The third argument to both the `styles` and `scripts` methods determines the rel
 
 ```javascript
 elixir(function(mix) {
-    mix.stylesIn("public/css");
+	mix.stylesIn("public/css");
 });
 ```
 
@@ -179,10 +179,10 @@ elixir(function(mix) {
 
 ```javascript
 elixir(function(mix) {
-    mix.scripts([
-        "jquery.js",
-        "app.js"
-    ]);
+	mix.scripts([
+		"jquery.js",
+		"app.js"
+	]);
 });
 ```
 
@@ -192,7 +192,7 @@ Again, this assumes all paths are relative to the `resources/js` directory.
 
 ```javascript
 elixir(function(mix) {
-    mix.scriptsIn("public/js/some/directory");
+	mix.scriptsIn("public/js/some/directory");
 });
 ```
 
@@ -209,7 +209,7 @@ elixir(function(mix) {
 
 ```javascript
 elixir(function(mix) {
-    mix.version("css/all.css");
+	mix.version("css/all.css");
 });
 ```
 
@@ -227,7 +227,7 @@ You may also pass an array to the `version` method to version multiple files:
 
 ```javascript
 elixir(function(mix) {
-    mix.version(["css/all.css", "js/app.js"]);
+	mix.version(["css/all.css", "js/app.js"]);
 });
 ```
 
@@ -240,7 +240,7 @@ elixir(function(mix) {
 
 ```javascript
 elixir(function(mix) {
-    mix.copy('vendor/foo/bar.css', 'public/css/bar.css');
+	mix.copy('vendor/foo/bar.css', 'public/css/bar.css');
 });
 ```
 
@@ -248,7 +248,7 @@ elixir(function(mix) {
 
 ```javascript
 elixir(function(mix) {
-    mix.copy('vendor/package/views', 'resources/views');
+	mix.copy('vendor/package/views', 'resources/views');
 });
 ```
 
@@ -272,23 +272,23 @@ Now that you've told Elixir which tasks to execute, you only need to trigger Gul
 
 #### Execute All Registered Tasks Once
 
-    gulp
+	gulp
 
 #### Watch Assets For Changes
 
-    gulp watch
+	gulp watch
 
 #### Only Compile Scripts
 
-    gulp scripts
+	gulp scripts
 
 #### Only Compile Styles
 
-    gulp styles
+	gulp styles
 
 #### Watch Tests And PHP Classes for Changes
 
-    gulp tdd
+	gulp tdd
 
 > **Note:** All tasks will assume a development environment, and will exclude minification. For production, use `gulp --production`.
 
@@ -299,17 +299,17 @@ You can even create your own Gulp tasks, and hook them into Elixir. Imagine that
  uses the Terminal to verbally notify you with some message. Here's what that might look like:
 
 ```javascript
- var gulp = require("gulp");
- var shell = require("gulp-shell");
- var elixir = require("laravel-elixir");
+var gulp = require("gulp");
+var shell = require("gulp-shell");
+var elixir = require("laravel-elixir");
 
- elixir.extend("message", function(message) {
+elixir.extend("message", function(message) {
 
-     gulp.task("say", function() {
-         gulp.src("").pipe(shell("say " + message));
-     });
+	gulp.task("say", function() {
+		gulp.src("").pipe(shell("say " + message));
+	});
 
-     return this.queueTask("say");
+	return this.queueTask("say");
 
  });
 ```
@@ -334,7 +334,7 @@ You're done! Now, you can mix it in.
 
 ```javascript
 elixir(function(mix) {
-    mix.message("Tea, Earl Grey, Hot");
+	mix.message("Tea, Earl Grey, Hot");
 });
 ```
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -1304,10 +1304,10 @@ When you pass a model to the `route` or `action` methods, it's primary key is in
 
 In this example the `$user->id` property will be inserted into the `{user}` place-holder of the generated URL. However, if you would like to use another property instead of the ID, you may override the `getRouteKey` method on your model:
 
-    public function getRouteKey()
-    {
-        return $this->slug;
-    }
+	public function getRouteKey()
+	{
+		return $this->slug;
+	}
 
 <a name="converting-to-arrays-or-json"></a>
 ## Converting To Arrays / JSON

--- a/installation.md
+++ b/installation.md
@@ -87,8 +87,8 @@ If the `.htaccess` file that ships with Laravel does not work with your Apache i
 
 On Nginx, the following directive in your site configuration will allow "pretty" URLs:
 
-    location / {
-        try_files $uri $uri/ /index.php?$query_string;
-    }
+	location / {
+		try_files $uri $uri/ /index.php?$query_string;
+	}
 
 Of course, when using [Homestead](/docs/5.0/homestead), pretty URLs will be configured automatically.

--- a/routing.md
+++ b/routing.md
@@ -65,7 +65,7 @@ Laravel automatically generates a CSRF "token" for each active user session mana
 
 #### Insert The CSRF Token Into A Form
 
-    <input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
+	<input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
 
 Of course, using the Blade [templating engine](/docs/5.0/templates):
 
@@ -80,10 +80,10 @@ In addition to looking for the CSRF token as a "POST" parameter, the middleware 
 	<meta name="csrf-token" content="{{ csrf_token() }}" />
 
 	$.ajaxSetup({
-            headers: {
-                'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
-            }
-        });
+			headers: {
+				'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+			}
+		});
 
 Now all AJAX requests will automatically include the CSRF token:
 
@@ -106,8 +106,8 @@ The value sent with the `_method` field will be used as the HTTP request method.
 
 	<form action="/foo/bar" method="POST">
 		<input type="hidden" name="_method" value="PUT">
-    	<input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
-    </form>
+		<input type="hidden" name="_token" value="<?php echo csrf_token(); ?>">
+	</form>
 
 <a name="route-parameters"></a>
 ## Route Parameters
@@ -204,7 +204,7 @@ Named routes allow you to conveniently generate URLs or redirects for a specific
 You may also specify route names for controller actions:
 
 	Route::get('user/profile', [
-        'as' => 'profile', 'uses' => 'UserController@showProfile'
+		'as' => 'profile', 'uses' => 'UserController@showProfile'
 	]);
 
 Now, you may use the route's name when generating URLs or redirects:

--- a/schema.md
+++ b/schema.md
@@ -231,9 +231,9 @@ Command  | Description
 
 To set the storage engine for a table, set the `engine` property on the schema builder:
 
-    Schema::create('users', function($table)
-    {
-        $table->engine = 'InnoDB';
+	Schema::create('users', function($table)
+	{
+		$table->engine = 'InnoDB';
 
-        $table->string('email');
-    });
+		$table->string('email');
+	});

--- a/templates.md
+++ b/templates.md
@@ -101,9 +101,9 @@ If you don't want the data to be escaped, you may use the following syntax:
 	@endforeach
 
 	@forelse($users as $user)
-	  	<li>{{ $user->name }}</li>
+		<li>{{ $user->name }}</li>
 	@empty
-	  	<p>No users</p>
+		<p>No users</p>
 	@endforelse
 
 	@while (true)

--- a/testing.md
+++ b/testing.md
@@ -151,18 +151,18 @@ Laravel ships with several `assert` methods to make testing a little easier:
 
 #### Asserting The Session Has Errors
 
-    public function testMethod()
-    {
-        $this->call('GET', '/');
+	public function testMethod()
+	{
+		$this->call('GET', '/');
 
-        $this->assertSessionHasErrors();
+		$this->assertSessionHasErrors();
 
-        // Asserting the session has errors for a given key...
-        $this->assertSessionHasErrors('name');
+		// Asserting the session has errors for a given key...
+		$this->assertSessionHasErrors('name');
 
-        // Asserting the session has errors for several keys...
-        $this->assertSessionHasErrors(['name', 'age']);
-    }
+		// Asserting the session has errors for several keys...
+ 		$this->assertSessionHasErrors(['name', 'age']);
+	}
 
 #### Asserting Old Input Has Some Data
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -195,12 +195,12 @@ For example, you may add `"laravelcollective/html": "~5.0"` to your `composer.js
 
 You'll also need to add the Form and HTML facades and service provider. Edit `config/app.php` and add this line to the 'providers' array:
 
-    'Collective\Html\HtmlServiceProvider',
+	'Collective\Html\HtmlServiceProvider',
 
 Next, add these lines to the 'aliases' array:
 
-    'Form' => 'Collective\Html\FormFacade',
-    'Html' => 'Collective\Html\HtmlFacade',
+	'Form' => 'Collective\Html\FormFacade',
+	'Html' => 'Collective\Html\HtmlFacade',
 
 ### CacheManager
 
@@ -275,7 +275,7 @@ If you are extending the `Illuminate\Pagination\Presenter` class, the abstract m
 
 If you are using the Iron.io queue driver, you will need to add a new `encrypt` option to your queue configuration file:
 
-    'encrypt' => true
+	'encrypt' => true
 
 <a name="upgrade-4.1.29"></a>
 ## Upgrading To 4.1.29 From <= 4.1.x

--- a/validation.md
+++ b/validation.md
@@ -35,18 +35,18 @@ Multiple rules may be delimited using either a "pipe" character, or as separate 
 
 #### Validating Multiple Fields
 
-    $validator = Validator::make(
-        [
-            'name' => 'Dayle',
-            'password' => 'lamepassword',
-            'email' => 'email@example.com'
-        ],
-        [
-            'name' => 'required',
-            'password' => 'required|min:8',
-            'email' => 'required|email|unique:users'
-        ]
-    );
+	$validator = Validator::make(
+		[
+			'name' => 'Dayle',
+			'password' => 'lamepassword',
+			'email' => 'email@example.com'
+		],
+		[
+			'name' => 'required',
+			'password' => 'required|min:8',
+		'email' => 'required|email|unique:users'
+		]
+	);
 
 Once a `Validator` instance has been created, the `fails` (or `passes`) method may be used to perform the validation.
 


### PR DESCRIPTION
Currently the indentation is, for the most part, tabs. However, some of the
indentation is spaces, and there doesn't seem to be a good reason for a
lot of this indentation switch.

For example, some of the indentation is only 3 spaces or 7 spaces instead of
4 or 8. This is even more inconsistent and has probably happened over time
as a result of PRs.  This fixes inconsistencies such as that and makes
it 1 tab or 2 tabs.

This does not change specifically-spaced formatting to tabs, such as
aligning far-spaced -> in the queries markdown document and other
documents, meaning that ->'s are still perfectly aligned.

For example, the following is changed:

Old:

    if (Auth::attempt(['email' => $email, 'password' => $password, 'active' => 1]))
    {
        // The user is active, not suspended, and exists.
    }

New:

	if (Auth::attempt(['email' => $email, 'password' => $password, 'active' => 1]))
	{
		// The user is active, not suspended, and exists.
	}

Alternatively, the following is not changed:

	DB::table('users')
	        ->join('contacts', function($join)
	        {
	        	$join->on('users.id', '=', 'contacts.user_id')
	        	     ->where('contacts.user_id', '>', 5);
	        })
	        ->get();

This is to preserve the formatting of -> alignment.