### PR TITLE
[5.3] Add unauthenticated method to exception handler

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -308,6 +308,8 @@ The base exception handler class now requires a `Illuminate\Container\Container`
 
     parent::__construct(app());
 
+Add the `unauthenticated` method [from GitHub](https://raw.githubusercontent.com/laravel/laravel/master/app/Exceptions/Handler.php) to `app/Exceptions/Handler.php` as it is no longer provided by the framework.
+
 ### Middleware
 
 #### `can` Middleware Namespace Change


### PR DESCRIPTION
I found a [breaking change to the framework](https://github.com/laravel/framework/pull/13709) that isn't yet documented.

The framework [calls this method](https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Exceptions/Handler.php#L135) but it was removed from the [base handler](https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Exceptions/Handler.php) in favor of it being provided in the [app skeleton](https://github.com/laravel/laravel/blob/master/app/Exceptions/Handler.php#L50)

Projects going through an upgrade will be missing this method.