### PR TITLE
Name roomId parameter to be matched by pattern

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -472,7 +472,7 @@ All presence channels are also private channels; therefore, users must be [autho
 
 The data returned by the authorization callback will be made available to the presence channel event listeners in your JavaScript application. If the user is not authorized to join the presence channel, you should return `false` or `null`:
 
-    Broadcast::channel('chat.*', function ($user, $roomId) {
+    Broadcast::channel('chat.{roomId}', function ($user, $roomId) {
         if ($user->canJoinRoom($roomId)) {
             return ['id' => $user->id, 'name' => $user->name];
         }


### PR DESCRIPTION
Hi,

The given code raises the following exception:
```php
Broadcast::channel('chat.*', function ($user, $roomId) {
    if ($user->canJoinRoom($roomId)) {
        return ['id' => $user->id, 'name' => $user->name];
    }
});
```
```
Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Too few arguments to function App\Providers\BroadcastServiceProvider::App\Providers\{closure}(), 1 passed in C:\dev\myproject\vendor\laravel\framework\src\Illuminate\Broadcasting\Broadcasters\Broadcaster.php on line 60 and exactly 2 expected in C:\dev\myproject\app\Providers\BroadcastServiceProvider.php:29
```

When I use it as shown under https://laravel.com/docs/5.4/broadcasting#concept-overview, it works as expected.

Used code:
```php
Broadcast::channel('chat.{roomId}', function ($user, $roomId) {
    if ($user->canJoinRoom($roomId)) {
        return ['id' => $user->id, 'name' => $user->name];
    }
});
```

Hope this helps.

