### PR TITLE
Correct Class naming in morphMap

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -452,8 +452,8 @@ By default, Laravel will use the fully qualified class name to store the type of
     use Illuminate\Database\Eloquent\Relations\Relation;
 
     Relation::morphMap([
-        'posts' => App\Post::class,
-        'videos' => App\Video::class,
+        'posts' => \App\Post::class,
+        'videos' => \App\Video::class,
     ]);
 
 You may register the `morphMap` in the `boot` function of your `AppServiceProvider` or create a separate service provider if you wish.


### PR DESCRIPTION
I tried creating a morphMap in a project with this syntax, only to notice that i had to add a \ before the class