### PR TITLE
Update column types table with newly added types.

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -215,6 +215,8 @@ Command  | Description
 `$table->timestamp('added_on');`  |  TIMESTAMP equivalent for the database.
 `$table->timestamps();`  |  Adds `created_at` and `updated_at` columns.
 `$table->uuid('id');`  |  UUID equivalent for the database.
+`$table->ipAddress('visitor');`  |  IP address equivalent for the database.
+`$table->macAddress('device');`  |  MAC address equivalent for the database.
 
 #### Column Modifiers
 

--- a/migrations.md
+++ b/migrations.md
@@ -197,9 +197,11 @@ Command  | Description
 `$table->float('amount');`  |  FLOAT equivalent for the database.
 `$table->increments('id');`  |  Incrementing ID (primary key) using a "UNSIGNED INTEGER" equivalent.
 `$table->integer('votes');`  |  INTEGER equivalent for the database.
+`$table->ipAddress('visitor');`  |  IP address equivalent for the database.
 `$table->json('options');`  |  JSON equivalent for the database.
 `$table->jsonb('options');`  |  JSONB equivalent for the database.
 `$table->longText('description');`  |  LONGTEXT equivalent for the database.
+`$table->macAddress('device');`  |  MAC address equivalent for the database.
 `$table->mediumInteger('numbers');`  |  MEDIUMINT equivalent for the database.
 `$table->mediumText('description');`  |  MEDIUMTEXT equivalent for the database.
 `$table->morphs('taggable');`  |  Adds INTEGER `taggable_id` and STRING `taggable_type`.
@@ -215,8 +217,6 @@ Command  | Description
 `$table->timestamp('added_on');`  |  TIMESTAMP equivalent for the database.
 `$table->timestamps();`  |  Adds `created_at` and `updated_at` columns.
 `$table->uuid('id');`  |  UUID equivalent for the database.
-`$table->ipAddress('visitor');`  |  IP address equivalent for the database.
-`$table->macAddress('device');`  |  MAC address equivalent for the database.
 
 #### Column Modifiers
 


### PR DESCRIPTION
The IP and MAC address types were [pulled](https://github.com/laravel/framework/pull/12884) and released with 5.2.27. I am proposing we add it to the schema builder column types documentation. 