### PR TITLE
Add a note about not using closures in config files

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -73,6 +73,8 @@ Now, when users of your package execute Laravel's `vendor:publish` command, your
 
     $value = config('courier.option');
 
+> {note} Be sure not to use any closures in your configuration files, as they will not be serialized correctly if your users use the `php artisan config:cache` command.
+
 #### Default Package Configuration
 
 You may also merge your own package configuration file with the application's published copy. This will allow your users to define only the options they actually want to override in the published copy of the configuration. To merge the configurations, use the `mergeConfigFrom` method within your service provider's `register` method:


### PR DESCRIPTION
Package developers all-too-frequently resort to putting closures in their config files. While this is an anti-pattern, it appears to work fine until a user tries to do `php artisan config:cache`, at which point the closure is not serialized correctly and the app breaks.

This PR is a (probably futile) attempt to make package developers aware of this issue before they cause it :)