### PR TITLE
[5.5] Document Collection::concat() method

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -53,6 +53,7 @@ For the remainder of this documentation, we'll discuss each method available on 
 [chunk](#method-chunk)
 [collapse](#method-collapse)
 [combine](#method-combine)
+[concat](#method-concat)
 [contains](#method-contains)
 [containsStrict](#method-containsstrict)
 [count](#method-count)
@@ -221,6 +222,19 @@ The `combine` method combines the keys of the collection with the values of anot
     $combined->all();
 
     // ['name' => 'George', 'age' => 29]
+
+<a name="method-concat"></a>
+#### `concat()` {#collection-method}
+
+The `concat` method appends the given `array` or collection values into the end of the collection, ignoring any existing keys in the given items:
+
+    $collection = collect(['John Doe']);
+
+    $concatenated = $collection->concat(['Jane Doe'])->concat(['name' => 'Johnny Doe']);
+
+    $concatenated->all();
+
+    // ['John Doe', 'Jane Doe', 'Johnny Doe']
 
 <a name="method-contains"></a>
 #### `contains()` {#collection-method}

--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -56,6 +56,7 @@ All Eloquent collections extend the base [Laravel collection](/docs/{{version}}/
 [chunk](/docs/{{version}}/collections#method-chunk)
 [collapse](/docs/{{version}}/collections#method-collapse)
 [combine](/docs/{{version}}/collections#method-combine)
+[concat](/docs/{{version}}/collections#method-concat)
 [contains](/docs/{{version}}/collections#method-contains)
 [containsStrict](/docs/{{version}}/collections#method-containsstrict)
 [count](/docs/{{version}}/collections#method-count)


### PR DESCRIPTION
Documentation for the `Collection::concat()` method introduced in laravel/framework#19318 and https://github.com/laravel/framework/commit/0f5337f854ecdd722e7e289ff58cc252337e7a9d.

Also updates the available Eloquent collections methods.