### PR TITLE
Fix language files override path

### DIFF
--- a/localization.md
+++ b/localization.md
@@ -82,6 +82,6 @@ Since the Laravel translator is powered by the Symfony Translation component, yo
 <a name="overriding-vendor-language-files"></a>
 ## Overriding Vendor Language Files
 
-Some packages may ship with their own language files. Instead of hacking the package's core files to tweak these lines, you may override them by placing your own files in the `resources/lang/vendor/{package}/{locale}` directory.
+Some packages may ship with their own language files. Instead of hacking the package's core files to tweak these lines, you may override them by placing your own files in the `resources/lang/vendor/{vendor}/{package}/{locale}` directory.
 
-So, for example, if you need to override the English language lines in `messages.php` for a package named `skyrim/hearthfire`, you would place a language file at: `resources/lang/vendor/hearthfire/en/messages.php`. In this file you should only define the language lines you wish to override. Any language lines you don't override will still be loaded from the package's original language files.
+So, for example, if you need to override the English language lines in `messages.php` for a package named `skyrim/hearthfire`, you would place a language file at: `resources/lang/vendor/skyrim/hearthfire/en/messages.php`. In this file you should only define the language lines you wish to override. Any language lines you don't override will still be loaded from the package's original language files.


### PR DESCRIPTION
- Add missing {vendor} segment