### PR TITLE
Different path for 'laravel' executable on Windows.

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -34,7 +34,7 @@ First, download the Laravel installer using Composer:
 
     composer global require "laravel/installer"
 
-Make sure to place the `~/.composer/vendor/bin` directory in your PATH so the `laravel` executable can be located by your system.
+Make sure to place the `~/.composer/vendor/bin` directory in your PATH so the `laravel` executable can be located by your system.  For Windows check '~/AppData/Roaming/Composer/vendor/bin' for the 'laravel' executable.
 
 Once installed, the `laravel new` command will create a fresh Laravel installation in the directory you specify. For instance, `laravel new blog` will create a directory named `blog` containing a fresh Laravel installation with all of Laravel's dependencies already installed. This method of installation is much faster than installing via Composer:
 

--- a/installation.md
+++ b/installation.md
@@ -34,7 +34,7 @@ First, download the Laravel installer using Composer:
 
     composer global require "laravel/installer"
 
-Make sure to place the `~/.composer/vendor/bin` directory in your PATH so the `laravel` executable can be located by your system.  For Windows check '~/AppData/Roaming/Composer/vendor/bin' for the 'laravel' executable.
+Make sure to place the `~/.composer/vendor/bin` directory in your PATH so the `laravel` executable can be located by your system. For Windows check '~/AppData/Roaming/Composer/vendor/bin' for the 'laravel' executable.
 
 Once installed, the `laravel new` command will create a fresh Laravel installation in the directory you specify. For instance, `laravel new blog` will create a directory named `blog` containing a fresh Laravel installation with all of Laravel's dependencies already installed. This method of installation is much faster than installing via Composer:
 


### PR DESCRIPTION
People following the docs to the letter on Windows machines will have trouble trying to do the installation via the Laravel Installer.