### PR TITLE
Add tip that directives auth & guest accept $guard argument

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -239,6 +239,8 @@ The `@auth` and `@guest` directives may be used to quickly determine if the curr
         // The user is not authenticated...
     @endguest
 
+> {tip} When working with multiple authentication guards, you may pass `$guard` argument to the `@auth($guard)` and `@guest($guard)` directives in order to check for a specific guard.
+
 <a name="switch-statements"></a>
 ### Switch Statements
 


### PR DESCRIPTION
Wording may be needed, or loosing the "tip" and just add it as text below the code.

I think experienced Laravel user will know this right away, but may help newcomers (as well as confuse them).