### PR TITLE
Change hard-coded class FQNs to class constants

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -55,7 +55,7 @@ A one-to-one relationship is a very basic relation. For example, a `User` model 
          */
         public function phone()
         {
-            return $this->hasOne('App\Phone');
+            return $this->hasOne(Phone::class);
         }
     }
 
@@ -65,11 +65,11 @@ The first argument passed to the `hasOne` method is the name of the related mode
 
 Eloquent assumes the foreign key of the relationship based on the model name. In this case, the `Phone` model is automatically assumed to have a `user_id` foreign key. If you wish to override this convention, you may pass a second argument to the `hasOne` method:
 
-    return $this->hasOne('App\Phone', 'foreign_key');
+    return $this->hasOne(Phone::class, 'foreign_key');
 
 Additionally, Eloquent assumes that the foreign key should have a value matching the `id` column of the parent. In other words, Eloquent will look for the value of the user's `id` column in the `user_id` column of the `Phone` record. If you would like the relationship to use a value other than `id`, you may pass a third argument to the `hasOne` method specifying your custom key:
 
-    return $this->hasOne('App\Phone', 'foreign_key', 'local_key');
+    return $this->hasOne(Phone::class, 'foreign_key', 'local_key');
 
 #### Defining The Inverse Of The Relation
 
@@ -88,7 +88,7 @@ So, we can access the `Phone` model from our `User`. Now, let's define a relatio
          */
         public function user()
         {
-            return $this->belongsTo('App\User');
+            return $this->belongsTo(User::class);
         }
     }
 
@@ -99,7 +99,7 @@ In the example above, Eloquent will try to match the `user_id` from the `Phone` 
      */
     public function user()
     {
-        return $this->belongsTo('App\User', 'foreign_key');
+        return $this->belongsTo(User::class, 'foreign_key');
     }
 
 If your parent model does not use `id` as its primary key, or you wish to join the child model to a different column, you may pass a third argument to the `belongsTo` method specifying your parent table's custom key:
@@ -109,7 +109,7 @@ If your parent model does not use `id` as its primary key, or you wish to join t
      */
     public function user()
     {
-        return $this->belongsTo('App\User', 'foreign_key', 'other_key');
+        return $this->belongsTo(User::class, 'foreign_key', 'other_key');
     }
 
 <a name="one-to-many"></a>
@@ -130,7 +130,7 @@ A "one-to-many" relationship is used to define relationships where a single mode
          */
         public function comments()
         {
-            return $this->hasMany('App\Comment');
+            return $this->hasMany(Comment::class);
         }
     }
 
@@ -150,9 +150,9 @@ Of course, since all relationships also serve as query builders, you can add fur
 
 Like the `hasOne` method, you may also override the foreign and local keys by passing additional arguments to the `hasMany` method:
 
-    return $this->hasMany('App\Comment', 'foreign_key');
+    return $this->hasMany(Comment::class, 'foreign_key');
 
-    return $this->hasMany('App\Comment', 'foreign_key', 'local_key');
+    return $this->hasMany(Comment::class, 'foreign_key', 'local_key');
 
 #### Defining The Inverse Of The Relation
 
@@ -171,7 +171,7 @@ Now that we can access all of a post's comments, let's define a relationship to 
          */
         public function post()
         {
-            return $this->belongsTo('App\Post');
+            return $this->belongsTo(Post::class);
         }
     }
 
@@ -188,7 +188,7 @@ In the example above, Eloquent will try to match the `post_id` from the `Comment
      */
     public function post()
     {
-        return $this->belongsTo('App\Post', 'foreign_key');
+        return $this->belongsTo(Post::class, 'foreign_key');
     }
 
 If your parent model does not use `id` as its primary key, or you wish to join the child model to a different column, you may pass a third argument to the `belongsTo` method specifying your parent table's custom key:
@@ -198,7 +198,7 @@ If your parent model does not use `id` as its primary key, or you wish to join t
      */
     public function post()
     {
-        return $this->belongsTo('App\Post', 'foreign_key', 'other_key');
+        return $this->belongsTo(Post::class, 'foreign_key', 'other_key');
     }
 
 <a name="many-to-many"></a>
@@ -221,7 +221,7 @@ Many-to-many relationships are defined by writing a method that calls the `belon
          */
         public function roles()
         {
-            return $this->belongsToMany('App\Role');
+            return $this->belongsToMany(Role::class);
         }
     }
 
@@ -239,11 +239,11 @@ Of course, like all other relationship types, you may call the `roles` method to
 
 As mentioned previously, to determine the table name of the relationship's joining table, Eloquent will join the two related model names in alphabetical order. However, you are free to override this convention. You may do so by passing a second argument to the `belongsToMany` method:
 
-    return $this->belongsToMany('App\Role', 'user_roles');
+    return $this->belongsToMany(Role::class, 'user_roles');
 
 In addition to customizing the name of the joining table, you may also customize the column names of the keys on the table by passing additional arguments to the `belongsToMany` method. The third argument is the foreign key name of the model on which you are defining the relationship, while the fourth argument is the foreign key name of the model that you are joining to:
 
-    return $this->belongsToMany('App\Role', 'user_roles', 'user_id', 'role_id');
+    return $this->belongsToMany(Role::class, 'user_roles', 'user_id', 'role_id');
 
 #### Defining The Inverse Of The Relationship
 
@@ -262,7 +262,7 @@ To define the inverse of a many-to-many relationship, you simply place another c
          */
         public function users()
         {
-            return $this->belongsToMany('App\User');
+            return $this->belongsToMany(User::class);
         }
     }
 
@@ -282,11 +282,11 @@ Notice that each `Role` model we retrieve is automatically assigned a `pivot` at
 
 By default, only the model keys will be present on the `pivot` object. If your pivot table contains extra attributes, you must specify them when defining the relationship:
 
-    return $this->belongsToMany('App\Role')->withPivot('column1', 'column2');
+    return $this->belongsToMany(Role::class)->withPivot('column1', 'column2');
 
 If you want your pivot table to have automatically maintained `created_at` and `updated_at` timestamps, use the `withTimestamps` method on the relationship definition:
 
-    return $this->belongsToMany('App\Role')->withTimestamps();
+    return $this->belongsToMany(Role::class)->withTimestamps();
 
 <a name="has-many-through"></a>
 ### Has Many Through
@@ -324,7 +324,7 @@ Now that we have examined the table structure for the relationship, let's define
          */
         public function posts()
         {
-            return $this->hasManyThrough('App\Post', 'App\User');
+            return $this->hasManyThrough(Post::class, User::class);
         }
     }
 
@@ -336,7 +336,7 @@ Typical Eloquent foreign key conventions will be used when performing the relati
     {
         public function posts()
         {
-            return $this->hasManyThrough('App\Post', 'App\User', 'country_id', 'user_id');
+            return $this->hasManyThrough(Post::class, User::class, 'country_id', 'user_id');
         }
     }
 
@@ -392,7 +392,7 @@ Next, let's examine the model definitions needed to build this relationship:
          */
         public function likes()
         {
-            return $this->morphMany('App\Like', 'likeable');
+            return $this->morphMany(Like::class, 'likeable');
         }
     }
 
@@ -403,7 +403,7 @@ Next, let's examine the model definitions needed to build this relationship:
          */
         public function likes()
         {
-            return $this->morphMany('App\Like', 'likeable');
+            return $this->morphMany(Like::class, 'likeable');
         }
     }
 
@@ -466,7 +466,7 @@ Next, we're ready to define the relationships on the model. The `Post` and `Vide
          */
         public function tags()
         {
-            return $this->morphToMany('App\Tag', 'taggable');
+            return $this->morphToMany(Tag::class, 'taggable');
         }
     }
 
@@ -487,7 +487,7 @@ Next, on the `Tag` model, you should define a method for each of its related mod
          */
         public function posts()
         {
-            return $this->morphedByMany('App\Post', 'taggable');
+            return $this->morphedByMany(Post::class, 'taggable');
         }
 
         /**
@@ -495,7 +495,7 @@ Next, on the `Tag` model, you should define a method for each of its related mod
          */
         public function videos()
         {
-            return $this->morphedByMany('App\Video', 'taggable');
+            return $this->morphedByMany(Video::class, 'taggable');
         }
     }
 
@@ -537,7 +537,7 @@ For example, imagine a blog system in which a `User` model has many associated `
          */
         public function posts()
         {
-            return $this->hasMany('App\Post');
+            return $this->hasMany(Post::class);
         }
     }
 
@@ -603,7 +603,7 @@ When accessing Eloquent relationships as properties, the relationship data is "l
          */
         public function author()
         {
-            return $this->belongsTo('App\Author');
+            return $this->belongsTo(Author::class);
         }
     }
 
@@ -802,7 +802,7 @@ When a model `belongsTo` or `belongsToMany` another model, such as a `Comment` w
          */
         public function post()
         {
-            return $this->belongsTo('App\Post');
+            return $this->belongsTo(Post::class);
         }
     }
 


### PR DESCRIPTION
Since Laravel has required PHP 5.5 for a while now, and the move to class constants has been done in most other places in the documentation, this brings the Eloquent relationships examples up to speed.