### PR TITLE
[5.4] Added deleteFileAfterSend() back in the docs

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -213,6 +213,8 @@ The `download` method may be used to generate a response that forces the user's 
     return response()->download($pathToFile);
 
     return response()->download($pathToFile, $name, $headers);
+    
+    return response()->download($pathToFile)->deleteFileAfterSend(true);
 
 > {note} Symfony HttpFoundation, which manages file downloads, requires the file being downloaded to have an ASCII file name.
 


### PR DESCRIPTION
Reason to add this back is because it is handy to know the functionality already sits in the framework.