### PR TITLE
[5.5] Add assertSuccessful method

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -180,6 +180,7 @@ Laravel provides a variety of custom assertion methods for your [PHPUnit](https:
 
 Method  | Description
 ------------- | -------------
+`$response->assertSuccessful();`  |  Assert that the response has a successful status code.
 `$response->assertStatus($code);`  |  Assert that the response has a given code.
 `$response->assertRedirect($uri);`  |  Assert that the response is a redirect to a given URI.
 `$response->assertHeader($headerName, $value = null);`  |  Assert that the given header is present on the response.


### PR DESCRIPTION
I feel that this is, for those who don't look through the main code base, a good method to have documented here.

I put the method first in the list because that is how it is in the `TestResponse` class.

I deleted the old branch when I made the last pull request, so I could not edit it. This one removes the `$uri` argument from the method. Sorry about that.