### PR TITLE
Added PDO as a PHP server requirement

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -19,6 +19,7 @@ The Laravel framework has a few system requirements. Of course, all of these req
 <div class="content-list" markdown="1">
 - PHP >= 5.5.9
 - OpenSSL PHP Extension
+- PDO PHP Extension
 - Mbstring PHP Extension
 - Tokenizer PHP Extension
 </div>


### PR DESCRIPTION
I was trying to build a production environment with a minimum number of PHP extensions loaded. Even though I specifically ask composer to skip the require-dev, seems Laravel requires the PDO extension. I was just thinking maybe it would be worth mentioning in the docs.

````
composer create-project laravel/laravel test --no-dev

....

- Installing laravel/framework (v5.1.2)
Loading from cache

Writing lock file
Generating autoload files
PHP Fatal error:  Class 'PDO' not found in /var/www/test/config/database.php on line 16
Script php artisan clear-compiled handling the post-install-cmd event returned with an error

  [RuntimeException]
  Error Output: PHP Fatal error:  Class 'PDO' not found in /var/www/test/config/database.php on line 16
````