### PR TITLE
[5.5] add note about mapping every project to a folder

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -114,6 +114,15 @@ The `folders` property of the `Homestead.yaml` file lists all of the folders you
         - map: ~/Code
           to: /home/vagrant/Code
 
+If you are only creating a few sites, this generic mapping will work just fine. However, as the number of sites continue to grow, you may begin to experience performance problems. This problem can be painfully apparent in lower end machines or projects that contain a very large number of files. If you are experiencing this issue, try mapping every project to its own Vagrant folder:
+
+    folders:
+        - map: ~/Code/project1
+          to: /home/vagrant/Code/project1
+        
+        - map: ~/Code/project2
+          to: /home/vagrant/Code/project2
+
 To enable [NFS](https://www.vagrantup.com/docs/synced-folders/nfs.html), you only need to add a simple flag to your synced folder configuration:
 
     folders:


### PR DESCRIPTION
mapping every project to a folder is best practice for performance reasons.

@svpernova09 this is in relation to our Slack discussion. does this cover this gist of what we were talking about?