### PR TITLE
Remove suggestion to install dompdf since now is required by default.

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -612,11 +612,7 @@ When listing the invoices for the customer, you may use the invoice's helper met
 <a name="generating-invoice-pdfs"></a>
 ### Generating Invoice PDFs
 
-Before generating invoice PDFs, you need to install the `dompdf` PHP library:
-
-    composer require dompdf/dompdf
-
-Then, from within a route or controller, use the `downloadInvoice` method to generate a PDF download of the invoice. This method will automatically generate the proper HTTP response to send the download to the browser:
+From within a route or controller, use the `downloadInvoice` method to generate a PDF download of the invoice. This method will automatically generate the proper HTTP response to send the download to the browser:
 
     use Illuminate\Http\Request;
 


### PR DESCRIPTION
Since https://github.com/laravel/cashier/pull/424/files, Cashier requires dompdf/dompdf by default.