### PR TITLE
Update Passport install instructions

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -40,7 +40,7 @@ Laravel already makes it easy to perform authentication via traditional login fo
 
 To get started, install Passport via the Composer package manager:
 
-    composer require laravel/passport
+    composer require laravel/passport=~1.0
 
 Next, register the Passport service provider in the `providers` array of your `config/app.php` configuration file:
 


### PR DESCRIPTION
Now that Laravel 5.4 is out, and Passport has a 2.0 release to go with it, the composer require command in the 5.3 docs needs to explicitly target the 1.0 release