### PR TITLE
Add back missing @hasSection documentation

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -164,6 +164,16 @@ For convenience, Blade also provides an `@unless` directive:
     @unless (Auth::check())
         You are not signed in.
     @endunless
+    
+You may also determine if a given layout section has any content using the `@hasSection` directive:
+
+    <title>
+        @hasSection ('title')
+            @yield('title') - App Name
+        @else
+            App Name
+        @endif
+    </title>
 
 <a name="loops"></a>
 ### Loops


### PR DESCRIPTION
Previously removed in commit https://github.com/laravel/docs/commit/fec6ca03fab981d9a751b476e71cf00c0f15c0af#diff-5ec203a153377bbcca8d0af017818bcf but still valid and useful syntax.