### PR TITLE
Do not use {!! !!} on Htmlables

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -738,7 +738,7 @@ The `config` helper may also be used to set configuration variables at runtime b
 
 The `csrf_field` function generates an HTML `hidden` input field containing the value of the CSRF token. For example, using [Blade syntax](/docs/{{version}}/blade):
 
-    {!! csrf_field() !!}
+    {{ csrf_field() }}
 
 <a name="method-csrf-token"></a>
 #### `csrf_token()` {#collection-method}
@@ -795,7 +795,7 @@ The `factory` function creates a model factory builder for a given class, name, 
 The `method_field` function generates an HTML `hidden` input field containing the spoofed value of the form's HTTP verb. For example, using [Blade syntax](/docs/{{version}}/blade):
 
     <form method="POST">
-        {!! method_field('delete') !!}
+        {{ method_field('DELETE') }}
     </form>
 
 <a name="method-old"></a>

--- a/quickstart-intermediate.md
+++ b/quickstart-intermediate.md
@@ -359,7 +359,7 @@ We'll skip over some of the Bootstrap CSS boilerplate and only focus on the thin
 
             <!-- New Task Form -->
             <form action="{{ url('task') }}" method="POST" class="form-horizontal">
-                {!! csrf_field() !!}
+                {{ csrf_field() }}
 
                 <!-- Task Name -->
                 <div class="form-group">
@@ -657,8 +657,8 @@ We left a "TODO" note in our code where our delete button is supposed to be. So,
         <!-- Delete Button -->
         <td>
             <form action="{{ url('task/'.$task->id) }}" method="POST">
-                {!! csrf_field() !!}
-                {!! method_field('DELETE') !!}
+                {{ csrf_field() }}
+                {{ method_field('DELETE') }}
 
                 <button type="submit" id="delete-task-{{ $task->id }}" class="btn btn-danger">
                     <i class="fa fa-btn fa-trash"></i>Delete

--- a/quickstart.md
+++ b/quickstart.md
@@ -233,7 +233,7 @@ We'll skip over some of the Bootstrap CSS boilerplate and only focus on the thin
 
 			<!-- New Task Form -->
 			<form action="{{ url('task') }}" method="POST" class="form-horizontal">
-				{!! csrf_field() !!}
+				{{ csrf_field() }}
 
                 <!-- Task Name -->
 				<div class="form-group">
@@ -423,8 +423,8 @@ We left a "TODO" note in our code where our delete button is supposed to be. So,
         <!-- Delete Button -->
         <td>
             <form action="{{ url('task/'.$task->id) }}" method="POST">
-                {!! csrf_field() !!}
-                {!! method_field('DELETE') !!}
+                {{ csrf_field() }}
+                {{ method_field('DELETE') }}
 
                 <button type="submit" class="btn btn-danger">
                     <i class="fa fa-trash"></i> Delete

--- a/testing.md
+++ b/testing.md
@@ -110,7 +110,7 @@ Now, let's write a test that clicks the link and asserts the user lands on the c
 Laravel also provides several methods for testing forms. The `type`, `select`, `check`, `attach`, and `press` methods allow you to interact with all of your form's inputs. For example, let's imagine this form exists on the application's registration page:
 
     <form action="/register" method="POST">
-        {!! csrf_field() !!}
+        {{ csrf_field() }}
 
         <div>
             Name: <input type="text" name="name">


### PR DESCRIPTION
Do not use `{!! !!}` on `Htmlable`s.

`routing.md` shows `csrf_field()` with the blade template syntax `{{ }}`, while on other pages it is wrapped with `{!! !!}` which is quite misleading.