### PR TITLE
Update v5.4 Upgrade Guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -228,10 +228,6 @@ The `Model::create` & `Model:: forceCreate` methods have been moved to the `Illu
         return $model;
     }
 
-#### The `getForeignKey` Method
-
-The `getForeignKey` method has been removed. Use the `getForeignKeyName` method instead.
-
 #### The `hydrate` Method
 
 If you are currently passing a custom connection name to this method, you should now use the `on` method:


### PR DESCRIPTION
Currently the Upgrade guide references a change in the API to
relations where the name of the `getForeignKey` method has changed
to `getForeignKeyName`  In reviewing the code and API docs this
doesn't seem to actually be true.

Example (https://laravel.com/api/5.4/Illuminate/Database/Eloquent/Relations/BelongsTo.html)

This commit removes the seemingly false reference.