### PR TITLE
Clarify mergeFromConfig() limitation

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -89,6 +89,8 @@ You may also merge your own package configuration file with the application's pu
         );
     }
 
+> {note} This will only merge the first level of the config array. If users partially define one of your multi-dimensional config arrays, the missing options will not be merged in.
+
 <a name="migrations"></a>
 ### Migrations
 


### PR DESCRIPTION
As mentioned here - https://github.com/laravel/framework/issues/16991 - this is expected behavior. 

So just documenting it to make it clear that multi-dimensional arrays can be partially filled by users, and the missing sections wont be filled by the `mergeFromConfig()`

I'm open to better wording on this to make it clearer if anyone has any ideas...?