### PR TITLE
Update authorization.md

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -75,12 +75,14 @@ This is identical to manually defining the following Gate definitions:
     Gate::define('posts.update', 'PostPolicy@update');
     Gate::define('posts.delete', 'PostPolicy@delete');
 
-By default, the `view`, `create`, `update`, and `delete` abilities will be defined. You may define additional abilities by passing an array as third argument to the `resource` method. The key of the array defines the name of the ability while the value defines the method name:
+By default, the `view`, `create`, `update`, and `delete` abilities will be defined. You may define additional abilities by passing an array as a third argument to the `resource` method. The key of the array defines the name of the ability while the value defines the method name:
 
     Gate::resource('posts', 'PostPolicy', [
-        'posts.photo' => 'updatePhoto',
-        'posts.image' => 'updateImage',
+        'photo' => 'updatePhoto',
+        'image' => 'updateImage',
     ]);
+    
+The above will then create 2 new Gate definitions, `posts.photo` and `posts.image`. Note that the definition names are automatically prefixed with the resources name.
 
 <a name="authorizing-actions-via-gates"></a>
 ### Authorizing Actions


### PR DESCRIPTION
Fixed Gate::resource's additional abilities argument, as the resources' key automatically gets prefixed by the resource.