### PR TITLE
Adding consistency in method injection documentation

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -305,7 +305,11 @@ In addition to constructor injection, you may also type-hint dependencies on you
 		}
 	}
 
-If your controller method is also expecting input from a route parameter, simply list your route arguments after your other dependencies:
+If your controller method is also expecting input from a route parameter, simply list your route arguments after your other dependencies. For example, if your route is defined like so:
+
+	Route::put('user/{id}', 'UserController@update');
+
+You may still type-hint the `Illuminate\Http\Request` and access your route parameter `id` by defining your controller method like the following:
 
 	<?php
 


### PR DESCRIPTION
If you look at the section on accessing requests in controllers here:

http://laravel.com/docs/5.1/requests#accessing-the-request

And then look at the similar example on method injection in controllers here:

http://laravel.com/docs/5.1/controllers#dependency-injection-and-controllers

You'll see a small discrepancy: the "Request" section gives an example of what the route looks like, while the controller section does not. This PR simply makes the "Controller" section consistent with the "Request" section, and adds the missing route example.