### PR TITLE
Add information about the ShouldQueue contract

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -383,6 +383,17 @@ Since all mailable classes generated using the `make:mail` command make use of t
         ->bcc($evenMoreUsers)
         ->queue($message);
 
+#### Queueing By Default
+
+If you've got mail that you always want to put on a queue and don't want to have to call `queue()` wherever you send it you can just have your mailable class implement the `Illuminate\Contracts\Queue\ShouldQueue` contract. Even if you call `send()` on a mailable class that implements this contract it will still be placed on the queue.
+
+    use Illuminate\Contracts\Queue\ShouldQueue;
+
+    class OrderShipped extends Mailable implements ShouldQueue
+    {
+        //
+    }
+
 <a name="mail-and-local-development"></a>
 ## Mail & Local Development
 


### PR DESCRIPTION
This just adds some information about how you can use the `ShouldQueue` contract on a `Mailable` class so that it will always be queued by default, regardless of whether you call `send()` or `queue()` on it. 

The `ShouldQueue` contract is in the mailable stub (though the class doesn't implement it by default) but I think it's worth documenting why it's there and how it can be used.