### PR TITLE
Fix event-fake link

### DIFF
--- a/events.md
+++ b/events.md
@@ -277,7 +277,7 @@ To dispatch an event, you may pass an instance of the event to the `event` helpe
         }
     }
 
-> {tip} When testing, it can be helpful to assert that certain events were dispatched without actually triggering their listeners. Laravel's [built-in testing helpers](/docs/{{version}}/mocking#mocking-events) makes it a cinch.
+> {tip} When testing, it can be helpful to assert that certain events were dispatched without actually triggering their listeners. Laravel's [built-in testing helpers](/docs/{{version}}/mocking#event-fake) makes it a cinch.
 
 <a name="event-subscribers"></a>
 ## Event Subscribers


### PR DESCRIPTION
Replace old "mocking-events" to "event-fake" HTML ID