### PR TITLE
Remove legacy providers from compile config in upgrade

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -93,6 +93,15 @@ If you are using the `config:cache` command during deployment, you **must** make
 
 If you are calling `env` from within your application, it is strongly recommended you add proper configuration values to your configuration files and call `env` from that location instead, allowing you to convert your `env` calls to `config` calls.
 
+#### Compliled Classes
+
+If present, remove the following lines from `config/compile.php` in the `files` array:
+
+    realpath(__DIR__.'/../app/Providers/BusServiceProvider.php'),
+    realpath(__DIR__.'/../app/Providers/ConfigServiceProvider.php'),
+
+Not doing so can trigger an error when running `php artisan optimize` if the service providers listed here do not exist.
+
 ### CSRF Verification
 
 CSRF verification is no longer automatically performed when running unit tests. This is unlikely to affect your application.


### PR DESCRIPTION
`php artisan optimize` was erroring with :

>[ErrorException]
>php_strip_whitespace(/path/to/project): failed to open stream: No such file or directory

due to legacy service providers remaining in the `config/compile.php` file. Removing the listing solved the issue.