### PR TITLE
Express why the event dispatcher will halt when your observer contain…

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -771,6 +771,8 @@ If you are listening for many events on a given model, you may use observers to 
         }
     }
 
+As you can see in the above example, the observer has no return value. The events dispatcher will halt when your observer returns anything other than `null`.  
+
 To register an observer, use the `observe` method on the model you wish to observe. You may register observers in the `boot` method of one of your service providers. In this example, we'll register the observer in the `AppServiceProvider`:
 
     <?php


### PR DESCRIPTION
Express why the event dispatcher will halt when your observer contains any other return value than null;

I've stumbled upon this situation where stacking observers did not work. Turns out that the events dispatcher will halt if your observer returns something that is not `null`.
https://github.com/laravel/framework/blob/5.4/src/Illuminate/Events/Dispatcher.php#L204

This is not made clear in the documentation, only with a docblock in the example with a return type void. I've added a line to express the necessity of this example.