### PR TITLE
Add symfony4 as a site type

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -268,7 +268,7 @@ Homestead supports several types of sites which allow you to easily run projects
           to: /home/vagrant/Code/Symfony/public
           type: symfony2
 
-The available site types are: `apache`, `laravel` (the default), `proxy`, `silverstripe`, `statamic`, and `symfony2`.
+The available site types are: `apache`, `laravel` (the default), `proxy`, `silverstripe`, `statamic`, `symfony2`, and `symfony4`.
 
 <a name="site-parameters"></a>
 #### Site Parameters


### PR DESCRIPTION
A new site type was added to Homestead in https://github.com/laravel/homestead/pull/600 this pr adds it to the documentation.