### PR TITLE
Include mention of @push and @stack

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -121,6 +121,18 @@ By default, Blade `{{ }}` statements are automatically sent through PHP's `htmle
 
 > **Note:** Be very careful when echoing content that is supplied by users of your application. Always use the double curly brace syntax to escape any HTML entities in the content.
 
+#### Stacks
+
+Blade allows for pushing to named stacks which can be rendered at some arbitrary point in a view or layout:
+
+    @push('scripts')
+    <script src="..."></script>
+    @endpush
+    
+This can be called any number of times, from any view. Finally, to render a stack, use the `@stack` syntax:
+
+    @stack('scripts')
+
 <a name="control-structures"></a>
 ## Control Structures
 


### PR DESCRIPTION
There's no mention in any documentation of `@push` and `@stack`, which are very useful features, particularly when it comes to complex view structures or layouts. This change introduces the idea and shows two examples of the actions available.