### PR TITLE
Restore description of queue:work command

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -342,6 +342,12 @@ In addition, you may specify the number of seconds to wait before polling for ne
 
 Note that the queue only "sleeps" if no jobs are on the queue. If more jobs are available, the queue will continue to work them without sleeping.
 
+#### Processing The First Job On The Queue
+
+To process only the first job on the queue, you may use the `queue:work` command:
+
+	php artisan queue:work
+
 <a name="supervisor-configuration"></a>
 ### Supervisor Configuration
 


### PR DESCRIPTION
From 5.0 to 5.1 the description of the queue:work command was removed. I'm not sure whether this was intentional, since it was part of a much larger batch of edits (059a01b65089819c4d81b0378be694e2d5a1bfdd).

Right now if you read through the queue docs, it's not really clear what difference is between `queue:listen` and `queue:work` is - there is no description of the latter.