### PR TITLE
[5.5] Document Collection::eachSpread() method

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -60,6 +60,7 @@ For the remainder of this documentation, we'll discuss each method available on 
 [diffAssoc](#method-diffassoc)
 [diffKeys](#method-diffkeys)
 [each](#method-each)
+[eachSpread](#method-eachspread)
 [every](#method-every)
 [except](#method-except)
 [filter](#method-filter)
@@ -347,6 +348,25 @@ The `each` method iterates over the items in the collection and passes each item
 If you would like to stop iterating through the items, you may return `false` from your callback:
 
     $collection = $collection->each(function ($item, $key) {
+        if (/* some condition */) {
+            return false;
+        }
+    });
+
+<a name="method-eachspread"></a>
+#### `eachSpread()` {#collection-method}
+
+The `eachSpread` method iterates over the collection's items passing each nested item value into the given callback:
+
+    $collection = collect([['John Doe', 35], ['Jane Doe', 33]]);
+
+    $collection->eachSpread(function ($name, $age) {
+        //
+    });
+
+You may stop iterating through the items by returning `false` from your callback:
+
+    $collection->eachSpread(function ($name, $age) {
         if (/* some condition */) {
             return false;
         }

--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -62,6 +62,7 @@ All Eloquent collections extend the base [Laravel collection](/docs/{{version}}/
 [diff](/docs/{{version}}/collections#method-diff)
 [diffKeys](/docs/{{version}}/collections#method-diffkeys)
 [each](/docs/{{version}}/collections#method-each)
+[eachSpread](/docs/{{version}}/collections#method-eachspread)
 [every](/docs/{{version}}/collections#method-every)
 [except](/docs/{{version}}/collections#method-except)
 [filter](/docs/{{version}}/collections#method-filter)


### PR DESCRIPTION
Documentation for the `Collection::eachSpread()` method introduced in laravel/framework#19235.

Also updates the available Eloquent collections methods.