### PR TITLE
[5.3] Replaced wrong whereInLoose() reference to whereInStrict()

### DIFF
--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -122,7 +122,7 @@ All Eloquent collections extend the base [Laravel collection](/docs/{{version}}/
 [where](/docs/{{version}}/collections#method-where)
 [whereStrict](/docs/{{version}}/collections#method-wherestrict)
 [whereIn](/docs/{{version}}/collections#method-wherein)
-[whereInLoose](/docs/{{version}}/collections#method-whereinloose)
+[whereInStrict](/docs/{{version}}/collections#method-whereinstrict)
 [zip](/docs/{{version}}/collections#method-zip)
 
 </div>


### PR DESCRIPTION
It remained unchanged since 5.2 days and I forgot to fix it within #3230. Sorry to have forgotten this, this *loose* => *strict* change was a bit confusing to track. :+1: