### PR TITLE
note that you can use a different env file when testing

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -30,6 +30,8 @@ It is often helpful to have different configuration values based on the environm
 
 To make this a cinch, Laravel utilizes the [DotEnv](https://github.com/vlucas/phpdotenv) PHP library by Vance Lucas. In a fresh Laravel installation, the root directory of your application will contain a `.env.example` file. If you install Laravel via Composer, this file will automatically be renamed to `.env`. Otherwise, you should rename the file manually.
 
+> {note} You can create a `.env.testing` file which will be used instead of the `.env` while testing. This can be useful when calling Artisan commands from within your tests.
+
 #### Retrieving Environment Configuration
 
 All of the variables listed in this file will be loaded into the `$_ENV` PHP super-global when your application receives a request. However, you may use the `env` helper to retrieve values from these variables in your configuration files. In fact, if you review the Laravel configuration files, you will notice several of the options already using this helper:


### PR DESCRIPTION
currently it's undocumented that you can use a different .env file based on the app_env. This is needed when running tests that call artisan which won't respect environment variables defined in phpunit.xml
