### PR TITLE
Testing: Add a note about new namespace for traits

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -382,6 +382,10 @@ Tests written on Laravel 5.3 will extend the `BrowserKitTest` class while any ne
 
 Once you have created this class, make sure to update all of your tests to extend your new `BrowserKitTest` class. This will allow all of your tests written on Laravel 5.3 to continue running on Laravel 5.4. If you choose, you can slowly begin to port them over to the new [Laravel 5.4 test syntax](/docs/5.4/http-tests) or [Laravel Dusk](/docs/5.4/dusk).
 
+If you are using `DatabaseMigrations`, `DatabaseTransactions`, `WithoutMiddleware`, or `WithoutEvents`, you'll need to reference the same classes within the `Laravel\BrowserKitTesting` namespace. For example, if you are including `use Illuminate\Foundation\Testing\DatabaseTransactions;` in your test, you should change this to:
+
+    use Laravel\BrowserKitTesting\DatabaseTransactions;
+
 > {note} If you are writing new tests and want them to use the Laravel 5.4 testing layer, make sure to extend the `TestCase` class.
 
 #### Installing Dusk In An Upgraded Application


### PR DESCRIPTION
The testing traits namespace has changed, so that `Illuminate\Foundation\Testing\DatabaseTransactions` is now `Laravel\BrowserKitTesting\DatabaseTransactions`.

If the old namespace is used, the `Laravel\BrowserKitTesting\TestCase::setUpTraits()` method does not set up the traits.