### PR TITLE
Update mix.md

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -241,7 +241,7 @@ Mix can automatically install the Babel plug-ins necessary for React support. To
 
     mix.react('resources/assets/js/app.jsx', 'public/js');
 
-Behind the scenes, React will download and include the appropriate `babel-preset-react` Babel plug-in.
+Behind the scenes, Mix will download and include the appropriate `babel-preset-react` Babel plug-in.
 
 <a name="vanilla-js"></a>
 ### Vanilla JS


### PR DESCRIPTION
>Behind the scenes, Mix will download and include the appropriate `babel-preset-react` Babel plug-in.

It used to say:

>Behind the scenes, React will download and include the appropriate `babel-preset-react` Babel plug-in.

Earlier it says that "Mix can automatically install the Babel plug-ins necessary for React support.". I am assuming Mix is downloading the appropriate plug-ins, and not React. Hence this PR.