### PR TITLE
Connecting to a real Selenium hub

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -96,7 +96,7 @@ Next, you may simply modify the `driver` method to connect to the URL and port o
     protected function driver()
     {
         return RemoteWebDriver::create(
-            'http://localhost:4444', DesiredCapabilities::phantomjs()
+            'http://localhost:4444/wd/hub', DesiredCapabilities::phantomjs()
         );
     }
 


### PR DESCRIPTION
When configuring Dusk to connect to a Selenium hub the example uri is not complete. To connect to a Selenium node it should connect to the hub (`http://HOSTNAME:4444/wd/hub`).  This PR fixes this uri.