### PR TITLE
Add Chinese docs link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,3 +3,7 @@
 ## Contribution Guidelines
 
 If you are submitting documentation for the **current stable release**, submit it to the corresponding branch. For example, documentation for Laravel 5.1 would be submitted to the `5.1` branch. Documentation intended for the next release of Laravel should be submitted to the `master` branch.
+
+## Multi-language Version
+
+Chinese [https://github.com/laragirl/docs](https://github.com/laragirl/docs)


### PR DESCRIPTION
I have a proposal, why not support other languages for the documentation. For example, There is a lot of Chinese developers also trying to learn Laravel and use it in real projects, that could be a huge "market". I'm a Laravel fan from China, and I'm trying to translate the latest documentation to Chinese, But I just thought, Why not finally show the Chinese version direct on Laravel.com,