### PR TITLE
Deprecated method 'lists', use 'pluck' instead

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -88,9 +88,9 @@ You may stop further chunks from being processed by returning `false` from the `
 
 #### Retrieving A List Of Column Values
 
-If you would like to retrieve an array containing the values of a single column, you may use the `lists` method. In this example, we'll retrieve an array of role titles:
+If you would like to retrieve an array containing the values of a single column, you may use the `pluck` method. In this example, we'll retrieve an array of role titles:
 
-    $titles = DB::table('roles')->lists('title');
+    $titles = DB::table('roles')->pluck('title');
 
     foreach ($titles as $title) {
         echo $title;
@@ -98,7 +98,7 @@ If you would like to retrieve an array containing the values of a single column,
 
  You may also specify a custom key column for the returned array:
 
-    $roles = DB::table('roles')->lists('title', 'name');
+    $roles = DB::table('roles')->pluck('title', 'name');
 
     foreach ($roles as $name => $title) {
         echo $title;


### PR DESCRIPTION
The method 'lists' is deprecated, promote the use of 'pluck'.