### PR TITLE
Change sentence about non directory to view composers

### DIFF
--- a/views.md
+++ b/views.md
@@ -93,7 +93,7 @@ Occasionally, you may need to share a piece of data with all views that are rend
 
 View composers are callbacks or class methods that are called when a view is rendered. If you have data that you want to be bound to a view each time that view is rendered, a view composer can help you organize that logic into a single location.
 
-Let's register our view composers within a [service provider](/docs/{{version}}/providers). We'll use the `view` helper to access the underlying `Illuminate\Contracts\View\Factory` contract implementation. Remember, Laravel does not include a default directory for view composers. You are free to organize them however you wish. For example, you could create an `App\Http\ViewComposers` directory:
+Let's register our view composers within a [service provider](/docs/{{version}}/providers). We'll use the `view` helper to access the underlying `Illuminate\Contracts\View\Factory` contract implementation.
 
 	<?php
 


### PR DESCRIPTION
Docs explains view composers are registered within a service provider. 

I'm not sure but makes sense, keep view composers under `app\Providers` directory by default. 