### PR TITLE
Update dusk.md

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -40,7 +40,7 @@ Laravel Dusk provides an expressive, easy-to-use browser automation and testing 
 
 To get started, you should add the `laravel/dusk` Composer dependency to your project:
 
-    composer require --dev laravel/dusk
+    composer require --dev laravel/dusk:^1.0
 
 Once Dusk is installed, you should register the `Laravel\Dusk\DuskServiceProvider` service provider. You should register the provider within the `register` method of your `AppServiceProvider` in order to limit the environments in which Dusk is available, since it exposes the ability to log in as other users:
 


### PR DESCRIPTION
Installing the latest dusk version (`2.0`) doesn't work with `Laravel 5.4.*` because it requires `illuminate/support 5.5`