### PR TITLE
5.2 upgrade note about db seeds being unguarded by default

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -113,6 +113,10 @@ Starting with MySQL 5.7, `0000-00-00 00:00:00` is no longer considered a valid d
 
 The `json` column type now creates actual JSON columns when used by the MySQL driver. If you are not running MySQL 5.7 or above, this column type will not be available to you. Instead, use the `text` column type in your migration.
 
+#### Seeding
+
+When runnning database seeders, all Eloquent models will now be unguarded by default. Previously a call to `Model::unguard()` was required. You can call `Model::reguard()` where this behaviour isn't desired.
+
 ### Eloquent
 
 #### Date Casts


### PR DESCRIPTION
Refers to [this change](https://github.com/laravel/framework/commit/41ff1a1fc838007b981ee27b043feae8e4974680#diff-14de5015be74d92950add13254e6eccdR63), seems worth mentioning since not everyone might test their seeds are functioning correctly immediately after upgrading.