### PR TITLE
Document "flatten" parameter of mix.copy()

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -285,6 +285,10 @@ The `copy` method may be used to copy files and directories to new locations. Th
 
     mix.copy('node_modules/foo/bar.css', 'public/css/bar.css');
 
+By default, copying a folder will flatten its structure, i.e. all files in its subfolder(s) will be pasted directly into the destination folder. In order to keep the structure recursively, set the third parameter to `false`:
+
+    mix.copy('assets/img', 'public/img', false);
+
 <a name="versioning-and-cache-busting"></a>
 ## Versioning / Cache Busting
 


### PR DESCRIPTION
The third (`flatten`) parameter of `mix.copy()` is weirdly set to `true` by default, causing [some confusion](https://laracasts.com/discuss/channels/elixir/copy-folder-structure-with-laravel-mix-laravel-54) to users. This PR aims to at least document this.