### PR TITLE
Changed the comparison operator to the right one

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -48,7 +48,7 @@ This command will place a new `OldMiddleware` class within your `app/Http/Middle
 
 	}
 
-As you can see, if the given `age` is less than `200`, the middleware will return an HTTP redirect to the client; otherwise, the request will be passed further into the application. To pass the request deeper into the application (allowing the middleware to "pass"), simply call the `$next` callback with the `$request`.
+As you can see, if the given `age` is less than or equal to `200`, the middleware will return an HTTP redirect to the client; otherwise, the request will be passed further into the application. To pass the request deeper into the application (allowing the middleware to "pass"), simply call the `$next` callback with the `$request`.
 
 It's best to envision middleware as a series of "layers" HTTP requests must pass through before they hit your application. Each layer can examine the request and even reject it entirely.
 

--- a/middleware.md
+++ b/middleware.md
@@ -39,7 +39,7 @@ This command will place a new `OldMiddleware` class within your `app/Http/Middle
 		 */
 		public function handle($request, Closure $next)
 		{
-			if ($request->input('age') < 200) {
+			if ($request->input('age') <= 200) {
 				return redirect('home');
 			}
 


### PR DESCRIPTION
Actually, the code example for the explanation of the OldMiddleware isn't right. There's the wrong comparison operator for this:  
> In this middleware, we will only allow access to the route if the supplied age is greater than 200.

But in the code example, we need the the `is less than or equal to (<=)` comparison operator instead of the `is less than` comparison operator.