### PR TITLE
Update path that Composer.php was moved.

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -65,7 +65,7 @@ The `slice`, `chunk`, and `reverse` methods now preserve keys on the collection.
 
 ### Composer Class
 
-The `Illuminate\Foundation\Support\Composer` class has been moved to `Illuminate\Support\Composer`. This is unlikely to affect your application if you were not manually using this class.
+The `Illuminate\Foundation\Composer` class has been moved to `Illuminate\Support\Composer`. This is unlikely to affect your application if you were not manually using this class.
 
 ### Commands And Handlers
 


### PR DESCRIPTION
According to this commit: [101cb80] (https://github.com/laravel/framework/commit/101cb80750cb81fe26cd38686b8464a7e943330d) 

Composer.php was moved from `Illuminate\Foundation` to `Illuminate\Support` and not from `Illuminate\Foundation\Support`