### PR TITLE
Different PATH variable for Laravel Installer 1.3.3?

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -34,7 +34,7 @@ First, download the Laravel installer using Composer:
 
     composer global require "laravel/installer"
 
-Make sure to place the `~/.composer/vendor/bin` directory (or the equivalent directory for your OS) in your PATH so the `laravel` executable can be located by your system.
+Make sure to place the `~/.composer/vendor/bin` directory (or the equivalent directory for your OS) in your PATH so the `laravel` executable can be located by your system. If this fails, you should instead try using `~/.config/composer/vendor/bin/` in your PATH.
 
 Once installed, the `laravel new` command will create a fresh Laravel installation in the directory you specify. For instance, `laravel new blog` will create a directory named `blog` containing a fresh Laravel installation with all of Laravel's dependencies already installed. This method of installation is much faster than installing via Composer:
 


### PR DESCRIPTION
Not sure if my system (Ubuntu 14.04 LTS), or if Laravel Installer 1.3.3 is the one which installs the composer configurations in `~/.config/composer/vendor/bin/` and **NOT** `~/.composer/vendor/bin`.