### PR TITLE
homestead make - path escaped for windows

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -150,7 +150,7 @@ Mac / Linux:
 
 Windows:
 
-	vendor\bin\homestead make
+	vendor\\bin\\homestead make
 
 Next, run the `vagrant up` command in your terminal and access your project at `http://homestead.app` in your browser. Remember, you will still need to add an `/etc/hosts` file entry for `homestead.app` or the domain of your choice.
 


### PR DESCRIPTION
backslashes in path need to be escaped for windows:
vendor\\bin\\homestead make
using forward slash works as well:
vendor/bin/homestead make