### PR TITLE
Update queues.md

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -346,7 +346,7 @@ Supervisor configuration files are typically stored in the `/etc/supervisor/conf
     redirect_stderr=true
     stdout_logfile=/home/forge/app.com/worker.log
 
-In this example, the `numprocs` directive will instruct Supervisor to run 8 `queue:work` processes and monitor all of them, automatically restarting them if they fail. Once the configuration file has been created, you may update the Supervisor configuration and start the processes using the following commands:
+In this example, the `numprocs` directive will instruct Supervisor to run 8 `queue:work` processes and monitor all of them, automatically restarting them if they fail. Make sure you edit the 'command' line if you are not using 'sqs' to: beanstalkd, redis, or whatever you are using. Once the configuration file has been created, you may update the Supervisor configuration and start the processes using the following commands:
 
     sudo supervisorctl reread
 


### PR DESCRIPTION
This caused me a bunch of grief. The example code is sqs specific, but it is very easy to overlook that since things that need to be changed appear to be marked in red. Except that's not how the docs really work. I don't care what the language is, but this piece of code should be clearer to show that sqs has been set as the service used when you may be using another service, like beanstalkd in my case.