### PR TITLE
[5.1] Use $this instead of parent::

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -251,7 +251,7 @@ Once the policy exists, we need to register it with the `Gate` class. The `AuthS
 	     */
 	    public function boot(GateContract $gate)
 	    {
-	        parent::registerPolicies($gate);
+	        $this->registerPolicies($gate);
 	    }
 	}
 

--- a/authorization.md
+++ b/authorization.md
@@ -42,7 +42,7 @@ The simplest way to determine if a user may perform a given action is to define 
 	     */
 	    public function boot(GateContract $gate)
 	    {
-	        parent::registerPolicies($gate);
+	        $this->registerPolicies($gate);
 
 	        $gate->define('update-post', function ($user, $post) {
 	        	return $user->id === $post->user_id;


### PR DESCRIPTION
Commit https://github.com/laravel/laravel/commit/50357d8bab3c43ac6b76a82038847c1061bf21c6 changes parent:: to $this.

Since upgrade guide links directily to [raw file](https://github.com/laravel/docs/edit/5.1/upgrade.md#L25), update documentation file to keep it consistent.