### PR TITLE
Add note regarding testing environment variables

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -29,6 +29,8 @@ When running tests, Laravel will automatically set the configuration environment
 
 You are free to create other testing environment configurations as necessary. The `testing` environment variables may be configured in the `phpunit.xml` file.
 
+> **Note:** Be sure to clear the configuration cache before running the tests, otherwise your testing environment variables won't be loaded.
+
 ### Defining & Running Tests
 
 To create a new test case, use the `make:test` Artisan command:


### PR DESCRIPTION
The behavior I reported in https://github.com/laravel/framework/issues/12874 turns out to be the expected one. And it has indeed a pretty straightforward solution, however I couldn't find a mention to this in the Testing section of the documentation.

This PR adds a note addressing this particular topic. I think it might save developers some time if they come across this.