### PR TITLE
[5.4] Document the `orderBy` changes to `chunk`

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -215,9 +215,21 @@ Related models will now use the same connection as the parent model. For example
 
 Eloquent will query the posts table on the `example` connection instead of the default database connection. If you want to read the `posts` relationship from the default connection, you should to explicitly set the model's connection to your application's default connection.
 
+#### The `chunk` Method
+
+The query builder `chunk` method will now require an `orderBy` clause to be more consistent with the `each` method; an exception will be thrown if one is not supplied. For example:
+
+    DB::table('users')->orderBy('id')->chunk(100, function ($users) {
+        foreach ($users as $user) {
+            //
+        }
+    });
+
+ The Eloquent query builder `chunk` method will automatically apply an `orderBy` clause on the model's primary key if one is not supplied.
+
 #### The `create` & `forceCreate` Methods
 
-The `Model::create` & `Model:: forceCreate` methods have been moved to the `Illuminate\Database\Eloquent\Builder` class in order to provide better support for creating models on multiple connections. However, if you are extending these methods in your own models, you will need to modify your implementation to call the `create` method on the builder. For example:
+The `Model::create` & `Model::forceCreate` methods have been moved to the `Illuminate\Database\Eloquent\Builder` class in order to provide better support for creating models on multiple connections. However, if you are extending these methods in your own models, you will need to modify your implementation to call the `create` method on the builder. For example:
 
     public static function create(array $attributes = [])
     {

--- a/upgrade.md
+++ b/upgrade.md
@@ -217,7 +217,7 @@ Eloquent will query the posts table on the `example` connection instead of the d
 
 #### The `chunk` Method
 
-The query builder `chunk` method will now require an `orderBy` clause to be more consistent with the `each` method; an exception will be thrown if one is not supplied. For example:
+The query builder `chunk` method now requires an `orderBy` clause, which provides consistency with the `each` method. An exception will be thrown if an `orderBy` clause is not supplied. For example:
 
     DB::table('users')->orderBy('id')->chunk(100, function ($users) {
         foreach ($users as $user) {
@@ -225,7 +225,7 @@ The query builder `chunk` method will now require an `orderBy` clause to be more
         }
     });
 
- The Eloquent query builder `chunk` method will automatically apply an `orderBy` clause on the model's primary key if one is not supplied.
+The Eloquent query builder `chunk` method will automatically apply an `orderBy` clause on the model's primary key if one is not supplied.
 
 #### The `create` & `forceCreate` Methods
 


### PR DESCRIPTION
Since [#16283](https://github.com/laravel/framework/pull/16283) an exception is thrown when the query builder's `chunk` method is called without an `orderBy` clause.
This PR adds documentation to the upgrade guide clarifying this change as well as the automatic `orderBy` application by Eloquent's query builder.
It also removed a superfluous space in the `create` section.