### PR TITLE
replace old ModelNotFoundException handling with new way

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -69,20 +69,37 @@ Once a model is defined, you are ready to start retrieving and creating records 
 
 #### Retrieving A Model By Primary Key Or Throw An Exception
 
-Sometimes you may wish to throw an exception if a model is not found, allowing you to catch the exceptions using an `App::error` handler and display a 404 page.
+Sometimes you may wish to throw an exception if a model is not found.
 
 	$model = User::findOrFail(1);
 
 	$model = User::where('votes', '>', 100)->firstOrFail();
 
-To register the error handler, listen for the `ModelNotFoundException`
+Doing this will let you catch the exception so you can log and display an error page as necessary. To register the error handler for the `ModelNotFoundException`, edit the `app/Exceptions/Handler.php` file.
 
 	use Illuminate\Database\Eloquent\ModelNotFoundException;
 
-	App::error(function(ModelNotFoundException $e)
-	{
-		return Response::make('Not Found', 404);
-	});
+	class Handler extends ExceptionHandler {
+		public function report(Exception $e)
+		{
+			if ($e instanceof ModelNotFoundException) {
+				// log the error
+			}
+		
+			return parent::report($e);
+		}
+		
+		public function render($request, Exception $e)
+		{
+			if ($e instanceof ModelNotFoundException) {
+				// display the error with a custom page (make the view in the views/errors folder)
+				// alternatively, for a simple 404 page use abort(404)
+				return response(view('errors.modelnotfound'), 404);
+			}
+		
+			return parent::render($request, $e);
+		}
+	}
 
 #### Querying Using Eloquent Models
 


### PR DESCRIPTION
The old code that was here no longer works in Laravel 5, so I removed it and replaced it with the current way of error handling.