### PR TITLE
[5.1] Further Documentation for Validation Extensions

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -649,7 +649,12 @@ The field under validation must match the given regular expression.
 <a name="rule-required"></a>
 #### required
 
-The field under validation must be present in the input data.
+The field under validation must be present in the input data and not empty. An empty field is one of:
+
+* `null`
+* A blank string or one that contains only whitespace
+* An array or `Countable` instance with a count less than 1
+* An uploaded file with no path
 
 <a name="rule-required-if"></a>
 #### required_if:_anotherfield_,_value_,...
@@ -836,3 +841,19 @@ When creating a custom validation rule, you may sometimes need to define custom 
             return str_replace(...);
         });
     }
+
+#### Implicit Extensions
+
+By default, when an attribute to be validated is not present or contains an empty value as defined by the [`required`](#rule-required) rule, normal validation rules—including custom extensions—are not run. For example, the [`integer`](#rule-integer) rule will not be run against a `null` value:
+
+    $rules = ['count' => 'integer'];
+    $input = ['count' => null];
+    Validator::make($input, $rules)->passes(); // passes and returns true
+
+For a rule to run even when an attribute is empty, it must imply that the attribute is required. To create such an "implicit" extension, use the `Validator::extendImplicit()` method:
+
+    Validator::extendImplicit('foo', function($attribute, $value, $parameters, $validator) {
+        return $value == 'foo';
+    });
+
+> **Note:** An "implicit" extension only _implies_ that the attribute is required. Whether it actually invalidates a missing or empty attribute is up to you.

--- a/validation.md
+++ b/validation.md
@@ -789,7 +789,7 @@ Laravel provides a variety of helpful validation rules; however, you may wish to
          */
         public function boot()
         {
-            Validator::extend('foo', function($attribute, $value, $parameters) {
+            Validator::extend('foo', function($attribute, $value, $parameters, $validator) {
                 return $value == 'foo';
             });
         }
@@ -805,7 +805,7 @@ Laravel provides a variety of helpful validation rules; however, you may wish to
         }
     }
 
-The custom validator Closure receives three arguments: the name of the `$attribute` being validated, the `$value` of the attribute, and an array of `$parameters` passed to the rule.
+The custom validator Closure receives four arguments: the name of the `$attribute` being validated, the `$value` of the attribute, an array of `$parameters` passed to the rule, and the `$validator` instance that calls it.
 
 You may also pass a class and method to the `extend` method instead of a Closure:
 


### PR DESCRIPTION
This PR does three things:

1. Correct the docs for `Validator::extend()`. There are four parameters passed to the extension, but the docs say there are only three. (Turns out that fourth param is pretty important for some types of extensions.)
2. Clarify what the `required` rule does.
3. Document the `Validator::extendImplicit()` method.