### PR TITLE
Add link to initial Laravel Mix repository

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -25,7 +25,7 @@
 <a name="introduction"></a>
 ## Introduction
 
-Laravel Mix provides a fluent API for defining Webpack build steps for your Laravel application using several common CSS and JavaScript pre-processors. Through simple method chaining, you can fluently define your asset pipeline. For example:
+[Laravel Mix](https://github.com/JeffreyWay/laravel-mix) provides a fluent API for defining Webpack build steps for your Laravel application using several common CSS and JavaScript pre-processors. Through simple method chaining, you can fluently define your asset pipeline. For example:
 
     mix.js('resources/assets/js/app.js', 'public/js')
        .sass('resources/assets/sass/app.scss', 'public/css');


### PR DESCRIPTION
I know it's easy to find it via Google but some people are confused how to start Mix on non Laravel project.
I suppose you don't want to insert full instuctions in Laravel docs so I propose compromise as link to @JeffreyWay repository.
https://github.com/laravel/docs/issues/3397