### PR TITLE
Remove Xdebug from list of provided software

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -33,7 +33,6 @@ Homestead runs on any Windows, Mac, or Linux system, and includes the Nginx web 
 - Git
 - PHP 7.0
 - HHVM
-- Xdebug
 - Nginx
 - MySQL
 - Sqlite3


### PR DESCRIPTION
Xdebug no longer seems to be included in the latest version of Homestead. Will need to re-implement as part of the provisioning process, or update the base box.