### PR TITLE
[5.4] Clarifies tests namespace change

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -371,15 +371,15 @@ All calls to the `$request->setSession()` method should be changed to `setLarave
 
 Laravel 5.4's testing layer has been re-written to be simpler and lighter out of the box. If you would like to continue using the testing layer present in Laravel 5.3, you may install the `laravel/browser-kit-testing` [package](https://github.com/laravel/browser-kit-testing) into your application. This package provides full compatibility with the Laravel 5.3 testing layer. In fact, you can run the Laravel 5.4 testing layer side-by-side with the Laravel 5.3 testing layer.
 
-#### Running Laravel 5.3 & 5.4 Tests In A Single Application
-
-Before getting started, you should add the `Tests` namespace to your `composer.json` file's `autoload-dev` block. This will allow Laravel to autoload any new tests you generate using the Laravel 5.4 test generators:
+In order to allow Laravel to autoload any new tests you generate using the Laravel 5.4 test generators, you should add the `Tests` namespace to your `composer.json` file's `autoload-dev` block:
 
     "psr-4": {
         "Tests\\": "tests/"
     }
 
-Next, install the `laravel/browser-kit-testing` package:
+#### Running Laravel 5.3 & 5.4 Tests In A Single Application
+
+First install the `laravel/browser-kit-testing` package:
 
     composer require laravel/browser-kit-testing
 


### PR DESCRIPTION
Makes clear the `composer.json`'s change is required even for those who skip the *"Running Laravel 5.3 & 5.4 Tests In A Single Application"* section.

It's a common issue when upgrading: https://github.com/laravel/dusk/issues/40#issuecomment-274961021