### PR TITLE
Fixed typo

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -127,7 +127,7 @@ elixir(function(mix) {
 });
 ```
 
-Again, like the `less` method, you may compile multiple scripts into a single CSS file, and even customize the output directory of the resulting CSS:
+Again, like the `less` method, you may compile multiple Sass files into a single CSS file, and even customize the output directory of the resulting CSS:
 
 ```javascript
 elixir(function(mix) {


### PR DESCRIPTION
Fixed a small typo, which instead of 'scripts', it should be 'Sass files', because right there, we're talking about Sass stylesheets compiling into CSS, and not scripts.