### PR TITLE
Change Cache Busting Code Example

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -308,7 +308,7 @@ Because versioned files are usually unnecessary in development, you may instruct
 
     mix.js('resources/assets/js/app.js', 'public/js');
 
-    if (mix.inProduction()) {
+    if (mix.config.inProduction) {
         mix.version();
     }
 


### PR DESCRIPTION
The use of `mix.inProduction()` does not appear to properly indicate to the Mix that the environment is actually in production. Using the current example, the `mix.version()` call will be skipped. See the following Laravel Mix issue: https://github.com/JeffreyWay/laravel-mix/issues/363