### PR TITLE
made user_id unsigned in quickstart-intermediate to be consistent 

### DIFF
--- a/quickstart-intermediate.md
+++ b/quickstart-intermediate.md
@@ -88,7 +88,7 @@ The migration will be placed in the `database/migrations` directory of your proj
         {
             Schema::create('tasks', function (Blueprint $table) {
                 $table->increments('id');
-                $table->integer('user_id')->index();
+                $table->integer('user_id')->unsigned()->index();
                 $table->string('name');
                 $table->timestamps();
             });


### PR DESCRIPTION
The user's id attribute is an unsigned integer, the user_id of the tasks model should also be unsigned.