### PR TITLE
Terminable route middleware clarification

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -245,6 +245,6 @@ Sometimes a middleware may need to do some work after the HTTP response has been
         }
     }
 
-The `terminate` method should receive both the request and the response. Once you have defined a terminable middleware, you should add it to the list of global middleware in your HTTP kernel.
+The `terminate` method should receive both the request and the response. Once you have defined a terminable middleware, you should add it to the list of route or global middleware in your `app/Http/Kernel.php` class.
 
 When calling the `terminate` method on your middleware, Laravel will resolve a fresh instance of the middleware from the [service container](/docs/{{version}}/container). If you would like to use the same middleware instance when the `handle` and `terminate` methods are called, register the middleware with the container using the container's `singleton` method.

--- a/middleware.md
+++ b/middleware.md
@@ -245,6 +245,6 @@ Sometimes a middleware may need to do some work after the HTTP response has been
         }
     }
 
-The `terminate` method should receive both the request and the response. Once you have defined a terminable middleware, you should add it to the list of route or global middleware in your `app/Http/Kernel.php` class.
+The `terminate` method should receive both the request and the response. Once you have defined a terminable middleware, you should add it to the list of route or global middleware in the `app/Http/Kernel.php` file.
 
 When calling the `terminate` method on your middleware, Laravel will resolve a fresh instance of the middleware from the [service container](/docs/{{version}}/container). If you would like to use the same middleware instance when the `handle` and `terminate` methods are called, register the middleware with the container using the container's `singleton` method.


### PR DESCRIPTION
There was some confusion with some developers because the documentation seemed to say that terminable middleware has to be defined in your *global* middleware list, but in fact terminable middleware can be used as *route* middleware as well.  I also decided to specify the location of Kernel.php rather than just saying HTTP kernel, but that change may not be as necessary.