### PR TITLE
Update charset/collation

### DIFF
--- a/database.md
+++ b/database.md
@@ -66,8 +66,8 @@ To see how read / write connections should be configured, let's look at this exa
         'database'  => 'database',
         'username'  => 'root',
         'password'  => '',
-        'charset'   => 'utf8',
-        'collation' => 'utf8_unicode_ci',
+        'charset' => 'utf8mb4',
+        'collation' => 'utf8mb4_unicode_ci',
         'prefix'    => '',
     ],
 


### PR DESCRIPTION
A fresh install of Laravel no longer uses utf8/utf8_unicode_ci for charset/collation.
Instead it uses utf8mb4/utf8mb4_unicode_ci.