### PR TITLE
Added closure serialisation note

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -135,6 +135,9 @@ If you wish to specify a specific queue or "tube" on which to push the message, 
 		$message->to('foo@example.com', 'John Smith')->subject('Welcome!');
 	});
 
+> Note: When queuing e-mails, the closure used to send the e-mail is serialized which can have an unexpected effect on the delivery of your e-mail. E-mails may send successfully using Mail::send, but can throw a `Trying to get property of non-object` exception when attempting to send via Mail::queue. In this event, you will need to convert any objects passed to the closure into an array, and update this change in the code used within the e-mail template.
+
+
 <a name="mail-and-local-development"></a>
 ## Mail & Local Development
 


### PR DESCRIPTION
E-mails that send using Mail::send, can fail to send when using Mail::queue in certain cases.

For example:

    // $data is an object

    Mail::queue('example.template', compact('data'), function($message) use ($recipient)
    {
        $message->to($recipient->email, $recipient->name)->subject('Example subject');
    });

and within the example/template.blade.php

    Outputting something from the data object {{ $data->someval }}

In this instance, due to the serialization of the closure sending can fail. It is therefore necessary to convert `$data` and `$recipient` to an array and change the code within the template.

    $data = $data->toArray();
    $recipient = $recipient->toArray();

    Mail::queue('example.template', compact('data'), function($message) use ($recipient)
    {
        $message->to($recipient['email'], $recipient['name'])->subject('Example subject');
    });

and within the example/template.blade.php, change to:

    Outputting something from the data object {{ $data['someval'] }}

