### PR TITLE
[5.5] Document Collection::dump() method

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -59,6 +59,7 @@ For the remainder of this documentation, we'll discuss each method available on 
 [diff](#method-diff)
 [diffAssoc](#method-diffassoc)
 [diffKeys](#method-diffkeys)
+[dump](#method-dump)
 [each](#method-each)
 [every](#method-every)
 [except](#method-except)
@@ -334,6 +335,26 @@ The `diffKeys` method compares the collection against another collection or a pl
     $diff->all();
 
     // ['one' => 10, 'three' => 30, 'five' => 50]
+
+<a name="method-dump"></a>
+#### `dump()` {#collection-method}
+
+The `dump` method dumps the given collection's items:
+
+    $collection = collect(['John Doe', 'Jane Doe']);
+
+    $collection->dump();
+
+    /*
+        Collection {
+            #items: array:2 [
+                0 => "John Doe"
+                1 => "Jane Doe"
+            ]
+        }
+    */
+
+If you also want to end the script execution after dumping, use the [`dd`](#method-dd) method instead.
 
 <a name="method-each"></a>
 #### `each()` {#collection-method}

--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -61,6 +61,7 @@ All Eloquent collections extend the base [Laravel collection](/docs/{{version}}/
 [count](/docs/{{version}}/collections#method-count)
 [diff](/docs/{{version}}/collections#method-diff)
 [diffKeys](/docs/{{version}}/collections#method-diffkeys)
+[dump](/docs/{{version}}/collections#method-dump)
 [each](/docs/{{version}}/collections#method-each)
 [every](/docs/{{version}}/collections#method-every)
 [except](/docs/{{version}}/collections#method-except)


### PR DESCRIPTION
Documentation for the `Collection::dump()` method introduced in laravel/framework#19755.

Also updates the available Eloquent collections methods.