### PR TITLE
missing PasswordReset event added to Authentication

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -532,4 +532,8 @@ Laravel raises a variety of [events](/docs/{{version}}/events) during the authen
         'Illuminate\Auth\Events\Lockout' => [
             'App\Listeners\LogLockout',
         ],
+
+        'Illuminate\Auth\Events\PasswordReset' => [
+            'App\Listeners\LogPasswordReset',
+        ],
     ];


### PR DESCRIPTION
The Illuminate\Auth\Events\PasswordReset event is missing form the docs for 5.5.