### PR TITLE
Fix return of Defining Abilities example

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -43,7 +43,7 @@ The simplest way to determine if a user may perform a given action is to define 
 	        $this->registerPolicies($gate);
 
 	        $gate->define('update-post', function ($user, $post) {
-	        	return $user->id === $post->user_id;
+	        	return $user->id == $post->user_id;
 	        });
 	    }
 	}


### PR DESCRIPTION
In the Defining Abilities section from [Authorization](https://github.com/laravel/docs/blob/5.2/authorization.md) the following example doesn't work as expected:

```
$gate->define('update-post', function ($user, $post) {
    return $user->id === $post->user_id;
});
```
In this case, the operator '===' won't return true even if the user id match the post id. Changing to '==' fixed the problem by comparing only by values, not by type.