### PR TITLE
Add important note about middleware terminate method

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -184,3 +184,5 @@ Sometimes a middleware may need to do some work after the HTTP response has alre
     }
 
 The `terminate` method should receive both the request and the response. Once you have defined a terminable middleware, you should add it to the list of global middlewares in your HTTP kernel.
+
+> **Note:** You must bind your middleware class to container as singleton if you want your `terminate` method to be called on the same instance as the `handle` method.


### PR DESCRIPTION
If middleware is not registered as singleton within container and it has terminate method, laravel will create a new instance of your middleware and call terminate on that instance, losing your previous instance properties.

This behaviour is not obvious without digging through the source code.

 Previous issue here: https://github.com/laravel/framework/issues/9683.