### PR TITLE
Update installation.md

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -161,6 +161,7 @@ For example, if your application is named "Horsefly", you could run the followin
 	php artisan app:name Horsefly
 
 Renaming your application is entirely optional, and you are free to keep the `App` namespace if you wish.
+If you do renamed your application, you will need to run `sudo composer update` so that your new app namespace is carried through out.
 
 <a name="maintenance-mode"></a>
 ## Maintenance Mode


### PR DESCRIPTION
To prevent an error on running the application, you need to run sudo composer update, so that the system/app sets up this new app namespace.  This alway happens to me when i do this, so though might be best to add it to these docs.

After the renaming and i run say php artisan straight after i get `PHP Fatal error:  Uncaught exception 'ReflectionException' with message..'Class NAMESPACE\Console\Kernel does not exist...`error message.  Then running composer update its fixed.