### PR TITLE
[5.5] Document Collection::dd() method

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -56,6 +56,7 @@ For the remainder of this documentation, we'll discuss each method available on 
 [contains](#method-contains)
 [containsStrict](#method-containsstrict)
 [count](#method-count)
+[dd](#method-dd)
 [diff](#method-diff)
 [diffAssoc](#method-diffassoc)
 [diffKeys](#method-diffkeys)
@@ -275,6 +276,24 @@ The `count` method returns the total number of items in the collection:
     $collection->count();
 
     // 4
+
+<a name="method-dd"></a>
+#### `dd()` {#collection-method}
+
+The `dd` method dumps the given collection's items and ends execution of the script:
+
+    $collection = collect(['John Doe', 'Jane Doe']);
+
+    $collection->dd();
+
+    /*
+        array:2 [
+            0 => "John Doe"
+            1 => "Jane Doe"
+        ]
+    */
+
+If you do not want to end the script execution, use the [`dump`](#method-dump) method instead.
 
 <a name="method-diff"></a>
 #### `diff()` {#collection-method}

--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -59,6 +59,7 @@ All Eloquent collections extend the base [Laravel collection](/docs/{{version}}/
 [contains](/docs/{{version}}/collections#method-contains)
 [containsStrict](/docs/{{version}}/collections#method-containsstrict)
 [count](/docs/{{version}}/collections#method-count)
+[dd](/docs/{{version}}/collections#method-dd)
 [diff](/docs/{{version}}/collections#method-diff)
 [diffKeys](/docs/{{version}}/collections#method-diffkeys)
 [each](/docs/{{version}}/collections#method-each)


### PR DESCRIPTION
Documentation for the `Collection::dd()` method introduced in https://github.com/laravel/framework/commit/f5fafad80dbb08353824483f5b849031693cc477.

Also updates the available Eloquent collections methods.