### PR TITLE
templates.md extending Blade example: use createMatcher instead of createOpenMatcher

### DIFF
--- a/templates.md
+++ b/templates.md
@@ -151,7 +151,7 @@ The following example creates a `@datetime($var)` directive which simply calls `
 
 	Blade::extend(function($view, $compiler)
 	{
-		$pattern = $compiler->createOpenMatcher('datetime');
+		$pattern = $compiler->createMatcher('datetime');
 
 		return preg_replace($pattern, '$1<?php echo $2->format(\'m/d/Y H:i\')); ?>', $view);
 	});


### PR DESCRIPTION
Issue: https://github.com/laravel/framework/issues/8224

> The documentation http://laravel.com/docs/5.0/templates#extending-blade is kinda weird because createMatcher and createPlainMatcher are discussed and when it comes to an example createOpenMatcher is used.