### PR TITLE
Removed references to php 5.3

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -180,7 +180,7 @@ Filter the array using the given Closure.
 
 ### head
 
-Return the first element in the array. Useful for method chaining in PHP 5.3.x.
+Return the first element in the array.
 
 	$first = head($this->returnsArray('foo'));
 
@@ -463,6 +463,6 @@ Get a View instance for the given view path.
 
 ### with
 
-Return the given object. Useful for method chaining constructors in PHP 5.3.x.
+Return the given object.
 
 	$value = with(new Foo)->doWork();


### PR DESCRIPTION
As laravel 4.X and 5 don't support php 5.3.x, i removed the references to it the help.