### PR TITLE
Add 5.2->5.3 upgrade note for the jobs table

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -325,9 +325,13 @@ It is no longer necessary to specify the `--daemon` option when calling the `que
 
 Various queue job events such as `JobProcessing` and `JobProcessed` no longer contain the `$data` property. You should update your application to call `$event->job->payload()` to get the equivalent data.
 
+#### Jobs Table
+
+If your application has a `jobs` table, you should first drop the `jobs_queue_reserved_reserved_at_index` index and then drop the `reserved` column of the table which is no longer required. Finally you should create a new compund index with `['queue', 'reserved_at']`.
+
 #### Failed Jobs Table
 
-If your application has a `failed_jobs` table, you should add a `exception` column to the table. The `exception` column should be a `TEXT` type column and will be used to store a string representation of the exception that caused the job to fail.
+If your application has a `failed_jobs` table, you should add an `exception` column to the table. The `exception` column should be a `TEXT` type column and will be used to store a string representation of the exception that caused the job to fail.
 
 #### Serializing Models On Legacy Style Queue Jobs
 


### PR DESCRIPTION
Apparently the jobs table no longer requires the 'reserved' column. New jobs will fail to be created if this column is still present since it is not nullable.