### PR TITLE
Add Documentation for multiple lang directories

### DIFF
--- a/localization.md
+++ b/localization.md
@@ -138,6 +138,13 @@ After defining a translation string that has pluralization options, you may use 
 
     echo trans_choice('messages.apples', 10);
 
+<a name="multiple-language-directories"></a>
+## Multiple Language Directories
+
+You may have multiple directories for storing languages files, these can be added in a Service Provider:
+
+    $this->loadTranslationsFrom($path, $namespace)
+
 <a name="overriding-package-language-files"></a>
 ## Overriding Package Language Files
 

--- a/localization.md
+++ b/localization.md
@@ -7,6 +7,7 @@
 - [Retrieving Translation Strings](#retrieving-translation-strings)
     - [Replacing Parameters In Translation Strings](#replacing-parameters-in-translation-strings)
     - [Pluralization](#pluralization)
+- [Multiple Language Directories](#multiple-language-directories)
 - [Overriding Package Language Files](#overriding-package-language-files)
 
 <a name="introduction"></a>


### PR DESCRIPTION
Just an idear, have seen least 2 times now where people missed out on this function :)

- [[5.4] Load languages files (lang) from multiple directories.](https://github.com/laravel/framework/pull/18108)
- [[5.4] Allow lang path to be an array](https://github.com/laravel/framework/pull/18256)

Please rewrite the text.. it can proberly be better ;)