### PR TITLE
Slice preserves keys by default

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -993,7 +993,7 @@ If you would like to limit the size of the returned slice, pass the desired size
 
     // [5, 6]
 
-The returned slice will have new, numerically indexed keys. If you wish to preserve the original keys, pass `true` as the third argument to the method.
+The returned slice will preserve keys by default. If you do not wish to preserve the original keys, you can chain the `values` method to reset them.
 
 <a name="method-sort"></a>
 #### `sort()` {#collection-method}


### PR DESCRIPTION
Issue raised here https://github.com/laravel/docs/issues/2428

The documentation for [`Collection::slice`](https://laravel.com/docs/master/collections#method-slice) currently states the following:

> The returned slice will have new, numerically indexed keys. If you wish to preserve the original keys, pass true as the third argument to the method.

Not only is this false in that the current behavior preserves keys by default, but slice doesn't even support a 3rd argument.

This separate pull request introduces the third argument and keeps the current behavior unchanged: https://github.com/laravel/framework/pull/14527