### PR TITLE
Change 'Adding Additional Sites' command to one that works

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -191,7 +191,7 @@ To connect to your MySQL or Postgres database from your host machine via Navicat
 <a name="adding-additional-sites"></a>
 ### Adding Additional Sites
 
-Once your Homestead environment is provisioned and running, you may want to add additional Nginx sites for your Laravel applications. You can run as many Laravel installations as you wish on a single Homestead environment. To add an additional site, simply add the site to your `~/.homestead/Homestead.yaml` file and then run the `vagrant provision` terminal command from your Homestead directory.
+Once your Homestead environment is provisioned and running, you may want to add additional Nginx sites for your Laravel applications. You can run as many Laravel installations as you wish on a single Homestead environment. To add an additional site, simply add the site to your `~/.homestead/Homestead.yaml` file and then run the `vagrant reload --provision` terminal command from your Homestead directory.
 
 <a name="configuring-cron-schedules"></a>
 ### Configuring Cron Schedules


### PR DESCRIPTION
The current command (`vagrant provision`) wasn't working. This new one does and follows the documents own advice earlier on.