### PR TITLE
Updated call to make:controller in quickstart-intermediate.md

### DIFF
--- a/quickstart-intermediate.md
+++ b/quickstart-intermediate.md
@@ -256,7 +256,7 @@ Now, all we have to do is add the authentication routes to our routes file. We c
 
 Since we know we're going to need to retrieve and store tasks, let's create a `TaskController` using the Artisan CLI, which will place the new controller in the `app/Http/Controllers` directory:
 
-	php artisan make:controller TaskController --plain
+	php artisan make:controller TaskController
 
 Now that the controller has been generated, let's go ahead and stub out some routes in our `app/Http/routes.php` file to point to the controller:
 


### PR DESCRIPTION
Removed `plain` argument which has been removed in v5.2 and replaced with the `resource` argument (which defaults to plain: https://github.com/laravel/framework/blob/7f62d81acb2001faafb21a32544464ebfc92476c/src/Illuminate/Routing/Console/ControllerMakeCommand.php#L42)

Code in the tutorial as it is right now returns an error: `The "--plain" option does not exist.`