### PR TITLE
remove --no-bin-links description

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -50,9 +50,6 @@ The only remaining step is to install Laravel Mix. Within a fresh installation o
 
     npm install
 
-If you are developing on a Windows system or you are running your VM on a Windows host system, you may need to run the `npm install` command with the `--no-bin-links` switch enabled:
-
-    npm install --no-bin-links
 
 <a name="running-mix"></a>
 ## Running Mix


### PR DESCRIPTION
If we use this in windows, when executing the `npm run dev` command we get `cross-env is not recognized as an internal or external command` error.
`npm install` alone is enough and works well.