### PR TITLE
$table type should be Blueprint

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -122,7 +122,7 @@ The `migrate:refresh` command will first roll back all of your database migratio
 
 To create a new database table, use the `create` method on the `Schema` facade. The `create` method accepts two arguments. The first is the name of the table, while the second is a `Closure` which receives a `Blueprint` object used to define the new table:
 
-    Schema::create('users', function ($table) {
+    Schema::create('users', function (Blueprint $table) {
         $table->increments('id');
     });
 


### PR DESCRIPTION
In the create method, we're told the closure receives a Blueprint $table, but Blueprint was not specified in the example.