### PR TITLE
Added note about the class namespace convention causing issues with phpD...

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -59,3 +59,5 @@ Laravel follows the [PSR-4](https://github.com/php-fig/fig-standards/blob/master
 - A class' opening `{` must be on the same line as the class name.
 - Functions and control structures must use Allman style braces.
 - Indent with tabs, align with spaces.
+
+> **Note:** By putting the class namespace declaration on the same line as `<?php`, phpDocumentor will throw error: "No summary was found for this file"


### PR DESCRIPTION
Added note about the class namespace convention causing issues with phpDocumentor.

Not sure if this belongs here, but I feel PHPDocumentor is used enough that we should at least make note that one of the conventions suggested in the Laravel docs will directly conflict with it.


Example of code used and error thrown by PHPDocumentor:

```php
<?php namespace Controllers;

/**
* This is supposed to be a file summary but won't be parsed as such due to the namespace
*/
```

```
Parsing /var/www/app/Controllers/TestController.php
  No summary was found for this file
```

And if I put the docblocks before the namespace, all works fine:

```php
<?php 
/**
* This is parsed just fine as a file summary.
*/
namespace Controllers;

```

```
Parsing /var/www/app/Controllers/TestController.php
```