### PR TITLE
Added makeWIth method with an associative array

### DIFF
--- a/container.md
+++ b/container.md
@@ -189,6 +189,10 @@ You may use the `make` method to resolve a class instance out of the container. 
 If you are in a location of your code that does not have access to the `$app` variable, you may use the global `resolve` helper:
 
     $api = resolve('HelpSpot\API');
+    
+If you want to inject parameters into the resolving class, then you may use `makeWith` method that accepts the name of the class as the first argument and parameters in the form of an array as a second argument:
+    
+    $api = $this->app->makeWith('HelpSpot\API', [$param1, $param2]);
 
 <a name="automatic-injection"></a>
 #### Automatic Injection

--- a/container.md
+++ b/container.md
@@ -190,9 +190,9 @@ If you are in a location of your code that does not have access to the `$app` va
 
     $api = resolve('HelpSpot\API');
     
-If you want to inject parameters into the resolving class, then you may use `makeWith` method that accepts the name of the class as the first argument and parameters in the form of an array as a second argument:
+If you want to inject parameters into the resolving class, then you may use `makeWith` method that accepts the name of the class as the first argument and parameters in the form of an associative array as a second argument:
     
-    $api = $this->app->makeWith('HelpSpot\API', [$param1, $param2]);
+    $api = $this->app->makeWith('HelpSpot\API', ['id' => 1]);
 
 <a name="automatic-injection"></a>
 #### Automatic Injection


### PR DESCRIPTION
Updated Service Container Docs. Added `makeWith` method with an example of an associative array