### PR TITLE
[5.3] Document looping event

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -547,3 +547,11 @@ Using the `before` and `after` methods on the `Queue` [facade](/docs/{{version}}
             //
         }
     }
+
+Using the `looping` method on the `Queue` [facade](/docs/{{version}}/facades), you may also specify callbacks to be executed before the daemon worker tries to fetch a job from the given queue. This is a good place to clean-up resources. For example, you can register a closure to refresh the DB connections or rollback the transactions that are left open by a previously failed job:
+
+    Queue::looping(function () {
+        while (DB::transactionLevel() > 0) {
+            DB::rollBack();
+        }
+    });


### PR DESCRIPTION
The example is what I use in my projects.
Another example is Laravel-Bugsnag batch sending report option. Inside a daemon queue worker instance, it flushes the report buffer on looping event.
The same technique may be used elsewhere, for example when sending events to Google Analytics.