### PR TITLE
Change newSubscription() plan argument

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -202,7 +202,7 @@ To create a subscription, first retrieve an instance of your billable model, whi
 
     $user = User::find(1);
 
-    $user->newSubscription('main', 'monthly')->create($stripeToken);
+    $user->newSubscription('main', 'gold-membership')->create($stripeToken);
 
 The first argument passed to the `newSubscription` method should be the name of the subscription. If your application only offers a single subscription, you might call this `main` or `primary`. The second argument is the specific Stripe / Braintree plan the user is subscribing to. This value should correspond to the plan's identifier in Stripe or Braintree.
 

--- a/billing.md
+++ b/billing.md
@@ -202,7 +202,7 @@ To create a subscription, first retrieve an instance of your billable model, whi
 
     $user = User::find(1);
 
-    $user->newSubscription('main', 'gold-membership')->create($stripeToken);
+    $user->newSubscription('main', 'premium')->create($stripeToken);
 
 The first argument passed to the `newSubscription` method should be the name of the subscription. If your application only offers a single subscription, you might call this `main` or `primary`. The second argument is the specific Stripe / Braintree plan the user is subscribing to. This value should correspond to the plan's identifier in Stripe or Braintree.
 


### PR DESCRIPTION
As per issue #3416, I've updated the plan argument provided as an example to newSubscription to make it easier to understand.