### PR TITLE
Remove documentation about composite primary key

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -318,7 +318,6 @@ Laravel will automatically generate a reasonable index name, but you may pass a 
 Command  | Description
 ------------- | -------------
 `$table->primary('id');`  |  Add a primary key.
-`$table->primary(['first', 'last']);`  |  Add composite keys.
 `$table->unique('email');`  |  Add a unique index.
 `$table->unique('state', 'my_index_name');`  |  Add a custom index name.
 `$table->index('state');`  |  Add a basic index.


### PR DESCRIPTION
It's not supported by eloquent as per laravel/framework#12442 (and in many other issues).

Mentioning it in migration documentation but then not being able to actually use it (or usable in broken way) would lead to sadness.