### PR TITLE
Doc specification of columns in with method

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -813,6 +813,16 @@ In this example, Eloquent will only eager load posts where the post's `title` co
         $query->orderBy('created_at', 'desc');
     }])->get();
 
+You may use [select](/docs/{{version}}/queries#selects) method to specify a custom select clause for the query:
+
+    $users = App\User::with(['posts' => function ($query) {
+        $query->select(['id', 'title']);
+    }])->get();
+
+Or you may specify the columns to eager load directly in the `with` method:
+
+    $users = App\User::with('posts:id,title')->get();
+
 <a name="lazy-eager-loading"></a>
 ### Lazy Eager Loading
 


### PR DESCRIPTION
Recently I saw [a tweet](https://twitter.com/stidges/status/908076318964817923) that shows how we can [specify columns](https://github.com/laravel/framework/blob/5.5/src/Illuminate/Database/Eloquent/Builder.php#L1075) directly when eager loading a relation:
![djoif5awaae_eyo](https://user-images.githubusercontent.com/16328050/30411970-e8e29988-98ea-11e7-8091-ac00ca4b101c.jpg)
This PR documents this.

PS: This is my first PR for docs, so sorry about any mistakes! Also, this feature is available since [Laravel 5.3](https://github.com/laravel/framework/blob/5.3/src/Illuminate/Database/Eloquent/Builder.php#L1130), so should we document it for those versions?