### PR TITLE
Change "vagrant provision" to "homestead provision"

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -186,7 +186,7 @@ To connect to your MySQL or Postgres database from your host machine via Navicat
 <a name="adding-additional-sites"></a>
 ### Adding Additional Sites
 
-Once your Homestead environment is provisioned and running, you may want to add additional Nginx sites for your Laravel applications. You can run as many Laravel installations as you wish on a single Homestead environment. To add an additional site, simply add the site to your `Homestead.yaml` file and then run the `vagrant provision` terminal command from your Homestead directory.
+Once your Homestead environment is provisioned and running, you may want to add additional Nginx sites for your Laravel applications. You can run as many Laravel installations as you wish on a single Homestead environment. To add an additional site, simply add the site to your `Homestead.yaml` file and then run the `homestead provision` terminal command from your Homestead directory.
 
 <a name="ports"></a>
 ### Ports


### PR DESCRIPTION
`vagrant provision` didn't work for me, after updating `Homestead.yaml`. 

`homestead provision`, however, did the trick perfectly. 