### PR TITLE
Make a note about the session being maintained

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -251,6 +251,8 @@ Often, you will be testing pages that require authentication. You can use Dusk's
         $first->loginAs(User::find(1))
               ->visit('/home');
     });
+    
+It's worth noting that the session will be maintained within each individual test file, so you may need to split tests that rely on different authentication states into different files or manually logout before/after each test.
 
 <a name="interacting-with-elements"></a>
 ## Interacting With Elements


### PR DESCRIPTION
I noticed that the session is maintained in each individual test file, which was causing some confusion when writing some different tests for a login form in the same file. I don't think it's an issue that this is the case, but I do think it's worth noting in the docs. It helps other developers recognise that it's intended behaviour and that they're not doing something wrong.