### PR TITLE
fix: syntax error in Eager Multiple Relationships usage

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -738,7 +738,7 @@ For this operation, only two queries will be executed:
 
 Sometimes you may need to eager load several different relationships in a single operation. To do so, just pass additional arguments to the `with` method:
 
-    $books = App\Book::with('author', 'publisher')->get();
+    $books = App\Book::with(['author', 'publisher'])->get();
 
 #### Nested Eager Loading
 


### PR DESCRIPTION
it caused show only one table's data which is the first parameter without array type