### PR TITLE
Add `limit` method to the query builder docs.

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -444,6 +444,14 @@ The `havingRaw` method may be used to set a raw string as the value of the `havi
                     ->havingRaw('SUM(price) > 2500')
                     ->get();
 
+#### limit 
+
+The `limit` method may be used to return a specified number of results. For example, we can find the first 10 rows in our users table:
+
+    $users = DB::table('users')
+                    ->limit(10)
+                    ->get();
+                    
 #### skip / take
 
 To limit the number of results returned from the query, or to skip a given number of results in the query, you may use the `skip` and `take` methods:

--- a/queries.md
+++ b/queries.md
@@ -446,7 +446,7 @@ The `havingRaw` method may be used to set a raw string as the value of the `havi
 
 #### limit 
 
-The `limit` method may be used to return a specified number of results. For example, we can find the first 10 rows in our users table:
+The `limit` method may be used to return a specified number of results. For example, we can return the first 10 rows found in our users table:
 
     $users = DB::table('users')
                     ->limit(10)


### PR DESCRIPTION
I found this missing when searching for limiting to a specified number of records. 