### PR TITLE
Corrected the mismatch in emails in the working with database example

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -321,7 +321,7 @@ Laravel also provides a variety of helpful tools to make it easier to test your 
     {
         // Make call to application...
 
-        $this->seeInDatabase('users', ['email' => 'sally@foo.com']);
+        $this->seeInDatabase('users', ['email' => 'sally@example.com']);
     }
 
 Of course, the `seeInDatabase` method and other helpers like it are for convenience. You are free to use any of PHPUnit's built-in assertion methods to supplement your tests.


### PR DESCRIPTION
The email in given in the description of the example in the section "Working With Databases" was "sally@example.com". But in the example it was "sally@foo.com" Corrected it now.