### PR TITLE
Fix "Exception Handling" instructions

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -185,7 +185,7 @@ Your `App\Exceptions\Handler` class' `$dontReport` property should be updated to
     use Illuminate\Auth\Access\AuthorizationException;
     use Illuminate\Database\Eloquent\ModelNotFoundException;
     use Symfony\Component\HttpKernel\Exception\HttpException;
-    use Illuminate\Foundation\Validation\ValidationException;
+    use Illuminate\Validation\ValidationException;
 
     /**
      * A list of the exception types that should not be reported.


### PR DESCRIPTION
Change "Illuminate\Foundation\Validation\ValidationException" as it's deprecated since 5.2.7