### PR TITLE
Improves upgrade guide on the change in the method: has

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -212,7 +212,7 @@ The unused `$data` and `$callback` arguments were removed from the `Illuminate\C
 
 #### The `has` Method
 
-The `$request->has` method will now return `true` for empty strings and `null`. A new `$request->filled` method has been added that provides the previous behavior of the `has` method.
+The `$request->has` method will now return `true` even if the input value is an empty string or `null`. A new `$request->filled` method has been added that provides the previous behavior of the `has` method.
 
 #### The `intersect` Method
 


### PR DESCRIPTION
This PR addresses the upgrade guide on the change on the method `has`. Currently it don't precise if we are talking about the input key or the input value.