### PR TITLE
Fixed backticks to single quotes

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -264,7 +264,7 @@ You may also nest the `*` notation. In this case, we will assert that each user 
     $this->get('/users')
          ->seeJsonStructure([
              '*' => [
-                 'id', 'name', 'email', `pets` => [
+                 'id', 'name', 'email', 'pets' => [
                      '*' => [
                          'name', 'age'
                      ]


### PR DESCRIPTION
This caught my eye as the backticks show the contents differently in the Markdown code formatter.