### PR TITLE
Adding doc for Elixir directing user to Mix

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -1,0 +1,3 @@
+# Compiling Assets (Laravel Elixir)
+
+> {note} Laravel Elixir is now called [Laravel Mix](/docs/{{version}}/mix).


### PR DESCRIPTION
The search bar in the Laravel docs do not throw up any result when searching for Elixir. It took me a while to figure out that it had been renamed. I imagine other people have had the same problem.