### PR TITLE
Fix installation instructions

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -56,7 +56,7 @@ Both Valet and Homestead are great choices for configuring your Laravel developm
 
 <div class="content-list" markdown="1">
 - Install or update [Homebrew](http://brew.sh/) to the latest version using `brew update`.
-- Install PHP 7.0 using Homebrew via `brew install homebrew/php/php70`.
+- Install PHP 7.0 using Homebrew via `brew install php70`.
 - Install Valet with Composer via `composer global require laravel/valet`. Make sure the `~/.composer/vendor/bin` directory is in your system's "PATH".
 - Run the `valet install` command. This will configure and install Valet and DnsMasq, and register Valet's daemon to launch when your system starts.
 </div>


### PR DESCRIPTION
I just tried to install valet on a colleague's mac and it failed using the `brew install homebrew/php/php70` command.

```
~$ brew install homebrew/php/php70
==> Tapping homebrew/php
Cloning into '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-php'...
remote: Counting objects: 652, done.
remote: Compressing objects: 100% (407/407), done.
remote: Total 652 (delta 364), reused 470 (delta 243), pack-reused 0
Receiving objects: 100% (652/652), 301.85 KiB | 0 bytes/s, done.
Resolving deltas: 100% (364/364), done.
Checking connectivity... done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-php/Formula/arcanist.rb
Formulae found in multiple taps:
 * homebrew/php/php53
 * josegonzalez/php/php53

Please use the fully-qualified name e.g. homebrew/php/php53 to refer the formula.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-php/Formula/behat.rb
Formulae found in multiple taps:
 * homebrew/php/php53
 * josegonzalez/php/php53
```

Using the `brew install php70` command worked like a charm.