### PR TITLE
Added some info about filp/whoops in updating dependencies

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -15,7 +15,7 @@ Laravel 5.5 requires PHP 7.0.0 or higher.
 
 ### Updating Dependencies
 
-Update your `laravel/framework` dependency to `5.5.*` in your `composer.json` file. In addition, you should update your `phpunit/phpunit` dependency to `~6.0`.
+Update your `laravel/framework` dependency to `5.5.*` in your `composer.json` file. In addition, you should update your `phpunit/phpunit` dependency to `~6.0` and add `filp/whoops` version `~2.0`in `require-dev`
 
 > {tip} If you commonly use the Laravel installer via `laravel new`, you should update your Laravel installer package using the `composer global update` command.
 


### PR DESCRIPTION
Added some information about adding filp/whoops package in `require-dev` after updating from 5.4 to 5.5 in the updating dependencies chapter.