### PR TITLE
Add documentation for when using cluster and encrypted

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -59,6 +59,12 @@ If you are broadcasting your events over [Pusher](https://pusher.com), you shoul
     composer require pusher/pusher-php-server
 
 Next, you should configure your Pusher credentials in the `config/broadcasting.php` configuration file. An example Pusher configuration is already included in this file, allowing you to quickly specify your Pusher key, secret, and application ID.
+Remeber if you have specified a cluster and encryption in Pusher.com you need to set them in the option like this:
+
+    'options' => [
+        'cluster' => 'eu',
+        'encrypted' => true
+    ],
 
 When using Pusher and [Laravel Echo](#installing-laravel-echo), you should specify `pusher` as your desired broadcaster when instantiating an Echo instance:
 


### PR DESCRIPTION
I've had some trouble finding out why my pusher.com didn't work, and that was because I didn't specify cluster and encrypted options.

I think it would be a good idea to have it in the documentation.