### PR TITLE
added psr-http-message-bridge component requirement

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -17,7 +17,8 @@ Laravel provides a clean, simple API over the popular [SwiftMailer](http://swift
 
 The API based drivers such as Mailgun and Mandrill are often simpler and faster than SMTP servers. All of the API drivers require that the Guzzle HTTP library be installed for your application. You may install Guzzle to your project by adding the following line to your `composer.json` file:
 
-    "guzzlehttp/guzzle": "~5.3|~6.0"
+    "guzzlehttp/guzzle": "~5.3|~6.0",
+    "symfony/psr-http-message-bridge": "~0.2"
 
 #### Mailgun Driver
 


### PR DESCRIPTION
This is remedy for

```bash
FatalThrowableError in Router.php line 1085:
Fatal error: Class 'Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory' not found
```

This happened, when I send an email using mailgun driver. After some research, I found that the required Class was not included out of the box. 

As you see in diff, what I did was just add a line in mail.md

```bash
"symfony/psr-http-message-bridge": "~0.2"
```

I'm using a framework version 5.2.22. Thanks.