### PR TITLE
The confirm method is automatically appending a '[yes/no]' string on …

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -303,9 +303,9 @@ The `secret` method is similar to `ask`, but the user's input will not be visibl
 
 #### Asking For Confirmation
 
-If you need to ask the user for a simple confirmation, you may use the `confirm` method. By default, this method will return `false`. However, if the user enters `y` in response to the prompt, the method will return `true`.
+If you need to ask the user for a simple confirmation, you may use the `confirm` method. By default, this method will return `false`. However, if the user enters `y` or `yes` in response to the prompt, the method will return `true`.
 
-    if ($this->confirm('Do you wish to continue? [y|N]')) {
+    if ($this->confirm('Do you wish to continue?')) {
         //
     }
 


### PR DESCRIPTION
…to the end of the question argument. The docs as written currently yield 'Do you want me to do this for you? [y|N] (yes/no) [no]:' which is confusing. This PR removes the [y|n] from the question and updates the explanation that answering 'y' or 'yes' will yield a true result.