### PR TITLE
Improve browserify example

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -213,8 +213,9 @@ elixir(function(mix) {
     mix.browserify('main.js');
 });
 
+// Specifying a specific output filename...
 elixir(function(mix) {
-    mix.browserify('main.js', 'public/assets/js/bundle.js');
+    mix.browserify('main.js', 'public/javascripts/script.js');
 });
 ```
 


### PR DESCRIPTION
This change seems trivial and useless, let me explain.

The *path* in the example now following the same naming convention as the CSS examples above, and it uses an redundant yet reasonable *path*, to avoid the confusion and misread with src path `resources/assets/js`. 