### PR TITLE
update queues.md to clarify location for failed() method

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -255,6 +255,8 @@ You may also define a `failed` method directly on a queue job class, allowing yo
 	{
 		// Called when the job is failing...
 	}
+	
+If your job is not self-handling and has a seperate handler class the `failed` method needs to be defined there instead.
 
 ### Retrying Failed Jobs
 


### PR DESCRIPTION
Current docs don't note that the failed() method needs to be defined on a handler class not the job class if you are using the job / handler system as per https://github.com/laravel/framework/issues/9799