### PR TITLE
Show how to create-project for 5.1 release

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -45,7 +45,7 @@ Once installed, the simple `laravel new` command will create a fresh Laravel ins
 
 Alternatively, you may also install Laravel by issuing the Composer `create-project` command in your terminal:
 
-    composer create-project laravel/laravel --prefer-dist blog
+    composer create-project laravel/laravel blog 5.1.*
 
 <a name="configuration"></a>
 ## Configuration


### PR DESCRIPTION
If you follow the Composer Create-Project install instructions on the 5.1 page you will currently get 5.2. Now that 5.2 has been released if you want to install 5.1 LTS the version needs to be specified.