### PR TITLE
Remove console check for package commands

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -247,12 +247,10 @@ To register your package's Artisan commands with Laravel, you may use the `comma
      */
     public function boot()
     {
-        if ($this->app->runningInConsole()) {
-            $this->commands([
-                FooCommand::class,
-                BarCommand::class,
-            ]);
-        }
+        $this->commands([
+            FooCommand::class,
+            BarCommand::class,
+        ]);
     }
 
 <a name="public-assets"></a>


### PR DESCRIPTION
In the documentation for 5.3-5.5 the example only registers commands in a package if `runningInConsole()`. This would prevent a developer from being able to programatically execute the command from a web (non-console) request, and therefore needlessly removes some artisan functionality from the command.

The 'default' should be to always register the command so as to not remove any functionality and confuse the situation.