### PR TITLE
Clarify $loginPath effect on bouncing users

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -128,6 +128,8 @@ When a user is successfully authenticated, they will be redirected to the `/home
 When a user is not successfully authenticated, they will be redirected to the `/auth/login` URI. You can customize the failed post-authentication redirect location by defining a `loginPath` property on the `AuthController`:
 
     protected $loginPath = '/login';
+    
+> **Note:** This variable will not change where a user is bounced if they try to access a protected page. That is controlled by the middleware `App\Http\Middleware\Authenticate` in its `handle` method.
 
 #### Customizations
 


### PR DESCRIPTION
I just lost about 20 minutes trying to figure out why changing the `$loginPath` property wasn't changing where I bounced when trying to access a protected route when not logged in. I'd like to save someone else the trouble.