### PR TITLE
Add references to JSX transformation in elixir docs

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -198,7 +198,7 @@ elixir(function(mix) {
 <a name="browserify"></a>
 ### Browserify
 
-Elixir also ships with a `browserify` method, which gives you all the benefits of requiring modules in the browser and using ECMAScript 6.
+Elixir also ships with a `browserify` method, which gives you all the benefits of requiring modules in the browser and using ECMAScript 6 and JSX.
 
 This task assumes that your scripts are stored in `resources/assets/js` and will place the resulting file in `public/js/main.js`:
 
@@ -226,13 +226,14 @@ elixir(function(mix) {
 <a name="babel"></a>
 ### Babel
 
-The `babel` method may be used to compile [ECMAScript 6 and 7](https://babeljs.io/docs/learn-es2015/) into plain JavaScript. This function accepts an array of files relative to the `resources/assets/js` directory, and generates a single `all.js` file in the `public/js` directory:
+The `babel` method may be used to compile [ECMAScript 6 and 7](https://babeljs.io/docs/learn-es2015/) and [JSX](https://facebook.github.io/react/docs/jsx-in-depth.html) into plain JavaScript. This function accepts an array of files relative to the `resources/assets/js` directory, and generates a single `all.js` file in the `public/js` directory:
 
 ```javascript
 elixir(function(mix) {
     mix.babel([
         'order.js',
-        'product.js'
+        'product.js',
+        'react-component.jsx'
     ]);
 });
 ```


### PR DESCRIPTION
As well as ES2015, by default, Babel 5.x runs with the react (JSX) transformation enabled. Elixir currently uses babel-core 5, but Babel 6 removes all default presets, which might cause some confusion as some developers might expect from looking at the current Babel documentation for the react preset to not be included by default.