### PR TITLE
Fix broken worker start command

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -353,7 +353,7 @@ In this example, the `numprocs` directive will instruct Supervisor to run 8 `que
 
 	sudo supervisorctl update
 
-	sudo supervisorctl start laravel-worker
+	sudo supervisorctl start laravel-worker:*
 
 For more information on configuring and using Supervisor, consult the [Supervisor documentation](http://supervisord.org/index.html). Alternatively, you may use [Laravel Forge](https://forge.laravel.com) to automatically configure and manage your Supervisor configuration from a convenient web interface.
 


### PR DESCRIPTION
there are 8 processes (numprocs=8) in the config given in the example. if that is the case when the command is run 'laravel-worker' is a group of processes, not a single process; therefore must be referenced as a group: 'laravel-worker:*' which references the group and all processes within it. Otherwise the command fails.