### PR TITLE
Documented for the `to` and `from` methods on the SlackMessage class

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -521,6 +521,41 @@ The example above will create a Slack message that looks like the following:
 
 <img src="https://laravel.com/assets/img/slack-fields-attachment.png">
 
+#### Customizing the recipient
+
+Slack is fairly flexible, which allows us to override the custom webhook's channel by using the `to` method. This method accepts both `#channel` and `@username` notation. The latter will send the notification to a specific user.
+
+    /**
+     * Get the Slack representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+                    ->to('#laravel-other');
+                    ->content('This will be posted in #laravel-other')
+    }
+
+
+#### Customizing the bot's username and icon
+
+By default, the incoming webhook will use the default identity that you have configured in Slack, but with the `from` method it's trivial to set a custom username and icon:
+
+    /**
+     * Get the Slack representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+                    ->from('Ghostbot', ':ghost:');
+                    ->content('Hello from Ghostbot!')
+    }
+
 <a name="routing-slack-notifications"></a>
 ### Routing Slack Notifications
 


### PR DESCRIPTION
This PR adds documentation for the fresh new `to` and `from` methods on the `SlackMessage` notification.

https://github.com/laravel/framework/pull/14910

English isn't my first language, so feel free to tear me a new one if it reads funkily. I'm also thinking it might be a good idea to add screenshots. Thoughts?
