### PR TITLE
Help user when calling commands in code when the command has an option that has no value

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -310,6 +310,13 @@ Sometimes you may wish to execute an Artisan command outside of the CLI. For exa
 
         //
     });
+    
+Another Example:
+
+    Route::get('/foo', function () {
+        $exitCode = Artisan::call('migrate:refresh', ['--seed' => true]);
+        //
+    });
 
 Using the `queue` method on the `Artisan` facade, you may even queue Artisan commands so they are processed in the background by your [queue workers](/docs/{{version}}/queues):
 


### PR DESCRIPTION
Talk about a formatting issue here https://github.com/laravel/docs/pull/1652 are fixed here.

BUT 

The docs on, the Artisan page, do not show how to call a command that is only and option like `--seed` with no value.

The conversation over there does not link to anything that helps with this issue so not sure why it is not worth adding this little touch to the docs for next time me, a team mate or other user goes to the docs for this?

Anyways just wanted to give it one last try as I think the initial comment was in haste linking to an unrelated doc. Maybe I just did not explain it well enough in my commit message sorry about that.