### PR TITLE
Added note about the flatten argument of .copy()

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -281,9 +281,9 @@ The `copy` method may be used to copy files and directories to new locations. Th
 
     mix.copy('node_modules/foo/bar.css', 'public/css/bar.css');
     
-By default, copying a directory will flatten the copied files - including all files but placing them in the root of the target directory without keeping the folder structure. If you wish to keep the exact folder stucture, you have to set the third parameter to `true`.
+By default, copying a directory will flatten the copied files - including all files but placing them in the root of the target directory without keeping the folder structure. If you wish to keep the exact folder stucture, you have to set the third parameter to `false`.
 
-    mix.copy('node_modules/foo/bar/', 'public/css/', true);
+    mix.copy('node_modules/foo/bar/', 'public/css/', false);
 
 <a name="versioning-and-cache-busting"></a>
 ## Versioning / Cache Busting

--- a/mix.md
+++ b/mix.md
@@ -280,6 +280,10 @@ Mix provides a useful `webpackConfig` method that allows you to merge any short 
 The `copy` method may be used to copy files and directories to new locations. This can be useful when a particular asset within your `node_modules` directory needs to be relocated to your `public` folder.
 
     mix.copy('node_modules/foo/bar.css', 'public/css/bar.css');
+    
+By default, copying a directory will flatten the copied files - including all files but placing them in the root of the target directory without keeping the folder structure. If you wish to keep the exact folder stucture, you have to set the third parameter to `true`.
+
+    mix.copy('node_modules/foo/bar/', 'public/css/', true);
 
 <a name="versioning-and-cache-busting"></a>
 ## Versioning / Cache Busting


### PR DESCRIPTION
The documentation isn't very clear about all of the arguments of the .copy() method, and its default behaviour is to flatten the directory structure, which is not necessarily expected.

Mix's own documentation does mention this in a footnote. https://github.com/JeffreyWay/laravel-mix/blob/master/docs/copying-files.md