### PR TITLE
[5.4] Adding a precision to whereHas

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -641,6 +641,8 @@ If you need even more power, you may use the `whereHas` and `orWhereHas` methods
     $posts = Post::whereHas('comments', function ($query) {
         $query->where('content', 'like', 'foo%');
     })->get();
+    
+Of course you may also use nested statements using dot notation, as you would with `has`.
 
 <a name="querying-relationship-absence"></a>
 ### Querying Relationship Absence


### PR DESCRIPTION
Hello, first time proposing changes to the doc, so I hope I'm doing things right!

I only added one line, under the `whereHas` example to explicitly say that you can also use nested statement with dot notation like you can do with the `has` method.

I'm making this edit because at first, reading the documentation, I didn't make the assumption that it was also possible because it wasn't written for `whereHas`. I just hope this small change can be beneficial to the understanding of the usage of the method.

I didn't write code example, I think that would be too much, but if it is required, please tell me, I'll write a small one.