### PR TITLE
add a note to migrations about dropping foreigns when renaming a table

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -169,6 +169,8 @@ To drop an existing table, you may use the `drop` or `dropIfExists` methods:
 
     Schema::dropIfExists('users');
 
+> **Note:** Before renaming a table, you will need to drop any existing foreign keys. After the table has been renamed, you will need to add them back on the new table name.
+
 <a name="creating-columns"></a>
 ### Creating Columns
 


### PR DESCRIPTION
I'm new to Laravel, and didn't know you should drop foreign keys and re-add them when renaming tables. After making this mistake for a while, I eventually had rebuild all of the migrations on one of my projects. I figure I can't be the only one who's made this mistake.