### PR TITLE
Specify the kilobyte measurement convention

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -563,7 +563,7 @@ The given _field_ must match the field under validation.
 <a name="rule-size"></a>
 #### size:_value_
 
-The field under validation must have a size matching the given _value_. For string data, _value_ corresponds to the number of characters. For numeric data, _value_ corresponds to a given integer value. For files, _size_ corresponds to the file size in kilobytes.
+The field under validation must have a size matching the given _value_. For string data, _value_ corresponds to the number of characters. For numeric data, _value_ corresponds to a given integer value. For files, _size_ corresponds to the file size in kilobytes (1 KB = 1024 bytes).
 
 <a name="rule-string"></a>
 #### string:_value_


### PR DESCRIPTION
The documentation should be updated to clear any doubts regarding the size of a kilobyte in the `size` validator rule.

Refer to this question: http://stackoverflow.com/questions/29767234/laravel-4-validator-file-size/29767440#29767440