### PR TITLE
Add/remove hyphens to improve readability

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -271,7 +271,7 @@ The `table` method makes it easy to correctly format multiple rows / columns of 
 
 #### Progress Bars
 
-For long running tasks, it could be helpful to show a progress indicator. Using the output object, we can start, advance and stop the Progress Bar. You have to define the number of steps when you start the progress, then advance the Progress Bar after each step:
+For long-running tasks, it could be helpful to show a progress indicator. Using the output object, we can start, advance and stop the Progress Bar. You have to define the number of steps when you start the progress, then advance the Progress Bar after each step:
 
     $users = App\User::all();
 

--- a/authentication.md
+++ b/authentication.md
@@ -475,7 +475,7 @@ After the password is reset, the user will automatically be logged into the appl
 <a name="social-authentication"></a>
 ## Social Authentication
 
-In addition to typical, form based authentication, Laravel also provides a simple, convenient way to authenticate with OAuth providers using [Laravel Socialite](https://github.com/laravel/socialite). Socialite currently supports authentication with Facebook, Twitter, LinkedIn, Google, GitHub and Bitbucket.
+In addition to typical, form-based authentication, Laravel also provides a simple, convenient way to authenticate with OAuth providers using [Laravel Socialite](https://github.com/laravel/socialite). Socialite currently supports authentication with Facebook, Twitter, LinkedIn, Google, GitHub and Bitbucket.
 
 To get started with Socialite, add to your `composer.json` file as a dependency:
 

--- a/blade.md
+++ b/blade.md
@@ -39,7 +39,7 @@ Two of the primary benefits of using Blade are _template inheritance_ and _secti
         </body>
     </html>
 
-As you can see, this file contains typical HTML mark-up. However, take note of the `@section` and `@yield` directives. The `@section` directive, as the name implies, defines a section of content, while the `@yield` directive is used to display the contents of a given section.
+As you can see, this file contains typical HTML markup. However, take note of the `@section` and `@yield` directives. The `@section` directive, as the name implies, defines a section of content, while the `@yield` directive is used to display the contents of a given section.
 
 Now that we have defined a layout for our application, let's define a child page that inherits the layout.
 
@@ -124,7 +124,7 @@ By default, Blade `{{ }}` statements are automatically sent through PHP's `htmle
 <a name="control-structures"></a>
 ## Control Structures
 
-In addition to template inheritance and displaying data, Blade also provides convenient short-cuts for common PHP control structures, such as conditional statements and loops. These short-cuts provide a very clean, terse way of working with PHP control structures, while also remaining familiar to their PHP counterparts.
+In addition to template inheritance and displaying data, Blade also provides convenient shortcuts for common PHP control structures, such as conditional statements and loops. These shortcuts provide a very clean, terse way of working with PHP control structures while also remaining familiar to their PHP counterparts.
 
 #### If Statements
 

--- a/elixir.md
+++ b/elixir.md
@@ -314,7 +314,7 @@ elixir(function(mix) {
 });
 ```
 
-Once the files have been versioned, you may use the `elixir` helper function to generate links to the proper hashed files. Remember, you only need to pass the name of the un-hashed file to the `elixir` helper function. The helper will use the un-hashed name to determine the current hashed version of the file:
+Once the files have been versioned, you may use the `elixir` helper function to generate links to the proper hashed files. Remember, you only need to pass the name of the unhashed file to the `elixir` helper function. The helper will use the unhashed name to determine the current hashed version of the file:
 
     <link rel="stylesheet" href="{{ elixir('css/all.css') }}">
 

--- a/installation.md
+++ b/installation.md
@@ -112,7 +112,7 @@ All of the variables listed in this file will be loaded into the `$_ENV` PHP sup
 
 Feel free to modify your environment variables as needed for your own local server, as well as your production environment. However, your `.env` file should not be committed to your application's source control, since each developer / server using your application could require a different environment configuration.
 
-If you are developing with a team, you may wish to continue including a `.env.example` file with your application. By putting place-holder values in the example configuration file, other developers on your team can clearly see which environment variables are needed to run your application.
+If you are developing with a team, you may wish to continue including a `.env.example` file with your application. By putting placeholder values in the example configuration file, other developers on your team can clearly see which environment variables are needed to run your application.
 
 #### Accessing The Current Application Environment
 

--- a/localization.md
+++ b/localization.md
@@ -56,11 +56,11 @@ If the specified language line does not exist, the `trans` function will simply 
 
 #### Replacing Parameters In Language Lines
 
-If you wish, you may define place-holders in your language lines. All place-holders are prefixed with a `:`. For example, you may define a welcome message with a place-holder name:
+If you wish, you may define placeholders in your language lines. All placeholders are prefixed with a `:`. For example, you may define a welcome message with a place-holder name:
 
     'welcome' => 'Welcome, :name',
 
-To replace the place-holders when retrieving a language line, pass an array of replacements as the second argument to the `trans` function:
+To replace the placeholders when retrieving a language line, pass an array of replacements as the second argument to the `trans` function:
 
     echo trans('messages.welcome', ['name' => 'Dayle']);
 

--- a/mail.md
+++ b/mail.md
@@ -10,11 +10,11 @@
 <a name="introduction"></a>
 ## Introduction
 
-Laravel provides a clean, simple API over the popular [SwiftMailer](http://swiftmailer.org) library. Laravel provides drivers for SMTP, Mailgun, Mandrill, Amazon SES, PHP's `mail` function, and `sendmail`, allowing you to quickly get started sending mail through a local or cloud based service of your choice.
+Laravel provides a clean, simple API over the popular [SwiftMailer](http://swiftmailer.org) library. Laravel provides drivers for SMTP, Mailgun, Mandrill, Amazon SES, PHP's `mail` function, and `sendmail`, allowing you to quickly get started sending mail through a local or cloud-based service of your choice.
 
 ### Driver Prerequisites
 
-The API based drivers such as Mailgun and Mandrill are often simpler and faster than SMTP servers. All of the API drivers require that the Guzzle HTTP library be installed for your application. You may install Guzzle to your project by adding the following line to your `composer.json` file:
+The API-based drivers such as Mailgun and Mandrill are often simpler and faster than SMTP servers. All of the API drivers require that the Guzzle HTTP library be installed for your application. You may install Guzzle to your project by adding the following line to your `composer.json` file:
 
     "guzzlehttp/guzzle": "~5.3|~6.0"
 

--- a/queues.md
+++ b/queues.md
@@ -18,7 +18,7 @@
 <a name="introduction"></a>
 ## Introduction
 
-The Laravel queue service provides a unified API across a variety of different queue back-ends. Queues allow you to defer the processing of a time consuming task, such as sending an e-mail, until a later time which drastically speeds up web requests to your application.
+The Laravel queue service provides a unified API across a variety of different queue back-ends. Queues allow you to defer the processing of a time-consuming task, such as sending an e-mail, until a later time which drastically speeds up web requests to your application.
 
 <a name="configuration"></a>
 ### Configuration
@@ -361,7 +361,7 @@ For more information on configuring and using Supervisor, consult the [Superviso
 <a name="daemon-queue-listener"></a>
 ### Daemon Queue Listener
 
-The `queue:work` Artisan command includes a `--daemon` option for forcing the queue worker to continue processing jobs without ever re-booting the framework. This results in a significant reduction of CPU usage when compared to the `queue:listen` command:
+The `queue:work` Artisan command includes a `--daemon` option for forcing the queue worker to continue processing jobs without ever rebooting the framework. This results in a significant reduction of CPU usage when compared to the `queue:listen` command:
 
 To start a queue worker in daemon mode, use the `--daemon` flag:
 
@@ -442,7 +442,7 @@ If you would like to register an event that will be called when a queued job fai
 
 #### Failed Method On Job Classes
 
-For more granular control, you may define a `failed` method directly on a queue job class, allowing you to perform job specific actions when a failure occurs:
+For more granular control, you may define a `failed` method directly on a queue job class, allowing you to perform job-specific actions when a failure occurs:
 
     <?php
 

--- a/releases.md
+++ b/releases.md
@@ -306,7 +306,7 @@ No more spending hours writing OAuth authentication flows. Get started in minute
 
 ### Flysystem Integration
 
-Laravel now includes the powerful [Flysystem](https://github.com/thephpleague/flysystem) filesystem abstraction library, providing pain free integration with local, Amazon S3, and Rackspace cloud storage - all with one, unified and elegant API! Storing a file in Amazon S3 is now as simple as:
+Laravel now includes the powerful [Flysystem](https://github.com/thephpleague/flysystem) filesystem abstraction library, providing pain-free integration with local, Amazon S3, and Rackspace cloud storage - all with one, unified and elegant API! Storing a file in Amazon S3 is now as simple as:
 
     Storage::put('file.txt', 'contents');
 
@@ -388,7 +388,7 @@ Laravel 4.2 requires PHP 5.4 or greater. This upgraded PHP requirement allows us
 
 ### Laravel Forge
 
-Laravel Forge, a new web based application, provides a simple way to create and manage PHP servers on the cloud of your choice, including Linode, DigitalOcean, Rackspace, and Amazon EC2. Supporting automated Nginx configuration, SSH key access, Cron job automation, server monitoring via NewRelic & Papertrail, "Push To Deploy", Laravel queue worker configuration, and more, Forge provides the simplest and most affordable way to launch all of your Laravel applications.
+Laravel Forge, a new web-based application, provides a simple way to create and manage PHP servers on the cloud of your choice, including Linode, DigitalOcean, Rackspace, and Amazon EC2. Supporting automated Nginx configuration, SSH key access, Cron job automation, server monitoring via NewRelic & Papertrail, "Push To Deploy", Laravel queue worker configuration, and more, Forge provides the simplest and most affordable way to launch all of your Laravel applications.
 
 The default Laravel 4.2 installation's `app/config/database.php` configuration file is now configured for Forge usage by default, allowing for more convenient deployment of fresh applications onto the platform.
 

--- a/routing.md
+++ b/routing.md
@@ -303,7 +303,7 @@ In addition to checking for the CSRF token as a POST parameter, the Laravel `Ver
 
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
-Once you have created the `meta` tag, you can instruct a library like jQuery to add the token to all request headers. This provides simple, convenient CSRF protection for your AJAX based applications:
+Once you have created the `meta` tag, you can instruct a library like jQuery to add the token to all request headers. This provides simple, convenient CSRF protection for your AJAX-based applications:
 
     $.ajaxSetup({
             headers: {

--- a/seeding.md
+++ b/seeding.md
@@ -92,6 +92,6 @@ Once you have written your seeder classes, you may use the `db:seed` Artisan com
 
     php artisan db:seed --class=UserTableSeeder
 
-You may also seed your database using the `migrate:refresh` command, which will also rollback and re-run all of your migrations. This command is useful for completely re-building your database:
+You may also seed your database using the `migrate:refresh` command, which will also rollback and re-run all of your migrations. This command is useful for completely rebuilding your database:
 
     php artisan migrate:refresh --seed

--- a/upgrade.md
+++ b/upgrade.md
@@ -170,7 +170,7 @@ In your `bootstrap/autoload.php` file, update the `$compiledPath` variable to:
 
 ### Fresh Install, Then Migrate
 
-The recommended method of upgrading is to create a new Laravel `5.0` install and then to copy your `4.2` site's unique application files into the new application. This would include controllers, routes, Eloquent models, Artisan commands, assets, and other code specific to your application.
+The recommended method of upgrading is to create a new Laravel `5.0` install and then to copy your `4.2` site's unique application files into the new application. This would include controllers, routes, Eloquent models, Artisan commands, assets, and other code-specific to your application.
 
 To start, [install a new Laravel 5.0 application](/docs/5.0/installation) into a fresh directory in your local environment.  Do not install any versions newer than 5.0 yet, since we need to complete the migration steps for 5.0 first. We'll discuss each piece of the migration process in further detail below.
 

--- a/validation.md
+++ b/validation.md
@@ -381,7 +381,7 @@ If needed, you may use custom error messages for validation instead of the defau
 
     $validator = Validator::make($input, $rules, $messages);
 
-In this example, the `:attribute` place-holder will be replaced by the actual name of the field under validation. You may also utilize other place-holders in validation messages. For example:
+In this example, the `:attribute` placeholder will be replaced by the actual name of the field under validation. You may also utilize other placeholders in validation messages. For example:
 
     $messages = [
         'same'    => 'The :attribute and :other must match.',
@@ -807,7 +807,7 @@ You will also need to define an error message for your custom rule. You can do s
 
     // The rest of the validation error messages...
 
-When creating a custom validation rule, you may sometimes need to define custom place-holder replacements for error messages. You may do so by creating a custom Validator as described above then making a call to the `replacer` method on the `Validator` facade. You may do this within the `boot` method of a [service provider](/docs/{{version}}/providers):
+When creating a custom validation rule, you may sometimes need to define custom placeholder replacements for error messages. You may do so by creating a custom Validator as described above then making a call to the `replacer` method on the `Validator` facade. You may do this within the `boot` method of a [service provider](/docs/{{version}}/providers):
 
     /**
      * Bootstrap any application services.


### PR DESCRIPTION
Some hyphenated words in the docs are unnecessarily hyphenated, since they have unhyphenated English equivalents.

For example, "place-holder" may be replaced with "placeholder".

Other sets of words in the docs *should* be hyphenated. For example, "AJAX based" should be "AJAX-based".