### PR TITLE
[5.2] Remove beta instructions

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -19,8 +19,6 @@
 
 ### Updating Dependencies
 
-If you are installing a beta release of Laravel 5.2, add `"minimum-stability": "beta"` to your `composer.json` file.
-
 Update your `composer.json` file to point to `laravel/framework 5.2.*`.
 
 Add `symfony/dom-crawler ~3.0` and `symfony/css-selector ~3.0` to the `require-dev` section of your `composer.json` file.


### PR DESCRIPTION
Not needed now that the final release is out.