### PR TITLE
Change bail example

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -112,11 +112,11 @@ As you can see, we simply pass the incoming HTTP request and desired validation 
 Sometimes you may wish to stop running validation rules on an attribute after the first validation failure. To do so, assign the `bail` rule to the attribute:
 
     $this->validate($request, [
-        'title' => 'bail|required|unique:posts|max:255',
+        'title' => 'bail|unique:posts|max:255',
         'body' => 'required',
     ]);
 
-In this example, if the `required` rule on the `title` attribute fails, the `unique` rule will not be checked. Rules will be validated in the order they are assigned.
+In this example, if the `unique` rule on the `title` attribute fails, the `max` rule will not be checked. Rules will be validated in the order they are assigned.
 
 #### A Note On Nested Attributes
 


### PR DESCRIPTION
I found `bail` example not so clear because if `required` fails other rules will not be checked whether `bail` exists or not.