### PR TITLE
Restore useful content eliminated in 5.1

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -63,6 +63,8 @@ Like Closure routes, you may specify names on controller routes:
 
     Route::get('foo', ['uses' => 'FooController@method', 'as' => 'name']);
 
+#### URLs To Controller Actions
+
 Once you have assigned a name to the controller route, you can easily generate URLs to the action. To generate a URL to a controller action, use the `action` helper method. Again, we only need to specify the part of the controller class name that comes after the base `App\Http\Controllers` namespace:
 
     $url = action('FooController@method');
@@ -70,6 +72,16 @@ Once you have assigned a name to the controller route, you can easily generate U
 You may also use the `route` helper to generate a URL to a named controller route:
 
     $url = route('name');
+
+If you wish to generate a URL to a controller action while using only the portion of the class name relative to your controller namespace, register the root controller namespace with the URL generator:
+
+	URL::setRootControllerNamespace('App\Http\Controllers');
+
+	$url = action('FooController@method');
+
+You may access the name of the controller action being run using the `currentRouteAction` method:
+
+	$action = Route::currentRouteAction();
 
 <a name="controller-middleware"></a>
 ## Controller Middleware


### PR DESCRIPTION
In 5.1, the `URLs To Controller Actions` section of this page was eliminated, and the explanation of `action()` was jammed into the `Naming Controller Routes` section. This was a step backwards in that the previous section name was more appropriate, and two important methods were scrubbed from the page.

Mention of the `URL::setRootControllerNamespace()` method was eliminated. This is a hugely useful method that is probably under-utilized because it is little-known. My feeling is that it has a place on this page.

Similarly, the `Route::currentRouteAction()` method was eliminated. There is no clear explanation as to why (at least that I'm able to find).

This change restores the `URLs to Controller Actions` section, verbatim, as it appeared in 5.0.