### PR TITLE
Fix the documentation for the `only` and `except` methods

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -147,10 +147,14 @@ You may also retrieve all of the input data as an `array` using the `all` method
 
 #### Retrieving A Portion Of The Input Data
 
-If you need to retrieve a sub-set of the input data, you may use the `only` and `except` methods. Both of these methods accept a single `array` as their only argument:
+If you need to retrieve a sub-set of the input data, you may use the `only` and `except` methods. Both of these methods will accept a single `array` as their only argument or a list of arguments:
 
+    $input = $request->only(['username', 'password']);
+    
     $input = $request->only('username', 'password');
 
+    $input = $request->except(['credit_card']);
+    
     $input = $request->except('credit_card');
 
 <a name="old-input"></a>


### PR DESCRIPTION
The documentation said that `only` and `expect` only accepted a single array as an argument but the examples showed the arguments broken out. The methods will accept both as input. I changed the documentation to show both examples.