### PR TITLE
Amended asset compilation 'copy' function to no longer suggest copyDirectory()

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -286,9 +286,9 @@ The `copy` method may be used to copy files and directories to new locations. Th
 
     mix.copy('node_modules/foo/bar.css', 'public/css/bar.css');
 
-When copying a directory, the `copy` method will flatten the directory's structure. To maintain the directory's original structure, you should use the `copyDirectory` method instead:
+When copying a directory, the `copy` method by default will flatten the directory's structure. To maintain the directory's original structure, you should pass `false` as the third parameter:
 
-    mix.copyDirectory('assets/img', 'public/img');
+    mix.copy('assets/img', 'public/img', false);
 
 <a name="versioning-and-cache-busting"></a>
 ## Versioning / Cache Busting


### PR DESCRIPTION
Just a small change here on something I noticed while setting up Mix.

The docs were recommending the use of the `copyDirectory` function for not flattening a directory using `copy`

The correct recommendation however it to pass `false` as the third parameter of the `copy` function.

Hope this is alright 🍡 