### PR TITLE
Remove 4.1 release notes

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -9,7 +9,6 @@
 - [Laravel 5.1](#laravel-5.1)
 - [Laravel 5.0](#laravel-5.0)
 - [Laravel 4.2](#laravel-4.2)
-- [Laravel 4.1](#laravel-4.1)
 
 <a name="support-policy"></a>
 ## Support Policy
@@ -1094,58 +1093,3 @@ A new `simplePaginate` method was added to the query and Eloquent builder which 
 ### Migration Confirmation
 
 In production, destructive migration operations will now ask for confirmation. Commands may be forced to run without any prompts using the `--force` command.
-
-<a name="laravel-4.1"></a>
-## Laravel 4.1
-
-### Full Change List
-
-The full change list for this release by running the `php artisan changes` command from a 4.1 installation, or by [viewing the change file on Github](https://github.com/laravel/framework/blob/4.1/src/Illuminate/Foundation/changes.json). These notes only cover the major enhancements and changes for the release.
-
-### New SSH Component
-
-An entirely new `SSH` component has been introduced with this release. This feature allows you to easily SSH into remote servers and run commands. To learn more, consult the [SSH component documentation](/docs/ssh).
-
-The new `php artisan tail` command utilizes the new SSH component. For more information, consult the `tail` [command documentation](http://laravel.com/docs/ssh#tailing-remote-logs).
-
-### Boris In Tinker
-
-The `php artisan tinker` command now utilizes the [Boris REPL](https://github.com/d11wtq/boris) if your system supports it. The `readline` and `pcntl` PHP extensions must be installed to use this feature. If you do not have these extensions, the shell from 4.0 will be used.
-
-### Eloquent Improvements
-
-A new `hasManyThrough` relationship has been added to Eloquent. To learn how to use it, consult the [Eloquent documentation](/docs/eloquent#has-many-through).
-
-A new `whereHas` method has also been introduced to allow [retrieving models based on relationship constraints](/docs/eloquent#querying-relations).
-
-### Database Read / Write Connections
-
-Automatic handling of separate read / write connections is now available throughout the database layer, including the query builder and Eloquent. For more information, consult [the documentation](/docs/database#read-write-connections).
-
-### Queue Priority
-
-Queue priorities are now supported by passing a comma-delimited list to the `queue:listen` command.
-
-### Failed Queue Job Handling
-
-The queue facilities now include automatic handling of failed jobs when using the new `--tries` switch on `queue:listen`. More information on handling failed jobs can be found in the [queue documentation](/docs/queues#failed-jobs).
-
-### Cache Tags
-
-Cache "sections" have been superseded by "tags". Cache tags allow you to assign multiple "tags" to a cache item, and flush all items assigned to a single tag. More information on using cache tags may be found in the [cache documentation](/docs/cache#cache-tags).
-
-### Flexible Password Reminders
-
-The password reminder engine has been changed to provide greater developer flexibility when validating passwords, flashing status messages to the session, etc. For more information on using the enhanced password reminder engine, [consult the documentation](/docs/security#password-reminders-and-reset).
-
-### Improved Routing Engine
-
-Laravel 4.1 features a totally re-written routing layer. The API is the same; however, registering routes is a full 100% faster compared to 4.0. The entire engine has been greatly simplified, and the dependency on Symfony Routing has been minimized to the compiling of route expressions.
-
-### Improved Session Engine
-
-With this release, we're also introducing an entirely new session engine. Similar to the routing improvements, the new session layer is leaner and faster. We are no longer using Symfony's (and therefore PHP's) session handling facilities, and are using a custom solution that is simpler and easier to maintain.
-
-### Doctrine DBAL
-
-If you are using the `renameColumn` function in your migrations, you will need to add the `doctrine/dbal` dependency to your `composer.json` file. This package is no longer included in Laravel by default.


### PR DESCRIPTION
Since 4.1 documentation is not available on the web isn't necessary to keep its release notes.