### PR TITLE
Updated the installation command to match the version

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -30,7 +30,7 @@ Currently, Scout ships with an [Algolia](https://www.algolia.com/) driver; howev
 
 First, install the Scout via the Composer package manager:
 
-    composer require laravel/scout
+    composer require laravel/scout:2.0.*
 
 Next, you should add the `ScoutServiceProvider` to the `providers` array of your `config/app.php` configuration file:
 


### PR DESCRIPTION
The installation `composer require laravel/scout` throws following error:

```bash
  Problem 1
    - Conclusion: remove laravel/framework v5.3.31
    - Conclusion: don't install laravel/framework v5.3.31
    - laravel/scout v3.0.0 requires illuminate/support ~5.4 -> satisfiable by illuminate/support[v5.4.0, v5.4.13, v5.4.17, v5.4.19, v5.4.27, v5.4.9].
    - laravel/scout v3.0.1 requires illuminate/support ~5.4 -> satisfiable by illuminate/support[v5.4.0, v5.4.13, v5.4.17, v5.4.19, v5.4.27, v5.4.9].
    - laravel/scout v3.0.2 requires illuminate/support ~5.4 -> satisfiable by illuminate/support[v5.4.0, v5.4.13, v5.4.17, v5.4.19, v5.4.27, v5.4.9].
    - laravel/scout v3.0.3 requires illuminate/support ~5.4 -> satisfiable by illuminate/support[v5.4.0, v5.4.13, v5.4.17, v5.4.19, v5.4.27, v5.4.9].
    - laravel/scout v3.0.4 requires illuminate/support ~5.4 -> satisfiable by illuminate/support[v5.4.0, v5.4.13, v5.4.17, v5.4.19, v5.4.27, v5.4.9].
    - laravel/scout v3.0.5 requires illuminate/support ~5.4 -> satisfiable by illuminate/support[v5.4.0, v5.4.13, v5.4.17, v5.4.19, v5.4.27, v5.4.9].
    - don't install illuminate/support v5.4.0|don't install laravel/framework v5.3.31
    - don't install illuminate/support v5.4.13|don't install laravel/framework v5.3.31
    - don't install illuminate/support v5.4.17|don't install laravel/framework v5.3.31
    - don't install illuminate/support v5.4.19|don't install laravel/framework v5.3.31
    - don't install illuminate/support v5.4.27|don't install laravel/framework v5.3.31
    - don't install illuminate/support v5.4.9|don't install laravel/framework v5.3.31
    - Installation request for laravel/framework (locked at v5.3.31, required as 5.3.*) -> satisfiable by laravel/framework[v5.3.31].
    - Installation request for laravel/scout ^3.0 -> satisfiable by laravel/scout[v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5].
```

Upon correcting it to `composer require laravel/scout:2.0.*` it works fine. Tested it on multiple platforms and installations.