### PR TITLE
Added Illuminate\Broadcasting\BroadcastServiceProvider to providers a…

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -111,6 +111,10 @@ By providing backwards compatibility for the Laravel 5.0 folder structure, you m
 
 If you are using the AWS SQS queue driver or the AWS SES e-mail driver, you should update your installed AWS PHP SDK to version 3.0.
 
+### Service Providers
+
+To use the new Broadcasting Events, 'Illuminate\Broadcasting\BroadcastServiceProvider' must be added to the providers array in 'app.php'
+
 ### Deprecations
 
 The following Laravel features have been deprecated and will be removed entirely with the release of Laravel 5.2 in December 2015:


### PR DESCRIPTION
Added instructions for adding Illuminate\Broadcasting\BroadcastServiceProvider to providers array so that the new broadcasting events work.

The following error was being thrown otherwise in the queue.

```
[Illuminate\Contracts\Container\BindingResolutionException]                  
  Target [Illuminate\Contracts\Broadcasting\Broadcaster] is not instantiable.  
```