### PR TITLE
Add missing ServiceProvider Changes for Upgrade to 5.0.16

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -471,6 +471,14 @@ In your `bootstrap/autoload.php` file, update the `$compiledPath` variable to:
 
     $compiledPath = __DIR__.'/../vendor/compiled.php';
 
+
+### Service Providers
+
+The `App\Providers\BusServiceProvider` may be removed from your service provider list in your `app.php` configuration file.
+
+The `App\Providers\ConfigServiceProvider` may be removed from your service provider list in your `app.php` configuration file.
+
+
 <a name="upgrade-5.0"></a>
 ## Upgrading To 5.0 From 4.2
 


### PR DESCRIPTION
I recently upgraded an app from 5.1.24 to 5.2.4. After the upgrade the app was broken because those 2 Service Provider got removed in [this commit](https://github.com/laravel/laravel/commit/1500a186966a4dad78032f13c5655d633c643d37#diff-ea70a5765dbab9fd8032c1d439521db8L143) long before 5.2.4.

Just thought we could add the removal of those Service Providers to the docs.