### PR TITLE
Add a note so the reader can find the install instructions for Laravel

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -96,6 +96,8 @@ Once Valet is installed, you're ready to start serving sites. Valet provides two
 
 **That's all there is to it.** Now, any Laravel project you create within your "parked" directory will automatically be served using the `http://folder-name.dev` convention.
 
+> {note} If you can't run the laravel command you should check the [laravel installation instructions](/docs/{{version}}/installation#installing-laravel).
+
 <a name="the-link-command"></a>
 **The `link` Command**
 


### PR DESCRIPTION
This PR comes out of this thread on Laracasts: https://laracasts.com/discuss/channels/laravel/laravel-new-does-not-work-after-installing-valet-command-not-found

Let me know if you want a PR for the other versions of Laravel as well :)