### PR TITLE
Fix docs for `Gate::resource` method.

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -78,8 +78,8 @@ This is identical to manually defining the following Gate definitions:
 By default, the `view`, `create`, `update`, and `delete` abilities will be defined. You can override the default abilities by passing an array as third argument to the `resource` method. The key of the array defines the name of the ability while the value defines the method name:
 
     Gate::resource('posts', 'PostPolicy', [
-        'posts.photo' => 'updatePhoto',
-        'posts.image' => 'updateImage',
+        'photo' => 'updatePhoto',
+        'image' => 'updateImage',
     ]);
 
 <a name="authorizing-actions-via-gates"></a>


### PR DESCRIPTION
By overriding the abilities array in the third parameter, The keys of this array will be concatenated with a period to the resource name in the first argument.

So keys should be `photo` & `image`, not `posts.photo` & `posts.image`.