### PR TITLE
Added note on .htaccess when upgrading from 5.3

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -508,6 +508,13 @@ When calling routes that are protected by Passport, your application's API consu
             'Authorization' => 'Bearer '.$accessToken,
         ],
     ]);
+    
+> {note} If you are using Apache and upgraded to Laravel 5.3 at some point, make sure the folowing is present in your `public/.htaccess` file:
+```
+# Handle Authorization Header
+RewriteCond %{HTTP:Authorization} .
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+```
 
 <a name="token-scopes"></a>
 ## Token Scopes


### PR DESCRIPTION
There is no upgrade note suggesting to add the following to .htaccess when migrating to 5.3
RewriteCond %{HTTP:Authorization} .
RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]

It really took me some time to figure that out :-)