### PR TITLE
Update query builder JSON docs

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -398,7 +398,7 @@ The query above will produce the following SQL:
 <a name="json-where-clauses"></a>
 ### JSON Where Clauses
 
-Laravel also supports querying JSON column types on databases that provide support for JSON column types. Currently, this includes MySQL 5.7, MariaDB 10.2.3, and Postgres. To query a JSON column, use the `->` operator:
+Laravel also supports querying JSON column types on databases that provide support for JSON column types. Currently, this includes MySQL 5.7 and Postgres. To query a JSON column, use the `->` operator:
 
     $users = DB::table('users')
                     ->where('options->language', 'en')


### PR DESCRIPTION
Removed MariaDB 10.2.3 from the list of databases that support JSON columns. It does not, and likely won't until 10.3 at least. 10.2.3 *does* include JSON *functions*, but not a JSON column type.

To confirm, I installed a fresh install of MariaDB 10.2.5, created a new Laravel app, added a migration that included `$table->json('test')`, and confirmed that the migration failed.