### PR TITLE
Routes for packages with working sessions

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -45,6 +45,28 @@ To define routes for your package, simply `require` the routes file from within 
         }
     }
 
+If your routes are for web or api use and you want to use the middleware from the users web are api [middleware group](docs/{{version}}/middleware#middleware-groups) to get things like session, crsf token, or anything else the user has defined,  you must use the `Illuminate\Routing\Router` to register your routes file under the correct middleware group. From within your routes file, you may use the `Route` facade to [register routes](/docs/{{version}}/routing) just as you would within a typical Laravel application:
+
+    At the top of your class:
+    use Illuminate\Routing\Router;
+
+    /**
+     * Perform post-registration booting of services.
+     *
+     * @param Router $router
+     * @return void
+     */
+    public function boot(Router $router)
+    {
+        if (! $this->app->routesAreCached()) {
+            $router->group([
+                'middleware' => 'web', // or 'api' for api routes
+            ], function () {
+                require __DIR__.'/../resources/routes.php';
+            });
+        }
+    }
+
 <a name="resources"></a>
 ## Resources
 


### PR DESCRIPTION
I've created a Laravel Package (https://github.com/loren138/cas-server) which uses sessions to store data about an active CAS Single Sign on Session, however, I had issues storing that data in the session.

First, I realized the 'web' middleware does not automatically get added to package route files (like for the normal routes.php file).  Then, I tried to add it using ``$this->middleware('web');`` in the controller which generated a session, but didn't save anything.  (I'm guessing this is related to https://github.com/laravel/framework/issues/13000.)

So I altered my service provider to load routes like this (following the model of the routing service provider):

        if (!$this->app->routesAreCached()) {
                $router->group([
                    'middleware' => 'web',
                ], function () {
                    require __DIR__.'/../resources/routes.php';
                });
        }

This worked.

I wasn't sure if I should remove the old documentation or not since some packagers may want to use only their own middleware.  Please let me know of anyways I should improve this and if I should do a separate pull request for the 5.3 and master branches.