### PR TITLE
Add note about reloading vagrant after .yaml change

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -111,6 +111,8 @@ You can make any Homestead site use [HHVM](http://hhvm.com) by setting the `hhvm
           to: /home/vagrant/Code/Laravel/public
           hhvm: true
 
+Note that whenever the `sites` property is altered it may be necessary to run `vagrant reload --provision` in order for the Homestead environment, or in particular the Nginx configuration file in `/etc/nginx/sites-enabled`, to be refreshed accordingly.
+
 #### The Hosts File
 
 You must add the "domains" for your Nginx sites to the `hosts` file on your machine. The `hosts` file will redirect requests for your Homestead sites into your Homestead machine. On Mac and Linux, this file is located at `/etc/hosts`. On Windows, it is located at `C:\Windows\System32\drivers\etc\hosts`. The lines you add to this file will look like the following:


### PR DESCRIPTION
I installed vagrant/virtualbox and followed the instructions to setup Homestead without any issues. Then proceeded to follow the Beginner Task List (https://laravel.com/docs/5.2/quickstart). I utilized composer to create the 'quickstart' directory as in the insturctions, completed the tutorial and navigated my browser to 'homestead.app' only to be presented with "No input file specified".

After reading through this forum post, in particular the answer by 'srhyne':
http://laravel.io/forum/06-04-2014-no-input-file-specified-using-homestead

I checked the /etc/nginx/sites-enabled/domain file only to see that the server.root path points to nonexistant 'Laravel' directory. I proceeded to change the ~/.homestead/Homestead.yaml to point to /home/vagrant/Code/quickstart/public and ran vagrant reload with no luck. The changes only took effect when ran vagrant reload --provision the changes took effect in the Ngix domain configuration and I was able to access the quickstart app via homestead.app in my browser.

