### PR TITLE
Use correct VMware vagrant box name

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -77,7 +77,7 @@ Once you have cloned the Homestead repository, run the `bash init.sh` command fr
 
 #### Setting Your Provider
 
-The `provider` key in your `Homestead.yaml` file indicates which Vagrant provider should be used: `virtualbox` or `vmware_fusion`. You may set this to whichever provider you prefer:
+The `provider` key in your `Homestead.yaml` file indicates which Vagrant provider should be used: `virtualbox` or `vmware_desktop`. You may set this to whichever provider you prefer:
 
 	provider: virtualbox
 


### PR DESCRIPTION
While VMware Fusion is supported, the correct Vagrant box provider name appears to be `vmware_desktop`, not `vmware_fusion`.