### PR TITLE
[5.5] Use the correct model name in relation with the factory name

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -40,7 +40,7 @@ The new factory will be placed in your `database/factories` directory.
 
 The `--model` option may be used to indicate the name of the model created by the factory. This option will pre-fill the generated factory file with the given model:
 
-    php artisan make:factory PostFactory --model=User
+    php artisan make:factory PostFactory --model=Post
 
 <a name="resetting-the-database-after-each-test"></a>
 ## Resetting The Database After Each Test


### PR DESCRIPTION
The factory name is `PostFactory`, maybe the model name should be `Post` instead of `User`