### PR TITLE
Added note about missing mass deletes with events

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -402,7 +402,7 @@ Of course, you may also run a delete query on a set of models. In this example, 
 
     $deletedRows = App\Flight::where('active', 0)->delete();
 
-> {note} When issuing a mass delete via Eloquent, the `deleting` and `deleted` model events will not be fired for the updated models. This is because the models are never actually retrieved when issuing a mass update.
+> {note} When issuing a mass delete via Eloquent, the `deleting` and `deleted` model events will not be fired for the deleted models. This is because the models are never actually retrieved when issuing a mass delete.
 
 <a name="soft-deleting"></a>
 ### Soft Deleting

--- a/eloquent.md
+++ b/eloquent.md
@@ -402,6 +402,8 @@ Of course, you may also run a delete query on a set of models. In this example, 
 
     $deletedRows = App\Flight::where('active', 0)->delete();
 
+> {note} When issuing a mass delete via Eloquent, the `deleting` and `deleted` model events will not be fired for the updated models. This is because the models are never actually retrieved when issuing a mass update.
+
 <a name="soft-deleting"></a>
 ### Soft Deleting
 


### PR DESCRIPTION
After encountering an issue with mass deleting not calling the `deleting` and `deleted` events, I have added a note.

See issue: https://github.com/laravel/framework/issues/14427