### PR TITLE
Change AuthController to LoginController

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -182,7 +182,7 @@ We will access Laravel's authentication services via the `Auth` [facade](/docs/{
 
     use Illuminate\Support\Facades\Auth;
 
-    class AuthController extends Controller
+    class LoginController extends Controller
     {
         /**
          * Handle an authentication attempt.


### PR DESCRIPTION
There is no AuthController in Laravel 5.3+, so manually authenticating user should be done in LoginController now