### PR TITLE
Update installation.md

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -20,7 +20,8 @@ However, if you are not using Homestead, you will need to make sure your server 
 - OpenSSL PHP Extension
 - PDO PHP Extension
 - Mbstring PHP Extension
-- Tokenizer PHP Extension
+- Zip PHP Extension
+- Dom PHP Extension
 </div>
 
 <a name="installing-laravel"></a>


### PR DESCRIPTION
I have added the missing extensions Dom and Zip to the list.
I removed Tokenizer from the list, since it is enabled by default since PHP 4.3. The reason is because it is not an extension that you can install, but a compile-time option (that is enabled by default.)