### PR TITLE
PATH for Laravel installer updated

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -34,7 +34,7 @@ First, download the Laravel installer using Composer:
 
     composer global require "laravel/installer"
 
-Make sure to place the `~/.composer/vendor/bin` directory (or the equivalent directory for your OS) in your $PATH so the `laravel` executable can be located by your system.
+Make sure to place the `$HOME/.composer/vendor/bin` directory (or the equivalent directory for your OS) in your $PATH so the `laravel` executable can be located by your system.
 
 Once installed, the `laravel new` command will create a fresh Laravel installation in the directory you specify. For instance, `laravel new blog` will create a directory named `blog` containing a fresh Laravel installation with all of Laravel's dependencies already installed:
 


### PR DESCRIPTION
Updated path for Laravel installer `~` with `$HOME` in order to make it work in your `. bashrc` or `.zshrc`, using path as `~/.composer/vendor/bin` is not working