### PR TITLE
Migrating Laravel Elixir to Laravel Mix

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -239,6 +239,10 @@ The `illuminate.log` event is now an object based event using the `Illuminate\Lo
 
 The `Illuminate\Http\Exception\HttpResponseException` has been renamed to `Illuminate\Http\Exceptions\HttpResponseException`. Note that `Exceptions` is now plural. Likewise, the `Illuminate\Http\Exception\PostTooLargeException` has been renamed to `Illuminate\Http\Exceptions\PostTooLargeException`.
 
+### Laravel Mix
+
+Laravel 5.4 introduces [Laravel Mix](/docs/{{version}}/mix) for compiling frontend assets. If you are switching to Laravel Mix from Laravel Elixir, you will need to remove any dependencies prefixed with 'laravel-elixir' from your 'package.json' file in order for Webpack to compile properly.
+
 ### Mail
 
 #### `Class@method` Syntax


### PR DESCRIPTION
Failing to remove 'laravel-elixir' from package.json causes very confusing errors with Laravel Mix that cost me several hours of debugging. I have seen other people dealing with this issue, so I think it would be a good idea to include in the upgrade guide.