### PR TITLE
add note for creating multiple factory files

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -472,7 +472,7 @@ When testing, it is common to need to insert a few records into your database be
 
 Within the Closure, which serves as the factory definition, you may return the default test values of all attributes on the model. The Closure will receive an instance of the [Faker](https://github.com/fzaninotto/Faker) PHP library, which allows you to conveniently generate various kinds of random data for testing.
 
-Of course, you are free to add your own additional factories to the `ModelFactory.php` file.
+Of course, you are free to add your own additional factories to the `ModelFactory.php` file. You may also create additional factory files for each model. For example, you could create a `UserFactory.php` and `BlogFactory.php`. This can help keep your factories organized better, especially if you are creating multiple factory types for each model.
 
 #### Multiple Factory Types
 


### PR DESCRIPTION
if you have a large number of models or many factory types for each model, having them all in the `ModelFactory.php` file quickly becomes unmanageable.  this note explains to users they are free to create multiple files in the `factories` directory, and they don't all have to go in the `ModelFactory.php` file.

IMHO I think multiple files should be the preferred and encouraged way. In fact, we could even make an Artisan `make` command for it as well. Wondering what your thoughts are on that?