### PR TITLE
Issue with api url in passport.md

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -631,7 +631,7 @@ Typically, if you want to consume your API from your JavaScript application, you
 
 This Passport middleware will attach a `laravel_token` cookie to your outgoing responses. This cookie contains an encrypted JWT that Passport will use to authenticate API requests from your JavaScript application. Now, you may make requests to your application's API without explicitly passing an access token:
 
-    axios.get('/user')
+    axios.get('/api/user')
         .then(response => {
             console.log(response.data);
         });


### PR DESCRIPTION
When using the laravel passport guide I got stuck when using the api with my own application. I figured out that laravel automaticly prepends the standard api route with `/api`.

That's why I updated th route in the api.

On a brand new laravel 5.4 I followed the passport installation instructions and the code

```
axios.get('/user')
    .then(response => {
        console.log(response.data);
    });
```

threw a 404 Not Found. [Link to docs](https://laravel.com/docs/5.4/passport#consuming-your-api-with-javascript)

When updating the url to `/api/user` it finally worked. This is my first attempt on using passport tho, if i did anything wrong please correct me 😄 