### PR TITLE
Overriding boot method should call parent.

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -547,6 +547,8 @@ For example, let's define an Eloquent event listener in a [service provider](/do
                     return false;
                 }
             });
+            
+            parent::boot();
         }
 
         /**


### PR DESCRIPTION
Otherwise bootable traits such as SoftDeletes.