### PR TITLE
Spelling correction

### DIFF
--- a/quickstart-intermediate.md
+++ b/quickstart-intermediate.md
@@ -786,7 +786,7 @@ Now that our policy is written, let's use it in our `destroy` method. All Larave
         // Delete The Task...
     }
 
-Let's examine this method call for a moment. The first argument passed to the `authorize` method is the name of the policy method we wish to call. The second argument is the model instance that is our current concern. Remember, we recently told Laravel that our `Task` model corresponds to our `TaskPolicy`, so the framework knows on which policy to to fire the `destroy` method. The current user will automatically be sent to the policy method, so we do not need to manually pass it here.
+Let's examine this method call for a moment. The first argument passed to the `authorize` method is the name of the policy method we wish to call. The second argument is the model instance that is our current concern. Remember, we recently told Laravel that our `Task` model corresponds to our `TaskPolicy`, so the framework knows on which policy to fire the `destroy` method. The current user will automatically be sent to the policy method, so we do not need to manually pass it here.
 
 If the action is authorized, our code will continue executing normally. However, if the action is not authorized (meaning the policy's `destroy` method returned `false`), a 403 exception will be thrown and an error page will be displayed to the user.
 


### PR DESCRIPTION
If I am not wrong, there only should be one "to" instead of "to to".
("...so the framework knows on which policy to to fire the `destroy`...")