### PR TITLE
Updated Authorization Readme File

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -321,3 +321,43 @@ Like most of the other authorization methods, you may pass a class name to the `
     @cannot('create', Post::class)
         <!-- The Current User Can't Create Posts -->
     @endcannot
+
+#### Custom Error Messages For Unauthorized Access
+
+You may pass an array instead of the model to the `@can` and `@cannot` directives with an added string for customizing the default unauthorized access error message:
+
+    <?php
+    use App\Post;
+    $customError = "Please ask your administration to grant you access to perform this operation.";
+
+    if ($user->can('create', [Post::class, $customError])) {
+        // Executes the "create" method on the relevant policy...
+    }
+
+You can also do the same with `@authorize` directive as well:
+
+    <?php
+
+    namespace App\Http\Controllers;
+
+    use App\Post;
+    use Illuminate\Http\Request;
+    use App\Http\Controllers\Controller;
+
+    class PostController extends Controller
+    {
+        /**
+         * Update the given blog post.
+         *
+         * @param  Request  $request
+         * @param  Post  $post
+         * @return Response
+         */
+        public function update(Request $request, Post $post)
+        {
+            $customError = "Please upgrade your account to perform this operation.";
+            $this->authorize('update', [$post, $customError]);
+
+            // The current user can update the blog post...
+        }
+    }

--- a/authorization.md
+++ b/authorization.md
@@ -322,19 +322,9 @@ Like most of the other authorization methods, you may pass a class name to the `
         <!-- The Current User Can't Create Posts -->
     @endcannot
 
-#### Custom Error Messages For Unauthorized Access
+#### Overriding The Default Unauthorized Access Error Message
 
-You may pass an array instead of the model to the `@can` and `@cannot` directives with an added string for customizing the default unauthorized access error message:
-
-    <?php
-    use App\Post;
-    $customError = "Please ask your administration to grant you access to perform this operation.";
-
-    if ($user->can('create', [Post::class, $customError])) {
-        // Executes the "create" method on the relevant policy...
-    }
-
-You can also do the same with `@authorize` directive as well:
+You can pass an extra **String/Collection**, as argument to the `@authorize` function, after the `ability` argument, as parameter to override the default unauthorized access error message:
 
     <?php
 
@@ -356,7 +346,7 @@ You can also do the same with `@authorize` directive as well:
         public function update(Request $request, Post $post)
         {
             $customError = "Please upgrade your account to perform this operation.";
-            $this->authorize('update', [$post, $customError]);
+            $this->authorize('update', $customError);
 
             // The current user can update the blog post...
         }


### PR DESCRIPTION
Added documentation to indicate the convention of using `@can`, `@cannot` and `@authorize` directives with custom error messages to override the default unauthorized access message.