### PR TITLE
Require any version of valet

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -56,7 +56,7 @@ Both Valet and Homestead are great choices for configuring your Laravel developm
 <div class="content-list" markdown="1">
 - Install or update [Homebrew](http://brew.sh/) to the latest version using `brew update`.
 - Install PHP 7.1 using Homebrew via `brew install homebrew/php/php71`.
-- Install Valet with Composer via `composer global require laravel/valet`. Make sure the `~/.composer/vendor/bin` directory is in your system's "PATH".
+- Install Valet with Composer via `composer global require laravel/valet:*`. Make sure the `~/.composer/vendor/bin` directory is in your system's "PATH".
 - Run the `valet install` command. This will configure and install Valet and DnsMasq, and register Valet's daemon to launch when your system starts.
 </div>
 


### PR DESCRIPTION
This makes sure that composer global update actually updates to any new (major) version. It's maybe too late for the upgrade to version 2 now, because everyone has a version constraint to Valet 1 now, but at least new people can just `composer global update` when Valet 3 or higher comes out.