### PR TITLE
Remove extra word

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -645,7 +645,7 @@ If you want to count the number of results from a relationship without actually 
         echo $post->comments_count;
     }
 
-You may add retrieve the "counts" for multiple relations as well as add constraints to the queries:
+You may add the "counts" for multiple relations as well as add constraints to the queries:
 
     $posts = Post::withCount(['votes', 'comments' => function ($query) {
         $query->where('content', 'like', 'foo%');


### PR DESCRIPTION
There may have been previous phrasing that used the word "retrieve", but the current version is clearer without that word, as it speaks of adding "counts" and adding constraints.