### PR TITLE
Fixed wrong type in Request docs

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -145,9 +145,9 @@ You may also retrieve all of the input data as an `array` using the `all` method
 
 If you need to retrieve a sub-set of the input data, you may use the `only` and `except` methods. Both of these methods accept a single `array` as their only argument:
 
-	$input = $request->only('username', 'password');
+	$input = $request->only(['username', 'password']);
 
-	$input = $request->except('credit_card');
+	$input = $request->except(['credit_card']);
 
 <a name="old-input"></a>
 ### Old Input


### PR DESCRIPTION
Methods 'only' and 'except' accept an array. See
http://laravel.com/api/5.1/Illuminate/Http/Request.html#method_only and
http://laravel.com/api/5.1/Illuminate/Http/Request.html#method_except.