### PR TITLE
Update envoy.md, add information about @finished directive

### DIFF
--- a/envoy.md
+++ b/envoy.md
@@ -171,6 +171,12 @@ Envoy also supports sending notifications to [Slack](https://slack.com) after ea
         @slack('webhook-url', '#bots')
     @endafter
 
+If you would like to send notifications just once when all tasks have been finished, you may use `@finished` directive.
+
+    @finished
+        @slack('webhook-url', '#bots')
+    @endfinished
+
 You may provide one of the following as the channel argument:
 
 <div class="content-list" markdown="1">


### PR DESCRIPTION
Add a postscripts about envoy
https://github.com/laravel/envoy/pull/98

It was `shutdown` directive when the pull request had been accepted, but I saw it had been formatted into `finished`.
So I reflected it into this document.