### PR TITLE
Add a 'PHPUnit Assertions' section to testing.md

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -7,6 +7,7 @@
     - [Sessions / Authentication](#sessions-and-authentication)
     - [Disabling Middleware](#disabling-middleware)
     - [Custom HTTP Requests](#custom-http-requests)
+    - [PHPUnit Assertions](#phpunit-assertions)
 - [Working With Databases](#working-with-databases)
     - [Resetting The Database After Each Test](#resetting-the-database-after-each-test)
     - [Model Factories](#model-factories)
@@ -290,6 +291,26 @@ If you would like to make a custom HTTP request into your application and get th
 If you are making `POST`, `PUT`, or `PATCH` requests you may pass an array of input data with the request. Of course, this data will be available in your routes and controller via the [Request instance](/docs/{{version}}/requests):
 
        $response = $this->call('POST', '/user', ['name' => 'Taylor']);
+
+<a name="phpunit-assertions"></a>
+### PHPUnit Assertions
+
+Laravel provides several additional assertion methods for [PHPUnit](https://phpunit.de/) tests:
+
+Method  | Description
+------------- | -------------
+`->assertResponseOk();`  |  Assert that the client response has an OK status code.
+`->assertResponseStatus($code);`  |  Assert that the client response has a given code.
+`->assertViewHas($key, $value = null);`  |  Assert that the response view has a given piece of bound data.
+`->assertViewHasAll(array $bindings);`  |  Assert that the view has a given list of bound data.
+`->assertViewMissing($key);`  |  Assert that the response view is missing a piece of bound data.
+`->assertRedirectedTo($uri, $with = []);`  |  Assert whether the client was redirected to a given URI.
+`->assertRedirectedToRoute($name, $parameters = [], $with = []);`  |  Assert whether the client was redirected to a given route.
+`->assertRedirectedToAction($name, $parameters = [], $with = []);`  |  Assert whether the client was redirected to a given action.
+`->assertSessionHas($key, $value = null);`  |  Assert that the session has a given list of values.
+`->assertSessionHasAll(array $bindings);`  |  Assert that the session has a given list of values.
+`->assertSessionHasErrors($bindings = [], $format = null);`  |  Assert that the session has errors bound.
+`->assertHasOldInput();`  |  Assert that the session has old input.
 
 <a name="working-with-databases"></a>
 ## Working With Databases


### PR DESCRIPTION
Added a section to the Testing documentation addressing the additional PHPUnit assertions provided by [AssertionsTrait](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Foundation/Testing/AssertionsTrait.php).