### PR TITLE
Use truthy example for has

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -560,9 +560,9 @@ The `has` method determines if a given key exists in the collection:
 
     $collection = collect(['account_id' => 1, 'product' => 'Desk']);
 
-    $collection->has('email');
+    $collection->has('product');
 
-    // false
+    // true
 
 <a name="method-implode"></a>
 #### `implode()` {#collection-method}


### PR DESCRIPTION
It better describes what's going on.

With the current example, there's no way from the code itself to see that we're checking keys and not values.