### PR TITLE
fix order of $key $value in first() of collections

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -367,7 +367,7 @@ For the inverse of `filter`, see the [reject](#method-reject) method.
 
 The `first` method returns the first element in the collection that passes a given truth test:
 
-    collect([1, 2, 3, 4])->first(function ($value, $key) {
+    collect([1, 2, 3, 4])->first(function ($key, $value) {
         return $value > 2;
     });
 


### PR DESCRIPTION
Seems pretty minor, but the order of $key and $value makes a difference. The current docs, with $value first, actually returns 4 instead of the 3 it suggests. Switching the order returns 3 as expected.