### PR TITLE
envoy.md: @include should not have a semi-colon

### DIFF
--- a/envoy.md
+++ b/envoy.md
@@ -55,7 +55,7 @@ Sometimes, you may need to execute some PHP code before evaluating your Envoy ta
 
 You may also use ```@include``` to include any outside PHP files:
 
-    @include('vendor/autoload.php');
+    @include('vendor/autoload.php')
 
 #### Confirming Tasks
 


### PR DESCRIPTION
@include should not have a semi-colon ending:

With a semi-colon:
```@include('vendor/autoload.php');``` => ```<?php require_once('vendor/autoload.php'); ?>;```

Without:
```@include('vendor/autoload.php')``` => ```<?php require_once('vendor/autoload.php'); ?>```