### PR TITLE
Fix #where-clauses index typo

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -6,7 +6,7 @@
 - [Selects](#selects)
 - [Joins](#joins)
 - [Unions](#unions)
-- [Where Clauses](#where-clause)
+- [Where Clauses](#where-clauses)
 	- [Advanced Where Clauses](#advanced-where-clauses)
 - [Ordering, Grouping, Limit, & Offset](#ordering-grouping-limit-and-offset)
 - [Inserts](#inserts)


### PR DESCRIPTION
Minor typo fix for #where-clauses index.