### PR TITLE
[5.0] Adjust install PHP version requirements

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -43,7 +43,7 @@ Laravel ships with scaffolding for user registration and authentication. If you 
 
 The Laravel framework has a few system requirements:
 
-- PHP >= 5.4
+- PHP >= 5.4, PHP < 7
 - Mcrypt PHP Extension
 - OpenSSL PHP Extension
 - Mbstring PHP Extension


### PR DESCRIPTION
Adjustment to exclude PHP 7 do to the psy version in 5.0 using libraries that aren't ready for PHP 7.
>"Cannot use PhpParser\Node\Scalar\String as String because 'String' is a special class name"