### PR TITLE
Adding a paragraph on string capitalisation in language parameter name

### DIFF
--- a/localization.md
+++ b/localization.md
@@ -62,7 +62,13 @@ If you wish, you may define place-holders in your language lines. All place-hold
 
 To replace the place-holders when retrieving a language line, pass an array of replacements as the second argument to the `trans` function:
 
-    echo trans('messages.welcome', ['name' => 'Dayle']);
+    echo trans('messages.welcome', ['name' => 'dayle']);
+    
+If your place-holder is in all caps, or has its first letter capitalised, the value will be capitalised correspondingly:
+
+    'welcome' => 'Welcome, :NAME', // Welcome, DAYLE
+    'goodbye' => 'Goodbye, :Name', // Goodbye, Dayle
+    
 
 <a name="pluralization"></a>
 ### Pluralization


### PR DESCRIPTION
I got caught out by a new addition in 5.2; translation keys will be run through `Str::upper` and `Str::ucfirst` and replaced with the correspondingly capitalised value.

See https://github.com/laravel/framework/commit/1bb387927591f28fcac44ab8c0d949ccb107409d

Cool addition, but so far undocumented. No longer!