### PR TITLE
Note renumbering key's

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -724,6 +724,8 @@ The `mapWithKeys` method iterates through the collection and passes each value t
         ]
     */
 
+> {note} Numeric keys will be renumbered with incrementing keys starting from zero.
+
 <a name="method-max"></a>
 #### `max()` {#collection-method}
 


### PR DESCRIPTION
Refs laravel/framework#16552

People can use a workaround with ``` keyBy() ``` or ``` pluck() ```
Example https://github.com/laravel/framework/issues/15409#issuecomment-247083776

Not sure if we could mention that, usually they can just use another function anyway...