### PR TITLE
Added morphMap details

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -429,19 +429,19 @@ The `likeable` relation on the `Like` model will return either a `Post` or `Comm
 
 By default, Laravel will use the fully qualified class name to store the type of the related model. For instance, given the example above where a `Like` may belong to a `Post` or a `Comment`, the default `likable_type` would be either `App\Post` or `App\Comment`, respectively. However, you may wish to decouple your database from your application's internal structure. In that case, you may define a relationship "morph map" to instruct Eloquent to use the table name associated with each model instead of the class name:
 
-    Relation::morphMap([
+    Illuminate\Database\Eloquent\Relations\Relation::morphMap([
         App\Post::class,
         App\Comment::class,
     ]);
 
 Or, you may specify a custom string to associate with each model:
 
-    Relation::morphMap([
+    Illuminate\Database\Eloquent\Relations\Relation::morphMap([
         'posts' => App\Post::class,
         'likes' => App\Like::class,
     ]);
 
-You may register the `morphMap` in your `AppServiceProvider` or create a separate service provider if you wish.
+You may register the `morphMap` in the `boot` function of your `AppServiceProvider` or create a separate service provider if you wish.
 
 <a name="many-to-many-polymorphic-relations"></a>
 ### Many To Many Polymorphic Relations


### PR DESCRIPTION
Added that the morphMap should be added in the boot function of a service provider, and added the FQCN of the Relation class used to the example code, so that users are not confused about what/where the namespace of the Relation class.