### PR TITLE
Update authorization.md

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -75,7 +75,7 @@ This is identical to manually defining the following Gate definitions:
     Gate::define('posts.update', 'PostPolicy@update');
     Gate::define('posts.delete', 'PostPolicy@delete');
 
-By default, the `view`, `create`, `update`, and `delete` abilities will be defined. You may define additional abilities by passing an array as third argument to the `resource` method. The key of the array defines the name of the ability while the value defines the method name:
+By default, the `view`, `create`, `update`, and `delete` abilities will be defined. You can override the default abilities by passing an array as third argument to the `resource` method. The key of the array defines the name of the ability while the value defines the method name:
 
     Gate::resource('posts', 'PostPolicy', [
         'posts.photo' => 'updatePhoto',


### PR DESCRIPTION
Fixing docs for Gate::resource() method where the documentation says passing the third attribute would merge with the default abilities. The current behaviour of this method is to override the default attributes.

More info on laravel/framework#20081