### PR TITLE
Use `.app` as alternative domain because `.local` is reserved by Mac OS X

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -69,7 +69,7 @@ Valet will automatically start its daemon each time your machine boots. There is
 
 By default, Valet serves your projects using the `.dev` TLD. If you'd like to use another domain, you can do so using the `valet domain tld-name` command.
 
-For example, if you'd like to use `.local` instead of `.dev`, run `valet domain local` and Valet will start serving your projects at `*.local` automatically.
+For example, if you'd like to use `.app` instead of `.dev`, run `valet domain app` and Valet will start serving your projects at `*.app` automatically.
 
 #### Database
 


### PR DESCRIPTION
In discussion with @adamwathan, .local usually works fine with Homestead because it's explicitly mapped in the hosts file, but it looks like the OS X DNS resolver gets priority over Dnsmasq. 

https://support.apple.com/en-ca/HT201275