### PR TITLE
add inconsistency note regarding resource route naming inside route groups

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -121,6 +121,8 @@ If you are using [route groups](#route-groups), you may specify an `as` keyword 
             // Route named "admin::dashboard"
         }]);
     });
+    
+> **Note:** When using [RESTful Resource Controllers](/docs/{{version}}/controllers#restful-resource-controllers) inside [route groups](#route-groups), both the `as` and `prefix` keyword in the route group attribute array are considered for the route names of the REST actions belonging to the RESTful resource.
 
 #### Generating URLs To Named Routes
 


### PR DESCRIPTION
Related laravel/framework#11657

[Fixed in 5.3](https://github.com/laravel/framework/pull/11679#issuecomment-169045871)

Don't know whether this is a good spot to note that inconsistency.