### PR TITLE
Update queue docs - Remove unused TOC link

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -6,7 +6,6 @@
     - [Job Class Structure](#job-class-structure)
 - [Pushing Jobs Onto The Queue](#pushing-jobs-onto-the-queue)
     - [Delayed Jobs](#delayed-jobs)
-    - [Dispatching Jobs From Requests](#dispatching-jobs-from-requests)
     - [Job Events](#job-events)
 - [Running The Queue Listener](#running-the-queue-listener)
     - [Supervisor Configuration](#supervisor-configuration)


### PR DESCRIPTION
The documentation on dispatching jobs from requests was removed in commit https://github.com/laravel/docs/commit/e756d8e029f90984f34e887b097332ad74105dbb, but the table of contents link has remained.