### PR TITLE
The Alias method

### DIFF
--- a/container.md
+++ b/container.md
@@ -9,6 +9,7 @@
 - [Resolving](#resolving)
     - [The Make Method](#the-make-method)
     - [Automatic Injection](#automatic-injection)
+    - [Alias](#alias)
 - [Container Events](#container-events)
 
 <a name="introduction"></a>
@@ -232,6 +233,13 @@ For example, you may type-hint a repository defined by your application in a con
             //
         }
     }
+
+<a name="alias"></a>
+#### The `alias` Method
+
+You may use the `alias` method to determine what class should be used by a contract:
+
+    $this->app->alias('mailer', \Illuminate\Contracts\Mail\Mailer::class)
 
 <a name="container-events"></a>
 ## Container Events


### PR DESCRIPTION
Ok - so I think the wording might be wrong for what I've written - but I dont know how to write it better. Rather than just create an issue for it, I wanted to start a PR and someone can write a better one if needed.

`alias()` is needed for when you want to use Lumen, Notifications and Mail. It address this issue https://github.com/laravel/lumen-framework/issues/503 - which is resolved with this command.

There might be other/better uses that could be put in the documentation as well.

p.s. Although this solves a Lumen issue - I'm doing the PR to the Laravel docs as the Lumen service docs basically says to look here :)