### PR TITLE
add misc upgrade notes

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -273,3 +273,7 @@ When allowing the dynamic `__call` method to share variables with a view, these 
 The `maximumVotes` variable may be accessed in the template like so:
 
     {{ $maximumVotes }}
+
+### Miscellaneous
+
+We also encourage you to view the changes in the `laravel/laravel` [GitHub repository](https://github.com/laravel/laravel). While many of these changes are not required, you may wish to keep these files in sync with your application. Some of these changes will be covered in this upgrade guide, but others, such as changes to configuration files or comments, will not be. You can easily view the changes with the [GitHub comparison tool](https://github.com/laravel/laravel/compare/5.4...master) and choose which updates are important to you.


### PR DESCRIPTION
this is the same note I added in the 5.4 upgrade. it helps users keep their `laravel/laravel` files up to date, and helps cover a couple of the more nuanced upgrades to the framework.