### PR TITLE
[5.2] Added deleteFileAfterSend() back in the docs

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -165,6 +165,8 @@ The `file` method can be used to display a file, such as an image or PDF, direct
     return response()->file($pathToFile);
 
     return response()->file($pathToFile, $headers);
+    
+    return response()->download($pathToFile)->deleteFileAfterSend(true);
 
 <a name="redirects"></a>
 ## Redirects


### PR DESCRIPTION
Reason to add this back is because it is handy to know the functionality already sits in the framework.