### PR TITLE
Use Auth::routes instead of Route::auth

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -50,11 +50,11 @@ The `make:console` command has been renamed to `make:command`.
 
 The two default authentication controllers provided with the framework have been split into four smaller controllers. This change provides cleaner, more focused authentication controllers by default. The easiest way to upgrade your application to the new authentication controllers is to [grab a fresh copy of each controller from GitHub](https://github.com/laravel/laravel/tree/master/app/Http/Controllers/Auth) and place them into your application.
 
-You should also make sure that you are calling the `Route::auth()` method in your `routes.php` file. This method will register the proper routes for the new authentication controllers.
+You should also make sure that you are calling the `Auth::routes()` method in your `routes.php` file. This method will register the proper routes for the new authentication controllers.
 
 Once these controllers have been placed into your application, you may need to re-implement any customizations you made to these controllers. For example, if you are customizing the authentication guard that is used for authentication, you may need to override the controller's `guard` method. You can examine each authentication controller's trait to determine which methods to override.
 
-> {tip} If you were not customizing the authentication controllers, you should just be able to drop in fresh copies of the controllers from GitHub and verify that you are calling the `Route::auth` method in your `routes.php` file.
+> {tip} If you were not customizing the authentication controllers, you should just be able to drop in fresh copies of the controllers from GitHub and verify that you are calling the `Auth::routes` method in your `routes.php` file.
 
 #### Password Reset Emails
 
@@ -78,7 +78,7 @@ Your `User` model **must** use the new `Illuminate\Notifications\Notifiable` tra
 
 #### POST To Logout
 
-The `Route::auth` method now registers a `POST` route for `/logout` instead of a `GET` route. This prevents other web applications from logging your users out of your application. To upgrade, you should either convert your logout requests to use the `POST` verb or register your own `GET` route for the `/logout` URI:
+The `Auth::routes` method now registers a `POST` route for `/logout` instead of a `GET` route. This prevents other web applications from logging your users out of your application. To upgrade, you should either convert your logout requests to use the `POST` verb or register your own `GET` route for the `/logout` URI:
 
     Route::get('/logout', 'Auth\LoginController@logout');
 


### PR DESCRIPTION
The <code>make:auth</code> command uses <code>Auth::routes</code> method in route’s stub.

Check this commit: https://github.com/laravel/framework/commit/f33a735d959ba1a572a678b386598fd79bd26e52