### PR TITLE
Undocumented alias methods

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -620,6 +620,8 @@ If you need even more power, you may use the `whereHas` and `orWhereHas` methods
         $query->where('content', 'like', 'foo%');
     })->get();
 
+> {tip} There are also handy aliases for finding models that don't have a relationship `doesntHave` and `whereDoesntHave`.
+
 <a name="counting-related-models"></a>
 ### Counting Related Models
 


### PR DESCRIPTION
I just used `doesntHave` in a project after finding it through a Google search. So I thought I'd add a tip to the documentation as it was the first place I looked and it isn't in here.