### PR TITLE
Add note about the removal of the ConfigureLogging

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -81,7 +81,7 @@ If you would like to render unescaped content in a section, you must declare the
 
 ### Bootstrappers
 
-If you are manually overriding the `$bootstrappers` array on your HTTP or Console kernel, you should rename the `DetectEnvironment` entry to `LoadEnvironmentVariables`.
+If you are manually overriding the `$bootstrappers` array on your HTTP or Console kernel, you should rename the `DetectEnvironment` entry to `LoadEnvironmentVariables` and remove `ConfigureLogging`.
 
 ### Broadcasting
 


### PR DESCRIPTION
As per this commit the `ConfigureLogging` bootstrapper is no more in 5.4. Seems the Monolog setup being moved to a base service provider in `Illuminate\Foundation\Application` https://github.com/laravel/framework/commit/919f21b3fddf47a25ef85167817a8827f59b271f#diff-67364880bdf444edbf5e384f3686b9b9