### PR TITLE
Note detaching parameter in sync()

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -836,6 +836,10 @@ You may also use the `sync` method to construct many-to-many associations. The `
 You may also pass additional intermediate table values with the IDs:
 
     $user->roles()->sync([1 => ['expires' => true], 2, 3]);
+    
+If you don't want to detach existing IDs, you can set the second parameter to false:
+
+    $user->roles()->sync([1, 2, 3], false);
 
 <a name="touching-parent-timestamps"></a>
 ### Touching Parent Timestamps


### PR DESCRIPTION
Rejected in #326 but I think this is still useful (also given all the upvotes on http://stackoverflow.com/questions/17472128/preventing-laravel-adding-multiple-records-to-a-pivot-table/22885499#22885499 it suggests it's a real 'thing')