### PR TITLE
Must explicitly specify 5.0

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -28,7 +28,7 @@ Once installed, the simple `laravel new` command will create a fresh Laravel ins
 
 You may also install Laravel by issuing the Composer `create-project` command in your terminal:
 
-	composer create-project laravel/laravel --prefer-dist
+	composer create-project laravel/laravel {directory} 5.0 --prefer-dist
 
 ### Scaffolding
 


### PR DESCRIPTION
If the installation is run like this, it will install version 5.1. I've updated this to match the format used in the 4.2 docs and it works.