### PR TITLE
Use full name for Task and TaskPolicy in AuthServiceProvider policies.

### DIFF
--- a/quickstart-intermediate.md
+++ b/quickstart-intermediate.md
@@ -734,7 +734,7 @@ Finally, we need to associate our `Task` model with our `TaskPolicy`. We can do 
      * @var array
      */
     protected $policies = [
-        Task::class => TaskPolicy::class,
+        'App\Task' => 'App\Policies\TaskPolicy',
     ];
 
 


### PR DESCRIPTION
This avoids having to add 'use' statements for them both (which is not in the documentation either).

See https://github.com/laravel/quickstart-intermediate/issues/10