### PR TITLE
Added an instruction to replace FollowSymLinks with SymLinksIfOwnerMatch if necessary

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -135,6 +135,8 @@ If the `.htaccess` file that ships with Laravel does not work with your Apache i
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteRule ^ index.php [L]
 
+If `Options +FollowSymLinks` creates a 500 error, try replacing it with `Options +SymLinksIfOwnerMatch`.
+
 ### Nginx
 
 On Nginx, the following directive in your site configuration will allow "pretty" URLs:


### PR DESCRIPTION
`Options +FollowSymLinks` will generate a 500 error if `AllowOverride None` is set in `httpd.conf`, which is by default in some systems due to a [security concern](http://serverfault.com/questions/244592/followsymlinks-on-apache-why-is-it-a-security-risk). HTML5Boilerplate also had [an instruction](https://github.com/h5bp/html5-boilerplate/blob/master/dist/.htaccess#L327) regarding this issue.