### PR TITLE
Add nullableMorphs in migrations

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -227,6 +227,7 @@ Command  | Description
 `$table->mediumInteger('numbers');`  |  MEDIUMINT equivalent for the database.
 `$table->mediumText('description');`  |  MEDIUMTEXT equivalent for the database.
 `$table->morphs('taggable');`  |  Adds unsigned INTEGER `taggable_id` and STRING `taggable_type`.
+`$table->nullableMorphs('taggable');`  |  Adds unsigned INTEGER `taggable_id` NULL and STRING `taggable_type` NULL.
 `$table->nullableTimestamps();`  |  Same as `timestamps()`.
 `$table->rememberToken();`  |  Adds `remember_token` as VARCHAR(100) NULL.
 `$table->smallIncrements('id');`  |  Incrementing ID (primary key) using a "UNSIGNED SMALL INTEGER" equivalent.
@@ -295,7 +296,7 @@ We could also modify a column to be nullable:
         $table->string('name', 50)->nullable()->change();
     });
 
-> {note} The following column types can not be "changed": char, double, enum, mediumInteger, timestamp, tinyInteger, ipAddress, json, jsonb, macAddress, mediumIncrements, morphs, nullableTimestamps, softDeletes, timeTz, timestampTz, timestamps, timestampsTz, unsignedMediumInteger, unsignedTinyInteger, uuid.
+> {note} The following column types can not be "changed": char, double, enum, mediumInteger, timestamp, tinyInteger, ipAddress, json, jsonb, macAddress, mediumIncrements, morphs, nullableMorphs, nullableTimestamps, softDeletes, timeTz, timestampTz, timestamps, timestampsTz, unsignedMediumInteger, unsignedTinyInteger, uuid.
 
 <a name="renaming-columns"></a>
 #### Renaming Columns


### PR DESCRIPTION
I don't know how to better describe that fields will be nullable:

```
Adds unsigned INTEGER `taggable_id` NULL and STRING `taggable_type` NULL
```

Or:

```
Adds nullable unsigned INTEGER `taggable_id` and nullable STRING `taggable_type`
```