### PR TITLE
Include examples of put/delete methods for implicit controllers

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -237,6 +237,23 @@ Laravel allows you to easily define a single route to handle every action in a c
         {
             //
         }
+        
+        /**
+         * Responds to requests to PUT /users/profile
+         */
+        public function putProfile()
+        {
+            //
+        }
+        
+        /**
+         * Responds to requests to DELETE /users/profile
+         */
+        public function deleteProfile()
+        {
+            //
+        }
+        
     }
 
 As you can see in the example above, `index` methods will respond to the root URI handled by the controller, which, in this case, is `users`.


### PR DESCRIPTION
I had a student ask whether Implicit controllers support put/delete in addition to get/post. This doc is *somewhat* vague about this, saying `The method names should begin with the HTTP verb `. You could infer from this that all 4 HTTP verbs are supported, however, in the examples we see only show get/post, so you might second guess this inference. 

In this proposed file change, I'm suggesting adding examples of put/delete. 

Alternatively, you could not add these examples, and instead make the instructions more explicit saying something like `all 4 HTTP verbs (get, post, put, delete) are supported.`