### PR TITLE
Complement note about facades not to be mocked

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -315,4 +315,4 @@ We can mock the call to the `Cache` facade by using the `shouldReceive` method, 
         }
     }
 
-> {note} You should not mock the `Request` facade. Instead, pass the input you desire into the HTTP helper methods such as `call` and `post` when running your test.
+> {note} You should not mock the `Request` facade. Instead, pass the input you desire into the HTTP helper methods such as `call` and `post` when running your test. Also notice that you cannot mock the `Config` facade. Instead use `Config::set($key,$value)` in your test.


### PR DESCRIPTION
Config cannot be mocked.

I spent some time researching why my Config mocking would fail and found that people hit this trap more often than not.

* https://github.com/laravel/framework/issues/4072
* https://github.com/laravel/framework/issues/11273
* https://github.com/laravel/framework/issues/8979

I believe, by adding this note, you can decrease the amount of issues reported and thus save your time for actual development and improvements, rather than discussing issues that are known.