### PR TITLE
Add reference to nullable(false) column modifier

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -268,6 +268,7 @@ Modifier  | Description
 `->default($value)`  |  Specify a "default" value for the column
 `->first()`  |  Place the column "first" in the table (MySQL Only)
 `->nullable()`  |  Allow NULL values to be inserted into the column
+`->nullable(false)` | Do not allow the column to contain NULL values
 `->storedAs($expression)`  |  Create a stored generated column (MySQL Only)
 `->unsigned()`  |  Set `integer` columns to `UNSIGNED`
 `->virtualAs($expression)`  |  Create a virtual generated column (MySQL Only)


### PR DESCRIPTION
I had to leave the docs in search for how to do this, and found the answer here:
https://stackoverflow.com/questions/14013832/make-column-not-nullable-in-a-laravel-migration