### PR TITLE
fix routing definition for `Explicit Binding`

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -263,7 +263,7 @@ To register an explicit binding, use the router's `model` method to specify the 
 
 Next, define a route that contains a `{user}` parameter:
 
-    Route::get('profile/{user}', function (App\User $user) {
+    Route::get('profile/{user}', function ($user) {
         //
     });
 


### PR DESCRIPTION
no need to add a type hint `App\User` in route definition for `Explicit Binding`.