### PR TITLE
Add a link to Contracts in documentation menu

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -23,6 +23,7 @@
     - [Application Structure](/docs/{{version}}/structure)
     - [Service Providers](/docs/{{version}}/providers)
     - [Service Container](/docs/{{version}}/container)
+    - [Contracts](/docs/{{version}}/contracts)
     - [Facades](/docs/{{version}}/facades)
 - Services
     - [Authentication](/docs/{{version}}/authentication)


### PR DESCRIPTION
The link to the documentation on Contracts was missing from the main menu. The link has been added under Architecture Foundations between Service Container and Facades.