### PR TITLE
Create Seeders with models or migrations

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -38,11 +38,15 @@ The easiest way to create a model instance is using the `make:model` [Artisan co
 
     php artisan make:model User
 
-If you would like to generate a [database migration](/docs/{{version}}/migrations) when you generate the model, you may use the `--migration` or `-m` option:
+If you would like to generate a [database migration](/docs/{{version}}/migrations) when you generate the model, you may use the `--migration` or `-m` option. The `--seeder` or `-s` option can be used to generate a [database seeder](/docs/{{version}}/seeding) along with the model. These two options may be used separately or combined:
 
     php artisan make:model User --migration
+    php artisan make:model User --seeder
+    php artisan make:model User --migration --seeder
 
     php artisan make:model User -m
+    php artisan make:model User -s
+    php artisan make:model User -m -s
 
 <a name="eloquent-model-conventions"></a>
 ### Eloquent Model Conventions

--- a/migrations.md
+++ b/migrations.md
@@ -40,6 +40,12 @@ The `--table` and `--create` options may also be used to indicate the name of th
 
     php artisan make:migration add_votes_to_users_table --table=users
 
+The `--seeder` option may also be used to generate a [database seeder](/docs/{{version}}/seeding) for your table:
+
+    php artisan make:migration create_users_table --create=users --seeder
+
+    php artisan make:migration add_votes_to_users_table --table=users --seeder
+
 If you would like to specify a custom output path for the generated migration, you may use the `--path` option when executing the `make:migration` command. The given path should be relative to your application's base path.
 
 <a name="migration-structure"></a>


### PR DESCRIPTION
Add documentation indicating that you can add `--seeder` to `artisan make:migration` or `artisan make:model` to create a matching Seeder. This depends on [laravel/framework PR 16177](https://github.com/laravel/framework/pull/16177).
