### PR TITLE
Removes tip duplication

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -181,8 +181,6 @@ When defining policy methods that will not receive a model instance, such as a `
         //
     }
 
-> {tip} If you used the `--model` option when generating your policy, all of the relevant "CRUD" policy methods will already be defined on the generated policy.
-
 <a name="policy-filters"></a>
 ### Policy Filters
 


### PR DESCRIPTION
Duplication of pretty much the same tip from the section above, "Policy Methods"?

{tip} If you used the `--model` option when generating your policy via the Artisan console, it will already contain methods for the `view`, `create`, `update`, and `delete` actions.