### PR TITLE
show users how to use the `subscribe` property to register subscribers

### DIFF
--- a/events.md
+++ b/events.md
@@ -279,3 +279,44 @@ Once the subscriber has been defined, it may be registered with the event dispat
 You may also use the [service container](/docs/{{version}}/container) to resolve your subscriber. To do so, simply pass the name of your subscriber to the `subscribe` method:
 
 	$events->subscribe('App\Listeners\UserEventHandler');
+	
+Another way to register subscribers is with the `subscribe` property of the `EventServiceProvider`. For example, let's add the `UserEventListener`.
+
+    <?php namespace App\Providers;
+    
+    use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+    use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+    class EventServiceProvider extends ServiceProvider
+    {
+        /**
+         * The event listener mappings for the application.
+         *
+         * @var array
+         */
+        protected $listen = [
+            'App\Events\PodcastWasPurchased' => [
+                'App\Listeners\EmailPurchaseConfirmation',
+            ],
+        ];
+        
+        /**
+         * The subscriber classes to register.
+         *
+         * @var array
+         */
+        protected $subscribe = [
+            'App\Listeners\UserEventListener',
+        ];
+
+        /**
+         * Register any other events for your application.
+         *
+         * @param  \Illuminate\Contracts\Events\Dispatcher  $events
+         * @return void
+         */
+        public function boot(DispatcherContract $events)
+        {
+            parent::boot($events);
+        }
+    }


### PR DESCRIPTION
there are many ways to register subscribers, but using the `subscribe`
property was not shown in the documentation