### PR TITLE
Add a note explaining the pitfalls of ->get

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -139,6 +139,8 @@ When working on forms with array inputs, you may use "dot" notation to access th
 
     $names = $request->input('products.*.name');
 
+> **Note:** When using Laravel's validation, do not use `$request->get('name')` in place of `$request->input('name')` as the former may potentially return a different unvalidated value.
+
 #### Retrieving JSON Input Values
 
 When sending JSON requests to your application, you may access the JSON data via the `input` method as long as the `Content-Type` header of the request is properly set to `application/json`. You may even use "dot" syntax to dig deeper into JSON arrays:


### PR DESCRIPTION
See laravel/framework#13138.

I'm not confident on the wording or placement here. I imagine we'd have to summarize the argument put forth in the above issue in just a sentence or two. Is "using Laravel's validation" descriptive enough or too broad?

One alternative I've considered:
> **Note:** When using Laravel's validation, do not use `$request->get('name')` in place of `$request->input('name')` as the former may potentially return a different value than the one Laravel has validated against.