### PR TITLE
Fix typo in Collection docs

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -316,7 +316,7 @@ If you would like to stop iterating through the items, you may return `false` fr
 
 The `every` method may be used to verify that all elements of a collection pass a given truth test:
 
-    collect([1, 2, 3, 4])->first(function ($value, $key) {
+    collect([1, 2, 3, 4])->every(function ($value, $key) {
         return $value > 2;
     });
 


### PR DESCRIPTION
The example for `every()` was incorrectly calling `first()`