### PR TITLE
`$primaryKey` is not necessarily `id`

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -67,7 +67,7 @@ Eloquent assumes the foreign key of the relationship based on the model name. In
 
     return $this->hasOne('App\Phone', 'foreign_key');
 
-Additionally, Eloquent assumes that the foreign key should have a value matching the `id` column of the parent. In other words, Eloquent will look for the value of the user's `id` column in the `user_id` column of the `Phone` record. If you would like the relationship to use a value other than `id`, you may pass a third argument to the `hasOne` method specifying your custom key:
+Additionally, Eloquent assumes that the foreign key should have a value matching the `id` (or an overwritten `$primaryKey`) column of the parent. In other words, Eloquent will look for the value of the user's `id` column in the `user_id` column of the `Phone` record. If you would like the relationship to use a value other than `id`, you may pass a third argument to the `hasOne` method specifying your custom key:
 
     return $this->hasOne('App\Phone', 'foreign_key', 'local_key');
 


### PR DESCRIPTION
Added comment to reflect the fact that the local key can be different from `id` if not specified in `hasOne` but overwritten in `$primaryKey`.