### PR TITLE
[5.4] clarify `optional` and `present`

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -971,6 +971,8 @@ In some situations, you may wish to run validation checks against a field **only
 
 In the example above, the `email` field will only be validated if it is present in the `$data` array.
 
+**Note:** If you are looking to validate an input that is always present, but may be empty, see [A Note On Optional Fields](#a-note-on-optional-fields)
+
 #### Complex Conditional Validation
 
 Sometimes you may wish to add validation rules based on more complex conditional logic. For example, you may wish to require a given field only if another field has a greater value than 100. Or, you may need two fields to have a given value only when another field is present. Adding these validation rules doesn't have to be a pain. First, create a `Validator` instance with your _static rules_ that never change:


### PR DESCRIPTION
While doing some work today, I ran into a scenario where I was trying to validate a text input that was allowed to be empty. This instance was the first time where I needed to use this functionality, so I did a quick google search for `laravel conditional validation`. The top result was the validation documentation page, with a quick link to `conditionally adding rules`. I thought this was what I needed, and the fact that the rule is named `sometimes` seemed to confirm that it was what I needed. It wasn't until a couple hours later that I noticed there was a small section in the document about optional fields and the `nullable` keyword was actually what I needed. 

I'm proposing a quick, one-sentence "heads up" to other developers who might of had the same thought process I did, and are looking in the same section I was.