### PR TITLE
[5.3] Use Comments instead of Likes in Polymorphic Relations example

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -419,7 +419,7 @@ Next, let's examine the model definitions needed to build this relationship:
     class Video extends Model
     {
         /**
-         * Get all of the video's comment.
+         * Get all of the video's comments.
          */
         public function comments()
         {
@@ -437,13 +437,13 @@ Once your database table and models are defined, you may access the relationship
         //
     }
 
-You may also retrieve the owner of a polymorphic relation from the polymorphic model by accessing the name of the method that performs the call to `morphTo`. In our case, that is the `commentable` method on the `Video` model. So, we will access that method as a dynamic property:
+You may also retrieve the owner of a polymorphic relation from the polymorphic model by accessing the name of the method that performs the call to `morphTo`. In our case, that is the `commentable` method on the `Comment` model. So, we will access that method as a dynamic property:
 
     $comment = App\Comment::find(1);
 
     $commentable = $comment->commentable;
 
-The `commentable` relation on the `Comment` model will return either a `Post` or `Comment` instance, depending on which type of model owns the comment.
+The `commentable` relation on the `Comment` model will return either a `Post` or `Video` instance, depending on which type of model owns the comment.
 
 #### Custom Polymorphic Types
 


### PR DESCRIPTION
I think comments example is more easy to understand since `likes` table structure in current docs almost identical to Many To Many Polymorphic's `taggables` table, and may be confused as `likes` is a pivot table. 

Showing that `comments` table is not the same as `taggables` and may contain, for example, `body` column, makes documentation more clean.