### PR TITLE
Fix inProduction detection

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -308,7 +308,7 @@ Because versioned files are usually unnecessary in development, you may wish to 
 
     mix.js('resources/assets/js/app.js', 'public/js');
 
-    if (mix.config.inProduction) {
+    if (mix.inProduction()) {
         mix.version();
     }
 


### PR DESCRIPTION
The latest version of Mix has `inProduction()` instead of `config.inProduction`, if I'm correct.