### PR TITLE
Use ::class notation for consistency

### DIFF
--- a/events.md
+++ b/events.md
@@ -29,8 +29,8 @@ The `EventServiceProvider` included with your Laravel application provides a con
      * @var array
      */
     protected $listen = [
-        'App\Events\PodcastWasPurchased' => [
-            'App\Listeners\EmailPurchaseConfirmation',
+        \App\Events\PodcastWasPurchased::class => [
+            \App\Listeners\EmailPurchaseConfirmation::class,
         ],
     ];
 
@@ -374,12 +374,12 @@ Event subscribers are classes that may subscribe to multiple events from within 
         public function subscribe($events)
         {
             $events->listen(
-                'App\Events\UserLoggedIn',
+                \App\Events\UserLoggedIn::class,
                 'App\Listeners\UserEventListener@onUserLogin'
             );
 
             $events->listen(
-                'App\Events\UserLoggedOut',
+                \App\Events\UserLoggedOut::class,
                 'App\Listeners\UserEventListener@onUserLogout'
             );
         }
@@ -414,6 +414,6 @@ Once the subscriber has been defined, it may be registered with the event dispat
          * @var array
          */
         protected $subscribe = [
-            'App\Listeners\UserEventListener',
+            \App\Listeners\UserEventListener::class,
         ];
     }

--- a/queues.md
+++ b/queues.md
@@ -278,7 +278,7 @@ It is very common to map HTTP request variables into jobs. So, instead of forcin
         {
             // Process the request...
 
-            $this->dispatchFrom('App\Jobs\ProcessOrder', $request);
+            $this->dispatchFrom(\App\Jobs\ProcessOrder::class, $request);
         }
     }
 
@@ -286,7 +286,7 @@ This method will examine the constructor of the given job class and extract vari
 
 You may also pass an array as the third argument to the `dispatchFrom` method. This array will be used to fill any constructor parameters that are not available on the request:
 
-    $this->dispatchFrom('App\Jobs\ProcessOrder', $request, [
+    $this->dispatchFrom(\App\Jobs\ProcessOrder::class, $request, [
         'taxPercentage' => 20,
     ]);
 


### PR DESCRIPTION
Updated a few instances where strings were used to refer to classes with `::class` notation.