### PR TITLE
Added the actual line to add to the `providers` array

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -117,7 +117,9 @@ First, add the Cashier package for Braintree to your dependencies:
 
 #### Service Provider
 
-Next, register the `Laravel\Cashier\CashierServiceProvider` [service provider](/docs/{{version}}/providers) in your `config/app.php` configuration file.
+Next, register the `Laravel\Cashier\CashierServiceProvider` [service provider](/docs/{{version}}/providers) in your `config/app.php` configuration file:
+
+    Laravel\Cashier\CashierServiceProvider::class
 
 #### Plan Credit Coupon
 


### PR DESCRIPTION
The wording of the _Service Provider_ paragraph is such that someone might think they should place `Laravel\Cashier\CashierServiceProvider` as an entry in the `providers` array rather than the full `Laravel\Cashier\CashierServiceProvider::class`.

This is quite important as not including it kills the app without a stacktrace of any kind.  `Laravel.log` does have clues for it, but it's an unusual outcome so I think docs should make it as clear as possible.