### PR TITLE
PhpRedis Support

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -2,6 +2,8 @@
 
 - [Introduction](#introduction)
     - [Configuration](#configuration)
+    - [Predis Configuration](#predis-configuration)
+    - [PhpRedis Configuration](#phpredis-configuration)
 - [Interacting With Redis](#interacting-with-redis)
     - [Pipelining Commands](#pipelining-commands)
 - [Pub / Sub](#pubsub)
@@ -13,7 +15,7 @@
 
     composer require predis/predis
 
-Or alternativly, install the [Redis PHP extension](https://github.com/phpredis/phpredis) installed via PECL.
+Or alternativly, install the [PhpRedis](https://github.com/phpredis/phpredis), the Redis PHP extension, via PECL.
 
 <a name="configuration"></a>
 ### Configuration
@@ -39,9 +41,21 @@ The default server configuration should suffice for development. However, you ar
 
 The `cluster` option will instruct the Laravel Redis client to perform client-side sharding across your Redis nodes, allowing you to pool nodes and create a large amount of available RAM. However, note that client-side sharding does not handle failover; therefore, is primarily suited for cached data that is available from another primary data store.
 
-Additionally, if you're using the Predis library, you may define an `options` array value in your Redis connection definition, allowing you to specify a set of Predis [client options](https://github.com/nrk/predis/wiki/Client-Options). The PECL extension does not support client options.
+<a name="predis-configuration"></a>
+### Predis Configuration
+
+Aside from `host`, `port`, `database` and `password` Predis supports additional [connection parameters](https://github.com/nrk/predis/wiki/Connection-Parameters) that may be added to each Redis server.
+
+Additionally to servers, you may define an `options` array value in your Redis connection definition, allowing you to specify a set of Predis [client options](https://github.com/nrk/predis/wiki/Client-Options).
+
+<a name="predis-configuration"></a>
+### PhpRedis Configuration
 
 > {note} If you have the Redis PHP extension installed via PECL, you will need to rename the alias for Redis in your `config/app.php` file.
+
+Aside from `host`, `port`, `database` and `password` PhpRedis supports the following connection parameters, that may be added to each Redis server: `persistent`, `prefix`, `read_timeout` and `timeout`.
+
+With Redis clusters, additionally to servers, you may define an `options` array value in your Redis connection definition, which supports the following options: `persistent`, `read_timeout` and `timeout`.
 
 <a name="interacting-with-redis"></a>
 ## Interacting With Redis

--- a/redis.md
+++ b/redis.md
@@ -39,7 +39,7 @@ The default server configuration should suffice for development. However, you ar
 
 The `cluster` option will instruct the Laravel Redis client to perform client-side sharding across your Redis nodes, allowing you to pool nodes and create a large amount of available RAM. However, note that client-side sharding does not handle failover; therefore, is primarily suited for cached data that is available from another primary data store.
 
-Additionally, if you're using the Predis library, you may define an `options` array value in your Redis connection definition, allowing you to specify a set of Predis [client options](https://github.com/nrk/predis/wiki/Client-Options).
+Additionally, if you're using the Predis library, you may define an `options` array value in your Redis connection definition, allowing you to specify a set of Predis [client options](https://github.com/nrk/predis/wiki/Client-Options). The PECL extension does not support client options.
 
 > {note} If you have the Redis PHP extension installed via PECL, you will need to rename the alias for Redis in your `config/app.php` file.
 

--- a/redis.md
+++ b/redis.md
@@ -11,7 +11,9 @@
 <a name="introduction"></a>
 ## Introduction
 
-[Redis](http://redis.io) is an open source, advanced key-value store. It is often referred to as a data structure server since keys can contain [strings](http://redis.io/topics/data-types#strings), [hashes](http://redis.io/topics/data-types#hashes), [lists](http://redis.io/topics/data-types#lists), [sets](http://redis.io/topics/data-types#sets), and [sorted sets](http://redis.io/topics/data-types#sorted-sets). Before using Redis with Laravel, you will need to install the `predis/predis` package via Composer:
+[Redis](http://redis.io) is an open source, advanced key-value store. It is often referred to as a data structure server since keys can contain [strings](http://redis.io/topics/data-types#strings), [hashes](http://redis.io/topics/data-types#hashes), [lists](http://redis.io/topics/data-types#lists), [sets](http://redis.io/topics/data-types#sets), and [sorted sets](http://redis.io/topics/data-types#sorted-sets).
+
+Before using Redis with Laravel, you will either need to install the `predis/predis` package via Composer:
 
     composer require predis/predis
 

--- a/redis.md
+++ b/redis.md
@@ -2,8 +2,8 @@
 
 - [Introduction](#introduction)
     - [Configuration](#configuration)
-    - [Predis Configuration](#predis-configuration)
-    - [PhpRedis Configuration](#phpredis-configuration)
+    - [Predis](#predis)
+    - [PhpRedis](#phpredis)
 - [Interacting With Redis](#interacting-with-redis)
     - [Pipelining Commands](#pipelining-commands)
 - [Pub / Sub](#pubsub)
@@ -41,15 +41,15 @@ The default server configuration should suffice for development. However, you ar
 
 The `cluster` option will instruct the Laravel Redis client to perform client-side sharding across your Redis nodes, allowing you to pool nodes and create a large amount of available RAM. However, note that client-side sharding does not handle failover; therefore, is primarily suited for cached data that is available from another primary data store.
 
-<a name="predis-configuration"></a>
-### Predis Configuration
+<a name="predis"></a>
+### Predis
 
 Aside from `host`, `port`, `database` and `password` Predis supports additional [connection parameters](https://github.com/nrk/predis/wiki/Connection-Parameters) that may be added to each Redis server.
 
 Additionally to servers, you may define an `options` array value in your Redis connection definition, allowing you to specify a set of Predis [client options](https://github.com/nrk/predis/wiki/Client-Options).
 
-<a name="predis-configuration"></a>
-### PhpRedis Configuration
+<a name="phpredis"></a>
+### PhpRedis
 
 > {note} If you have the Redis PHP extension installed via PECL, you will need to rename the alias for Redis in your `config/app.php` file.
 

--- a/redis.md
+++ b/redis.md
@@ -13,6 +13,8 @@
 
     composer require predis/predis
 
+Or alternativly, install the [Redis PHP extension](https://github.com/phpredis/phpredis) installed via PECL.
+
 <a name="configuration"></a>
 ### Configuration
 
@@ -20,11 +22,14 @@ The Redis configuration for your application is located in the `config/database.
 
     'redis' => [
 
+        'client' => 'predis',
+        
         'cluster' => false,
 
         'default' => [
-            'host' => '127.0.0.1',
-            'port' => 6379,
+            'host' => env('REDIS_HOST', 'localhost'),
+            'password' => env('REDIS_PASSWORD', null),
+            'port' => env('REDIS_PORT', 6379),
             'database' => 0,
         ],
 
@@ -34,9 +39,7 @@ The default server configuration should suffice for development. However, you ar
 
 The `cluster` option will instruct the Laravel Redis client to perform client-side sharding across your Redis nodes, allowing you to pool nodes and create a large amount of available RAM. However, note that client-side sharding does not handle failover; therefore, is primarily suited for cached data that is available from another primary data store.
 
-Additionally, you may define an `options` array value in your Redis connection definition, allowing you to specify a set of Predis [client options](https://github.com/nrk/predis/wiki/Client-Options).
-
-If your Redis server requires authentication, you may supply a password by adding a `password` configuration item to your Redis server configuration array.
+Additionally, if you're using the Predis library, you may define an `options` array value in your Redis connection definition, allowing you to specify a set of Predis [client options](https://github.com/nrk/predis/wiki/Client-Options).
 
 > {note} If you have the Redis PHP extension installed via PECL, you will need to rename the alias for Redis in your `config/app.php` file.
 


### PR DESCRIPTION
What's still missing from the documentation is the difference in connection parameters.

Predis and PhpRedis both support:

- `host`
- `password`
- `port`
- `database`
- `timeout`
- `persistent`

Predis supports these:

- `scheme`
- `path`
- `async`
- `read_write_timeout`
- `alias`
- `weight`
- `iterable_multibulk`
- `throw_errors`

PhpRedis supports these:

- `read_timeout`
- `prefix`

Especially the `read_write_timeout` and `read_timeout` is noticeable. I tried to prevent that, but https://github.com/laravel/framework/commit/bae60487cd2749eb57d2e2eeb7bf8c3ce71ef3ec#diff-dbfdb06f6a76b9f93f18f77fa7f4b298 reverted my attempt.

I'm not quite sure how to mention that without adding new sections. Any suggestions?