### PR TITLE
Alternate methods for registering commands and middleware

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -281,6 +281,13 @@ Within this file, you will find a list of commands in the `commands` property. T
         'App\Console\Commands\SendEmails'
     ];
 
+Alternatively you may register your command from any service provider.  This should be done within the `register` method
+
+    public function register()
+    {
+        $this->commands('App\Console\Commands\SendEmails');
+    }
+
 <a name="calling-commands-via-code"></a>
 ## Calling Commands Via Code
 

--- a/middleware.md
+++ b/middleware.md
@@ -97,6 +97,19 @@ However, this middleware would perform its task **after** the request is handled
 
 If you want a middleware to be run during every HTTP request to your application, simply list the middleware class in the `$middleware` property of your `app/Http/Kernel.php` class.
 
+Alternatively you may register your global middleware from any service provider.  This should be done within the `boot` method.
+
+	use Illuminate\Contracts\Http\Kernel;
+
+	public function boot(Kernel $kernel)
+	{
+		// Push your global middleware to the end of the stack
+		$kernel->pushMiddleware('App\Http\Middleware\OldMiddleware');
+
+		// Prepend your global middleware to the front of the stack
+		$kernel->prependMiddleware('App\Http\Middleware\OldMiddleware');
+	}
+
 ### Assigning Middleware To Routes
 
 If you would like to assign middleware to specific routes, you should first assign the middleware a short-hand key in your `app/Http/Kernel.php` file. By default, the `$routeMiddleware` property of this class contains entries for the middleware included with Laravel. To add your own, simply append it to this list and assign it a key of your choosing. For example:
@@ -108,6 +121,15 @@ If you would like to assign middleware to specific routes, you should first assi
         'auth.basic' => 'Illuminate\Auth\Middleware\AuthenticateWithBasicAuth',
         'guest' => 'App\Http\Middleware\RedirectIfAuthenticated',
     ];
+
+Alternatively you may assign a short-hand key from any service provider.  This should be done within the `boot` method.
+
+	use Illuminate\Routing\Router;
+
+	public function boot(Router $router)
+	{
+		$router->middleware('auth.admin', 'App\Http\Middleware\AuthenticateAdmin');
+	}
 
 Once the middleware has been defined in the HTTP kernel, you may use the `middleware` key in the route options array:
 

--- a/packages.md
+++ b/packages.md
@@ -7,6 +7,8 @@
 - [Public Assets](#public-assets)
 - [Publishing File Groups](#publishing-file-groups)
 - [Routing](#routing)
+- [Middleware](#middleware)
+- [Commands](#commands)
 
 <a name="introduction"></a>
 ## Introduction
@@ -152,3 +154,33 @@ To load a routes file for your package, simply `include` it from within your ser
 	}
 
 > **Note:** If your package is using controllers, you will need to make sure they are properly configured in your `composer.json` file's auto-load section.
+
+<a name="middleware"></a>
+## Middleware
+
+To define global or route based middleware from your package, simply define them within your service provider's `boot` method.
+
+	use Illuminate\Routing\Router;
+	use Illuminate\Contracts\Http\Kernel;
+
+	public function boot(Kernel $kernel, Router $router)
+	{
+		// Push your global middleware to the end of the stack
+		$kernel->pushMiddleware('App\Http\Middleware\OldMiddleware');
+
+		// Prepend your global middleware to the front of the stack
+		$kernel->prependMiddleware('App\Http\Middleware\OldMiddleware');
+
+		// Assign a short-hand key for route based middleware
+		$router->middleware('auth.admin', 'App\Http\Middleware\AuthenticateAdmin');
+	}
+
+<a name="commands"></a>
+## Commands
+
+To register your package's artisan commands, simply define them within your service provider's `register` method.
+
+	public function register()
+	{
+		$this->commands('App\Console\Commands\SendEmails');
+	}


### PR DESCRIPTION
I believe it is important to list the alternate more dynamic methods of registering command and middleware for us package maintainers. I added to the individual middleware/artisan.md AND to packages.md. If anything, at least keep this alternate method documented in the packages.md