### PR TITLE
Clarify what queue:work --sleep exactly does

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -396,7 +396,7 @@ The `retry_after` configuration option and the `--timeout` CLI option are differ
 
 #### Worker Sleep Duration
 
-When jobs are available on the queue, the worker will keep processing jobs with no delay in between them. However, the `sleep` option determines how long the worker will "sleep" if there are no new jobs available:
+When jobs are available on the queue, the worker will keep processing jobs with no delay in between them. However, the `sleep` option determines how long the worker will "sleep" if there are no new jobs available. While sleeping, the worker will not process any new jobs - the jobs will be processed after the worker wakes up again.
 
     php artisan queue:work --sleep=3
 


### PR DESCRIPTION
I've had a discussion with a fellow Laravel Developer, where we actually disagreed on the actual meaning of the --sleep option in the Queue Worker.
This should clarify the expected behaviour.