### PR TITLE
Camel cased relationship names require a snake case column name when using withCount

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -687,6 +687,8 @@ You may also alias the relationship count result, allowing multiple counts on th
     echo $posts[0]->comments_count;
 
     echo $posts[0]->pending_comments_count;
+    
+> {tip} If your relationship names are camel cased, you will need to use the snake case version when referencing the column name. For example, if you had a relationship on your model named `authorNotes`, your column name will be `author_notes_count`.
 
 <a name="eager-loading"></a>
 ## Eager Loading

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -688,7 +688,7 @@ You may also alias the relationship count result, allowing multiple counts on th
 
     echo $posts[0]->pending_comments_count;
     
-> {tip} If your relationship names are camel cased, you will need to use the snake case version when referencing the column name. For example, if you had a relationship on your model named `authorNotes`, your column name will be `author_notes_count`.
+> {tip} If your relationship names are camel cased, you will need to use the snake case version when referencing the column name. For example, if you have a relationship on your model named `authorNotes`, your column name will be `author_notes_count`.
 
 <a name="eager-loading"></a>
 ## Eager Loading


### PR DESCRIPTION
I reported the below issue when debugging a possible bug in Laravel. Column names for the count property require snake case naming convention. Had this caveat been in the the documentation, I would have amended accordingly. 

https://github.com/laravel/framework/issues/18381