### PR TITLE
Change dot to colon

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1437,7 +1437,7 @@ This method has the same signature as the [`where`](#method-where) method; howev
 <a name="method-wherein"></a>
 #### `whereIn()` {#collection-method}
 
-The `whereIn` method filters the collection by a given key / value contained within the given array.
+The `whereIn` method filters the collection by a given key / value contained within the given array:
 
     $collection = collect([
         ['product' => 'Desk', 'price' => 200],


### PR DESCRIPTION
Since I ended the sentence with a dot in the whereNotIn documentation because I had copy pasted it from whereIn, this puts a colon in whereIn as well. :)