### PR TITLE
Update to @after with variables

### DIFF
--- a/envoy.md
+++ b/envoy.md
@@ -170,7 +170,7 @@ After running a task, you may send a notification to your team's HipChat room us
 If you wish, you may also pass a custom message to send to the HipChat room. Any variables available to your Envoy tasks will also be available when constructing the message:
 
     @after
-        @hipchat('token', 'room', 'Envoy', "{{ $task }} ran in the {{ $env }} environment.")
+        @hipchat('token', 'room', 'Envoy', "$task ran in the $env environment.")
     @endafter
 
 <a name="slack"></a>


### PR DESCRIPTION
All the code in the @after is actually executed as php, so the {{ @task }} gets compiled to "<?php echo $task ?> ran in the <?php echo $task ?> environment." which makes it actually not show, losing the braces will make it just parse the variable