### PR TITLE
Observers != Events

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -736,9 +736,11 @@ To get started, define an `$events` property on your Eloquent model that maps va
     }
 
 <a name="observers"></a>
-### Observers
+## Observers
 
-If you are listening for many events on a given model, you may use observers to group all of your listeners into a single class. Observers classes have method names which reflect the Eloquent events you wish to listen for. Each of these methods receives the model as their only argument. Laravel does not include a default directory for observers, so you may create any directory you like to house your observer classes:
+If you are listening for many events on a given model, you may use observers to group all of your listeners into a single class. Observers will not fire for any of the events defined in the [`$events`](#events) property and do not require an [event class](/docs/{{version}}/events) to be created.
+
+An Observer class has method names which reflect the Eloquent events you wish to listen for. Each of these methods receives the model as their only argument. Laravel does not include a default directory for observers, so you may create any directory you like to house your observer classes:
 
     <?php
 


### PR DESCRIPTION
It appears, in my testing that if you're using the `$events` property to define "traditional" events then the Observable class will not fire. E.g.,

```php
class Document extends Model
{
    protected $events = [
        'saved' => DocumentSaved::class,
    ];

    public function boot() {
        static::observe(DocumentObserver::class);
    }
```

```php
class DocumentObserver
{

    public function saved(Document $document)
    {
        dd('does not fire');
    }
```

I uncovered this while simplifying some code. I was in the process of removing an event for an observable and found it it didn't fire until I removed the `$events` property. Not sure if this is intended but the documentation update should make it a little more clear for future people.