### PR TITLE
Add Eloquent: API Resources hint for using hasOne relationships

### DIFF
--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -190,6 +190,7 @@ If you would like to include related resources in your response, you may simply 
         ];
     }
 
+> {tip} For hasOne relationships, use `make` method instead.
 > {tip} If you would like to include relationships only when they have already been loaded, check out the documentation on [conditional relationships](#conditional-relationships).
 
 #### Resource Collections


### PR DESCRIPTION
I opened and closed an issue regarding this on the laravel/framework repo, because I thought there was a bug regarding the new Eloquent Resource feature (which I have found to be very cool btw), because I couldn't include my relationship using the Resource::collection as is stated on this example:

```php
/**
 * Transform the resource into an array.
 *
 * @param  \Illuminate\Http\Request
 * @return array
 */
public function toArray($request)
{
    return [
        'id' => $this->id,
        'name' => $this->name,
        'email' => $this->email,
        'posts' => Post::collection($this->posts),
        'created_at' => $this->created_at,
        'updated_at' => $this->updated_at,
    ];
}
```

I figured out that the collection method only works on hasMany relationships  and I was trying to include a hasOne relationship. Thanks to my IDE's autocomplete I realized that a Resource::make method exists and can be used for hasOne relationships. Still, I banged my head for two days before realizing this and I think that a little tip can avoid people from having this issue.