### PR TITLE
Changed --prefer-dist in the quick install guide to 4.2.*

### DIFF
--- a/quick.md
+++ b/quick.md
@@ -28,7 +28,7 @@ The Laravel framework utilizes [Composer](http://getcomposer.org) for installati
 
 Now you can install Laravel by issuing the following command from your terminal:
 
-	composer create-project laravel/laravel your-project-name --prefer-dist
+	composer create-project laravel/laravel your-project-name 4.2.*
 
 This command will download and install a fresh copy of Laravel in a new `your-project-name` folder within your current directory.
 


### PR DESCRIPTION
People around the net have been confused about the 4.2 quick guide installing version 5.*, this change will show people how to install the right version.