### PR TITLE
[5.4] Change user_id to unsigned integer

### DIFF
--- a/session.md
+++ b/session.md
@@ -44,7 +44,7 @@ When using the `database` session driver, you will need to create a table to con
 
     Schema::create('sessions', function ($table) {
         $table->string('id')->unique();
-        $table->integer('user_id')->nullable();
+        $table->unsignedInteger('user_id')->nullable();
         $table->string('ip_address', 45)->nullable();
         $table->text('user_agent')->nullable();
         $table->text('payload');


### PR DESCRIPTION
In the session database table, user_id should be an unsigned integer.