### PR TITLE
Add missing anchor reference

### DIFF
--- a/session.md
+++ b/session.md
@@ -10,6 +10,7 @@
 
 Since HTTP driven applications are stateless, sessions provide a way to store information about the user across requests. Laravel ships with a variety of session back-ends available for use through a clean, unified API. Support for popular back-ends such as [Memcached](http://memcached.org), [Redis](http://redis.io), and databases is included out of the box.
 
+<a name="configuration"></a>
 ### Configuration
 
 The session configuration file is stored at `config/session.php`. Be sure to review the well documented options available to you in this file. By default, Laravel is configured to use the `file` session driver, which will work well for many applications. In production applications, you may consider using the `memcached` or `redis` drivers for even faster session performance.


### PR DESCRIPTION
This anchor referenced here:
https://raw.githubusercontent.com/laravel/docs/master/installation.md
https://laravel.com/docs/master/installation#configuration

Configuration > Additional Configuration
```
- [Session](/docs/{{version}}/session#configuration)
```

> **Note:** This issue affects **5.1** & **5.2** branches too.