### PR TITLE
Update upgrade.md

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -636,7 +636,7 @@ The name of the trait and interface used by [Laravel Cashier](/docs/{{version}}/
 
 Move all of your command classes from your old `app/commands` directory to the new `app/Console/Commands` directory. Next, add the `app/Console/Commands` directory to the `classmap` directive of your `composer.json` file.
 
-Then, copy your list of Artisan commands from `start/artisan.php` into the `command` array of the `app/Console/Kernel.php` file.
+Then, copy your list of Artisan commands from `start/artisan.php` into the `commands` array of the `app/Console/Kernel.php` file.
 
 ### Database Migrations & Seeds
 


### PR DESCRIPTION
"Grammer" error.  Array name in code is plural and should not be singular in doc.