### PR TITLE
Remove Invalid anchor link for Multiple DB Connections

### DIFF
--- a/database.md
+++ b/database.md
@@ -7,7 +7,6 @@
 - [Running Raw SQL Queries](#running-queries)
     - [Listening For Query Events](#listening-for-query-events)
 - [Database Transactions](#database-transactions)
-- [Using Multiple Database Connections](#accessing-connections)
 
 <a name="introduction"></a>
 ## Introduction


### PR DESCRIPTION
Does not currently have a section in v5.3+ docs for multiple db connections on this page