### PR TITLE
Install Homestead as a dev dependency

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -147,7 +147,7 @@ Instead of installing Homestead globally and sharing the same Homestead box acro
 
 To install Homestead directly into your project, require it using Composer:
 
-    composer require laravel/homestead
+    composer require laravel/homestead --dev
 
 Once Homestead has been installed, use the `make` command to generate the `Vagrantfile` and `Homestead.yaml` file in your project root. The `make` command will automatically configure the `sites` and `folders` directives in the `Homestead.yaml` file.
 


### PR DESCRIPTION
I think Homestead should be installed as a dev dependency and not as an project dependency.