### PR TITLE
Fixed HTML code blocks

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -214,9 +214,7 @@ This will append a unique hash to the filename, allowing for cache-busting. For 
 
 Within your views, you may use the `elixir()` function to load the appropriately hashed asset. Here's an example:
 
-```html
-<link rel="stylesheet" href="{{ elixir("css/all.css") }}">
-```
+    <link rel="stylesheet" href="{{ elixir("css/all.css") }}">
 
 Behind the scenes, the `elixir()` function will determine the name of the hashed file that should be included. Don't you feel the weight lifting off your shoulders already?
 
@@ -228,10 +226,8 @@ elixir(function(mix) {
 });
 ```
 
-```html
-<link rel="stylesheet" href="{{ elixir("css/all.css") }}">
-<script src="{{ elixir("js/app.js") }}"></script>
-```
+    <link rel="stylesheet" href="{{ elixir("css/all.css") }}">
+    <script src="{{ elixir("js/app.js") }}"></script>
 
 #### Copy a File to a New Location
 


### PR DESCRIPTION
Because of the `}}` blade vars (since it's HTML), it fails to show as a proper code block in the docs at the moment.