### PR TITLE
Clarify 2nd argument of firstOrNew & firstOrCreate (5.4)

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -388,10 +388,10 @@ There are two other methods you may use to create models by mass assigning attri
 The `firstOrNew` method, like `firstOrCreate` will attempt to locate a record in the database matching the given attributes. However, if a model is not found, a new model instance will be returned. Note that the model returned by `firstOrNew` has not yet been persisted to the database. You will need to call `save` manually to persist it:
 
     // Retrieve the flight by the attributes, or create it if it doesn't exist...
-    $flight = App\Flight::firstOrCreate(['name' => 'Flight 10']);
+    $flight = App\Flight::firstOrCreate(['name' => 'Flight 10'], ['delayed' => 1]);
 
     // Retrieve the flight by the attributes, or instantiate a new instance...
-    $flight = App\Flight::firstOrNew(['name' => 'Flight 10']);
+    $flight = App\Flight::firstOrNew(['name' => 'Flight 10'], ['delayed' => 1]);
 
 #### `updateOrCreate`
 


### PR DESCRIPTION
There is a second argument to these functions ( [as you can see here](https://github.com/illuminate/database/blob/5.4/Eloquent/Builder.php#L334) ).
It's not said in the text but adding a second argument to the examples should be clear enough.