### PR TITLE
Add note about delayed job behavior when using QUEUE_DRIVER=sync

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -192,6 +192,8 @@ If you would like to delay the execution of a queued job, you may use the `delay
 
 > {note} The Amazon SQS queue service has a maximum delay time of 15 minutes.
 
+> {note} Delayed jobs will execute immediately if QUEUE_DRIVER=sync 
+
 <a name="customizing-the-queue-and-connection"></a>
 ### Customizing The Queue & Connection
 


### PR DESCRIPTION
This is obvious once you think about it, but not really called out anywhere. Should be helpful if someone is having an issue testing delayed jobs