### PR TITLE
Add documentation about configuring the log level

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -168,3 +168,11 @@ An array of contextual data may also be passed to the log methods. This contextu
 Monolog has a variety of additional handlers you may use for logging. If needed, you may access the underlying Monolog instance being used by Laravel:
 
     $monolog = Log::getMonolog();
+
+#### Configuring the default log level
+
+By default, Laravel will write out all log levels to the log file. On your production environment, this may be considered too much noise, so you can configure the default log level by adding the `log_level` key to your `app.php` configuration file. Laravel will continue to log all levels greater than or equal to the nominated severity level.
+
+For example, if in your production environment, you were to set the log level to **error**, Laravel will continue to log **error**, **critical**, **alert**, and **emergency** messages to the log file.
+
+    'log_level' => app_env('APP_LOG_FILE', 'debug'),


### PR DESCRIPTION
This documentation ties in with changes in https://github.com/laravel/framework/commit/fbd6e7793766c4b3671328b80fb315391f11a3ed that were tagged in [v5.2.35](https://github.com/laravel/framework/releases/tag/v5.2.35) of the framework.