### PR TITLE
Include Socialite facade for the AuthController

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -507,6 +507,7 @@ Next, you are ready to authenticate users! You will need two routes: one for red
     namespace App\Http\Controllers;
 
     use Illuminate\Routing\Controller;
+    use Socialite;
 
     class AuthController extends Controller
     {


### PR DESCRIPTION
A novice user might not catch that they have to include the Socialite facade in the AuthController if they are trying to use Socialite.