### PR TITLE
@isset directive has only an isset control.

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -220,7 +220,7 @@ For convenience, Blade also provides an `@unless` directive:
 In addition to the conditional directives already discussed, the `@isset` and `@empty` directives may be used as convenient shortcuts for their respective PHP functions:
 
     @isset($records)
-        // $records is defined and is not null...
+        // $records is defined...
     @endisset
 
     @empty($records)


### PR DESCRIPTION
I caught sight of that there is no any is_null control in the `compileIsset` method. Also, there shouldn't be. :)

https://github.com/laravel/framework/blob/5.5/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php#L142