### PR TITLE
Revision to docs\Upgrade.md

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -492,7 +492,7 @@ If you are queueing jobs using this syntax, Eloquent models will no longer be au
 ### Routing
 
 #### New routes Folder
-Routes have been moved into their own directory, named 'routes'.  The routes themselves have been divided into two files.  Move existing routes related to the web interface of an application into 'web.php', while stateless routes should be placed in 'api.php'
+Routes have been moved into their own directory, named `routes`.  The routes themselves have been divided into two files.  Move existing routes related to the web interface of an application into `routes\web.php`, while stateless routes should be placed in `routes\api.php`.  As part of this split, `app\Http\Kernel.php` has been revised to add MiddlewareGroups corresponding to `web` and `api`.  Pull a new copy (https://github.com/laravel/laravel/blob/5.3/app/Http/Kernel.php) and add any custom middleware to the appropriate group.
 
 #### Resource Parameters Are Singular By Default
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -62,7 +62,7 @@ The `make:console` command has been renamed to `make:command`.
 
 The two default authentication controllers provided with the framework have been split into four smaller controllers. This change provides cleaner, more focused authentication controllers by default. The easiest way to upgrade your application to the new authentication controllers is to [grab a fresh copy of each controller from GitHub](https://github.com/laravel/laravel/tree/5.3/app/Http/Controllers/Auth) and place them into your application.
 
-You should also make sure that you are calling the `Auth::routes()` method in your `routes/web.php` file. This method will register the proper routes for the new authentication controllers.
+You should also make sure that you are calling the `Auth::routes()` method in your `routes/web.php` file (see Routing, below). This method will register the proper routes for the new authentication controllers.
 
 Once these controllers have been placed into your application, you may need to re-implement any customizations you made to these controllers. For example, if you are customizing the authentication guard that is used for authentication, you may need to override the controller's `guard` method. You can examine each authentication controller's trait to determine which methods to override.
 
@@ -490,6 +490,9 @@ If you are queueing jobs using this syntax, Eloquent models will no longer be au
     Queue::push(new ClassName);
 
 ### Routing
+
+#### New routes Folder
+Routes have been moved into their own directory, named 'routes'.  The routes themselves have been divided into two files.  Move existing routes related to the web interface of an application into 'web.php', while stateless routes should be placed in 'api.php'
 
 #### Resource Parameters Are Singular By Default
 


### PR DESCRIPTION
This revises the Routing section of the 5.3 upgrade guide to address the move of routes to the routes folder, the split into web.php and api.php, and the associated change in Kernel.php.