### PR TITLE
Use single quotes for paths in version helper

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -246,7 +246,7 @@ elixir(function(mix) {
 
 After generating the versioned file, you may use Laravel's global `elixir` PHP helper function within your [views](/docs/{{version}}/views) to load the appropriately hashed asset. The `elixir` function will automatically determine the name of the hashed file:
 
-	<link rel="stylesheet" href="{{ elixir("css/all.css") }}">
+	<link rel="stylesheet" href="{{ elixir('css/all.css') }}">
 
 #### Versioning Multiple Files
 
@@ -260,9 +260,9 @@ elixir(function(mix) {
 
 Once the files have been versioned, you may use the `elixir` helper function to generate links to the proper hashed files. Remember, you only need to pass the name of the un-hashed file to the `elixir` helper function. The helper will use the un-hashed name to determine the current hashed version of the file:
 
-	<link rel="stylesheet" href="{{ elixir("css/all.css") }}">
+	<link rel="stylesheet" href="{{ elixir('css/all.css') }}">
 
-	<script src="{{ elixir("js/app.js") }}"></script>
+	<script src="{{ elixir('js/app.js') }}"></script>
 
 <a name="calling-existing-gulp-tasks"></a>
 ## Calling Existing Gulp Tasks


### PR DESCRIPTION
Can't copy and paste without swapping or escaping the quotes as is.