### PR TITLE
Add Public Driver explanation

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -28,6 +28,16 @@ When using the `local` driver, note that all file operations are relative to the
 
     Storage::disk('local')->put('file.txt', 'Contents');
 
+#### The Public Driver
+
+The `public` driver is similar to the `local` driver, but is meant for files that are publicly accessible. By default, these files reside in `storage/app/public`. To make them accessible from the web, it is recommended that you create a symlink from `public/storage` to `storage/app/public`. This will keep your writeable/shared files neatly in 1 folder.
+
+    Storage::disk('public')->put('file.txt', 'Contents')
+
+You can create an url to the files, just like regular public files.
+
+    $url = asset('storage/file.txt');
+    
 #### Other Driver Prerequisites
 
 Before using the S3 or Rackspace drivers, you will need to install the appropriate package via Composer:


### PR DESCRIPTION
This is explained here: http://taylorotwell.com/spark-storage/
But is not explained on the docs. I added it to make the 'standard' clear for everyone.