### PR TITLE
Add example for VALUE_IS_ARRAY

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -50,6 +50,10 @@ For options, the argument `mode` may be: `InputOption::VALUE_REQUIRED`, `InputOp
 
 The `VALUE_IS_ARRAY` mode indicates that the switch may be used multiple times when calling the command:
 
+	InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY
+	
+Would then allow for this command:
+
 	php artisan foo --option=bar --option=baz
 
 The `VALUE_NONE` option indicates that the option is simply used as a "switch":


### PR DESCRIPTION
Using the docs I got

~~~
  [InvalidArgumentException]
  Impossible to have an option mode VALUE_IS_ARRAY if the option does not accept a value.
~~~

Looking in the code for `InputOption::VALUE_IS_ARRAY` I could not find and example, so figured it would be good to add to docs.