### PR TITLE
Homestead - Fix "Per Project Installation" command

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -138,11 +138,11 @@ Once Homestead has been installed, use the `make` command to generate the `Vagra
 
 Mac / Linux:
 
-    php vendor/bin/homestead make
+    vendor/bin/homestead make
 
 Windows:
 
-	vendor\\bin\\homestead make
+    vendor\\bin\\homestead make
 
 Next, run the `vagrant up` command in your terminal and access your project at `http://homestead.app` in your browser. Remember, you will still need to add an `/etc/hosts` file entry for `homestead.app` or the domain of your choice.
 


### PR DESCRIPTION
`vendor/bin/homestead` is a shell script, not a PHP script.