### PR TITLE
Update vendor publish --tag syntax

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -203,7 +203,7 @@ By default, the email's subject is the class name of the notification formatted 
 
 You can modify the HTML and plain-text template used by mail notifications by publishing the notification package's resources. After running this command, the mail notification templates will be located in the `resources/views/vendor/notifications` directory:
 
-    php artisan vendor:publish --tag laravel-notifications
+    php artisan vendor:publish --tag=laravel-notifications
 
 <a name="error-messages"></a>
 ### Error Messages

--- a/packages.md
+++ b/packages.md
@@ -235,4 +235,4 @@ You may want to publish groups of package assets and resources separately. For i
 
 Now your users may publish these groups separately by referencing their tag when executing the `vendor:publish` command:
 
-    php artisan vendor:publish --tag="config"
+    php artisan vendor:publish --tag=config


### PR DESCRIPTION
Make `--tag` syntax consistent with the rest of the docs.