### PR TITLE
[Homestead] Using the %windir% environment variable to get the correct path ..

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -125,7 +125,7 @@ By default, each site will be accessible by HTTP via port 8000 and HTTPS via por
 
 #### The Hosts File
 
-Don't forget to add the "domains" for your Nginx sites to the `hosts` file on your machine! The `hosts` file will redirect your requests for the local domains into your Homestead environment. On Mac and Linux, this file is located at `/etc/hosts`. On Windows, it is located at `C:\Windows\System32\drivers\etc\hosts`. The lines you add to this file will look like the following:
+Don't forget to add the "domains" for your Nginx sites to the `hosts` file on your machine! The `hosts` file will redirect your requests for the local domains into your Homestead environment. On Mac and Linux, this file is located at `/etc/hosts`. On Windows, it is located at `%windir%\System32\drivers\etc\hosts`. The lines you add to this file will look like the following:
 
 	192.168.10.10  homestead.app
 


### PR DESCRIPTION
Use the '%windir%' environment variable to get the correct Windows path, not everyone is running Windows on the C:\ partition ...