### PR TITLE
Removed extra equals sign

### DIFF
--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -108,7 +108,7 @@ Occasionally, you may need to add array attributes that do not have a correspond
          */
         public function getIsAdminAttribute()
         {
-            return $this->attributes['admin'] == 'yes';
+            return $this->attributes['admin'] = 'yes';
         }
     }
 


### PR DESCRIPTION
Double equals would force an evaluation for a value that doesn't exist in the attributes array.