### PR TITLE
update queues.md to clarify that onQueue() from Queueable trait

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -187,7 +187,7 @@ Of course, sometimes you may wish to dispatch a job from somewhere in your appli
 
 You may also specify the queue a job should be sent to.
 
-By pushing jobs to different queues, you may "categorize" your queued jobs, and even prioritize how many workers you assign to various queues. This does not push jobs to different queue "connections" as defined by your queue configuration file, but only to specific queues within a single connection. To specify the queue, use the `onQueue` method on the job instance. The `onQueue` method is provided by the base `App\Jobs\Job` class included with Laravel:
+By pushing jobs to different queues, you may "categorize" your queued jobs, and even prioritize how many workers you assign to various queues. This does not push jobs to different queue "connections" as defined by your queue configuration file, but only to specific queues within a single connection. To specify the queue, use the `onQueue` method on the job instance. The `onQueue` method is provided by the `Illuminate\Bus\Queueable` trait which is already added to the `App\Jobs\Job` base class created by Laravel for you to extend:
 
     <?php
 


### PR DESCRIPTION
…and not the default abstract job class.

The current wording would lead you to believe that the method is defined right there in the base class but it's not, the base class just uses the trait which you can import for yourself elsewhere.