### PR TITLE
StudlyCase instead of CamelCase

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -17,7 +17,7 @@ In addition to custom accessors and mutators, Eloquent can also automatically ca
 
 #### Defining An Accessor
 
-To define an accessor, create a `getFooAttribute` method on your model where `Foo` is the "camel" cased name of the column you wish to access. In this example, we'll define an accessor for the `first_name` attribute. The accessor will automatically be called by Eloquent when attempting to retrieve the value of `first_name`:
+To define an accessor, create a `getFooAttribute` method on your model where `Foo` is the "studly" cased name of the column you wish to access. In this example, we'll define an accessor for the `first_name` attribute. The accessor will automatically be called by Eloquent when attempting to retrieve the value of `first_name`:
 
     <?php
 
@@ -47,7 +47,7 @@ As you can see, the original value of the column is passed to the accessor, allo
 
 #### Defining A Mutator
 
-To define a mutator, define a `setFooAttribute` method on your model where `Foo` is the "camel" cased name of the column you wish to access. So, again, let's define a mutator for the `first_name` attribute. This mutator will be automatically called when we attempt to set the value of the `first_name` attribute on the model:
+To define a mutator, define a `setFooAttribute` method on your model where `Foo` is the "studly" cased name of the column you wish to access. So, again, let's define a mutator for the `first_name` attribute. This mutator will be automatically called when we attempt to set the value of the `first_name` attribute on the model:
 
     <?php
 


### PR DESCRIPTION
As there is already "get" prepended to the method, "studly" case is correct I think. "studly" case is used in example as well.