### PR TITLE
Help users install the latest version of Laravel 5.0

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -28,7 +28,11 @@ Once installed, the simple `laravel new` command will create a fresh Laravel ins
 
 You may also install Laravel by issuing the Composer `create-project` command in your terminal:
 
-	composer create-project laravel/laravel {directory} 5.0 --prefer-dist
+	composer create-project laravel/laravel {directory} "~5.0.0" --prefer-dist
+
+Once installed, you should upgrade to the latest packages. First, remove `{directory}/vendor/compiled.php` file.
+
+Then, change your current directory to `{directory}` and issue `composer update` command in your terminal.
 
 ### Scaffolding
 


### PR DESCRIPTION
With the older version of installation procedure (simply telling
Composer to install "5.0"), it doesn't actually install the latest
version of laravel/laravel (currently 5.0.22), but instead installs
5.0.0. And there's a bunch of differences between those two versions, so
it's not ideal.
That wouldn't be an issue, if Composer could update laravel/laravel in
the current project, but of course it can't, so a developer is stuck
with older files.

My proposed fix is to tell Composer to install "~5.0.0" version, which
installs the latest version, up to (but excluding) 5.1 version.
Currently, this means 5.0.22.
But since 5.0.22 comes with composer.lock (5.0.0 doesn't), Composer
installs older versions of packages, which means we have to upgrade
those.
But there's another issue - since compiled.php location changed between
laravel/framework 5.0.16 (the version that gets installed with
laravel/laravel 5.0.22) and laravel/framework 5.0.33 (currently latest),
we have to delete compiled.php file before doing the upgrade.
Hence a somewhat longer installation procedure.

Also, laravel/installer throws errors on PHP 5.4, which is relevant to
Laravel 5.0 branch, since it's the last version running on PHP 5.4,
which is one of the major reasons for still using 5.0 (for those stuck
on PHP 5.4).
But that's a separate issue.