### PR TITLE
DB is on the root's namespace

### DIFF
--- a/seeding.md
+++ b/seeding.md
@@ -24,7 +24,7 @@ As an example, let's modify the `DatabaseSeeder` class which is included with a 
 
 	<?php
 
-	use DB;
+	use \DB;
 	use Illuminate\Database\Seeder;
 	use Illuminate\Database\Eloquent\Model;
 


### PR DESCRIPTION
I just installed a clean version of Laravel, without any namespace tweaking on composer.json and this example does not work unless I put a backslash in front of DB in its use statement.