### PR TITLE
Eloquent's vs. Collections's lists() correction.

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -70,6 +70,14 @@ If you are overriding the `find` method in your own models and calling `parent::
 		return $model;
 	}
 
+#### The `lists` Method
+
+The `lists` method now returns a `Collection` instance instead of a plain array for Eloquent queries. If you would like to convert the `Collection` into a plain array, use the `all` method:
+
+	User::lists('id')->all();
+
+Be aware that the Query Builder `lists` method still returns an array.
+
 #### Date Formatting
 
 Previously, the storage format for Eloquent date fields could be modified by overriding the `getDateFormat` method on your model. This is still possible; however, for convenience you may simply specify a `$dateFormat` property on the model instead of overriding the method.
@@ -95,7 +103,7 @@ The `groupBy` method now returns `Collection` instances for each item in the par
 
 #### The `lists` Method
 
-The `lists` method now returns a `Collection` instance for Eloquent queries. If you would like to convert the `Collection` into a plain array, use the `all` method:
+The `lists` method now returns a `Collection` instance instead of a plain array for Collections. If you would like to convert the `Collection` into a plain array, use the `all` method:
 
 	$collection->lists('id')->all();
 


### PR DESCRIPTION
Eloquent and Collection each have their own distinct lists() method, and both were changed to return a Collection instead of an array in Laravel 5.1.  The upgrade guide failed to mention that Collection's lists() method now returns a Collection, but it did mention that Eloquent's lists() returns a Collection... but it mentioned that under the "Collection Class" section of the instructions.  Hopefully this will clear up the confusion.