### PR TITLE
[5.4] Added Cache::rememberForever()

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -148,6 +148,12 @@ Sometimes you may wish to retrieve an item from the cache, but also store a defa
 
 If the item does not exist in the cache, the `Closure` passed to the `remember` method will be executed and its result will be placed in the cache.
 
+You may use the `rememberForever` method to retrieve an item from the cache or store it forever:
+
+    $value = Cache::rememberForever('users', function() {
+        return DB::table('users')->get();
+    });
+
 #### Retrieve & Delete
 
 If you need to retrieve an item from the cache and then delete the item, you may use the `pull` method. Like the `get` method, `null` will be returned if the item does not exist in the cache:

--- a/passport.md
+++ b/passport.md
@@ -428,7 +428,7 @@ Once a grant has been enabled, developers may use their client ID to request an 
 
 The client credentials grant is suitable for machine-to-machine authentication. For example, you might use this grant in a scheduled job which is performing maintenance tasks over an API. To use this method you first need to add new middleware to your `$routeMiddleware` in `app/Http/Kernel.php`:
 
-    use Laravel\Passport\Http\Middleware\CheckClientCredentials::class;
+    use Laravel\Passport\Http\Middleware\CheckClientCredentials;
 
     protected $routeMiddleware = [
         'client' => CheckClientCredentials::class,


### PR DESCRIPTION
### Description
`Cache::rememberForever()` is missing from official doc. This method is different from `forever()` because it allows to execute a callback and to cache the result.

### Files
`/docs/cache.md`

### Datasource
[Laravel APIs](https://laravel.com/api/5.4/Illuminate/Contracts/Cache/Repository.html#method_rememberForever)

### Related to
[https://github.com/laravel/docs/pull/3617](https://github.com/laravel/docs/pull/3617)