### PR TITLE
Add console.php to the routes directory section

### DIFF
--- a/structure.md
+++ b/structure.md
@@ -71,9 +71,13 @@ The `resources` directory contains your views as well as your raw, un-compiled a
 <a name="the-routes-directory"></a>
 #### The Routes Directory
 
-The `routes` directory contains all of the route definitions for your application. By default, two route files are included with Laravel: `web.php` and `api.php`. The `web.php` file contains routes that the `RouteServiceProvider` places in the `web` middleware group, which provides session state, CSRF protection, and cookie encryption. If your application does not offer a stateless, RESTful API, all of your routes will most likely be defined in the `web.php` file.
+The `routes` directory contains all of the route definitions for your application. By default, three route files are included with Laravel: `web.php`, `api.php` and `console.php`. 
+
+The `web.php` file contains routes that the `RouteServiceProvider` places in the `web` middleware group, which provides session state, CSRF protection, and cookie encryption. If your application does not offer a stateless, RESTful API, all of your routes will most likely be defined in the `web.php` file.
 
 The `api.php` file contains routes that the `RouteServiceProvider` places in the `api` middleware group, which provides rate limiting. These routes are intended to be stateless, so requests entering the application through these routes are intended to be authenticated via tokens and will not have access to session state.
+
+The `console.php` file is where you may define all of your Closure based console commands. Each Closure is bound to a command instance allowing a simple approach to interacting with each command's IO methods. Even though this file does not define HTTP routes, it defines console based entry points (routes) into your application.
 
 <a name="the-storage-directory"></a>
 #### The Storage Directory


### PR DESCRIPTION
Now that `routes/console.php` is official, it needs to be included in the docs. :smiling_imp: 

I stole the description from other documentation and the comment in the file, but feel free to replace with something better.