### PR TITLE
Add suggestion for `dump` method

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -754,7 +754,7 @@ The `dd` function dumps the given variable and ends execution of the script:
 
     dd($value);
     
-If you do not want to halt the execution of your script, try use the `dump` function included from Symfony instead. 
+If you do not want to halt the execution of your script, try using the `dump` function included with Symfony instead.
 
 
 <a name="method-dispatch"></a>

--- a/helpers.md
+++ b/helpers.md
@@ -753,6 +753,9 @@ The `csrf_token` function retrieves the value of the current CSRF token:
 The `dd` function dumps the given variable and ends execution of the script:
 
     dd($value);
+    
+If you do not want to halt the execution of your script, try use the `dump` function included from Symfony instead. 
+
 
 <a name="method-dispatch"></a>
 #### `dispatch()` {#collection-method}


### PR DESCRIPTION
Many people see this page and go looking for a ```dd``` method that does not halt the execution of the script.

I'm not sure if here is the best place to put it, but for lack of a better place, it sure would save some time for those in the same situation as myself.