### PR TITLE
Add note about retrieving JSON input

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -169,6 +169,8 @@ You may also access user input using dynamic properties on the `Illuminate\Http\
 
 When using dynamic properties, Laravel will first look for the parameter's value in the request payload and then in the route parameters.
 
+> **Note:** Some JavaScript libraries may send input to the application as JSON. If the request's `Content-Type` header is set properly, you may access this data via the request instance methods as normal.
+
 <a name="old-input"></a>
 ### Old Input
 


### PR DESCRIPTION
Newcomers may not know that Laravel automatically maps JSON data to the request input, especially if they are just sending data with something like jQuery and not setting their Content-Type header.

There was a note about accepting JSON input in the 4.2 docs, which is where I borrowed the language from.

At the very least, this will be a hint for anyone who comes to the Requests page of the docs and does a cmd+F for 'json'.