### PR TITLE
Use pushd & popd instead of cd in convenience func

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -175,8 +175,9 @@ If you prefer to use MariaDB instead of MySQL, you may add the `mariadb` option 
 Sometimes you may want to `vagrant up` your Homestead machine from anywhere on your filesystem. You can do this by adding a simple Bash function to your Bash profile. This function will allow you to run any Vagrant command from anywhere on your system and will automatically point that command to your Homestead installation:
 
     function homestead() {
-        cd ~/Homestead
+        pushd ~/Homestead > /dev/null
         vagrant $*
+        popd > /dev/null
     }
 
 Make sure to tweak the `~/Homestead` path in the function to the location of your actual Homestead installation. Once the function is installed, you may run commands like `homestead up` or `homestead ssh` from anywhere on your system.


### PR DESCRIPTION
The current suggested convenience function in the Homestead documentation causes the user's current shell to actually change directories to the specified Homestead directory depending on how their default shell works.

Moving to pushd & popd circumvents this issue. The downside is that the function is less compact, but its just an additional line, with the inclusion of sending output to /dev/null so that pushd & popd don't announce the directory change.

Its possible that this does not affect enough users to warrant a change, but it seemed worth the pull request anyway.