### PR TITLE
Change `artisan key:generate` to `php artisan key:generate`

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -57,7 +57,7 @@ After installing Laravel, you may need to configure some permissions. Directorie
 
 #### Application Key
 
-The next thing you should do after installing Laravel is set your application key to a random string. If you installed Laravel via Composer or the Laravel installer, this key has already been set for you by the `artisan key:generate` command. Typically, this string should be 32 characters long. The key can be set in the `.env` environment file. If you have not renamed the `.env.example` file to `.env`, you should do that now. **If the application key is not set, your user sessions and other encrypted data will not be secure!**
+The next thing you should do after installing Laravel is set your application key to a random string. If you installed Laravel via Composer or the Laravel installer, this key has already been set for you by the `php artisan key:generate` command. Typically, this string should be 32 characters long. The key can be set in the `.env` environment file. If you have not renamed the `.env.example` file to `.env`, you should do that now. **If the application key is not set, your user sessions and other encrypted data will not be secure!**
 
 #### Additional Configuration
 


### PR DESCRIPTION
Made this change so newer users understand that they need to use the "php" command in front of "artisan key:generate"