### PR TITLE
Add server docs

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -8,7 +8,7 @@
 - [Unions](#unions)
 - [Where Clauses](#where-clauses)
     - [Advanced Where Clauses](#advanced-where-clauses)
-        - [JSON Where Clause](#json-where-clause)
+    - [JSON Where Clauses](#json-where-clauses)
 - [Ordering, Grouping, Limit, & Offset](#ordering-grouping-limit-and-offset)
 - [Inserts](#inserts)
 - [Updates](#updates)
@@ -240,30 +240,6 @@ You may also pass an array of conditions to the `where` function:
         ['subscribed','<>','1'],
     ])->get();
 
-<a name="json-where-clause"></a>
-##### JSON where clause (5.2.23+)
-
-Let's say you have a `users` table with a `details` column of type `JSON`, the column has the following value:
-
-    {
-        "title": "Mrs.",
-        "language": "en",
-        "favourites": {
-            "food": "burger",
-            "drink": "tea"
-        }
-    }
-
-To get JSON values, you can do this:
-
-    $users = DB::table('users')
-                    ->where('datails->language', 'en')
-                    ->get();
-
-    $users = DB::table('users')
-                    ->where('datails->favourites->food', 'burger')
-                    ->get();
-
 #### Or Statements
 
 You may chain where constraints together, as well as add `or` clauses to the query. The `orWhere` method accepts the same arguments as the `where` method:
@@ -355,6 +331,19 @@ The query above will produce the following SQL:
     where exists (
         select 1 from orders where orders.user_id = users.id
     )
+
+<a name="json-where-clauses"></a>
+## JSON Where Clauses
+
+Laravel supports querying JSON column types on databases that provide support for JSON column types. Currently, this includes MySQL 5.7 and Postgres. To query a JSON column, use the `->` operator:
+
+    $users = DB::table('users')
+                    ->where('options->language', 'en')
+                    ->get();
+
+    $users = DB::table('users')
+                    ->where('preferences->dining->meal', 'salad')
+                    ->get();
 
 <a name="ordering-grouping-limit-and-offset"></a>
 ## Ordering, Grouping, Limit, & Offset

--- a/queries.md
+++ b/queries.md
@@ -8,6 +8,7 @@
 - [Unions](#unions)
 - [Where Clauses](#where-clauses)
     - [Advanced Where Clauses](#advanced-where-clauses)
+        - [JSON Where Clause](#json-where-clause)
 - [Ordering, Grouping, Limit, & Offset](#ordering-grouping-limit-and-offset)
 - [Inserts](#inserts)
 - [Updates](#updates)
@@ -238,6 +239,30 @@ You may also pass an array of conditions to the `where` function:
         ['status','1'],
         ['subscribed','<>','1'],
     ])->get();
+
+<a name="json-where-clause"></a>
+##### JSON where clause (5.2.23+)
+
+Let's say you have a `users` table with a `details` column of type `JSON`, the column has the following value:
+
+    {
+        "title": "Mrs.",
+        "language": "en",
+        "favourites": {
+            "food": "burger",
+            "drink": "tea"
+        }
+    }
+
+To get JSON values, you can do this:
+
+    $users = DB::table('users')
+                    ->where('datails->language', 'en')
+                    ->get();
+
+    $users = DB::table('users')
+                    ->where('datails->favourites->food', 'burger')
+                    ->get();
 
 #### Or Statements
 

--- a/quickstart-intermediate.md
+++ b/quickstart-intermediate.md
@@ -255,7 +255,7 @@ Once the `auth` routes are registered, verify that the `$redirectTo` property on
 
     protected $redirectTo = '/tasks';
 
-It is also necessary to update the `app/Middleware/RedirectIfAuthenticated.php` with the proper redirect path:
+It is also necessary to update the `app/Http/Middleware/RedirectIfAuthenticated.php` with the proper redirect path:
 
     return redirect('/tasks');
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -272,6 +272,12 @@ Now we have defined a basic layout and view for our application. Remember, we ar
 		return view('tasks');
 	});
 
+Now that we have a task view set up, we should be able to see it in the browser to make sure we've set everything up correctly thus far. To do so, return to your console and enter:
+
+	php artisan serve
+
+Navigate to `localhost:8000` in your browser, and if everything's working, you should see the form we built in the previous step.
+
 Next, we're ready to add code to our `POST /task` route to handle the incoming form input and add a new task to the database.
 
 <a name="adding-tasks"></a>

--- a/routing.md
+++ b/routing.md
@@ -4,6 +4,7 @@
 - [Route Parameters](#route-parameters)
     - [Required Parameters](#required-parameters)
     - [Optional Parameters](#parameters-optional-parameters)
+    - [Regular Expression Constraints](#parameters-regular-expression-constraints)
 - [Named Routes](#named-routes)
 - [Route Groups](#route-groups)
     - [Middleware](#route-group-middleware)
@@ -92,6 +93,50 @@ Occasionally you may need to specify a route parameter, but make the presence of
 
     Route::get('user/{name?}', function ($name = 'John') {
         return $name;
+    });
+
+<a name="parameters-regular-expression-constraints"></a>
+### Regular Expression Constraints
+
+You may constrain the format of your route parameters using the `where` method on a route instance. The `where` method accepts the name of the parameter and a regular expression defining how the parameter should be constrained:
+
+    Route::get('user/{name}', function ($name) {
+        //
+    })
+    ->where('name', '[A-Za-z]+');
+
+    Route::get('user/{id}', function ($id) {
+        //
+    })
+    ->where('id', '[0-9]+');
+
+    Route::get('user/{id}/{name}', function ($id, $name) {
+        //
+    })
+    ->where(['id' => '[0-9]+', 'name' => '[a-z]+']);
+
+<a name="parameters-global-constraints"></a>
+#### Global Constraints
+
+If you would like a route parameter to always be constrained by a given regular expression, you may use the `pattern` method. You should define these patterns in the `boot` method of your `RouteServiceProvider`:
+
+    /**
+     * Define your route model bindings, pattern filters, etc.
+     *
+     * @param  \Illuminate\Routing\Router  $router
+     * @return void
+     */
+    public function boot(Router $router)
+    {
+        $router->pattern('id', '[0-9]+');
+
+        parent::boot($router);
+    }
+
+Once the pattern has been defined, it is automatically applied to all routes using that parameter name:
+
+    Route::get('user/{id}', function ($id) {
+        // Only called if {id} is numeric.
     });
 
 <a name="named-routes"></a>


### PR DESCRIPTION
I'm a Rails developer, and my first ever exposure to Laravel went like this: Laravel site -> Installation instructions -> Quickstart. That seemed like a reasonable path for me to follow.

I got about halfway through the quickstart and realized that I wanted to start up the server as a sanity check to make sure everything was working. But it's nowhere to be found.

I thought this was odd, especially since instructions on starting the server [in the docs for 4.2](https://laravel.com/docs/4.2/quick).

I mention the piece about being a Rails developer and my exposure to Laravel because I had not yet seen the `php artisan serve` command and had to Google to find it. I finally found it and ran it and realized I had to fix a couple things, which derailed my progress on the quickstart. I would have been even more confused and frustrated had I gotten to the end of the tutorial (by which time the server is still not started) and realized I had no idea how to check on my progress and, when I found issues, I'd have no idea at which step in the process they were introduced.

This PR adds (or, rather, re-adds) a quick line or two about how to start the server at what seems like the appropriate time: the first point in the tutorial in which the user would get any output in the browser. It's possible that this was removed intentionally, but I can tell you as a new user that this is a really key piece of information to have in the quickstart.