### PR TITLE
dd note

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -898,6 +898,8 @@ The `dd` function dumps the given variables and ends execution of the script:
 
     dd($value1, $value2, $value3, ...);
 
+> {note} Be aware that `dd` calls `die` which prevents running of [Terminable Middleware](https://laravel.com/docs/5.4/middleware#terminable-middleware). It can cause that queued cookies will not be appended to the response.
+
 If you do not want to halt the execution of your script, use the `dump` function instead:
 
     dump($value);

--- a/helpers.md
+++ b/helpers.md
@@ -898,7 +898,7 @@ The `dd` function dumps the given variables and ends execution of the script:
 
     dd($value1, $value2, $value3, ...);
 
-> {note} Be aware that `dd` calls `die` which prevents running of [Terminable Middleware](https://laravel.com/docs/5.4/middleware#terminable-middleware). It can cause that queued cookies will not be appended to the response.
+> {note} Be aware that `dd` calls `die` which prevents running "after" middlewares. It can cause that queued cookies will not be appended to the response.
 
 If you do not want to halt the execution of your script, use the `dump` function instead:
 


### PR DESCRIPTION
I've seen many times people were confused about why their `Auth` or cookies don't work.
It was because they use `dd` for debug and it prevents `\Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse` from running.

