### PR TITLE
Add information about adding additional Ngrok commands to the share option

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -312,6 +312,8 @@ Sometimes you may wish to share what you're currently working on with coworkers 
 
 To solve this problem, Homestead includes its own `share` command. To get started, SSH into your Homestead machine via `vagrant ssh` and run `share homestead.app`. This will share the `homestead.app` site from your `Homestead.yaml` configuration file. Of course, you may substitute any of your other configured sites for `homestead.app`.
 
+If you want to change the region or add another Ngrok parameter you can do so by adding these after the first parameter like so `share homestead.app -region=eu -subdomain=laravel`.
+
 After running the command, you will see an Ngrok screen appear which contains the activity log and the publicly accessible URLs for the shared site.
 
 > {note} Remember, Vagrant is inherently insecure and you are exposing your virtual machine to the Internet when running the `share` command.

--- a/homestead.md
+++ b/homestead.md
@@ -312,7 +312,7 @@ Sometimes you may wish to share what you're currently working on with coworkers 
 
 To solve this problem, Homestead includes its own `share` command. To get started, SSH into your Homestead machine via `vagrant ssh` and run `share homestead.app`. This will share the `homestead.app` site from your `Homestead.yaml` configuration file. Of course, you may substitute any of your other configured sites for `homestead.app`.
 
-If you want to change the region or add another Ngrok parameter you can do so by adding these after the first parameter like so `share homestead.app -region=eu -subdomain=laravel`.
+If you want to change the region, subdomain, or add any other Ngrok parameter you can do so by adding these after the first parameter like so `share homestead.app -region=eu -subdomain=laravel`. Which will change the Ngrok region to Europe and change the subdomain to `laravel`.
 
 After running the command, you will see an Ngrok screen appear which contains the activity log and the publicly accessible URLs for the shared site.
 


### PR DESCRIPTION
Hello,

I have added a little section to the documentation which explains that you can add additional Ngrok commands to the `share` command in Homestead.

laravel/homestead#499 is the pull request with the change.