### PR TITLE
Remove optional year field from Cron example

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -75,7 +75,7 @@ Of course, there are a variety of schedules you may assign to your task:
 
 Method  | Description
 ------------- | -------------
-`->cron('* * * * * *');`  |  Run the task on a custom Cron schedule
+`->cron('* * * * *');`  |  Run the task on a custom Cron schedule
 `->everyMinute();`  |  Run the task every minute
 `->everyFiveMinutes();`  |  Run the task every five minutes
 `->everyTenMinutes();`  |  Run the task every ten minutes


### PR DESCRIPTION
Did not understand what that 6th asterisk was. It's an optional year field added by the [Cron Expression](https://github.com/mtdowling/cron-expression) library.

I suggest removing it, as it is non-standard Cron (therefore confusing) and seldom useful.