### PR TITLE
  Missing Parameter in Passport Example #2781

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -380,6 +380,7 @@ When using the password grant, you may wish to authorize the token for all of th
         'form_params' => [
             'grant_type' => 'password',
             'client_id' => 'client-id',
+            'client_secret' => 'client-secret',
             'username' => 'taylor@laravel.com',
             'password' => 'my-password',
             'scope' => '*',


### PR DESCRIPTION
Added missing parameter 'client_secret' to the request all token example in passport.