### PR TITLE
Remove unnecessary use statement

### DIFF
--- a/seeding.md
+++ b/seeding.md
@@ -24,7 +24,6 @@ As an example, let's modify the `DatabaseSeeder` class which is included with a 
 
     <?php
 
-    use DB;
     use Illuminate\Database\Seeder;
     use Illuminate\Database\Eloquent\Model;
 


### PR DESCRIPTION
The file isn't namespaced therefore the `use` statement will show the following error when running `php artisan db:seed`:

>  [ErrorException]                                             
>  The use statement with non-compound name 'DB' has no effect

This may confuse a newcomer or somebody unfamiliar in PHP namespaces.