### PR TITLE
Remove invalid method

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -154,7 +154,7 @@ If your form contains `file` input types, you may attach files to the form using
     public function testPhotoCanBeUploaded()
     {
         $this->visit('/upload')
-             ->name('File Name', 'name')
+             ->type('File Name', 'name')
              ->attach($absolutePathToFile, 'photo')
              ->press('Upload')
              ->see('Upload Successful!');


### PR DESCRIPTION
The name method does not exist. To type text into a form input field, the method is _type_.