### PR TITLE
Improve Elixir doc

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -53,6 +53,8 @@ Next, you'll want to pull in [Gulp](http://gulpjs.com) as a global NPM package:
 The only remaining step is to install Elixir! Within a fresh installation of Laravel, you'll find a `package.json` file in the root. Think of this like your `composer.json` file, except it defines Node dependencies instead of PHP. You may install the dependencies it references by running:
 
 	npm install
+	
+> **Note:** Windows users who experience errors in their install should try and run `npm install --no-bin-links`
 
 <a name="running-elixir"></a>
 ## Running Elixir


### PR DESCRIPTION
Windows users (even when running Homestead) often need to include `--no-bin-links` when doing the install. This is because the symlink function does not work (even in Homestead).

Discussed here: https://github.com/npm/npm/issues/7308