### PR TITLE
Hint at change of default billable model

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -145,7 +145,7 @@ When calling the `Cache::extend` method with a Closure, `$this` will be bound to
 
 ### Cashier
 
-If you are using Cashier, you should upgrade your `laravel/cashier` package to the `~7.0` release. This release of Cashier only upgrades a few internal methods to be compatible with Laravel 5.3 and is not a breaking change.
+If you are using Cashier, you should upgrade your `laravel/cashier` package to the `~7.0` release. In case your billable model isn't `App\User` you should change the name of the column `user_id` in your `subscriptions` table to the appropriate foreign key name (e.g. `team_id`).
 
 ### Collections
 


### PR DESCRIPTION
If people use another model for billing than `App\User` they'll have problems after upgrading from 5.2 to 5.3 because Cashier looks for a configured model now.
Therefore they should rename the column `user_id` in the `subscriptions` table to the appropriate name.