### PR TITLE
Add Login Failed Event to Events List in Authentication

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -521,6 +521,10 @@ Laravel raises a variety of [events](/docs/{{version}}/events) during the authen
             'App\Listeners\LogSuccessfulLogin',
         ],
 
+        'Illuminate\Auth\Events\Failed' => [
+            'App\Listeners\LogFailedLogin',
+        ],
+
         'Illuminate\Auth\Events\Logout' => [
             'App\Listeners\LogSuccessfulLogout',
         ],


### PR DESCRIPTION
The Events section of the Authentication page currently only documents six of the possible seven events that are raised by Laravel during the login and registration process.  This PR adds the `Illuminate\Auth\Events\Failed` event, in the same way as the other events are listed.