### PR TITLE
Provide link to facade documentation

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -115,7 +115,7 @@ If you are developing with a team, you may wish to continue including a `.env.ex
 
 #### Accessing The Current Application Environment
 
-You may access the current application environment via the `environment` method on the `App` facade:
+You may access the current application environment via the `environment` method on the `App` [facade](/docs/{{version}}/facades):
 
 	$environment = App::environment();
 


### PR DESCRIPTION
The installation page would be frequented with new users who might not know about a facade. Pointing them to its documentation would greatly help.