### PR TITLE
Improve Date validation docs

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -483,8 +483,8 @@ The field under validation must be a valid URL according to the `checkdnsrr` PHP
 
 The field under validation must be a value after a given date. The dates will be passed into the `strtotime` PHP function. You can also pass another field here:
 
-    'start' => 'required|date'
-    'end' => 'required|date|after:start'
+    'start_date' => 'required|date|after:tomorrow'
+    'finish_date' => 'required|date|after:start_date'
 
 <a name="rule-alpha"></a>
 #### alpha
@@ -534,7 +534,7 @@ The field under validation must be a valid date according to the `strtotime` PHP
 <a name="rule-date-format"></a>
 #### date_format:_format_
 
-The field under validation must match the given _format_. The format will be evaluated using the PHP `date_parse_from_format` function. *Note:* You should use either `date` or `date_format` - not both.
+The field under validation must match the given _format_. The format will be evaluated using the PHP `date_parse_from_format` function. _Note:_ You should use either `date` or `date_format` - not both.
 
 <a name="rule-different"></a>
 #### different:_field_

--- a/validation.md
+++ b/validation.md
@@ -481,7 +481,10 @@ The field under validation must be a valid URL according to the `checkdnsrr` PHP
 <a name="rule-after"></a>
 #### after:_date_
 
-The field under validation must be a value after a given date. The dates will be passed into the `strtotime` PHP function.
+The field under validation must be a value after a given date. The dates will be passed into the `strtotime` PHP function. You can also pass another field here:
+
+    'start' => 'required|date'
+    'end' => 'required|date|after:start'
 
 <a name="rule-alpha"></a>
 #### alpha
@@ -531,7 +534,7 @@ The field under validation must be a valid date according to the `strtotime` PHP
 <a name="rule-date-format"></a>
 #### date_format:_format_
 
-The field under validation must match the given _format_. The format will be evaluated using the PHP `date_parse_from_format` function.
+The field under validation must match the given _format_. The format will be evaluated using the PHP `date_parse_from_format` function. *Note:* You should use either `date` or `date_format` - not both.
 
 <a name="rule-different"></a>
 #### different:_field_


### PR DESCRIPTION
Two adjustments. Added a cool feature that I didnt know about (and is very useful - so should be in the docs) that you can use `after` against another field - which is extremely awesome.

Also - added a point that people should *not* use `date` and `date_format` in the same validation rule - otherwise you'll run into issues (which I've just had for the past 30mins). The reason is `date` will parse with `strtotime` - and that can cause certain formats to fail - such as `mm-dd-YYYY`.