### PR TITLE
[5.3] Add a note about a join clause

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -274,6 +274,10 @@ The `JoinClause` class has been rewritten to unify its syntax with the query bui
         $join->on('foo', 'bar')->where('bar', 'baz');
     });
 
+The operator of the ``on`` clause is now checked as well and can no longer contain invalid values. If you were relying on that feature (e.g. `$join->on('foo', 'in', DB::raw('("bar")'))`) you should rewrite the condition using the appropriate where clause:
+
+    $join->whereIn('foo', ['bar']);
+
 The `$bindings` property was also removed. To manipulate join bindings directly you may use the `addBinding` method:
 
     $query->join(DB::raw('('.$subquery->toSql().') table'), function ($join) use ($subquery) {


### PR DESCRIPTION
References https://github.com/laravel/framework/issues/15366

The operator of the join clause is now checked by the query builder and must be one of these:
https://github.com/laravel/framework/blob/5.3/src/Illuminate/Database/Query/Builder.php#L192