### PR TITLE
Added reguard method

### DIFF
--- a/seeding.md
+++ b/seeding.md
@@ -80,6 +80,8 @@ Within the `DatabaseSeeder` class, you may use the `call` method to execute addi
         $this->call(UserTableSeeder::class);
         $this->call(PostsTableSeeder::class);
         $this->call(CommentsTableSeeder::class);
+        
+        Model::reguard();
     }
 
 <a name="running-seeders"></a>


### PR DESCRIPTION
In the current boiler plate code found in DatabaseSeeder.php, there's a `Model::reguard();` at the end of the `run()` method. This change updates the documentation to reflect this.