### PR TITLE
Fix case issue under Binding Instances

### DIFF
--- a/container.md
+++ b/container.md
@@ -98,7 +98,7 @@ You may also bind an existing object instance into the container using the `inst
 
     $api = new HelpSpot\API(new HttpClient);
 
-    $this->app->instance('HelpSpot\Api', $api);
+    $this->app->instance('HelpSpot\API', $api);
 
 #### Binding Primitives
 


### PR DESCRIPTION
Fixes #3346 by correcting the capitalization under a model binding example input.