### PR TITLE
Consistency and better context to route binding

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -263,7 +263,7 @@ To register an explicit binding, use the router's `model` method to specify the 
 
 Next, define a route that contains a `{user}` parameter:
 
-    $router->get('profile/{user}', function (App\User $user) {
+    Route::get('profile/{user}', function (App\User $user) {
         //
     });
 
@@ -275,7 +275,7 @@ If a matching model instance is not found in the database, a 404 HTTP response w
 
 If you wish to use your own resolution logic, you may use the `Route::bind` method. The `Closure` you pass to the `bind` method will receive the value of the URI segment and should return the instance of the class that should be injected into the route:
 
-    $router->bind('user', function ($value) {
+    Route::bind('user', function ($value) {
         return App\User::where('name', $value)->first();
     });
 

--- a/routing.md
+++ b/routing.md
@@ -275,9 +275,14 @@ If a matching model instance is not found in the database, a 404 HTTP response w
 
 If you wish to use your own resolution logic, you may use the `Route::bind` method. The `Closure` you pass to the `bind` method will receive the value of the URI segment and should return the instance of the class that should be injected into the route:
 
-    Route::bind('user', function ($value) {
-        return App\User::where('name', $value)->first();
-    });
+    public function boot()
+    {
+        parent::boot();
+
+        Route::bind('user', function ($value) {
+            return App\User::where('name', $value)->first();
+        });
+    }
 
 <a name="form-method-spoofing"></a>
 ## Form Method Spoofing


### PR DESCRIPTION
I've fixed the examples of explicit route model binding.  In the current examples `$router` is used when the text refers to the `Route` facade.  This was probably missed from 5.2->5.3 since the parameters for `boot()` were removed in 5.3.  This change makes it more consistent.

I also added context of location to the example of a custom resolution using `Route::bind()` by wrapping the example inside the `boot()` method of the service provider.  The reasoning is the previous example shows putting the explicit binding in the `boot()` method, then refers to adding a route to the route file.  Adding context back to the `boot()` will make it more clear that we are back in the `RouteServiceProvider`'s `boot()` method rather than in the route file.

Hope these changes make sense,
Luke