### PR TITLE
Fix Command to run Homestead CLI

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -146,7 +146,7 @@ Once Homestead has been installed, use the `make` command to generate the `Vagra
 
 Mac / Linux:
 
-    ./vendor/bin/homestead make
+    sh vendor/bin/homestead make
 
 Windows:
 

--- a/homestead.md
+++ b/homestead.md
@@ -146,7 +146,7 @@ Once Homestead has been installed, use the `make` command to generate the `Vagra
 
 Mac / Linux:
 
-    php vendor/bin/homestead make
+    ./vendor/bin/homestead make
 
 Windows:
 


### PR DESCRIPTION
The file vendor/bin/homestead is a shell script, not a php file. This executes the command correctly
