### PR TITLE
Document the new ‘retrieved’ Eloquent event & method

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -717,7 +717,7 @@ Now, you may pass the parameters when calling the scope:
 
 Eloquent models fire several events, allowing you to hook into the following points in a model's lifecycle: `creating`, `created`, `retrieved`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`. Events allow you to easily execute code each time a specific model class is saved or updated in the database.
 
-Whenever a new model is saved for the first time, the `creating` and `created` events will fire. If a model already existed in the database and the `save` method is called, the `updating` / `updated` events will fire. However, in both cases, the `saving` / `saved` events will fire.
+Whenever a new model is saved for the first time, the `creating` and `created` events will fire. If a model already existed in the database and the `save` method is called, the `updating` / `updated` events will fire. However, in both cases, the `saving` / `saved` events will fire. The `retrieved` event will fire when an already existing model is retrieved from the database.
 
 To get started, define a `$dispatchesEvents` property on your Eloquent model that maps various points of the Eloquent model's lifecycle to your own [event classes](/docs/{{version}}/events):
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -715,7 +715,7 @@ Now, you may pass the parameters when calling the scope:
 <a name="events"></a>
 ## Events
 
-Eloquent models fire several events, allowing you to hook into the following points in a model's lifecycle: `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`. Events allow you to easily execute code each time a specific model class is saved or updated in the database.
+Eloquent models fire several events, allowing you to hook into the following points in a model's lifecycle: `creating`, `created`, `retrieved`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`. Events allow you to easily execute code each time a specific model class is saved or updated in the database.
 
 Whenever a new model is saved for the first time, the `creating` and `created` events will fire. If a model already existed in the database and the `save` method is called, the `updating` / `updated` events will fire. However, in both cases, the `saving` / `saved` events will fire.
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -93,6 +93,10 @@ If you are overriding the `is` method of your Eloquent model, you should remove 
 
 The `$events` property on your models should be renamed to `$dispatchesEvents`. This change was made because of a high number of users needing to define an `events` relationship, which caused a conflict with the old property name.
 
+#### New `retrieved` Method
+
+A `retrieved` method has been added to allow the registration of an event listener for when an already existing model is retrieved from the database. If you have any custom method named `retrieved` on your model, you should rename it to avoid a naming conflict.
+
 #### Pivot `$parent` Property
 
 The protected `$parent` property on the `Illuminate\Database\Eloquent\Relations\Pivot` class has been renamed to `$pivotParent`.


### PR DESCRIPTION
Following the merge of https://github.com/laravel/framework/pull/20852, this PR brings the related documentation.

I made atomic commits to allow to select which parts are wanted, in case not all three of them are deemed necessary.
Two commits update the Eloquent documentation, and the third adds a warning in the 5.5 upgrade guide about a potential (although unlikely) naming conflict with previously existing code.