### PR TITLE
Revert "Add json to unsupported column types doctrine"

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -286,7 +286,7 @@ We could also modify a column to be nullable:
         $table->string('name', 50)->nullable()->change();
     });
 
-> {note} Modifying any column in a table that also has a column of type `enum`, `json` or `jsonb` is not currently supported.
+> {note} Modifying any column in a table that also has a column of type `enum` is not currently supported.
 
 <a name="renaming-columns"></a>
 #### Renaming Columns
@@ -297,7 +297,7 @@ To rename a column, you may use the `renameColumn` method on the Schema builder.
         $table->renameColumn('from', 'to');
     });
 
-> {note} Renaming any column in a table that also has a column of type `enum`, `json` or `jsonb` is not currently supported.
+> {note} Renaming any column in a table that also has a column of type `enum` is not currently supported.
 
 <a name="dropping-columns"></a>
 ### Dropping Columns


### PR DESCRIPTION
This reverts commit 0fb2802faf24629f93568bc6abec28e05fd871cd.

As stated in the commit, json and jsonb work again in 5.3.