### PR TITLE
External link about progress bar was misleading

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -275,15 +275,15 @@ For long running tasks, it could be helpful to show a progress indicator. Using 
 
     $users = App\User::all();
 
-    $this->output->progressStart(count($users));
+    $bar = $this->output->createProgressBar(count($users));
 
     foreach ($users as $user) {
         $this->performTask($user);
 
-        $this->output->progressAdvance();
+        $bar->advance();
     }
 
-    $this->output->progressFinish();
+    $bar->finish();
 
 For more advanced options, check out the [Symfony Progress Bar component documentation](http://symfony.com/doc/2.7/components/console/helpers/progressbar.html).
 


### PR DESCRIPTION
The recommended methods progressStart, progressAdvance and progressFinish do not give access to the actual ProgressBar component, so it can't be customized without reading deep on Laravel's and Symfony's code. So the external link to Synfony's docs become misleading: http://stackoverflow.com/questions/32015511/laravel-5-1-how-to-set-a-message-on-progress-bar/32018827#32018827

There are two options to fix this section (I opted for the first one):

1) Recommend the createProgressBar method instead, so you have access to the actual ProgressBar object (and then Symfony docs won't confuse you, because you're just at home); 

OR

2) Add a note near Symfony's docs link, informing something like: "if you need to access the actual ProgressBar object in order to customize it, you should call createProgressBar() instead". (followed by an example line)