### PR TITLE
Spelling correction for lifecycle

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -18,7 +18,7 @@
     - [Service Container](/docs/{{version}}/container)
     - [Contracts](/docs/{{version}}/contracts)
     - [Facades](/docs/{{version}}/facades)
-    - [Request Lifecycle](/docs/{{version}}/lifecycle)
+    - [Request Life Cycle](/docs/{{version}}/life-cycle)
     - [Application Structure](/docs/{{version}}/structure)
 - Services
     - [Authentication](/docs/{{version}}/authentication)

--- a/eloquent.md
+++ b/eloquent.md
@@ -1251,7 +1251,7 @@ Now, when you utilize the Eloquent model:
 <a name="model-events"></a>
 ## Model Events
 
-Eloquent models fire several events, allowing you to hook into various points in the model's lifecycle using the following methods: `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`.
+Eloquent models fire several events, allowing you to hook into various points in the model's life cycle using the following methods: `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`.
 
 Whenever a new item is saved for the first time, the `creating` and `created` events will fire. If an item is not new and the `save` method is called, the `updating` / `updated` events will fire. In both cases, the `saving` / `saved` events will fire.
 

--- a/errors.md
+++ b/errors.md
@@ -64,7 +64,7 @@ Optionally, you may provide a response:
 
 	abort(403, 'Unauthorized action.');
 
-This method may be used at any time during the request's lifecycle.
+This method may be used at any time during the request's life cycle.
 
 ### Custom 404 Error Page
 

--- a/lifecycle.md
+++ b/lifecycle.md
@@ -1,7 +1,7 @@
-# Request Lifecycle
+# Request Life Cycle
 
 - [Introduction](#introduction)
-- [Lifecycle Overview](#lifecycle-overview)
+- [Life Cycle Overview](#life-cycle-overview)
 - [Focus On Service Providers](#focus-on-service-providers)
 
 <a name="introduction"></a>
@@ -13,8 +13,8 @@ The goal of this document is to give you a good, high-level overview of how the 
 
 If you don't understand all of the terms right away, don't lose heart! Just try to get a basic grasp of what is going on, and your knowledge will grow as you explore other sections of the documentation.
 
-<a name="lifecycle-overview"></a>
-## Lifecycle Overview
+<a name="life-cycle-overview"></a>
+## Life Cycle Overview
 
 #### First Things
 

--- a/structure.md
+++ b/structure.md
@@ -40,7 +40,7 @@ The "meat" of your application lives in the `app` directory. By default, this di
 
 The `app` directory ships with a variety of additional directories such as `Console`, `Http`, and `Providers`. Think of the `Console` and `Http` directories as providing an API into the "core" of your application. The HTTP protocol and CLI are both mechanisms to interact with your application, but do not actually contain application logic. In other words, they are simply two ways of issuing commands to your application. The `Console` directory contains all of your Artisan commands, while the `Http` directory contains your controllers, filters, and requests.
 
-The `Commands` directory, of course, houses the commands for your application. Commands represent jobs that can be queued by your application, as well as tasks that you can run synchronously within the current request lifecycle.
+The `Commands` directory, of course, houses the commands for your application. Commands represent jobs that can be queued by your application, as well as tasks that you can run synchronously within the current request life cycle.
 
 The `Events` directory, as you might expect, houses event classes. Of course, using classes to represent events is not required; however, if you choose to use them, this directory is the default location they will be created by the Artisan command line.
 


### PR DESCRIPTION
The correct spelling of life cycle is with two words.