### PR TITLE
Correct reference to resources directory name

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -492,7 +492,7 @@ The `public_path` function returns the fully qualified path to the `public` dire
 <a name="method-resource-path"></a>
 #### `resource_path()` {#collection-method}
 
-The `resource_path` function returns the fully qualified path to the `resources` directory. You may also use the `resource_path` function to generate a fully qualified path to a given file relative to the storage directory:
+The `resource_path` function returns the fully qualified path to the `resources` directory. You may also use the `resource_path` function to generate a fully qualified path to a given file relative to the resources directory:
 
     $path = resource_path();
 


### PR DESCRIPTION
When describing the `resource_path()` helper, there was an incorrect mention of the "storage directory" – likely due to copy & paste from the `storage_path()` helper docs.

This PR just updates that to say "resources directory" instead.