### PR TITLE
[5.2] Blade - Missing parens in string interpolation

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -255,7 +255,7 @@ The following example creates a `@datetime($var)` directive which formats a give
         public function boot()
         {
             Blade::directive('datetime', function($expression) {
-                return "<?php echo with{$expression}->format('m/d/Y H:i'); ?>";
+                return "<?php echo with({$expression})->format('m/d/Y H:i'); ?>";
             });
         }
 


### PR DESCRIPTION
Given that `with` is a helper function, if `$foo = 44`, `"with{$foo}"` is
`"with44"`, not `"with(44)"`.