### PR TITLE
Added 5.3 upgrade option for Route::resource nested in a Route::group…

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -453,7 +453,9 @@ URL prefixes no longer affect the route names assigned to routes when using `Rou
 
 If your application is using `Route::resource` within a `Route::group` call that specified a `prefix` option, you should examine all of your calls to the `route` helper and verify that you are no longer appending the URI `prefix` to the route name.
 
-If this change causes you to have two routes with the same name, you may use the `names` option when calling `Route::resource` to specify a custom name for a given route. Refer to the [resource routing documentation](/docs/5.3/controllers#resource-controllers) for more information.
+If this change causes you to have two routes with the same name, you have two options:
+1. use the `names` option when calling `Route::resource` to specify a custom name for a given route. Refer to the [resource routing documentation](/docs/5.3/controllers#resource-controllers) for more information.
+2. use `as` option when calling `Route::resource` to specify a custom prefix for a given route resource (e.g., if you used `'prefix' => 'admin'` on a `Route::group` before you would use `'as' => 'admin'` on a `Route::resource` to achieve the same result).
 
 ### Validation
 


### PR DESCRIPTION
… with a prefix

If a user had a 2 resource routes with same named controllers in 2 different Route::groups this breaks in L5.3. It was before mentioned that the solution is using names option on Route::resource, but that means we have to specify each method separately. If we simply wish to prefix entire route resource we can use 'as' option (this feature is not documented, but it is working in L5.3).