### PR TITLE
Fix path in Webpack example

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -228,7 +228,7 @@ To choose a different output or base directory, simply specify your desired path
 ```javascript
 elixir(function(mix) {
     mix.webpack(
-        './resources/assets/js/app.js',
+        './app/assets/js/app.js',
         './public/dist'
     );
 });


### PR DESCRIPTION
Make the path in the example block of code consistent with the path in the paragraph that introduces it.