### PR TITLE
Update reference to dollars() function changed in Cashier 6.0

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -313,7 +313,7 @@ When listing the invoices for the customer, you may use the invoice's helper met
         @foreach ($invoices as $invoice)
             <tr>
                 <td>{{ $invoice->date()->toFormattedDateString() }}</td>
-                <td>{{ $invoice->dollars() }}</td>
+                <td>{{ $invoice->total() }}</td>
                 <td><a href="/user/invoice/{{ $invoice->id }}">Download</a></td>
             </tr>
         @endforeach


### PR DESCRIPTION
Getting the total amount for an invoice changed from $invoice->dollars() to $invoice->total() in Cashier 6.0. This should be updated in the documentation.