### PR TITLE
Fix typo

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -256,7 +256,7 @@ If you have additional Stripe webhook events you would like to handle, simply ex
 
     <?php
 
-    namespace App\Http\Controller;
+    namespace App\Http\Controllers;
 
     use Laravel\Cashier\WebhookController as BaseController;
 


### PR DESCRIPTION
change namespace App\Http\Controller to App\Http\Controllers; in other
webhooks example