### PR TITLE
[5.3] Authorization - Customizing `email` to `username`

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -79,7 +79,7 @@ When a user is not successfully authenticated, they will be automatically redire
 
 #### User Field Customization
 
-By default, Laravel uses the `email` field for authorization. If you would like to override this, you may add a `username()` method to your `LoginController` or `RegisterController`. Below is an example for using `username` for authorization:
+By default, Laravel uses the `email` field for authorization. If you would like to override this, you may add a `username()` method to your `LoginController`. Below is an example for using `username` for authorization:
 
     public function username() {
         return 'username';

--- a/authentication.md
+++ b/authentication.md
@@ -77,6 +77,14 @@ When a user is successfully authenticated, they will be redirected to the `/home
 
 When a user is not successfully authenticated, they will be automatically redirected back to the login form.
 
+#### User Field Customization
+
+By default, Laravel uses the `email` field for authorization. If you would like to override this, you may add a `username()` method to your `LoginController` or `RegisterController`. Below is an example for using `username` for authorization:
+
+    public function username() {
+        return 'username';
+    }
+
 #### Guard Customization
 
 You may also customize the "guard" that is used to authenticate and register users. To get started, define a `guard` method on your `LoginController`, `RegisterController`, and `ResetPasswordController`. The method should return a guard instance:


### PR DESCRIPTION
This PR adds some additional clarity on how to change the default user key for authorization from `email` to something else, such as `username`. This is a common question that comes up from other devs, and since this behavior changed between 5.2 and 5.3, it seems like something that the docs could benefit from having.

Happy to make copy-edits, if requested.
