### PR TITLE
[5.1] Add Amazon S3 driver upgrade instructions from 5.0 to 5.1

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -112,6 +112,12 @@ By providing backwards compatibility for the Laravel 5.0 folder structure, you m
 Add the protected `$baseUrl` property to the `tests/TestCase.php` file:
 
 	protected $baseUrl = 'http://localhost';
+	
+### Filesystem
+
+If you are using the Amazon S3 driver, you will need to update the related package via Composer:
+
+- Amazon S3: `league/flysystem-aws-s3-v3 ~1.0`
 
 ### Amazon Web Services SDK
 


### PR DESCRIPTION
The new flysystem-aws version is already stated in the filesystem documentation, but it's missing from the upgrade guide.