### PR TITLE
Port forwarding example out of range

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -311,8 +311,8 @@ By default, the following ports are forwarded to your Homestead environment:
 If you wish, you may forward additional ports to the Vagrant box, as well as specify their protocol:
 
     ports:
-        - send: 93000
-          to: 9300
+        - send: 50000
+          to: 5000
         - send: 7777
           to: 777
           protocol: udp


### PR DESCRIPTION
Changed the port forwarding example ports to the same ports that are in the default Homestead.yaml config file to keep them within the allowed port range.