### PR TITLE
[5.2] Add an example for Global Scopes

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -550,6 +550,10 @@ To assign a global scope to a model, you should override a given model's `boot` 
         }
     }
 
+Now the query `User::all()` will produce the following SQL query:
+
+    select * from `users` where `age` > 200
+    
 <a name="local-scopes"></a>
 ### Local Scopes
 


### PR DESCRIPTION
Scope wasn't the name of the interface. It was ScopeInterface.