### PR TITLE
Change Artisan facade class reference to Illuminate\Contracts\Console…

### DIFF
--- a/facades.md
+++ b/facades.md
@@ -65,7 +65,7 @@ Below you will find every facade and its underlying class. This is a useful tool
 Facade  |  Class  |  Service Container Binding
 ------------- | ------------- | -------------
 App  |  [Illuminate\Foundation\Application](http://laravel.com/api/{{version}}/Illuminate/Foundation/Application.html)  | `app`
-Artisan  |  [Illuminate\Console\Application](http://laravel.com/api/{{version}}/Illuminate/Console/Application.html)  |  `artisan`
+Artisan  |  [Illuminate\Contracts\Console\Kernel](http://laravel.com/api/{{version}}/Illuminate/Contracts/Console/Kernel.html)  |  `artisan`
 Auth  |  [Illuminate\Auth\AuthManager](http://laravel.com/api/{{version}}/Illuminate/Auth/AuthManager.html)  |  `auth`
 Auth (Instance)  |  [Illuminate\Auth\Guard](http://laravel.com/api/{{version}}/Illuminate/Auth/Guard.html)  |
 Blade  |  [Illuminate\View\Compilers\BladeCompiler](http://laravel.com/api/{{version}}/Illuminate/View/Compilers/BladeCompiler.html)  |  `blade.compiler`


### PR DESCRIPTION
As discussed in PR [#11062](https://github.com/laravel/framework/pull/11062) of the framework, the correct class reference for the Artisan facade is now `Illuminate\Contracts\Console\Kernel` and not `Illuminate\Console\Application`.