### PR TITLE
[5.5] Recommend the null coalescing operator

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -148,13 +148,9 @@ Of course, you are not limited to displaying the contents of the variables passe
 
 #### Echoing Data If It Exists
 
-Sometimes you may wish to echo a variable, but you aren't sure if the variable has been set. We can express this in verbose PHP code like so:
+Sometimes you may wish to echo a variable, but you aren't sure if the variable has been set. You can do this using PHP's null coalescing operator:
 
-    {{ isset($name) ? $name : 'Default' }}
-
-However, instead of writing a ternary statement, Blade provides you with the following convenient shortcut, which will be compiled to the ternary statement above:
-
-    {{ $name or 'Default' }}
+    {{ $name ?? 'Default' }}
 
 In this example, if the `$name` variable exists, its value will be displayed. However, if it does not exist, the word `Default` will be displayed.
 


### PR DESCRIPTION
This removes the docs for the `or` functionality blade provides, and recommends the use of PHP's built in null coalescing operator.