### PR TITLE
Reopening #2860 with a proper explanation

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -724,6 +724,8 @@ The `mapWithKeys` method iterates through the collection and passes each value t
         ]
     */
 
+> {note} Numeric keys will be renumbered with incrementing keys starting from zero.
+
 <a name="method-max"></a>
 #### `max()` {#collection-method}
 


### PR DESCRIPTION
Refs #2860

Given the following collection:

```php
[
    [
        'id' => 2,
        'city' => 'Boston',
        'state' => 'Massachusetts'
    ],
    [
        'id' => 4,
        'city' => 'Seattle',
        'state' => 'Washington'
    ],
]
```

You want to use ``` mapWithKeys ``` on this collection to return the following:

```php
[
    2 => 'Boston, Massachusetts',
    4 => 'Seattle, Washington'
]
```

And then you would list this on your view for a select form or something like that, you'd use this syntax for the method:

```php
$collection->mapWithKeys(function ($item) {
    return [$item['id'] => $item['city'].', '.$item['state']];
});
```

But since it calls collapse then it will renumber the array keys, this will result in:

```php
[
    0 => 'Boston, Massachusetts',
    1 => 'Seattle, Washington'
]
```

That's what i'm meaning, you can close this and give a better explanation if you think that ppl won't get the right idea with the one i gave...

