### PR TITLE
Add empty line to comply to CommonMark guidelines

### DIFF
--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -49,6 +49,7 @@ All Eloquent collections extend the base [Laravel collection](/docs/{{version}}/
 </style>
 
 <div id="collection-method-list" markdown="1">
+
 [all](/docs/{{version}}/collections#method-all)
 [chunk](/docs/{{version}}/collections#method-chunk)
 [collapse](/docs/{{version}}/collections#method-collapse)
@@ -102,6 +103,7 @@ All Eloquent collections extend the base [Laravel collection](/docs/{{version}}/
 [where](/docs/{{version}}/collections#method-where)
 [whereLoose](/docs/{{version}}/collections#method-whereloose)
 [zip](/docs/{{version}}/collections#method-zip)
+
 </div>
 
 <a name="custom-collections"></a>


### PR DESCRIPTION
As the [CommonMark specs](http://spec.commonmark.org/0.22/#html-blocks) state, an empty line between HTML and MD blocks is mandatory.