### PR TITLE
Using attach() you can't combine records with ids only & other with attributes

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -927,7 +927,7 @@ For convenience, `attach` and `detach` also accept arrays of IDs as input:
 
     $user->roles()->detach([1, 2, 3]);
 
-    $user->roles()->attach([1 => ['expires' => $expires], 2, 3]);
+    $user->roles()->attach([1 => ['expires' => $expires], 2 => ['expires' => $expires]]);
 
 #### Syncing Associations
 


### PR DESCRIPTION
```
->attach([1 => ['expires' => $expires], 2]);
```

The generated insert statement will contain inconsistent columns which will result an SQL error.

It works with `sync()` since we attach records one by one inside `attachNew()`