### PR TITLE
[5.5] Document Social Authentication (Laravel Socialite)

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -79,4 +79,4 @@
     - [Horizon](/docs/{{version}}/horizon)
     - [Passport](/docs/{{version}}/passport)
     - [Scout](/docs/{{version}}/scout)
-    - [Socialite](https://github.com/laravel/socialite)
+    - [Socialite](/docs/{{version}}/socialite)

--- a/socialite.md
+++ b/socialite.md
@@ -1,0 +1,166 @@
+# Social Authentication (Laravel Socialite)
+
+- [Introduction](#introduction)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Basic Usage](#basic-usage)
+    - [Routing](#routing)
+    - [Optional Parameters](#optional-parameters)
+    - [Access Scopes](#access-scopes)
+    - [Stateless Authentication](#stateless-authentication)
+    - [Retrieving User Details](#retrieving-user-details)
+
+<a name="introduction"></a>
+## Introduction
+
+In addition to typical, form based authentication, Laravel also provides a simple, convenient way to authenticate with OAuth providers using [Laravel Socialite](https://github.com/laravel/socialite). Socialite currently supports authentication with Facebook, Twitter, LinkedIn, Google, GitHub and Bitbucket.
+
+> {tip} Adapters for other platforms are listed at the community driven [Socialite Providers](https://socialiteproviders.github.io/) website.
+
+<a name="installation"></a>
+## Installation
+
+To get started with Socialite, use Composer to add the package to your project's dependencies:
+
+    composer require laravel/socialite
+
+<a name="configuration"></a>
+## Configuration
+
+### OAuth Services
+
+After installing the Socialite library, you will also need to add credentials for the OAuth services your application utilizes. These credentials should be placed in your `config/services.php` configuration file, and should use the key `facebook`, `twitter`, `linkedin`, `google`, `github` or `bitbucket`, depending on the providers your application requires. For example:
+
+```php
+'github' => [
+    'client_id' => env('GITHUB_CLIENT_ID'),         // Your GitHub Client ID
+    'client_secret' => env('GITHUB_CLIENT_SECRET'), // Your GitHub Client Secret
+    'redirect' => 'http://your-callback-url',
+],
+```
+
+If the `redirect` option contains a relative path, it will automatically be resolved to a fully qualified URL.
+
+<a name="basic-usage"></a>
+## Basic Usage
+
+<a name="routing"></a>
+### Routing
+
+Next, you are ready to authenticate users! You will need two routes: one for redirecting the user to the OAuth provider, and another for receiving the callback from the provider after authentication. We will access Socialite using the `Socialite` facade:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use Socialite;
+
+class LoginController extends Controller
+{
+    /**
+     * Redirect the user to the GitHub authentication page.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function redirectToProvider()
+    {
+        return Socialite::driver('github')->redirect();
+    }
+
+    /**
+     * Obtain the user information from GitHub.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function handleProviderCallback()
+    {
+        $user = Socialite::driver('github')->user();
+
+        // $user->token;
+    }
+}
+```
+
+The `redirect` method takes care of sending the user to the OAuth provider, while the `user` method will read the incoming request and retrieve the user's information from the provider.
+
+Of course, you will need to define routes to your controller methods:
+
+```php
+Route::get('login/github', 'Auth\LoginController@redirectToProvider');
+Route::get('login/github/callback', 'Auth\LoginController@handleProviderCallback');
+```
+
+<a name="optional-parameters"></a>
+### Optional Parameters
+
+A number of OAuth providers support optional parameters in the redirect request. To include any optional parameters in the request, call the `with` method with an associative array:
+
+```php
+return Socialite::driver('google')
+    ->with(['hd' => 'example.com'])
+    ->redirect();
+```
+
+When using the `with` method, be careful not to pass any reserved keywords such as `state` or `response_type`.
+
+<a name="access-scopes"></a>
+### Access Scopes
+
+Before redirecting the user, you may also add additional "scopes" on the request using the `scopes` method. This method will merge all existing scopes with the ones you supply:
+
+```php
+return Socialite::driver('github')
+    ->scopes(['read:user', 'public_repo'])
+    ->redirect();
+```
+
+You can overwrite all exisiting scopes using the `setScopes` method:
+
+```php
+return Socialite::driver('github')
+    ->setScopes(['read:user', 'public_repo'])
+    ->redirect();
+```
+
+<a name="stateless-authentication"></a>
+### Stateless Authentication
+
+The `stateless` method may be used to disable session state verification. This is useful when adding social authentication to an API:
+
+```php
+return Socialite::driver('google')->stateless()->user();
+```
+
+<a name="retrieving-user-details"></a>
+### Retrieving User Details
+
+Once you have a user instance, you can grab a few more details about the user:
+
+```php
+$user = Socialite::driver('github')->user();
+
+// OAuth Two Providers
+$token = $user->token;
+$refreshToken = $user->refreshToken; // not always provided
+$expiresIn = $user->expiresIn;
+
+// OAuth One Providers
+$token = $user->token;
+$tokenSecret = $user->tokenSecret;
+
+// All Providers
+$user->getId();
+$user->getNickname();
+$user->getName();
+$user->getEmail();
+$user->getAvatar();
+```
+
+#### Retrieving User Details From Token
+
+If you already have a valid access token for a user, you can retrieve their details using the `userFromToken` method:
+
+```php
+$user = Socialite::driver('github')->userFromToken($token);
+```


### PR DESCRIPTION
Yesterday a friend at [Laravel Brasil Facebook group](https://facebook.com/groups/laravelbrasil/) asked me why Laravel Sociliate documentation wasn't yet hosted in the Laravel website as any other  official package. I didn't know exactly why, but I thought it would be time to change that. 😃 

To get this job done it will require some other steps that I pretend to do only if the proposal got accepted. This will include for example separated PRs for the branches 5.4, 5.3 and 5.2 (which have more configuration steps) and later an update to the Laravel Socialite's repository.

This documentation was derived from the Laravel Socialite's repository and adapted for the Laravel 5.5 release which does not require the manual configuration of service provider and facade stuff.
I also better structured the documentation sections as in other files and improved some code snippets to make things more easier to grasp.

Please, let me know if this is something worth to contribute. I believe this would be a nice step to ease the future documentation contributions of this great package. 😄 