### PR TITLE
Remove intersectByKeys method from 5.4 docs

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -73,7 +73,6 @@ For the remainder of this documentation, we'll discuss each method available on 
 [has](#method-has)
 [implode](#method-implode)
 [intersect](#method-intersect)
-[intersectByKeys](#method-intersectbykeys)
 [isEmpty](#method-isempty)
 [isNotEmpty](#method-isnotempty)
 [keyBy](#method-keyby)
@@ -610,28 +609,6 @@ The `intersect` method removes any values from the original collection that are 
     $intersect->all();
 
     // [0 => 'Desk', 2 => 'Chair']
-
-
-<a name="method-intersectbykeys"></a>
-#### `intersectByKeys()` {#collection-method}
-
-The `intersectByKeys` method removes any keys from the original collection that are not present in the given `array` or collection:
-
-    $collection = collect([
-        'job' => 'Programmer',
-        'age' => 18,
-        'car' => 'Honda Civic'
-    ]);
-
-    $intersect = $collection->intersectByKeys([
-        'job' => 'Waiter',
-        'car' => 'Honda Accord'
-    ]);
-
-    $intersect->all();
-
-    // ['job' => 'Programmer', 'car' => 'Honda Civic']
-
 
 <a name="method-isempty"></a>
 #### `isEmpty()` {#collection-method}


### PR DESCRIPTION
Sorry guys, the PR I proposed was targeting `5.4` instead of `master`. This PR removes `intersectByKeys` from the 5.4 docs as it is not available.