### PR TITLE
Add path for Social Authentication

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -14,6 +14,7 @@
     - [Other Authentication Methods](#other-authentication-methods)
 - [HTTP Basic Authentication](#http-basic-authentication)
     - [Stateless HTTP Basic Authentication](#stateless-http-basic-authentication)
+- [Social Authentication](https://github.com/laravel/socialite)
 - [Adding Custom Guards](#adding-custom-guards)
 - [Adding Custom User Providers](#adding-custom-user-providers)
     - [The User Provider Contract](#the-user-provider-contract)


### PR DESCRIPTION
I came to know about Socialite only after seeing the **Social Authentication** heading in the v5.2 docs under Authentication.
I think it will help others too if we were to include it here.