### PR TITLE
Update "receivesBroadcastNotificationsOn" return value.

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -517,13 +517,11 @@ If you would like to customize which channels a notifiable entity receives its b
         /**
          * The channels the user receives notification broadcasts on.
          *
-         * @return array
+         * @return string
          */
         public function receivesBroadcastNotificationsOn()
         {
-            return [
-                new PrivateChannel('users.'.$this->id),
-            ];
+            return 'users.'.$this->id;
         }
     }
 


### PR DESCRIPTION
The "receivesBroadcastNotificationsOn" method is used in "Illuminate\Notifications\Events\BroadcastNotificationCreated@channelName" which actually returns a string.

https://github.com/laravel/framework/issues/17883#issuecomment-301479258