### PR TITLE
Include Form Model Binding With Generic Controller Methods

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -252,6 +252,12 @@ You may use the `method_field` helper to generate the `_method` input:
 
     {{ method_field('PUT') }}
 
+#### Form Model Binding With Generic Controller Methods
+
+If you have multiple models that use the same method of the same controller, it may be necessary to specify a URL that you have already enumerated in your `web.php` file. This can be done the following way in blade:
+
+    {!! Form::model($model, ['method'=>'PATCH','url'=>["/foo/$bar", $model->id]]) !!}
+    
 <a name="accessing-the-current-route"></a>
 ## Accessing The Current Route
 


### PR DESCRIPTION
The action method was pointing to a route for a different model, because they used the same Controller and Method. This was surprisingly frustrating until I realized I could specify the 'url' attribute directly. It wasn't mentioned anywhere, and I thought it might be useful to someone else!