### PR TITLE
Mention about the rules order

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -112,7 +112,7 @@ Sometimes you may wish to stop running validation rules on an attribute after th
         'body' => 'required',
     ]);
 
-In this example, if the `required` rule on the `title` attribute fails, the `unique` rule will not be checked.
+In this example, if the `required` rule on the `title` attribute fails, the `unique` rule will not be checked. Rules will be validated in the order that you assign the rules.
 
 #### A Note On Nested Attributes
 


### PR DESCRIPTION
Mentioning that the rules will be validated in the order that the user assign the rules. This will help them to assign the rules in proper order to avoid errors. If the order is wrong even after the `bail` rule is used, user will not get any advantage.