### PR TITLE
Add upgrade note on @php blade directive

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -320,6 +320,20 @@ When allowing the dynamic `__call` method to share variables with a view, these 
 The `maximumVotes` variable may be accessed in the template like so:
 
     {{ $maximumVotes }}
+    
+#### `@php` Blade Directive
+
+The `@php` blade directive no longer accepts inline tags, use the full form or regular `<?php` code block. 
+For example, in Laravel 5.4 the following blade template would set the variable `$teamMember` to true:
+
+    @php($teamMember = true)
+    
+In Laravel 5.5 you must use the `@endphp` tag like so:
+
+    @php
+        $teamMember = true;
+    @endphp
+
 
 ### Miscellaneous
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -323,17 +323,11 @@ The `maximumVotes` variable may be accessed in the template like so:
     
 #### `@php` Blade Directive
 
-The `@php` blade directive no longer accepts inline tags, use the full form or regular `<?php` code block. 
-For example, in Laravel 5.4 the following blade template would set the variable `$teamMember` to true:
-
-    @php($teamMember = true)
-    
-In Laravel 5.5 you must use the `@endphp` tag like so:
+The `@php` blade directive no longer accepts inline tags. Instead, use the full form of the directive:
 
     @php
         $teamMember = true;
     @endphp
-
 
 ### Miscellaneous
 


### PR DESCRIPTION
As referenced in https://github.com/laravel/framework/issues/20994 the inline `@php($teamMember = true)` blade directive is no longer supported.

Instead recommend approach is to use full `@php` and `@endphp` template or revert to php tags.

Suggestion on better wording always welcome