### PR TITLE
Add tip for installing ACL dependencies before upgrading

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -16,6 +16,8 @@ Laravel 5.1.11 includes support for [authorization](/docs/{{version}}/authorizat
 
 > **Note:** These upgrades are **optional**, and ignoring them will not affect your application.
 
+> **Note:** Before proceeding be sure to run `composer update laravel/framework` first to install the dependencies for the following upgrades.
+
 #### Create The Policies Directory
 
 First, create an empty `app/Policies` directory within your application.


### PR DESCRIPTION
Silly me, I made the basic mistake of not running `composer update` **first** before adding the ACL AuthController code to one of my apps, and had to undo it all. This just helps others not make the same basic mistake by clarifying the order in which steps should be done.