### PR TITLE
Update homestead.md - Upgrading To PHP 7.0 section

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -81,15 +81,15 @@ Once you have cloned the Homestead repository, run the `bash init.sh` command fr
 <a name="upgrading-to-php-7"></a>
 #### Upgrading To PHP 7.0
 
-If you are already using the PHP 5.x Homestead box, you may easily upgrade your installation to PHP 7.0. First, clone the `php-7` branch of the `laravel/homestead` repository into a new folder:
+If you are already using the PHP 5.x Homestead box, you may easily upgrade your installation to PHP 7.0. First, clone the `php-7` branch of the `laravel/homestead` repository into a new folder, e.g.:
 
-    git clone -b php-7 https://github.com/laravel/homestead.git Homestead
+    git clone -b php-7 https://github.com/laravel/homestead.git Homestead_PHP_7
 
-There is no need to run the `init.sh` script and overwrite your entire `Homestead.yaml` file. Instead, simply add the `box` directive to the top of your existing `Homestead.yaml` file:
+If you already have `Homestead.yaml` in your `~/.homestead` directory, there is no need to run the `init.sh` script, otherwise you might need to run `bash init.sh` from your new clone directory first and then copy your existing `Homestead.yaml` into  `~/.homestead` directory (overwriting thus the one genereted by `init.sh`). In both cases, add then the `box` directive to the top of your `~/.homestead/Homestead.yaml` file (on a new line after `---` mark):
 
     box: laravel/homestead-7
 
-Next, you may run the `vagrant up` command from the directory that contains your clone of the `laravel/homestead` repository.
+Next, you may run the `vagrant up` command from the directory that contains your new clone of the `laravel/homestead` repository.
 
 <a name="configuring-homestead"></a>
 ### Configuring Homestead


### PR DESCRIPTION
 - using different directory name as an example for new clone
 - adding condition of already having `~/.homestead/Homestead.yml`
(this condition is not true for older version of Homestead, from which one might also want to upgrade, and not be aware of the difference.)
 - adding instruction how to upgrade from older version of Homestead
 - clarifying the position of box directive
 - clarifying from which directory to run `vagrant up` from