### PR TITLE
Unclear note on Eloquent: Serialization page

### DIFF
--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -72,7 +72,7 @@ Sometimes you may wish to limit the attributes, such as passwords, that are incl
         protected $hidden = ['password'];
     }
 
-> {note} When hiding relationships, use the relationship's method name, not its dynamic property name.
+> {note} When hiding relationships, use the relationship's method name.
 
 Alternatively, you may use the `visible` property to define a white-list of attributes that should be included in your model's array and JSON representation. All other attributes will be hidden when the model is converted to an array or JSON:
 


### PR DESCRIPTION
[Here](https://laravel.com/docs/5.4/eloquent-serialization#hiding-attributes-from-json) we have note that says 
`When hiding relationships, use the relationship's method name, not its dynamic property name.`
which I can't understand.
Can really dynamic property name be different from relationship's method name?

[Here](https://stackoverflow.com/questions/20671191/how-do-i-correctly-hide-model-relationships-from-returning-in-toarray-or-tojso) someone has similar question.