### PR TITLE
Parameters out of order for array_where

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -403,7 +403,7 @@ The `array_where` function filters the array using the given Closure:
 
     $array = [100, '200', 300, '400', 500];
 
-    $array = array_where($array, function ($value, $key) {
+    $array = array_where($array, function ($key, $value) {
         return is_string($value);
     });
 


### PR DESCRIPTION
$key before $value. It's fine in 5.2 backwards just not 5.3.