### PR TITLE
vendor/bin/homestead is a shell script - removing unnecessary PHP call

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -169,7 +169,7 @@ Once Homestead has been installed, use the `make` command to generate the `Vagra
 
 Mac / Linux:
 
-    php vendor/bin/homestead make
+    vendor/bin/homestead make
 
 Windows:
 


### PR DESCRIPTION
In the "Per project installation" chapter, the **Mac/Linux** section indicates a user should execute the command `php vendor/bin/homestead`, implying that homestead is a PHP script rather than a shell script. Executing it as php will simply output the script contents to the screen.