### PR TITLE
Authorization before filter note

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -229,6 +229,8 @@ For certain users, you may wish to authorize all actions within a given policy. 
 
 If you would like to deny all authorizations for a user you should return `false` from the `before` method. If `null` is returned, the authorization will fall through to the policy method.
 
+> {note} The `before` method of a policy class will not be called if the class doesn't contain a method with name matching the name of the ability being checked.
+
 <a name="authorizing-actions-using-policies"></a>
 ## Authorizing Actions Using Policies
 


### PR DESCRIPTION
It's noted in the [upgrade guide (5.4 -> 5.5)](https://laravel.com/docs/5.5/upgrade#upgrade-5.5.0), but missing in actual documentation.

Wording may be needed to fit documentation **note** style.

---
I feel this needs to be in docs since I used policies heavily and during the development stage I usually have empty policy classes with only `before()` method...