### PR TITLE
Add Laravel TestTools Chrome extension to Application Testing section

### DIFF
--- a/application-testing.md
+++ b/application-testing.md
@@ -48,6 +48,8 @@ You may also use the 'visitRoute' method to make a 'GET' request via a named rou
 <a name="interacting-with-your-application"></a>
 ## Interacting With Your Application
 
+> {tip} You can also use the community driven [Laravel TestTools](https://chrome.google.com/webstore/detail/laravel-testtools/ddieaepnbjhgcbddafciempnibnfnakl?lang=en) Chrome extension to help you write application tests.
+
 Of course, you can do much more than simply assert that text appears in a given response. Let's take a look at some examples of clicking links and filling out forms:
 
 <a name="interacting-with-links"></a>


### PR DESCRIPTION
The extension is already used by more than 4.000 users per week. Adding it to the official documentation will make even more people get started with application testing (which is good, right?)