### PR TITLE
Updates SQS disclaimer.

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -314,7 +314,7 @@ This command will instruct all queue workers to gracefully "die" after they fini
 
 In your `config/queue.php` configuration file, each queue connection defines a `retry_after` option. This option specifies how many seconds the queue connection should wait before retrying a job that is being processed. For example, if the value of `retry_after` is set to `90`, the job will be released back onto the queue if it has been processing for 90 seconds without being deleted. Typically, you should set the `retry_after` value to the maximum number of seconds your jobs should reasonably take to complete processing.
 
-> {note} The only queue connection which does not contain a `retry_after` value is Amazon SQS. By default, SQS retries the job after the [Default Visibility Timeout](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html) value. To handle failed jobs, you can configure a [Dead Letter Queue](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html) from the Amazon web console.
+> {note} The only queue connection which does not contain a `retry_after` value is Amazon SQS. SQS will retry the job after the [Default Visibility Timeout](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html) value managed within the Amazon web console.
 
 #### Worker Timeouts
 

--- a/queues.md
+++ b/queues.md
@@ -314,7 +314,7 @@ This command will instruct all queue workers to gracefully "die" after they fini
 
 In your `config/queue.php` configuration file, each queue connection defines a `retry_after` option. This option specifies how many seconds the queue connection should wait before retrying a job that is being processed. For example, if the value of `retry_after` is set to `90`, the job will be released back onto the queue if it has been processing for 90 seconds without being deleted. Typically, you should set the `retry_after` value to the maximum number of seconds your jobs should reasonably take to complete processing.
 
-> {note} The only queue connection which does not contain a `retry_after` value is Amazon SQS. When using SQS, you must configure the retry threshold from the Amazon web console.
+> {note} The only queue connection which does not contain a `retry_after` value is Amazon SQS. By default, SQS retries the job after the [Default Visibility Timeout](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html) value. To handle failed jobs, you can configure a [Dead Letter Queue](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html) from the Amazon web console.
 
 #### Worker Timeouts
 


### PR DESCRIPTION
This update adds some context to the SQS disclaimer without adding too much more text. Since SQS handles queues in such a different manner, some further description could be helpful. I originally spotted the SQS disclaimer while re-reading the docs and the callout was definitely useful in the fact that I could disregard my failed-jobs issues, but left me with nowhere to go. Not sure how Laravel likes to use vendor URLs in documentation, so please close this PR if that's not acceptable, or I can re-write to use link-less descriptions. 