### PR TITLE
Fix Mix navigation, Updated React anchor link to #react

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -13,7 +13,7 @@
     - [Source Maps](#css-source-maps)
 - [Working With JavaScript](#working-with-scripts)
     - [Vendor Extraction](#vendor-extraction)
-    - [React](#react-support)
+    - [React](#react)
     - [Vanilla JS](#vanilla-js)
     - [Custom Webpack Configuration](#custom-webpack-configuration)
 - [Copying Files & Directories](#copying-files-and-directories)


### PR DESCRIPTION
Fixed the React navigation link on the Mix docs, current anchor goes to #react-support which doesn't exist. Updated to #react to match the name used on the title.