### PR TITLE
e function sets double_encode to false

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -531,7 +531,7 @@ The `class_basename` returns the class name of the given class with the class' n
 <a name="method-e"></a>
 #### `e()` {#collection-method}
 
-The `e` function runs `htmlspecialchars` over the given string:
+The `e` function runs `htmlspecialchars` with the `double_encode` option set to false over the given string:
 
     echo e('<html>foo</html>');
 

--- a/helpers.md
+++ b/helpers.md
@@ -531,7 +531,7 @@ The `class_basename` returns the class name of the given class with the class' n
 <a name="method-e"></a>
 #### `e()` {#collection-method}
 
-The `e` function runs `htmlspecialchars` with the `double_encode` option set to false over the given string:
+The `e` function runs PHP's `htmlspecialchars` function with the `double_encode` option set to `false`:
 
     echo e('<html>foo</html>');
 


### PR DESCRIPTION
This behaviour is not intuitive as the parameter is set to true per default in htmlspecialchars.