### PR TITLE
Adding ::class

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -117,7 +117,7 @@ First, add the Cashier package for Braintree to your `composer.json` file and ru
 
 #### Service Provider
 
-Next, register the `Laravel\Cashier\CashierServiceProvider` [service provider](/docs/{{version}}/providers) in your `config/app.php` configuration file.
+Next, register the `Laravel\Cashier\CashierServiceProvider::class` [service provider](/docs/{{version}}/providers) in your `config/app.php` configuration file.
 
 #### Plan Credit Coupon
 


### PR DESCRIPTION
 Adding the ::class part of the service provider name as Laravel 5.4 fails without it.