### PR TITLE
working command to generate the `Vagrantfile` and `Homestead.yaml` on per project installation

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -151,7 +151,8 @@ To install Homestead directly into your project, require it using Composer:
 
 Once Homestead has been installed, use the `make` command to generate the `Vagrantfile` and `Homestead.yaml` file in your project root. The `make` command will automatically configure the `sites` and `folders` directives in the `Homestead.yaml` file:
 
-	php vendor/bin/homestead make
+	php vendor/laravel/homestead/homestead make
+
 
 Next, run the `vagrant up` command in your terminal and access your project at `http://homestead.app` in your browser. Remember, you will still need to add an `/etc/hosts` file entry for `homestead.app` or the domain of your choice.
 


### PR DESCRIPTION
I followed exactly the steps in http://laravel.com/docs/5.1/homestead#per-project-installation and after running the command `php vendor/bin/homestead make` it did not create `Vagrantfile` and `Homestead.yaml` in my project root and instead it shows this on my cmd: 

![capture](https://cloud.githubusercontent.com/assets/9766310/8426798/1daebd26-1f45-11e5-85e3-2b6ad58c1184.PNG)

i ran this on cmd `php vendor/laravel/homestead/homestead make` and it exactly did what `php vendor/bin/homestead make` supposed to do: created `Vagrantfile` and `Homestead.yaml` with proper configurations inside