### PR TITLE
Adding documentation for the fourth parameter of unique validation rule

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -713,6 +713,10 @@ Sometimes, you may wish to ignore a given ID during the unique check. For exampl
 
     'email' => 'unique:users,email_address,'.$user->id
 
+If your table uses a custom ID column name, you may specify it as the fourth parameter:
+
+    'email' => 'unique:users,email_address,'.$user->id.',user_id'
+
 **Adding Additional Where Clauses:**
 
 You may also specify more conditions that will be added as "where" clauses to the query:


### PR DESCRIPTION
The fourth parameter of the unique validation rule isn't explained anywhere on the documentation.
I'm maintaining a Laravel app where the previous developer used 'custom_id' instead of just 'id' and it took me a while to figure it out why my validation kept failing! Had to check the next example (Adding Additional Where Clauses) to get it.
Maybe this could help someone in the same situation.