### PR TITLE
Use app host for Socket.IO script + websocket

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -86,18 +86,20 @@ When the Redis broadcaster publishes an event, it will be published on the event
 
 #### Socket.IO
 
-If you are going to pair the Redis broadcaster with a Socket.IO server, you will need to include the Socket.IO JavaScript client library in your application's `head` HTML element:
+If you are going to pair the Redis broadcaster with a Socket.IO server, you will need to include the Socket.IO JavaScript client library in your application's `head` HTML element. The Socket.IO serves this client for your convenience. Assuming you are running the server on the same domain on port 6001:
 
-    <script src="https://cdn.socket.io/socket.io-1.4.5.js"></script>
+    <script src="//{{ Request::getHost() }}:6001/socket.io/socket.io.js"></script>
 
-Next, you will need to instantiate Echo with the `socket.io` connector and a `host`. For example, if your application and socket server are running on the `app.dev` domain you should instantiate Echo like so:
+Next, you will need to instantiate Echo with the `socket.io` connector and a `host`.
 
     import Echo from "laravel-echo"
 
     window.Echo = new Echo({
         broadcaster: 'socket.io',
-        host: 'http://app.dev:6001'
+        host: window.location.hostname + ':6001'
     });
+
+You can run the server on de different domain, but be aware that Laravel session cookies will only be shared with the same domain, so you will need to user an alternative authentication method.
 
 Finally, you will need to run a compatible Socket.IO server. Laravel does not include a Socket.IO server implementation; however, a community driven Socket.IO server is currently maintained at the [tlaverdure/laravel-echo-server](https://github.com/tlaverdure/laravel-echo-server) GitHub repository.
 


### PR DESCRIPTION
- Socket.IO serves the client SDK by default. The CDN is not maintained/updated and is currently out-of-date (Current version is 1.7.2 and 1.4.5 is 1 year old)
- The socket should usually run on the same domain to provide session sharing. Otherwise authentication will fail (eg. when using IP instead of host). Also simplifies multiple environments, domain aliases etc).