### PR TITLE
Document $casts changes

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -87,6 +87,21 @@ If you are overriding the `is` method of your Eloquent model, you should remove 
 
 The `$events` property on your models should be renamed to `$dispatchesEvents`. This change was made because of a high number of users needing to define an `events` relationship, which caused a conflict with the old property name.
 
+#### Model `$casts` Property
+
+Since 5.5 attribute casting works in both directions. Cehck out your seeds for places where you cast attributes manually if you insert casted attributes. For example:
+
+    // App\User.php
+    $casts = [
+        'items' => 'json'
+    ];
+
+    // in the seeder:
+    User::create([
+        // ... other attributes
+        'items' => json_encode([...]) // you should remove json_encode
+    ]);
+
 #### Pivot `$parent` Property
 
 The protected `$parent` property on the `Illuminate\Database\Eloquent\Relations\Pivot` class has been renamed to `$pivotParent`.


### PR DESCRIPTION
Since 5.5 attribute casting works in both directions and it ruined my seeds when i updated to 5.5, I thought we should inform other developers about that issue, because it runs without an error, but when you access the attribute it will not cast back to array, because it was encoded twice...