### PR TITLE
Add vagrant provider option for Homestead in VMWare Workstation on Windows

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -50,7 +50,7 @@ Homestead is currently built and tested using Vagrant 1.7.
 
 Before launching your Homestead environment, you must install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or [VMWare](http://www.vmware.com) as well as [Vagrant](http://www.vagrantup.com/downloads.html). All of these software packages provide easy-to-use visual installers for all popular operating systems.
 
-To use the VMware provider, you will need to purchase both VMware Fusion / Desktop and the [VMware Vagrant plug-in](http://www.vagrantup.com/vmware). VMware provides much faster shared folder performance out of the box.
+To use the VMware provider, you will need to purchase both VMware Fusion / Workstation and the [VMware Vagrant plug-in](http://www.vagrantup.com/vmware). VMware provides much faster shared folder performance out of the box.
 
 #### Installing The Homestead Vagrant Box
 
@@ -77,7 +77,7 @@ Once you have cloned the Homestead repository, run the `bash init.sh` command fr
 
 #### Setting Your Provider
 
-The `provider` key in your `Homestead.yaml` file indicates which Vagrant provider should be used: `virtualbox` or `vmware_fusion`. You may set this to whichever provider you prefer:
+The `provider` key in your `Homestead.yaml` file indicates which Vagrant provider should be used: `virtualbox`, `vmware_fusion` or `vmware_workstation`. You may set this to whichever provider you prefer:
 
     provider: virtualbox
 


### PR DESCRIPTION
To get Homestead working in VMWare on Windows, the provider must be set to `vmware_workstation`. As fusion is exclusive to Mac and Workstation is exclusive to Windows. 

There is no VMWare Application called "Desktop".