### PR TITLE
Clarify 2nd argument of firstOrCreate (5.3)

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -388,7 +388,7 @@ There are two other methods you may use to create models by mass assigning attri
 The `firstOrNew` method, like `firstOrCreate` will attempt to locate a record in the database matching the given attributes. However, if a model is not found, a new model instance will be returned. Note that the model returned by `firstOrNew` has not yet been persisted to the database. You will need to call `save` manually to persist it:
 
     // Retrieve the flight by the attributes, or create it if it doesn't exist...
-    $flight = App\Flight::firstOrCreate(['name' => 'Flight 10']);
+    $flight = App\Flight::firstOrCreate(['name' => 'Flight 10'], ['delayed' => 1]);
 
     // Retrieve the flight by the attributes, or instantiate a new instance...
     $flight = App\Flight::firstOrNew(['name' => 'Flight 10']);


### PR DESCRIPTION
In 5.3, `firstOrCreate()` [has a second parameter](https://github.com/illuminate/database/blob/5.3/Eloquent/Builder.php#L240) while `firstOrNew()` don't yet.
Clarify that in the example.