### PR TITLE
[5.4] Typo fix Custom Pivot Table Models section.

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -300,7 +300,7 @@ Of course, if you leverage a realtime facade in this way, you may easily write a
 
 ### Custom Pivot Table Models
 
-In Laravel 5.3, all "pivot" table models for `belongsToMany` relationships used the same built-in `Pivot` model instance. In Laravel 5.4, you may defined custom models for your pivot tables. If you would like to define a custom model to represent the intermediate table of your relationship, use the `using` method when defining the relationship:
+In Laravel 5.3, all "pivot" table models for `belongsToMany` relationships used the same built-in `Pivot` model instance. In Laravel 5.4, you may define custom models for your pivot tables. If you would like to define a custom model to represent the intermediate table of your relationship, use the `using` method when defining the relationship:
 
     <?php
 


### PR DESCRIPTION
There was a typo "you may defined custom models" should be "you may define custom models"