### PR TITLE
Names of tagged flush example where switched

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -290,7 +290,7 @@ You may flush all items that are assigned a tag or list of tags. For example, th
 
 	Cache::tags(['people', 'authors'])->flush();
 
-In contrast, this statement would remove only caches tagged with `authors`, so `John` would be removed, but not `Anne`.
+In contrast, this statement would remove only caches tagged with `authors`, so `Anne` would be removed, but not `John`.
 
 	Cache::tags('authors')->flush();
 


### PR DESCRIPTION
This time in the right branch, sorry for the trouble Taylor.

So, while reading the cache docs I found this error.

`Anne` is tagged as `['people', 'authors']` while `John` is tagged as `['people', 'artists']`. So if you do `Cache::tags('authors')->flush();` then `Anne` will be deleted not `John` as suggested by the docs.

Fixed this logical mistake.