### PR TITLE
more clarity on CreateFreshApiToken Middleware

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -628,6 +628,8 @@ Typically, if you want to consume your API from your JavaScript application, you
         // Other middleware...
         \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
     ],
+    
+> {note} If you are using a multiple auth guards then, you should make sure that middleware is only applied for the routes that uses the same provider as passport uses. Otherwise it will attach the cookie to all the requestes regardless of guards for any authenticated user, which causes the other autheticated guard user can issue requests to the passport authenticated routes.
 
 This Passport middleware will attach a `laravel_token` cookie to your outgoing responses. This cookie contains an encrypted JWT that Passport will use to authenticate API requests from your JavaScript application. Now, you may make requests to your application's API without explicitly passing an access token:
 


### PR DESCRIPTION
As per the documentation it says to define the middleware in the web groups which is applied to all the routes by default.
If the application is using a multi auth guard setup and if the all the routes are defined in the web.php file than this adds the `laravel_token` to all the requests regardless of whatever the guards logged in. Which causes a security flaw by which any authenticated user can issue/access routes of the passport guard applied.
I was having this issue which is a intended behaviour but it was nowhere mentioned in the documentation, So I though it might help for the users who has multiple auth guard setups.
To Fix it It should be said that the middleware should only applied in those routes whose auth provider is same as the api guard provider otherwise it will get cookie even if it is not logged in to that api guard provider