### PR TITLE
In homestead - tell users that when adding new sites - need to run vagrant reload --provision

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -362,7 +362,7 @@ Another option is to wrap every test case in a database transaction. Again, Lara
         }
     }
 
-> **Note:** This trait will only wrap the default database in a transaction.
+> **Note:** This trait will only wrap the default database connection in a transaction.
 
 <a name="model-factories"></a>
 ### Model Factories

--- a/testing.md
+++ b/testing.md
@@ -362,6 +362,8 @@ Another option is to wrap every test case in a database transaction. Again, Lara
         }
     }
 
+> **Note:** This trait will only wrap the default database in a transaction.
+
 <a name="model-factories"></a>
 ### Model Factories
 


### PR DESCRIPTION
Hello,

In http://laravel.com/docs/5.1/homestead Configuring Nginx Sites section there is not told that need to run 
vagrant reload --provision

I was just running vagrant reload all the time and did not think that I need to add provision parameter. I imagined provision means runnig shell scripts, but yaml file did not look like shell script.

I believe you would save some time for new users by doing so.
