### PR TITLE
Added note about Valet not working out of the box

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -110,6 +110,8 @@ Once Valet is installed, you're ready to start serving sites. Valet provides two
 
 **That's all there is to it.** Now, any Laravel project you create within your "parked" directory will automatically be served using the `http://folder-name.dev` convention.
 
+If the only thing you see in your browser is "It Works" message you may want to run this command: `sudo apachectl stop; valet restart`.
+
 <a name="the-link-command"></a>
 **The `link` Command**
 


### PR DESCRIPTION
Many people (including myself) didn't get Valet working out of the box. It was caused by Apache already running in the background. Simple restart of the Apache and Valet using `sudo apachectl stop; valet restart` worked.

https://laracasts.com/discuss/channels/laravel/valet-v112-update-just-keep-getting-the-it-works#reply-165001