### PR TITLE
[5.3] Remove "extends Event"

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -185,7 +185,7 @@ The `ShouldBroadcast` interface requires you to implement a single method: `broa
     use Illuminate\Broadcasting\InteractsWithSockets;
     use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
-    class ServerCreated extends Event implements ShouldBroadcast
+    class ServerCreated implements ShouldBroadcast
     {
         use SerializesModels;
 


### PR DESCRIPTION
 Remove "extends Event" on ServerCreated class, since there in no App\Events\Event class anymore.