### PR TITLE
Remove erroneous php prefix

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -138,7 +138,7 @@ Once Homestead has been installed, use the `make` command to generate the `Vagra
 
 Mac / Linux:
 
-    php vendor/bin/homestead make
+	vendor/bin/homestead make
 
 Windows:
 


### PR DESCRIPTION
Using the command as stated outputs the contents of the file because it is not a PHP file.
Composer installs a "proxy" file that handles cygwin detection and forwards the request to the real script.
( https://getcomposer.org/doc/articles/vendor-binaries.md#what-about-windows-and-bat-files- )
The real script uses the environment shebang invocation method to resolve php.

Example:

![image](https://cloud.githubusercontent.com/assets/488872/18628999/c4d26288-7e17-11e6-9e37-0cb3d5c5998f.png)

Note: tab spacing difference brings it inline with the windows equivalent of the same command in this section.