### PR TITLE
add fluent rule information to not_in description

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -828,7 +828,16 @@ The field under validation may be `null`. This is particularly useful when valid
 <a name="rule-not-in"></a>
 #### not_in:_foo_,_bar_,...
 
-The field under validation must not be included in the given list of values.
+The field under validation must not be included in the given list of values. Like the converse [`in`](#rule-in) rule, often you require to `implode` an array, the `Rule::notIn` method may be used to fluently construct the rule:
+
+    use Illuminate\Validation\Rule;
+
+    Validator::make($data, [
+        'toppings' => [
+            'required',
+            Rule::notIn(['sprinkles', 'cherries']),
+        ],
+    ]);
 
 <a name="rule-numeric"></a>
 #### numeric


### PR DESCRIPTION
The `not_in` rule did not have any information about having an available fluent rule - I've added this.