### PR TITLE
Fix second parameter in array_has() usage example

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -242,7 +242,7 @@ The `array_has` function checks that a given item exists in an array using "dot"
 
     $array = ['products' => ['desk' => ['price' => 100]]];
 
-    $hasDesk = array_has($array, ['products.desk']);
+    $hasDesk = array_has($array, 'products.desk');
 
     // true
 


### PR DESCRIPTION
Arr::has() accepts a string $key as its second parameter. With the original docs example I was misled into thinking the array_has() helper would accept an array of multiple keys to check. That would be pretty cool though.