### PR TITLE
Fix assigning multiple route middleware

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -127,11 +127,11 @@ Once the middleware has been defined in the HTTP kernel, you may use the `middle
         //
     })->middleware('auth');
 
-You may also assign multiple middleware to the route:
+You may also assign multiple middleware to the route by passing in an array:
 
     Route::get('/', function () {
         //
-    })->middleware('first', 'second');
+    })->middleware(['first', 'second']);
 
 When assigning middleware, you may also pass the fully qualified class name:
 


### PR DESCRIPTION
Docs currently show multiple parameters when you actually need to pass in an array. I have updated the text and code sample to demonstrate this.