### PR TITLE
Cache: sample names of tagged flush where switched

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -290,7 +290,7 @@ You may flush all items that are assigned a tag or list of tags. For example, th
 
 	Cache::tags(['people', 'authors'])->flush();
 
-In contrast, this statement would remove only caches tagged with `authors`, so `John` would be removed, but not `Anne`.
+In contrast, this statement would remove only caches tagged with `authors`, so `Anne` would be removed, but not `John`.
 
 	Cache::tags('authors')->flush();
 

--- a/pagination.md
+++ b/pagination.md
@@ -73,7 +73,7 @@ You may also use the `simplePaginate` method when paginating Eloquent models:
 
 Sometimes you may wish to create a pagination instance manually, passing it an array of items. You may do so by creating either an `Illuminate\Pagination\Paginator` or `Illuminate\Pagination\LengthAwarePaginator` instance, depending on your needs.
 
-The `Paginator` class does not need to know the total number of items in the result set; however, because of this, the class does not have methods for retrieve the index of the last page. The `LengthAwarePaginator` accepts almost the same arguments as the `Paginator`; however, it does require a count of the total number of items in the result set.
+The `Paginator` class does not need to know the total number of items in the result set; however, because of this, the class does not have methods for retrieving the index of the last page. The `LengthAwarePaginator` accepts almost the same arguments as the `Paginator`; however, it does require a count of the total number of items in the result set.
 
 In other words, the `Paginator` corresponds to the `simplePaginate` method on the query builder and Eloquent, while the `LengthAwarePaginator` corresponds to the `paginate` method.
 

--- a/routing.md
+++ b/routing.md
@@ -183,7 +183,7 @@ If the route defines parameters, you may pass the parameters as the second argum
 <a name="route-groups"></a>
 ## Route Groups
 
-Route groups allow you to share route attributes, such as middleware or namespaces, across a large number of routes without needing to define those attributes on each individual routes. Shared attributes are specified in an array format as the first parameter to the `Route::group` method.
+Route groups allow you to share route attributes, such as middleware or namespaces, across a large number of routes without needing to define those attributes on each individual route. Shared attributes are specified in an array format as the first parameter to the `Route::group` method.
 
 To learn more about route groups, we'll walk through several common use-cases for the feature.
 
@@ -269,7 +269,7 @@ Of course, using the Blade [templating engine](/docs/{{version}}/blade):
 
     {!! csrf_field() !!}
 
-You do not need to manually verify the CSRF token on POST, PUT, or DELETE requests. The `VerifyCsrfToken` [HTTP middleware](/docs/{{version}}/middleware) will verify token in the request input matches the token stored in the session.
+You do not need to manually verify the CSRF token on POST, PUT, or DELETE requests. The `VerifyCsrfToken` [HTTP middleware](/docs/{{version}}/middleware) will verify that the token in the request input matches the token stored in the session.
 
 <a name="csrf-excluding-uris"></a>
 ### Excluding URIs From CSRF Protection


### PR DESCRIPTION
So, while reading the cache docs I found this error:

`Anne` is tagged as `['people', 'authors']` while `John` is tagged as `['people', 'artists']`.
So if you do `Cache::tags('authors')->flush();` then `Anne` will be deleted - not `John` as suggested by the docs.

Fixed this logical mistake.