### PR TITLE
Fixed correct name for HTTP/2

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -20,7 +20,7 @@ Valet is a Laravel development environment for Mac minimalists. No Vagrant, No A
 
 Laravel Valet configures your Mac to always run [Caddy](https://caddyserver.com) in the background when your machine starts. Then, using [DnsMasq](https://en.wikipedia.org/wiki/Dnsmasq), Valet proxies all requests on the `*.dev` domain to point to sites installed on your local machine.
 
-In other words, a blazing fast Laravel development environment that uses roughly 7mb of RAM. Valet isn't a complete replacement for Vagrant or Homestead, but provides a great alternative if you want flexible basics, prefer extreme speed, or are working on a machine with a limited amount of RAM.
+In other words, a blazing fast Laravel development environment that uses roughly 7 MB of RAM. Valet isn't a complete replacement for Vagrant or Homestead, but provides a great alternative if you want flexible basics, prefer extreme speed, or are working on a machine with a limited amount of RAM.
 
 Out of the box, Valet support includes, but is not limited to:
 
@@ -125,7 +125,7 @@ To see a listing of all of your linked directories, run the `valet links` comman
 <a name="securing-sites"></a>
 **Securing Sites With TLS**
 
-By default, Valet serves sites over plain HTTP. However, if you would like to serve a site over encrypted TLS using HTTP2, use the `secure` command. For example, if your site is being served by Valet on the `laravel.dev` domain, you should run the following command to secure it:
+By default, Valet serves sites over plain HTTP. However, if you would like to serve a site over encrypted TLS using HTTP/2, use the `secure` command. For example, if your site is being served by Valet on the `laravel.dev` domain, you should run the following command to secure it:
 
     valet secure laravel
 


### PR DESCRIPTION
Super pedantic, but the correct name is HTTP/2, as per [the homepage](https://http2.github.io/).

Formatting for RAM usage I've fixed as per formatting seen [here](https://en.wikipedia.org/wiki/Random-access_memory#Virtual_memory).