### PR TITLE
Add note for scope overwriting (Socialite)

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -432,6 +432,8 @@ The `redirect` method takes care of sending the user to the OAuth provider, whil
     return Socialite::driver('github')
                 ->scopes(['scope1', 'scope2'])->redirect();
 
+> **Note:** Using `scopes` method will overwrite default scope `email`. If you want to get user's email, you should add it to scopes manually.
+
 Once you have a user instance, you can grab a few more details about the user:
 
 #### Retrieving User Details


### PR DESCRIPTION
Can't get user's email if I have set additional scopes like `user_birthday` for Facebook.

I only get email if I add `email` it to scopes manually or if user has its email available publicly.