### PR TITLE
Add `blog` for consistency between two examples

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -43,9 +43,9 @@ Once installed, the simple `laravel new` command will create a fresh Laravel ins
 
 #### Via Composer Create-Project
 
-You may also install Laravel by issuing the Composer `create-project` command in your terminal:
+Alternatively, you may also install Laravel by issuing the Composer `create-project` command in your terminal:
 
-    composer create-project laravel/laravel --prefer-dist
+    composer create-project laravel/laravel --prefer-dist blog
 
 <a name="configuration"></a>
 ## Configuration


### PR DESCRIPTION
Being a complete noob, I was confused -- probably longer than I should have been -- about creating a fresh Laravel install for a number of reasons:

- it wasn't immediately clear to me the difference between using `laravel new ...` and `composer create-project ...`
- the example shown seemed inconsistent (a new `blog` project vs a new `laravel` in the other)
- the `composer create-project` implicitly creates `laravel` directory which is slightly different than the `Laravel` shown in the yaml

I'm probably obsessing and I don't really expect this PR to go through, I just wanted somewhere to discuss it. :smile: