### PR TITLE
The class-specific resolving example missed the abstract.

### DIFF
--- a/container.md
+++ b/container.md
@@ -206,7 +206,7 @@ The service container fires an event each time it resolves an object. You may li
         // Called when container resolves object of any type...
     });
 
-    $this->app->resolving(function (FooBar $fooBar, $app) {
+    $this->app->resolving(FooBar::class, function (FooBar $fooBar, $app) {
         // Called when container resolves objects of type "FooBar"...
     });
 


### PR DESCRIPTION
I believe this is true but I'm not 100%. Based on my experience last night diving the code, I think that the container isn't smart enough to auto-detect the type from the type hint in the closure and that it actually has an `$abstract` passed to it.

I want to post a follow-up PR to this for `afterResolving` which I ultimately ended up using. Would it be safe to describe `afterResolving` as a hook that is fired after an object and all of it's dependencies (and their dependencies) have been resolved? Versus `resolving` being a hook that is fired as soon as an object is resolved, even if the object that depended on it hasn't been completely resolved itself yet?