### PR TITLE
Misunderstanding in variable names fix

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -199,7 +199,7 @@ To create a subscription, first retrieve an instance of your billable model, whi
 
     $user = User::find(1);
 
-    $user->newSubscription('main', 'monthly')->create($creditCardToken);
+    $user->newSubscription('main', 'monthly')->create($stripeToken);
 
 The first argument passed to the `newSubscription` method should be the name of the subscription. If your application only offers a single subscription, you might call this `main` or `primary`. The second argument is the specific Stripe / Braintree plan the user is subscribing to. This value should correspond to the plan's identifier in Stripe or Braintree.
 
@@ -209,7 +209,7 @@ The `create` method will begin the subscription as well as update your database 
 
 If you would like to specify additional customer details, you may do so by passing them as the second argument to the `create` method:
 
-    $user->newSubscription('main', 'monthly')->create($creditCardToken, [
+    $user->newSubscription('main', 'monthly')->create($stripeToken, [
         'email' => $email,
     ]);
 
@@ -221,7 +221,7 @@ If you would like to apply a coupon when creating the subscription, you may use 
 
     $user->newSubscription('main', 'monthly')
          ->withCoupon('code')
-         ->create($creditCardToken);
+         ->create($stripeToken);
 
 <a name="checking-subscription-status"></a>
 ### Checking Subscription Status
@@ -358,7 +358,7 @@ If the user cancels a subscription and then resumes that subscription before the
 
 The `updateCard` method may be used to update a customer's credit card information. This method accepts a Stripe token and will assign the new credit card as the default billing source:
 
-    $user->updateCard($creditCardToken);
+    $user->updateCard($stripeToken);
 
 <a name="subscription-trials"></a>
 ## Subscription Trials
@@ -372,7 +372,7 @@ If you would like to offer trial periods to your customers while still collectin
 
     $user->newSubscription('main', 'monthly')
                 ->trialDays(10)
-                ->create($creditCardToken);
+                ->create(f);
 
 This method will set the trial period ending date on the subscription record within the database, as well as instruct Stripe / Braintree to not begin billing the customer until after this date.
 
@@ -416,7 +416,7 @@ Once you are ready to create an actual subscription for the user, you may use th
 
     $user = User::find(1);
 
-    $user->newSubscription('main', 'monthly')->create($creditCardToken);
+    $user->newSubscription('main', 'monthly')->create($stripeToken);
 
 <a name="handling-stripe-webhooks"></a>
 ## Handling Stripe Webhooks


### PR DESCRIPTION
Stripe doesn't use credit card token (it's another entity) in case of creating subscriptions. To manage subscriptions you need `stripeToken` - it's not related to credit card, but to a complex of data. Using it you can obtain other info and store subscriptions as usual.
See https://stripe.com/docs/recipes/subscription-signup 
I think the variable must be with the same name, like in original Stripe documentation.