### PR TITLE
Add a note saying the switch to Paginator::render() is not required in 5.2

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -693,6 +693,8 @@ If your application code was injecting `Illuminate\Cache\CacheManager` to get a 
 
 Replace any calls to `$paginator->links()` with `$paginator->render()`.
 
+> **Note:** This is not required if you upgrade straight to 5.2 as the `links()` method is now available as an alias to `render()`
+
 Replace any calls to `$paginator->getFrom()` and `$paginator->getTo()` with `$paginator->firstItem()` and `$paginator->lastItem()` respectively.
 
 Remove the "get" prefix from calls to `$paginator->getPerPage()`, `$paginator->getCurrentPage()`, `$paginator->getLastPage()` and `$paginator->getTotal()` (e.g. `$paginator->perPage()`).


### PR DESCRIPTION
I was surprised when my app worked without doing this modification. Then I found that it has been added recently: https://github.com/laravel/framework/commit/ad6e7c20df84d3be5b2ea2d360cd61d36377ff33

As the 5.2 pagination documentation uses this newly created alias, I think it is officially safe to keep using it.

I'm not sure how to formulate it in the docs but as there is no Issues page I did my best to change this myself =|