### PR TITLE
Fix log documentation

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -116,7 +116,7 @@ The views within this directory should be named to match the HTTP status code th
 <a name="logging"></a>
 ## Logging
 
-The Laravel logging facilities provide a simple layer on top of the powerful [Monolog](http://github.com/seldaek/monolog) library. By default, Laravel is configured to create daily log files for your application which are stored in the `storage/logs` directory. You may write information to the logs using the `Log` [facade](/docs/{{version}}/facades):
+The Laravel logging facilities provide a simple layer on top of the powerful [Monolog](http://github.com/seldaek/monolog) library. By default, Laravel is configured to create a log file for your application in the `storage/logs` directory. You may write information to the logs using the `Log` [facade](/docs/{{version}}/facades):
 
     <?php
 


### PR DESCRIPTION
Although the default log setting is `single`, as mentioned above on the same page, this paragraph said that the default is `daily`. This PR corrects that.