### PR TITLE
Empty lines in favor of CommonMark guidelines

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -47,6 +47,7 @@ You may select any method from this table to see an example of its usage:
 </style>
 
 <div id="collection-method-list" markdown="1">
+
 [all](#method-all)
 [avg](#method-avg)
 [chunk](#method-chunk)
@@ -111,6 +112,7 @@ You may select any method from this table to see an example of its usage:
 [whereIn](#method-wherein)
 [whereInLoose](#method-whereinloose)
 [zip](#method-zip)
+
 </div>
 
 <a name="method-listing"></a>

--- a/helpers.md
+++ b/helpers.md
@@ -25,6 +25,7 @@ Laravel includes a variety of "helper" PHP functions. Many of these functions ar
 ### Arrays
 
 <div class="collection-method-list" markdown="1">
+
 [array_add](#method-array-add)
 [array_collapse](#method-array-collapse)
 [array_divide](#method-array-divide)
@@ -49,6 +50,7 @@ Laravel includes a variety of "helper" PHP functions. Many of these functions ar
 ### Paths
 
 <div class="collection-method-list" markdown="1">
+
 [app_path](#method-app-path)
 [base_path](#method-base-path)
 [config_path](#method-config-path)
@@ -56,11 +58,13 @@ Laravel includes a variety of "helper" PHP functions. Many of these functions ar
 [elixir](#method-elixir)
 [public_path](#method-public-path)
 [storage_path](#method-storage-path)
+
 </div>
 
 ### Strings
 
 <div class="collection-method-list" markdown="1">
+
 [camel_case](#method-camel-case)
 [class_basename](#method-class-basename)
 [e](#method-e)
@@ -78,21 +82,25 @@ Laravel includes a variety of "helper" PHP functions. Many of these functions ar
 [studly_case](#method-studly-case)
 [trans](#method-trans)
 [trans_choice](#method-trans-choice)
+
 </div>
 
 ### URLs
 
 <div class="collection-method-list" markdown="1">
+
 [action](#method-action)
 [asset](#method-asset)
 [secure_asset](#method-secure-asset)
 [route](#method-route)
 [url](#method-url)
+
 </div>
 
 ### Miscellaneous
 
 <div class="collection-method-list" markdown="1">
+
 [auth](#method-auth)
 [back](#method-back)
 [bcrypt](#method-bcrypt)
@@ -114,6 +122,7 @@ Laravel includes a variety of "helper" PHP functions. Many of these functions ar
 [value](#method-value)
 [view](#method-view)
 [with](#method-with)
+
 </div>
 
 <a name="method-listing"></a>


### PR DESCRIPTION
Scanned every file of the documentation and added empty lines (when needed)
Now the HTML method lists are compiled correctly under all MD compilers