### PR TITLE
Update queues to add sleep

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -346,6 +346,14 @@ The `retry_after` configuration option and the `--timeout` CLI option are differ
 
 > {note} The `--timeout` value should always be at least several seconds shorter than your `retry_after` configuration value. This will ensure that a worker processing a given job is always killed before the job is retried. If your `--timeout` option is longer than your `retry_after` configuration value, your jobs may be processed twice.
 
+#### Specifying Queue Sleep Duration
+
+You may specify the number of seconds to wait before polling for new jobs:
+
+php artisan queue:work --sleep=3
+
+> {note} The queue only "sleeps" if no jobs are on the queue. If more jobs are available, the queue will continue to work them without sleeping.
+
 <a name="supervisor-configuration"></a>
 ## Supervisor Configuration
 


### PR DESCRIPTION
I noticed the `--sleep` option has disappeared from the docs?

Is this intentional?

If it is intentional - then there needs to be a different PR to remove the reference to `--sleep` from the supervisor demo code that still includes it there...