### PR TITLE
Add note about @each not inheriting variables

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -352,7 +352,7 @@ You may also pass a fourth argument to the `@each` directive. This argument dete
 
     @each('view.name', $jobs, 'job', 'view.empty')
 
-> {note} Views included via @each do not inherit variables contained in the parent view. If your child view requires parent variables, you will need to use @foreach and @include.
+> {note} Views rendered via `@each` do not inherit the variables from the parent view. If the child view requires these variables, you should use `@foreach` and `@include` instead.
 
 <a name="stacks"></a>
 ## Stacks

--- a/blade.md
+++ b/blade.md
@@ -352,6 +352,8 @@ You may also pass a fourth argument to the `@each` directive. This argument dete
 
     @each('view.name', $jobs, 'job', 'view.empty')
 
+> {note} Views included via @each do not inherit variables contained in the parent view. If your child view requires parent variables, you will need to use @foreach and @include.
+
 <a name="stacks"></a>
 ## Stacks
 


### PR DESCRIPTION
This has caused some confusion, I think, because the documentation is ambiguous about the difference in variable inheritance between `@include` and `@each`. PR to master branch, but this technically could go to all of the documentation versions.