### PR TITLE
Add contextual binding tip

### DIFF
--- a/container.md
+++ b/container.md
@@ -155,6 +155,8 @@ Sometimes you may have two classes that utilize the same interface, but you wish
                   return Storage::disk('s3');
               });
 
+> {tip} Contextual binding is only available to constructors.
+
 <a name="tagging"></a>
 ### Tagging
 


### PR DESCRIPTION
Note that contextual binding is only available for constructors.