### PR TITLE
Point to 5.2 version of config/auth.php (rather than master)

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -524,7 +524,7 @@ Add `"symfony/dom-crawler": "~3.0"` and `"symfony/css-selector": "~3.0"` to the 
 
 #### Configuration File
 
-You should update your `config/auth.php` configuration file with the following: [https://github.com/laravel/laravel/blob/master/config/auth.php](https://github.com/laravel/laravel/blob/master/config/auth.php)
+You should update your `config/auth.php` configuration file with the following: [https://github.com/laravel/laravel/blob/5.2/config/auth.php](https://github.com/laravel/laravel/blob/5.2/config/auth.php)
 
 Once you have updated the file with a fresh copy, set your authentication configuration options to their desired value based on your old configuration file. If you were using the typical, Eloquent based authentication services available in Laravel 5.1, most values should remain the same.
 


### PR DESCRIPTION
Otherwise instructions like "take special note of the passwords.users.email configuration option in the new auth.php" are confusing, as passwords.users.email no longer exists in the master branch version of the file.