### PR TITLE
Let people know they can pass synced folder options in the homestead.yml

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -98,6 +98,17 @@ To enable [NFS](http://docs.vagrantup.com/v2/synced-folders/nfs.html), just add 
           to: /home/vagrant/Code
           type: "nfs"
 
+You can pass any options supported by vagrant [Synced Folders](https://www.vagrantup.com/docs/synced-folders/basic_usage.html) by placing them under the the options key:
+
+    folders:
+        - map: ~/Code
+          to: /home/vagrant/Code
+          type: "rsync"
+	  options:
+	      rsync__args: ["--verbose", "--archive", "--delete", "-zz"]
+	      rsync__exclude: ["node_modules"]
+	  
+	  
 #### Configuring Nginx Sites
 
 Not familiar with Nginx? No problem. The `sites` property allows you to easily map a "domain" to a folder on your Homestead environment. A sample site configuration is included in the `Homestead.yaml` file. Again, you may add as many sites to your Homestead environment as necessary. Homestead can serve as a convenient, virtualized environment for every Laravel project you are working on:


### PR DESCRIPTION
It took me far longer than I care to admit to learn that you could pass-through arbitrary configuration options to vagrant synced folders from within the homestead.yml. Maybe my rsync case makes a bad example, but I think the docs should mention the fact that you can do this.