### PR TITLE
Add information about the missing logger attribute in the base exception handler class

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -246,6 +246,10 @@ The base exception handler class now requires a `Illuminate\Container\Container`
 
     parent::__construct(app());
 
+#### Logger
+
+The base exception handler `\Psr\Log\LoggerInterface` attribute has been removed. You should use `$this->container['log']`, `app('log')` or the facade `Log::` instead of `$this->log`.
+
 ### Middleware
 
 #### `can` Middleware Namespace Change


### PR DESCRIPTION
The LoggerInterface is now missing from the base exception handler class.

See laravel/framework@a92651e