### PR TITLE
[5.4] Require v2 of pusher for Laravel 5.4

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -58,7 +58,7 @@ Before broadcasting any events, you will first need to register the `App\Provide
 
 If you are broadcasting your events over [Pusher](https://pusher.com), you should install the Pusher PHP SDK using the Composer package manager:
 
-    composer require pusher/pusher-php-server
+    composer require pusher/pusher-php-server "^2.6"
 
 Next, you should configure your Pusher credentials in the `config/broadcasting.php` configuration file. An example Pusher configuration is already included in this file, allowing you to quickly specify your Pusher key, secret, and application ID. The `config/broadcasting.php` file's `pusher` configuration also allows you to specify additional `options` that are supported by Pusher, such as the cluster:
 


### PR DESCRIPTION
Pusher v3 uses namespaces, Laravel 5.4 code doesn't.