### PR TITLE
Added note about upgrading translation files for vendor packages.

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -123,6 +123,10 @@ By providing backwards compatibility for the Laravel 5.0 folder structure, you m
 
 The `createMatcher`, `createOpenMatcher`, and `createPlainMatcher` methods have been removed from the Blade compiler. Use the new `directive` method to create custom directives for Blade in Laravel 5.1. Consult the [extending blade](/docs/{{version}}/blade#extending-blade) documentation for more information.
 
+### Translation Files
+
+The default directory for published language files for vendor packages has been moved. Move any vendor package language files from `resources/lang/packages/{locale}/{namespace}` to `resources/lang/vendor/{namespace}/{locale}` directory. For example, `Acme/Anvil` package's `acme/anvil::foo` namespaced English language file would be moved from `resources/lang/packages/en/acme/anvil/foo.php` to `resources/lang/vendor/acme/anvil/en/foo.php`.
+
 ### Tests
 
 Add the protected `$baseUrl` property to the `tests/TestCase.php` file:


### PR DESCRIPTION
Because https://github.com/laravel/framework/commit/5d93473b56b7ce481000902ec8f2e3c426be7c03 was applied to Laravel 5.1 and was not documented anywhere else for package maintainers.