### PR TITLE
Update for QueryExecuted change

### DIFF
--- a/database.md
+++ b/database.md
@@ -140,8 +140,10 @@ If you would like to receive each SQL query executed by your application, you ma
          */
         public function boot()
         {
-            DB::listen(function($sql, $bindings, $time) {
-                //
+            DB::listen(function($query) {
+                // $query->sql
+                // $query->bindings
+                // $query->time
             });
         }
 


### PR DESCRIPTION
It looks like when you call `DB::listen()`, you no longer receive multiple parameters for the `$sql` and `$bindings`. Instead, you get a `QueryExecuted` DTO. This PR updates the docs to reflect that.