### PR TITLE
Update code in facades.md for simplicity

### DIFF
--- a/facades.md
+++ b/facades.md
@@ -108,7 +108,7 @@ The `Facade` base class makes use of the `__callStatic()` magic-method to defer 
 
     namespace App\Http\Controllers;
 
-    use Cache;
+    use Illuminate\Support\Facades\Cache;
     use App\Http\Controllers\Controller;
 
     class UserController extends Controller

--- a/facades.md
+++ b/facades.md
@@ -108,8 +108,8 @@ The `Facade` base class makes use of the `__callStatic()` magic-method to defer 
 
     namespace App\Http\Controllers;
 
-    use Illuminate\Support\Facades\Cache;
     use App\Http\Controllers\Controller;
+    use Illuminate\Support\Facades\Cache;
 
     class UserController extends Controller
     {


### PR DESCRIPTION
`use Cache;` is too confusing without the full namespace, to be in the documentation. It looks like an error or distracts the users from the topic, unless there is an extra line added, talking about AliasLoader which will check the facade class from array of class aliases in config/app.php.