### PR TITLE
Add a note to the query builder regarding returning the correct object

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -481,6 +481,8 @@ Scopes allow you to define common sets of constraints that you may easily re-use
         }
     }
 
+> **Note:** A query scope always needs to return a [query builder](/docs/{{version}}/queries) object.
+
 #### Utilizing A Query Scope
 
 Once the scope has been defined, you may call the scope methods when querying the model. However, you do not need to include the `scope` prefix when calling the method. You can even chain calls to various scopes, for example:


### PR DESCRIPTION
Some uses complained about not being able to return a count in the query scope. We know the query scope should always return a query builder object. I added the note in the documentation to make this clearer!

See the following issues:
* https://github.com/laravel/framework/issues/10701
* https://github.com/laravel/framework/issues/5405
* https://laracasts.com/discuss/channels/laravel/scope-query-unable-to-return-false-zero-instead-eloquent-builder-returns-an-object?page=1#reply-108939
