### PR TITLE
Mentioned dynamic where in query builder docs

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -218,6 +218,10 @@ For convenience, if you simply want to verify that a column is equal to a given 
 
     $users = DB::table('users')->where('votes', 100)->get();
 
+or pass only the value to a dynamic `whereX` method, where X is the studly-caps name of a column to which `where` clause should be applied:
+
+    $users = DB::table('users')->whereVotes(100)->get();
+
 Of course, you may use a variety of other operators when writing a `where` clause:
 
     $users = DB::table('users')


### PR DESCRIPTION
I find dynamic wheres a very convenient way of making code that uses query builder more readable and I think they should be at least mentioned in the docs.

I believe they deserve a separate section in the query builder docs, but on the other hand I see you try to keep the docs as simple as possible. If you like I could add more info about using dynamic where to the docs, just let me know