### PR TITLE
Added dependencies for event broadcast

### DIFF
--- a/events.md
+++ b/events.md
@@ -206,6 +206,13 @@ To assist you in building these types of applications, Laravel makes it easy to 
 
 All of the event broadcasting configuration options are stored in the `config/broadcasting.php` configuration file. Laravel supports several broadcast drivers out of the box: [Pusher](https://pusher.com), [Redis](/docs/{{version}}/redis), and a `log` driver for local development and debugging. A configuration example is included for each of these drivers.
 
+#### Broadcast Dependencies
+
+The following dependencies are needed for the listed broadcast drivers:
+
+- Pusher: `pusher/pusher-php-server ~2.0`
+- Redis: `predis/predis ~1.0`
+
 #### Queue Prerequisites
 
 Before broadcasting events, you will also need to configure and run a [queue listener](/docs/{{version}}/queues). All event broadcasting is done via queued jobs so that the response time of your application is not seriously affected.


### PR DESCRIPTION
Added the Pusher and Redis dependencies to events.md so you don't have to search on packagist for the right pusher package or click through to the Redis docs.