### PR TITLE
Remove Option #1 from Homestead installation documentation

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -60,19 +60,9 @@ If this command fails, you may have an old version of Vagrant that requires the 
 
 ### Installing Homestead
 
-#### Option 1 - Manually Via Git (No Local PHP)
+PHP and [Composer](https://getcomposer.org/) are required to install Homestead.
 
-If you do not want to install PHP on your local machine, you may install Homestead manually by simply cloning the repository. Consider cloning the repository into a `Homestead` folder within your "home" directory, as the Homestead box will serve as the host to all of your Laravel (and PHP) projects:
-
-	git clone https://github.com/laravel/homestead.git Homestead
-
-Once you have installed the Homestead CLI tool, run the `bash init.sh` command to create the `Homestead.yaml` configuration file:
-
-	bash init.sh
-
-The `Homestead.yaml` file will be placed in your `~/.homestead` directory.
-
-#### Option 2 - With Composer + PHP Tool
+#### Composer + PHP Tool
 
 Once the box has been added to your Vagrant installation, you are ready to install the Homestead CLI tool using the Composer `global` command:
 


### PR DESCRIPTION
I was helping someone out who was trying to do `homestead up` without Composer.

If I look at the code in the `./homestead` file I see that there is no possible way that Option 1 can work because the vendor and autoloader would not exist, and the [homestead script requires an autoloader](https://github.com/laravel/homestead/blob/master/homestead#L7). The `./scripts/init.sh` script does not provide these files either. I looked in `./scripts/homestead.rb`, and did not find anything relevant there either. I assume that there is no way to install Homestead without Composer, and I think it would be best to remove this from the documentation in order to improve the experience of new Homestead users.

I'm not familiar with Laravel or Homestead, and so I may be missing some bit of code or Vagrant logic where this magically works, but from [this laracast](https://laracasts.com/discuss/channels/general-discussion/step-by-step-setup-guide-for-homestead-on-os-x) it seems that Option 1 is discouraged and not supported.