### PR TITLE
remove unnecessary `php` command

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -169,7 +169,7 @@ Once Homestead has been installed, use the `make` command to generate the `Vagra
 
 Mac / Linux:
 
-    php vendor/bin/homestead make
+    vendor/bin/homestead make
 
 Windows:
 


### PR DESCRIPTION
`vendor/bin/homestead` is a sh file
so php command is unnecessary, and php just print shell code