### PR TITLE
Remove  Note for only "implicit" binding Key Customizing

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -196,7 +196,7 @@ In this example, since the Eloquent `$user` variable defined on the route matche
 
 #### Customizing The Key Name
 
-If you would like implicit model binding to use a database column other than `id` when retrieving a given model class, you may override the `getRouteKeyName` method on the Eloquent model:
+If you would like model binding to use a database column other than `id` when retrieving a given model class, you may override the `getRouteKeyName` method on the Eloquent model:
 
     /**
      * Get the route key for the model.


### PR DESCRIPTION
Remove the Word  "implicit" because Customizing works for booth, implicit and explicit.