### PR TITLE
doc travis-ci dusk squelch static assets

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -643,7 +643,7 @@ To run your Dusk tests on Travis CI, we will need to use the "sudo-enabled" Ubun
         - sh -e /etc/init.d/xvfb start
         - ./vendor/laravel/dusk/bin/chromedriver-linux &
         - cp .env.testing .env
-        - php artisan serve &
+        - php artisan serve > /dev/null 2>&1 &
 
     script:
         - php artisan dusk


### PR DESCRIPTION
Currently the test output is polluted by the PHP built-in server logging.

![noisy](https://i.imgur.com/hd77X2m.png)

This silences requests for assets, such as `/favicon.ico` and `Invalid request (Unexpected EOF)` not fixed until PHP 7.2
https://bugs.php.net/bug.php?id=60471

![quite](https://i.imgur.com/4DmBbJ9.png)
