### PR TITLE
Improve explanation of str_finish

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -624,9 +624,10 @@ You may also pass an array of values to determine if the given string contains a
 <a name="method-str-finish"></a>
 #### `str_finish()` {#collection-method}
 
-The `str_finish` function adds a single instance of the given value to a string:
+The `str_finish` function adds a single instance of the given value to a string if it does not already end with it:
 
     $string = str_finish('this/string', '/');
+    $string2 = str_finish('this/string/', '/');
 
     // this/string/
 


### PR DESCRIPTION
It was unclear that it doesn't append the value if the string already ends with it.

Closes #3505