### PR TITLE
Updated Scout documentation, PHP 7.0 system requirement

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -2,6 +2,7 @@
 
 - [Introduction](#introduction)
 - [Installation](#installation)
+    - [Server Requirements](#server-requirements)
     - [Queueing](#queueing)
     - [Driver Prerequisites](#driver-prerequisites)
 - [Configuration](#configuration)
@@ -53,6 +54,11 @@ Finally, add the `Laravel\Scout\Searchable` trait to the model you would like to
     {
         use Searchable;
     }
+
+<a name="server-requirements"></a>
+### Server Requirements
+
+The Scout library requires PHP >= 7.0, the latest version of [Homestead](/docs/{{version}}/homestead) satisfies this requirement.
 
 <a name="queueing"></a>
 ### Queueing


### PR DESCRIPTION
When installing Scout, i received the error

`Cannot bind an instance to a static closure`

Updating PHP version to 7 fixed this issue and i was able to use the Scout library.

Updated documentation to reflect this.