### PR TITLE
Homestead Docs: Amend Path Tip

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -80,6 +80,8 @@ Once the box has been added to your Vagrant installation, you are ready to insta
 
 Make sure to place the `~/.composer/vendor/bin` directory in your PATH so the `homestead` executable is found when you run the `homestead` command in your terminal.
 
+	PATH=~/.composer/vendor/bin:$PATH
+
 Once you have installed the Homestead CLI tool, run the `init` command to create the `Homestead.yaml` configuration file:
 
 	homestead init


### PR DESCRIPTION
Adds a terminal command tip for amending your path for composer executables.

Where people might typically land searching for `command not found: homestead`
- [zsh: command not found: homestead - Laracasts](https://laracasts.com/discuss/channels/general-discussion/zsh-command-not-found-homestead)
- [How should I set the PATH variable - superuser](http://superuser.com/a/324617)

This has hung a few people up in the past that are not very familiar with how PATH works. Might save 
some digging, though I know this can differ from system to system. I ended up in the same error state, until I remembered I shouldn't be using `export $PATH =`