### PR TITLE
Noting issue with modifying columns where an enum is present in the table

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -256,7 +256,7 @@ We could also modify a column to be nullable:
         $table->string('name', 50)->nullable()->change();
     });
 
-> **Note:** Modifying any column in a table with an `enum` column is not currently supported.
+> **Note:** Modifying any column in a table that also has a column of type `enum` is not currently supported.
 
 <a name="renaming-columns"></a>
 #### Renaming Columns
@@ -267,7 +267,7 @@ To rename a column, you may use the `renameColumn` method on the Schema builder.
         $table->renameColumn('from', 'to');
     });
 
-> **Note:** Renaming any column in a table with an `enum` column is not currently supported.
+> **Note:** Renaming any column in a table that also has a column of type `enum` is not currently supported.
 
 <a name="dropping-columns"></a>
 ### Dropping Columns

--- a/migrations.md
+++ b/migrations.md
@@ -256,6 +256,8 @@ We could also modify a column to be nullable:
         $table->string('name', 50)->nullable()->change();
     });
 
+> **Note:** Modifying any column in a table with an `enum` column is not currently supported.
+
 <a name="renaming-columns"></a>
 #### Renaming Columns
 
@@ -265,7 +267,7 @@ To rename a column, you may use the `renameColumn` method on the Schema builder.
         $table->renameColumn('from', 'to');
     });
 
-> **Note:** Renaming columns in a table with a `enum` column is not currently supported.
+> **Note:** Renaming any column in a table with an `enum` column is not currently supported.
 
 <a name="dropping-columns"></a>
 ### Dropping Columns


### PR DESCRIPTION
### Problem

When a database migration is being run on a table that contains an `enum` data type, and that migration involves modifying a column on the table, the following error occurs while running `php artisan migrate`:

```
[Doctrine\DBAL\DBALException]                                                                    
  Unknown database type enum requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it.
```

The error occurs because when a column is being modified with `->change()`, Doctrine's DBAL package iterates through the columns in the table in order to perform a diff for generating the appropriate `ALTER` statements. The package maps column data types (e.g. MySQL types) to PHP data types, but `enum` does not have a proper mapping and so it fails. Particularly, the [`_getPortableTableColumnDefinition()`](https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php#L105) method is problematic.

Doctrine has made it clear they will not be supporting enums: https://github.com/doctrine/dbal/pull/2304

### About the change

Thus, this PR adds documentation making it more clear that columns on tables with an `enum` column cannot be modified. Even if the new migration does not touch the `enum` column, any other columns in that table are unable to be modified. New columns can be added, however, as long as `->change()` is not invoked. This note is particularly important because if an enum was used, old migrations must be altered to turn the `enum()` into `string()`, as well as manually changing from `ENUM` to `VARCHAR` in the table via SQL, all before any changes can be made on the table in subsequent migrations.

I'm open to any wording adjustments that will further clarify the point.