### PR TITLE
Override plural by the range

### DIFF
--- a/localization.md
+++ b/localization.md
@@ -134,6 +134,10 @@ You may even create more complex pluralization rules which specify translation s
 
     'apples' => '{0} There are none|[1,19] There are some|[20,*] There are many',
 
+You may even override some ranges of plural rules by putting it after all the line:
+
+    'apples' => 'There are one|There are many|{0} There are none',
+
 After defining a translation string that has pluralization options, you may use the `trans_choice` function to retrieve the line for a given "count". In this example, since the count is greater than one, the plural form of the translation string is returned:
 
     echo trans_choice('messages.apples', 10);


### PR DESCRIPTION
Since https://github.com/laravel/framework/pull/17826 bring back the plurals, I find that Symfony's construction like `{0} There are none|There are one|There are many` is no longer work. However, it works in opposite direction now (like in PR). Since there is no mention how user can do that later, we can add this now.

Also it should works in other languages (like Russian) with more complex plural:
`'comments_count' => ':count комментарий|:count комментария|:count комментариев|{0} Нет комментариев',`
0 => Нет комментариев
1 => 1 комментарий
2 => 2 комментария
5 => 5 комментариев