### PR TITLE
array_fetch wrong bracket parring - typo

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -49,7 +49,7 @@ The `array_fetch` method returns a flattened array containing the selected neste
 	$array = [
 		['developer' => ['name' => 'Taylor']],
 		['developer' => ['name' => 'Dayle']]
-	);
+	];
 
 	$array = array_fetch($array, 'developer.name');
 


### PR DESCRIPTION
In the code example of the `array_fetch()` were used wrong closing -  `);` instead of proper `];`. Probably it is a leftover from v.4.2 where `array` uses parenthesis. 

Additionally, same typo is in the master branch :wink:  