### PR TITLE
BrowserKit tests will need the BrowserKitTest namespace for migrations and transactions

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -370,6 +370,8 @@ Once you have created this class, make sure to update all of your tests to exten
 
 > {note} If you are writing new tests and want them to use the Laravel 5.4 testing layer, make sure to extend the `TestCase` class.
 
+> {note} If using the DatabaseMigrations or DatabaseTransactions traits then you will need to update their namespace to `Laravel\BrowserKitTesting\DatabaseMigrations` and `Laravel\BrowserKitTesting\DatabaseTransactions`.
+
 #### Environment
 
 The Laravel 5.4 test class no longer manually forces `putenv('APP_ENV=testing')` for each test. Instead, the framework utilizes the `APP_ENV` variable from the loaded `.env` file.

--- a/upgrade.md
+++ b/upgrade.md
@@ -370,7 +370,7 @@ Once you have created this class, make sure to update all of your tests to exten
 
 > {note} If you are writing new tests and want them to use the Laravel 5.4 testing layer, make sure to extend the `TestCase` class.
 
-> {note} If using the DatabaseMigrations or DatabaseTransactions traits then you will need to update their namespace to `Laravel\BrowserKitTesting\DatabaseMigrations` and `Laravel\BrowserKitTesting\DatabaseTransactions`.
+> {note} If using the DatabaseMigrations or DatabaseTransactions traits in your BrowserKitTests then you will need to update their namespace to `Laravel\BrowserKitTesting\DatabaseMigrations` and `Laravel\BrowserKitTesting\DatabaseTransactions`.
 
 #### Environment
 


### PR DESCRIPTION
Just came across an issue where the DatabaseMigrations trait wan't being used. I noticed that it needs to be using the BrowserKit version. It was undocumented so this PR notes the namespace change need.