### PR TITLE
Update JSON post example to use `$this->json`

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -176,7 +176,7 @@ Laravel also provides several helpers for testing JSON APIs and their responses.
          */
         public function testBasicExample()
         {
-            $this->post('/user', ['name' => 'Sally'])
+            $this->json('POST', '/user', ['name' => 'Sally'])
                  ->seeJson([
                      'created' => true,
                  ]);
@@ -201,7 +201,7 @@ If you would like to verify that the given array is an **exact** match for the J
          */
         public function testBasicExample()
         {
-            $this->post('/user', ['name' => 'Sally'])
+            $this->json('POST', '/user', ['name' => 'Sally'])
                  ->seeJsonEquals([
                      'created' => true,
                  ]);


### PR DESCRIPTION
The current docs use `$this->post` to send a request to JSON APIs.
However, the `$this->post` method sends form encoded data.
While this works for APIs using `Request::get`, it breaks for APIs which rely on `Request::json`.

This PR updates the docs to use the `$this->json` method for testing JSON APIs.