### PR TITLE
Updated composer bin path

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -34,7 +34,7 @@ First, download the Laravel installer using Composer:
 
     composer global require "laravel/installer"
 
-Make sure to place the `~/.composer/vendor/bin` directory (or the equivalent directory for your OS) in your PATH so the `laravel` executable can be located by your system.
+Make sure to place the `~/.config/composer/vendor/bin` directory (or the equivalent directory for your OS) in your PATH so the `laravel` executable can be located by your system.
 
 Once installed, the `laravel new` command will create a fresh Laravel installation in the directory you specify. For instance, `laravel new blog` will create a directory named `blog` containing a fresh Laravel installation with all of Laravel's dependencies already installed. This method of installation is much faster than installing via Composer:
 


### PR DESCRIPTION
Path seems to have changed according to the Homestead installation I did today.
It pointed out the updated path after I did `composer global require "laravel/installer"` 