### PR TITLE
Updated queues doc to include details for pushing jobs to multiple queue connections

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -225,6 +225,52 @@ By pushing jobs to different queues, you may "categorize" your queued jobs, and 
             $this->dispatch($job);
         }
     }
+    
+> **Note:** The `DispatchesJobs` trait pushes jobs to queues within the default queue connection. 
+
+#### Specifying The Queue Connection For A Job
+
+If you are working with multiple queue connections, you can also specify which connection to push a job to. To specify the connection, use the `onConnection` method on the job instance. The `onConnection` method is provided by the `Illuminate\Bus\Queueable` trait, which is already included on the `App\Jobs\Job` base class:
+
+    <?php
+
+    namespace App\Http\Controllers;
+
+    use App\User;
+    use Illuminate\Http\Request;
+    use App\Jobs\SendReminderEmail;
+    use App\Http\Controllers\Controller;
+
+    class UserController extends Controller
+    {
+        /**
+         * Send a reminder e-mail to a given user.
+         *
+         * @param  Request  $request
+         * @param  int  $id
+         * @return Response
+         */
+        public function sendReminderEmail(Request $request, $id)
+        {
+            $user = User::findOrFail($id);
+
+            $job = (new SendReminderEmail($user))->onConnection('redis-alternate');
+
+            $this->dispatch($job);
+        }
+    }
+    
+Of course, you can also chain the `onConnection` and `onQueue` methods to specify the connection and the queue for a job:
+
+    public function sendReminderEmail(Request $request, $id)
+    {
+        $user = User::findOrFail($id);
+        
+        $job = (new SendReminderEmail($user))->onConnection('redis-alternate')->onQueue('emails');
+        
+        $this->dispatch($job);
+        
+    }
 
 <a name="delayed-jobs"></a>
 ### Delayed Jobs


### PR DESCRIPTION
The current documentation (`5.2`) does not include any details about pushing jobs to different queue connections (although the functionality exists in the `Illuminate\Bus\Queueable` trait). Through this PR we hope we can contribute to making this easier to understand for other developers.