### PR TITLE
Sort use statements by length

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -341,8 +341,8 @@ Next, you should create a [service provider](/docs/{{version}}/providers) such a
 
     use Storage;
     use League\Flysystem\Filesystem;
-    use Spatie\Dropbox\Client as DropboxClient;
     use Illuminate\Support\ServiceProvider;
+    use Spatie\Dropbox\Client as DropboxClient;
     use Spatie\FlysystemDropbox\DropboxAdapter;
 
     class DropboxServiceProvider extends ServiceProvider

--- a/redis.md
+++ b/redis.md
@@ -122,8 +122,8 @@ You may interact with Redis by calling various methods on the `Redis` [facade](/
 
     namespace App\Http\Controllers;
 
-    use Illuminate\Support\Facades\Redis;
     use App\Http\Controllers\Controller;
+    use Illuminate\Support\Facades\Redis;
 
     class UserController extends Controller
     {


### PR DESCRIPTION
Sort `use` statements by length in order to be consistent with the rest of the documentation.

Both changes would apply to the `5.4` branch, and the change in `redis.md` would apply to the `5.3` branch. Do you want me to create PRs for those too?