### PR TITLE
[5.4] Mix docs incorrectly say that `version()` only runs in production

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -192,7 +192,7 @@ The `copy` method may be used to copy files and directories to new locations. Th
 
 Many developers suffix their compiled assets with a timestamp or unique token to force browsers to load the fresh assets instead of serving stale copies of the code. Mix can handle this for you using the `version` method.
 
-When executed in a production environment (`npm run production`), the `version` method will automatically append a unique hash to the filenames of all compiled files, allowing for more convenient cache busting:
+The `version` method will automatically append a unique hash to the filenames of all compiled files, allowing for more convenient cache busting:
 
     mix.js('resources/assets/js/app.js', 'public/js')
        .version();
@@ -200,6 +200,14 @@ When executed in a production environment (`npm run production`), the `version` 
 After generating the versioned file, you won't know the exact file name. So, you should use Laravel's global `mix` function within your [views](/docs/{{version}}/views) to load the appropriately hashed asset. The `mix` function will automatically determine the current name of the hashed file:
 
     <link rel="stylesheet" href="{{ mix('/css/app.css') }}">
+
+Because versioning files typically is unneccesary in development, you may wish to have `version` run only in production (such when you run `npm run production`):
+
+    mix.js('resources/assets/js/app.js', 'public/js');
+    
+    if (mix.config.inProduction) {
+        mix.version();
+    }
 
 <a name="notifications"></a>
 ## Notifications

--- a/mix.md
+++ b/mix.md
@@ -201,7 +201,7 @@ After generating the versioned file, you won't know the exact file name. So, you
 
     <link rel="stylesheet" href="{{ mix('/css/app.css') }}">
 
-Because versioning files typically is unneccesary in development, you may wish to have `version` run only in production (such when you run `npm run production`):
+Because versioning files typically is unnecessary in development, you may wish to have `version` run only in production (such when you run `npm run production`):
 
     mix.js('resources/assets/js/app.js', 'public/js');
     


### PR DESCRIPTION
The [documentation for `mix.version()`](https://github.com/laravel/docs/blob/5.4/mix.md#versioning--cache-busting) says (emphasis mine):

> **When executed in a production environment** (`npm run production`), the `version` method will automatically append a unique hash to the filenames of all compiled files, allowing for more convenient cache busting

However, Mix actually creates the hashed names whenever you run it with `version()`, whatever environment you are in.  This has been updated [today](https://github.com/JeffreyWay/laravel-mix/commit/27902ec2f6720e39156e9ed1b111c15fbfc634db#diff-bb1bd93b5077affc1930c467e3197e96L30) in the Mix documentation, so it should be updated here.

This PR also adds an example of how to run `version` only in production, as the docs used to say it did.