### PR TITLE
Update requirement of ironMQ to v3 API

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -44,7 +44,7 @@ The following dependencies are needed for the listed queue drivers:
 
 - Amazon SQS: `aws/aws-sdk-php ~3.0`
 - Beanstalkd: `pda/pheanstalk ~3.0`
-- IronMQ: `iron-io/iron_mq ~2.0`
+- IronMQ: `iron-io/iron_mq ~2.0|~4.0`
 - Redis: `predis/predis ~1.0`
 
 <a name="writing-job-classes"></a>


### PR DESCRIPTION
Update docs of ironMQ according to [https://github.com/laravel/framework/pull/10848](https://github.com/laravel/framework/pull/10848) and [https://github.com/iron-io/iron_mq_php/tree/v4](https://github.com/iron-io/iron_mq_php/tree/v4)