### PR TITLE
Add `array_prepend` to list of available methods

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -39,6 +39,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [array_last](#method-array-last)
 [array_only](#method-array-only)
 [array_pluck](#method-array-pluck)
+[array_prepend](#method-array-prepend)
 [array_pull](#method-array-pull)
 [array_set](#method-array-set)
 [array_sort](#method-array-sort)


### PR DESCRIPTION
I'm submitting this PR to `master` branch, however it also appears to be needed in 5.2 and 5.3 docs. The method is listed on the helpers page, just not the link under Available Methods.

This is my first docs PR, should I submit separate PRs for the stable version branches? Not sure what is most appropriate.