### PR TITLE
Add method to start PHP server directly

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -56,6 +56,10 @@ Alternatively, you may also install Laravel by issuing the Composer `create-proj
 If you have PHP installed locally and you would like to use PHP's built-in development server to serve your application, you may use the `serve` Artisan command. This command will start a development server at `http://localhost:8000`:
 
     php artisan serve
+    
+Alternatively, you can start the built-in server directly using this command:
+
+    php -S localhost:8000 -t public
 
 Of course, more robust local development options are available via [Homestead](/docs/{{version}}/homestead) and [Valet](/docs/{{version}}/valet).
 


### PR DESCRIPTION
In some cases `artisan serve` is [buggy](https://github.com/yajra/laravel-datatables/issues/497#issuecomment-205602652), some people might prefer starting the server without the artisan overhead.

Note: this isn't specific to version 5.4, I was just unsure whether to open  a pull request to the master branch or this one.