### PR TITLE
send mail example doesn't work without from set

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -81,6 +81,7 @@ To send a message, use the `send` method on the `Mail` [facade](/docs/{{version}
 
             Mail::send('emails.reminder', ['user' => $user], function ($m) use ($user) {
                 $m->to($user->email, $user->name)->subject('Your Reminder!');
+                $m->from('no-reply@mydomain.com', 'My Domain Sender');
             });
         }
     }


### PR DESCRIPTION
the mail sending example does not work, a message seems to need the from sender set in order to work. If this is necessary and not optional it should be in the documentation.