### PR TITLE
Added note about pcntl

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -389,6 +389,8 @@ Be sure to review the full [pagination documentation](/docs/{{version}}/paginati
 
 In your queue configuration, all `expire` configuration items should be renamed to `retry_after`. Likewise, the Beanstalk configuration's `ttr` item should be renamed to `retry_after`. This name change provides more clarity on the purpose of this configuration option.
 
+If your application makes use of the `--timeout` option for queue workers, you'll need to have the [pcntl extension](http://php.net/manual/en/pcntl.installation.php).
+
 #### Closures
 
 Queueing Closures is no longer supported. If you are queueing a Closure in your application, you should convert the Closure to a class and queue an instance of the class:


### PR DESCRIPTION
This PR adds a note about the newly required extension in Laravel 5.3.  There are several [search results](https://www.google.com/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=laravel%20pcntl) for people running into this issue and there's an [exception handling the error clause](https://github.com/laravel/framework/commit/40438b3b88d7164f3c18f463ee1587bde9ad8ef4#diff-8cb7a41b646a3fd1e7e37a6766a5dc75R69).  This adds a note to those considering upgrading so they understand the need to modify production environments during/prior to upgrading.