### PR TITLE
[5.4] Add note to run php artisan view:clear

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -41,6 +41,8 @@ Once the package has been installed, you should add `Laravel\Tinker\TinkerServic
 
 Laravel 5.4 requires Guzzle 6.0 or greater.
 
+> {note} After upgrading all packages, you should run `php artisan view:clear` to avoid various errors related to the removal of `Illuminate\View\Factory::getFirstLoop()`.
+
 ### Authorization
 
 #### The `getPolicyFor` Method


### PR DESCRIPTION
Not sure where you want to stick this, but it is pretty important to run `view:clear` to avoid all sorts of view errors once the 5.4 upgrade has been completed. I don't think it is common knowledge to run this command after an upgrade. I don't mind if you close this PR and add the info in yourself where appropriate.