### PR TITLE
Adding gc_collect_cycles tip

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -353,7 +353,7 @@ You may customize your queue worker even further by only processing particular q
 
 #### Resource Considerations
 
-Daemon queue workers do not "reboot" the framework before processing each job. Therefore, you should free any heavy resources after each job completes. For example, if you are doing image manipulation with the GD library, you should free the memory with `imagedestroy` when you are done.
+Daemon queue workers do not "reboot" the framework before processing each job. Therefore, you should free any heavy resources after each job completes. For example, if you are doing image manipulation with the GD library, you should free the memory with `imagedestroy` when you are done.  It may also help to run [gc_collect_cycles](http://php.net/manual/en/function.gc-collect-cycles.php) after your job finishes to explicitly free up memory.
 
 <a name="queue-priorities"></a>
 ### Queue Priorities


### PR DESCRIPTION
I found that **without** explicitly calling gc_collect_cycles() at the end of my job's `handle()`, my worker would continue to consume memory until it died.  This could be due to the PHP configuration of my host but, nonetheless, this tip could save folks in a similar situation some time.