### PR TITLE
Taggables

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -499,7 +499,7 @@ Next, we're ready to define the relationships on the model. The `Post` and `Vide
          */
         public function tags()
         {
-            return $this->morphToMany('App\Tag', 'taggable');
+            return $this->morphToMany('App\Tag', 'taggables');
         }
     }
 
@@ -520,7 +520,7 @@ Next, on the `Tag` model, you should define a method for each of its related mod
          */
         public function posts()
         {
-            return $this->morphedByMany('App\Post', 'taggable');
+            return $this->morphedByMany('App\Post', 'taggables');
         }
 
         /**
@@ -528,7 +528,7 @@ Next, on the `Tag` model, you should define a method for each of its related mod
          */
         public function videos()
         {
-            return $this->morphedByMany('App\Video', 'taggable');
+            return $this->morphedByMany('App\Video', 'taggables');
         }
     }
 


### PR DESCRIPTION
In the Table Structure it is called `taggables`, but in the Model Structure the table name passed to `morphToMany` is `taggable`. In this PR this is changed to `taggables` so it's consistent.