### PR TITLE
Example for using namespaces in a nested Route::group is wrong

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -254,7 +254,7 @@ You may use the `namespace` parameter in your group attribute array to specify t
 
 		Route::group(['namespace' => 'User'], function()
 		{
-			// Controllers Within The "App\Http\Controllers\Admin" Namespace
+			// Controllers Within The "App\Http\Controllers\Admin\User" Namespace
 		});
 	});
 


### PR DESCRIPTION
```php
Route::group(['namespace' => 'Admin'], function()
{
    // Controllers Within The "App\Http\Controllers\Admin" Namespace

    Route::group(['namespace' => 'User'], function()
    {
        // Controllers Within The "App\Http\Controllers\Admin" Namespace
    });
});
```

The namespace of the second group should be App\Http\Controllers\Admin\User.

Not sure if this should be the point of the documentation, or that it was nested by accident.