### PR TITLE
Link to Sentry's Laravel integration

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -47,7 +47,7 @@ All exceptions are handled by the `App\Exceptions\Handler` class. This class con
 <a name="report-method"></a>
 ### The Report Method
 
-The `report` method is used to log exceptions or send them to an external service like [BugSnag](https://bugsnag.com). By default, the `report` method simply passes the exception to the base class where the exception is logged. However, you are free to log exceptions however you wish.
+The `report` method is used to log exceptions or send them to an external service like [BugSnag](https://bugsnag.com) or [Sentry](https://github.com/getsentry/sentry-laravel). By default, the `report` method simply passes the exception to the base class where the exception is logged. However, you are free to log exceptions however you wish.
 
 For example, if you need to report different types of exceptions in different ways, you may use the PHP `instanceof` comparison operator:
 


### PR DESCRIPTION
Sentry is mentioned in various places in Laravel, but historically has never been supported super well. This adds a link to the new (official) integration for Sentry + Laravel. We're about to start pushing back hard on "logging is not error reporting", and are trying to move away from the Monolog-as-a-default handler (which has its own problems in Laravel, that we'll hopefully provide a solution to in a followup PR).

Might be worthwhile to actually split this off from the paragraph and do some kind of "Third Party Services" section. Happy to help improve this, just let us know your thoughts for overall direction.