### PR TITLE
Add 5.2 version to 5.2 install docs.

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -44,7 +44,7 @@ Once installed, the `laravel new` command will create a fresh Laravel installati
 
 Alternatively, you may also install Laravel by issuing the Composer `create-project` command in your terminal:
 
-    composer create-project --prefer-dist laravel/laravel blog
+    composer create-project --prefer-dist laravel/laravel blog "5.2.*"
 
 <a name="configuration"></a>
 ### Configuration


### PR DESCRIPTION
I noticed this was missing since 5.3's release earlier this week.