### PR TITLE
Describe Blade or behaviour

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -158,6 +158,8 @@ However, instead of writing a ternary statement, Blade provides you with the fol
 
 In this example, if the `$name` variable exists, its value will be displayed. However, if it does not exist, the word `Default` will be displayed.
 
+> {note} The `or` syntax only works when working with variables. Using function calls like `{{ old('name') or 'Default' }}` will not work.
+
 #### Displaying Unescaped Data
 
 By default, Blade `{{ }}` statements are automatically sent through PHP's `htmlspecialchars` function to prevent XSS attacks. If you do not want your data to be escaped, you may use the following syntax:


### PR DESCRIPTION
The `or` behaviour to use defaults in blade does not work when the first parameter is not a variable.
This is caused by the regex
```php
return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s', 'isset($1) ? $1 : $2', $value);
```

in [CompilesEchos.php](https://github.com/laravel/framework/blob/5.4/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php#L103)
 and discussed in https://github.com/laravel/framework/issues/17754

It's behaviour is not exactly like the ternary statement earlier in the docs, so a little clarification on what does and what doesn't work might help someone.