### PR TITLE
Warn readers about false positive cache results

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -38,7 +38,7 @@ Additionally, you may define an `options` array value in your Redis connection d
 
 If your Redis server requires authentication, you may supply a password by adding a `password` configuration item to your Redis server configuration array.
 
-> {note} If you have the Redis PHP extension installed via PECL, you will need to rename the alias for Redis in your `config/app.php` file.
+> {note} If you have the Redis PHP extension installed via PECL, you will need to use [this package](https://github.com/tillkruss/laravel-phpredis) to prevent false positive cache results and rename the alias for Redis in your `config/app.php` file.
 
 <a name="interacting-with-redis"></a>
 ## Interacting With Redis


### PR DESCRIPTION
Using PhpRedis instead of Predis with Laravel’s default `RedisServiceProvider` will result in false-positive cache results across the framework, because PhpRedis returns `false` instead of `null` if a key does not exist.

This PR warns the user about this unexpected behaviour and links to a drop-in replacement.