### PR TITLE
Use Class Notation in EventServiceProvider Events instead of 'Namespace\Classname'-Notation

### DIFF
--- a/events.md
+++ b/events.md
@@ -31,8 +31,8 @@ The `EventServiceProvider` included with your Laravel application provides a con
      * @var array
      */
     protected $listen = [
-        'App\Events\OrderShipped' => [
-            'App\Listeners\SendShipmentNotification',
+        App\Events\OrderShipped::class => [
+            App\Listeners\SendShipmentNotification::class,
         ],
     ];
 
@@ -255,12 +255,12 @@ Event subscribers are classes that may subscribe to multiple events from within 
         public function subscribe($events)
         {
             $events->listen(
-                'Illuminate\Auth\Events\Login',
+                Illuminate\Auth\Events\Login::class,
                 'App\Listeners\UserEventSubscriber@onUserLogin'
             );
 
             $events->listen(
-                'Illuminate\Auth\Events\Logout',
+                Illuminate\Auth\Events\Logout::class,
                 'App\Listeners\UserEventSubscriber@onUserLogout'
             );
         }
@@ -295,6 +295,6 @@ After writing the subscriber, you are ready to register it with the event dispat
          * @var array
          */
         protected $subscribe = [
-            'App\Listeners\UserEventSubscriber',
+            App\Listeners\UserEventSubscriber::class,
         ];
     }


### PR DESCRIPTION
Use Class Notation in EventServiceProvider Events instead of 'Namespace\Classname'-Notation where it is possible