### PR TITLE
[5.3] Fix class name

### DIFF
--- a/facades.md
+++ b/facades.md
@@ -169,7 +169,7 @@ Lang  |  [Illuminate\Translation\Translator](http://laravel.com/api/{{version}}/
 Log  |  [Illuminate\Log\Writer](http://laravel.com/api/{{version}}/Illuminate/Log/Writer.html)  |  `log`
 Mail  |  [Illuminate\Mail\Mailer](http://laravel.com/api/{{version}}/Illuminate/Mail/Mailer.html)  |  `mailer`
 Notification  |  [Illuminate\Notifications\ChannelManager](http://laravel.com/api/{{version}}/Illuminate/Notifications/ChannelManager.html)  |  
-Password  |  [Illuminate\Auth\Passwords\PasswordBroker](http://laravel.com/api/{{version}}/Illuminate/Auth/Passwords/PasswordBroker.html)  |  `auth.password`
+Password  |  [Illuminate\Auth\Passwords\PasswordBrokerManager](http://laravel.com/api/{{version}}/Illuminate/Auth/Passwords/PasswordBrokerManager.html)  |  `auth.password`
 Queue  |  [Illuminate\Queue\QueueManager](http://laravel.com/api/{{version}}/Illuminate/Queue/QueueManager.html)  |  `queue`
 Queue (Instance)  |  [Illuminate\Contracts\Queue\Queue](http://laravel.com/api/{{version}}/Illuminate/Contracts/Queue/Queue.html)  |  `queue`
 Queue (Base Class) |  [Illuminate\Queue\Queue](http://laravel.com/api/{{version}}/Illuminate/Queue/Queue.html)  |


### PR DESCRIPTION
The `Password` facade uses the `auth.password` as the accessor which is an instance of `\Illuminate\Auth\Passwords\PasswordBrokerManager`.