### PR TITLE
Fix typo intersectKey to intersectByKeys

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -74,7 +74,7 @@ For the remainder of this documentation, we'll discuss each method available on 
 [has](#method-has)
 [implode](#method-implode)
 [intersect](#method-intersect)
-[intersectKey](#method-intersectkey)
+[intersectByKeys](#method-intersectbykeys)
 [isEmpty](#method-isempty)
 [isNotEmpty](#method-isnotempty)
 [keyBy](#method-keyby)
@@ -634,16 +634,16 @@ The `intersect` method removes any values from the original collection that are 
 
     // [0 => 'Desk', 2 => 'Chair']
 
-<a name="method-intersectkey"></a>
-#### `intersectKey()` {#collection-method}
+<a name="method-intersectbykeys"></a>
+#### `intersectByKeys()` {#collection-method}
 
-The `intersectKey` method removes any keys from the original collection that are not present in the given `array` or collection:
+The `intersectByKeys` method removes any keys from the original collection that are not present in the given `array` or collection:
 
     $collection = collect([
         'serial' => 'UX301', 'type' => 'screen', 'year' => 2009
     ]);
 
-    $intersect = $collection->intersectKey([
+    $intersect = $collection->intersectByKeys([
         'reference' => 'UX404', 'type' => 'tab', 'year' => 2011
     ]);
 


### PR DESCRIPTION
In the example usage for ``intersectByKeys`` the method were called ``intersectKey``.