### PR TITLE
Event implements a mediator pattern, not an observer pattern

### DIFF
--- a/events.md
+++ b/events.md
@@ -17,7 +17,7 @@
 <a name="introduction"></a>
 ## Introduction
 
-Laravel's events provides a simple observer implementation, allowing you to subscribe and listen for events in your application. Event classes are typically stored in the `app/Events` directory, while their listeners are stored in `app/Listeners`.
+Laravel's events provides a simple mediator implementation, allowing you to subscribe and listen for events in your application. Event classes are typically stored in the `app/Events` directory, while their listeners are stored in `app/Listeners`.
 
 <a name="registering-events-and-listeners"></a>
 ## Registering Events / Listeners


### PR DESCRIPTION
I always thought Laravel's event system is based on a mediator implementation, but the doc says it is an observer implementation. As the Laravel acts as a central point for all the listeners, isn't it acting as a mediator?