### PR TITLE
update to Echo install section to account for 1.3.0 change

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -375,6 +375,8 @@ Once Echo is installed, you are ready to create a fresh Echo instance in your ap
         broadcaster: 'pusher',
         key: 'your-pusher-key'
     });
+    
+> {tip} Echo version 1.3.0+ also requires you to register the library you wish to us. eg. `window.Pusher = require('pusher-js');`.    
 
 When creating an Echo instance that uses the `pusher` connector, you may also specify a `cluster` as well as whether the connection should be encrypted:
 


### PR DESCRIPTION
With the recent change in 1.3.0 there is a doc update at the top but it should also be added here. Some users will see the skip links at the top and navigate directly down the page, missing the initial install instructions.