### PR TITLE
Include the simpler Closure technique for Mail::send()

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -2,6 +2,9 @@
 
 - [Introduction](#introduction)
     - [Driver Prerequisites](#driver-prerequisites)
+- [Sending Mail](#sending-mail)
+    - [Attachments](#attachments)
+    - [Inline Attachments](#inline-attachments)
 - [Generating Mailables](#generating-mailables)
 - [Writing Mailables](#writing-mailables)
     - [Configuring The Sender](#configuring-the-sender)
@@ -61,11 +64,146 @@ Next, set the `driver` option in your `config/mail.php` configuration file to `s
         'secret' => 'your-ses-secret',
         'region' => 'ses-region',  // e.g. us-east-1
     ],
+    
+<a name="sending-mail"></a>
+## Sending Mail
+
+Laravel allows you to store your e-mail messages in [views](/docs/{{version}}/views). For example, to organize your e-mails, you could create an `emails` directory within your `resources/views` directory:
+
+To send a message, use the `send` method on the `Mail` [facade](/docs/{{version}}/facades). The `send` method accepts three arguments. First, the name of a [view](/docs/{{version}}/views) that contains the e-mail message. Secondly, an array of data you wish to pass to the view. Lastly, a `Closure` callback which receives a message instance, allowing you to customize the recipients, subject, and other aspects of the mail message:
+
+    <?php
+
+    namespace App\Http\Controllers;
+
+    use Mail;
+    use App\User;
+    use Illuminate\Http\Request;
+    use App\Http\Controllers\Controller;
+
+    class UserController extends Controller
+    {
+        /**
+         * Send an e-mail reminder to the user.
+         *
+         * @param  Request  $request
+         * @param  int  $id
+         * @return Response
+         */
+        public function sendEmailReminder(Request $request, $id)
+        {
+            $user = User::findOrFail($id);
+
+            Mail::send('emails.reminder', ['user' => $user], function ($m) use ($user) {
+                $m->from('hello@app.com', 'Your Application');
+
+                $m->to($user->email, $user->name)->subject('Your Reminder!');
+            });
+        }
+    }
+
+Since we are passing an array containing the `user` key in the example above, we could display the user's name within our e-mail view using the following PHP code:
+
+    <?php echo $user->name; ?>
+
+> **Note:** A `$message` variable is always passed to e-mail views, and allows the [inline embedding of attachments](#attachments). So, you should avoid passing a `message` variable in your view payload.
+
+#### Building The Message
+
+As previously discussed, the third argument given to the `send` method is a `Closure` allowing you to specify various options on the e-mail message itself. Using this Closure you may specify other attributes of the message, such as carbon copies, blind carbon copies, etc:
+
+    Mail::send('emails.welcome', $data, function ($message) {
+        $message->from('us@example.com', 'Laravel');
+
+        $message->to('foo@example.com')->cc('bar@example.com');
+    });
+
+Here is a list of the available methods on the `$message` message builder instance:
+
+    $message->from($address, $name = null);
+    $message->sender($address, $name = null);
+    $message->to($address, $name = null);
+    $message->cc($address, $name = null);
+    $message->bcc($address, $name = null);
+    $message->replyTo($address, $name = null);
+    $message->subject($subject);
+    $message->priority($level);
+    $message->attach($pathToFile, array $options = []);
+
+    // Attach a file from a raw $data string...
+    $message->attachData($data, $name, array $options = []);
+
+    // Get the underlying SwiftMailer message instance...
+    $message->getSwiftMessage();
+
+> **Note:** The message instance passed to a `Mail::send` Closure extends the SwiftMailer message class, allowing you to call any method on that class to build your e-mail messages.
+
+#### Mailing Plain Text
+
+By default, the view given to the `send` method is assumed to contain HTML. However, by passing an array as the first argument to the `send` method, you may specify a plain text view to send in addition to the HTML view:
+
+    Mail::send(['html.view', 'text.view'], $data, $callback);
+
+Or, if you only need to send a plain text e-mail, you may specify this using the `text` key in the array:
+
+    Mail::send(['text' => 'view'], $data, $callback);
+
+#### Mailing Raw Strings
+
+You may use the `raw` method if you wish to e-mail a raw string directly:
+
+    Mail::raw('Text to e-mail', function ($message) {
+        //
+    });
+
+<a name="attachments"></a>
+### Attachments
+
+To add attachments to an e-mail, use the `attach` method on the `$message` object passed to your Closure. The `attach` method accepts the full path to the file as its first argument:
+
+    Mail::send('emails.welcome', $data, function ($message) {
+        //
+
+        $message->attach($pathToFile);
+    });
+
+When attaching files to a message, you may also specify the display name and / or MIME type by passing an `array` as the second argument to the `attach` method:
+
+    $message->attach($pathToFile, ['as' => $display, 'mime' => $mime]);
+
+The `attachData` method may be used to attach a raw string of bytes as an attachment. For example, you might use this method if you have generated a PDF in memory and want to attach it to the e-mail without writing it to disk:
+
+    $message->attachData($pdf, 'invoice.pdf');
+
+    $message->attachData($pdf, 'invoice.pdf', ['mime' => $mime]);
+
+<a name="inline-attachments"></a>
+### Inline Attachments
+
+#### Embedding An Image In An E-Mail View
+
+Embedding inline images into your e-mails is typically cumbersome; however, Laravel provides a convenient way to attach images to your e-mails and retrieving the appropriate CID. To embed an inline image, use the `embed` method on the `$message` variable within your e-mail view. Remember, Laravel automatically makes the `$message` variable available to all of your e-mail views:
+
+    <body>
+        Here is an image:
+
+        <img src="<?php echo $message->embed($pathToFile); ?>">
+    </body>
+
+#### Embedding Raw Data In An E-Mail View
+
+If you already have a raw data string you wish to embed into an e-mail message, you may use the `embedData` method on the `$message` variable:
+
+    <body>
+        Here is an image from raw data:
+
+        <img src="<?php echo $message->embedData($data, $name); ?>">
+    </body>
 
 <a name="generating-mailables"></a>
 ## Generating Mailables
 
-In Laravel, each type of email sent by your application is represented as a "mailable" class. These classes are stored in the `app/Mail` directory. Don't worry if you don't see this directory in your application, since it will be generated for you when you create your first mailable class using the `make:mail` command:
+Using the `Mail::send()` function with a Closure as explained above is the easiest way send emails.  But for some situations you may prefer to create a separate dedicated class that handles the sending of easy type of email in your application.  In Laravel, this can be done by creating a "mailable" class. These classes are stored in the `app/Mail` directory. Don't worry if you don't see this directory in your application, since it will be generated for you when you create your first mailable class using the `make:mail` command:
 
     php artisan make:mail OrderShipped
 


### PR DESCRIPTION
The Mailable way to send emails adds an extra layer of complexity to sending emails, involving creating a separate Mailable class (possibly having to create one for each kind of email your app sends). That's a significant amount of extra code for something that used to be simple. For a lot of situations, developers would prefer a way to simply send an email without creating a separate dedicated class just to send an email.

The original pre-5.3 way to use Mail::send() still works, it just isn't in the documentation any more. This pull restores the documentation of the simpler use of Mail::send(), while also still explaining Mailable for devs that need or prefer to create a separate class to handle sending an email.