### PR TITLE
[5.5] Document some missing helpers and improve others

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -41,6 +41,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [array_pluck](#method-array-pluck)
 [array_prepend](#method-array-prepend)
 [array_pull](#method-array-pull)
+[array_random](#method-array-random)
 [array_set](#method-array-set)
 [array_sort](#method-array-sort)
 [array_sort_recursive](#method-array-sort-recursive)
@@ -74,18 +75,23 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [e](#method-e)
 [ends_with](#method-ends-with)
 [kebab_case](#method-kebab-case)
+[preg_replace_array](#method-preg-replace-array)
 [snake_case](#method-snake-case)
-[str_limit](#method-str-limit)
 [starts_with](#method-starts-with)
 [str_after](#method-str-after)
 [str_before](#method-str-before)
 [str_contains](#method-str-contains)
 [str_finish](#method-str-finish)
 [str_is](#method-str-is)
+[str_limit](#method-str-limit)
 [str_plural](#method-str-plural)
 [str_random](#method-str-random)
+[str_replace_array](#method-str-replace-array)
+[str_replace_first](#method-str-replace-first)
+[str_replace_last](#method-str-replace-last)
 [str_singular](#method-str-singular)
 [str_slug](#method-str-slug)
+[str_start](#method-str-start)
 [studly_case](#method-studly-case)
 [title_case](#method-title-case)
 [trans](#method-trans)
@@ -113,16 +119,20 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [abort](#method-abort)
 [abort_if](#method-abort-if)
 [abort_unless](#method-abort-unless)
+[app](#method-app)
 [auth](#method-auth)
 [back](#method-back)
 [bcrypt](#method-bcrypt)
+[broadcast](#method-broadcast)
 [cache](#method-cache)
 [collect](#method-collect)
 [config](#method-config)
+[cookie](#method-cookie)
 [csrf_field](#method-csrf-field)
 [csrf_token](#method-csrf-token)
 [dd](#method-dd)
 [dispatch](#method-dispatch)
+[dispatch_now](#method-dispatch-now)
 [env](#method-env)
 [event](#method-event)
 [factory](#method-factory)
@@ -132,15 +142,20 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [now](#method-now)
 [old](#method-old)
 [optional](#method-optional)
+[policy](#method-policy)
 [redirect](#method-redirect)
 [report](#method-report)
 [request](#method-request)
 [rescue](#method-rescue)
+[resolve](#method-resolve)
 [response](#method-response)
 [retry](#method-retry)
 [session](#method-session)
 [tap](#method-tap)
 [today](#method-today)
+[throw_if](#method-throw-if)
+[throw_unless](#method-throw-unless)
+[validator](#method-validator)
 [value](#method-value)
 [view](#method-view)
 
@@ -363,6 +378,17 @@ The `array_pull` function returns and removes a key / value pair from the array:
 A default value may be passed as the third argument to the method. This value will be returned if the key doesn't exist:
 
     $value = array_pull($array, $key, $default);
+
+<a name="method-array-random"></a>
+#### `array_random()` {#collection-method}
+
+The `array_random()` function returns a random value from an array:
+
+    $array = [1, 2, 3, 4, 5];
+
+    $random = array_random($array);
+
+    // 4 - (retrieved randomly)
 
 <a name="method-array-set"></a>
 #### `array_set()` {#collection-method}
@@ -610,6 +636,16 @@ The `kebab_case` function converts the given string to `kebab-case`:
 
     // foo-bar
 
+<a name="method-preg-replace-array"></a>
+#### `preg_replace_array()` {#collection-method}
+
+The `preg_replace_array()` function replaces a given pattern in the string sequentially with an array:
+
+    $string = 'The event will take place between :start and :end';
+
+    $replaced = preg_replace_array('/:[a-z_]+/', ['8:30', '9:00'], $string);
+
+    // The event will take place between 8:30 and 9:00
 
 <a name="method-snake-case"></a>
 #### `snake_case()` {#collection-method}
@@ -619,15 +655,6 @@ The `snake_case` function converts the given string to `snake_case`:
     $snake = snake_case('fooBar');
 
     // foo_bar
-
-<a name="method-str-limit"></a>
-#### `str_limit()` {#collection-method}
-
-The `str_limit` function limits the number of characters in a string. The function accepts a string as its first argument and the maximum number of resulting characters as its second argument:
-
-    $value = str_limit('The PHP framework for web artisans.', 7);
-
-    // The PHP...
 
 <a name="method-starts-with"></a>
 #### `starts_with()` {#collection-method}
@@ -676,8 +703,11 @@ You may also pass an array of values to determine if the given string contains a
 
 The `str_finish` function adds a single instance of the given value to a string if it does not already end with it:
 
-    $string = str_finish('this/string', '/');
-    $string2 = str_finish('this/string/', '/');
+    $adjusted = str_finish('this/string', '/');
+
+    // this/string/
+
+    $adjusted = str_finish('this/string/', '/');
 
     // this/string/
 
@@ -693,6 +723,21 @@ The `str_is` function determines if a given string matches a given pattern. Aste
     $value = str_is('baz*', 'foobar');
 
     // false
+
+<a name="method-str-limit"></a>
+#### `str_limit()` {#collection-method}
+
+The `str_limit` function limits the number of characters in a string. The function accepts a string as its first argument and the maximum number of resulting characters as its second argument:
+
+    $truncated = str_limit('The quick brown fox jumps over the lazy dog', 20);
+
+    // The quick brown fox...
+
+You may also pass a third argument to change the string that will be appended to the end:
+
+    $truncated = str_limit('The quick brown fox jumps over the lazy dog', 20, ' (...)');
+
+    // The quick brown fox (...)
 
 <a name="method-str-plural"></a>
 #### `str_plural()` {#collection-method}
@@ -724,6 +769,35 @@ The `str_random` function generates a random string of the specified length. Thi
 
     $string = str_random(40);
 
+<a name="method-str-replace-array"></a>
+#### `str_replace_array()` {#collection-method}
+
+The `str_replace_array()` function replaces a given value in the string sequentially with an array:
+
+    $string = 'The event will take place between ? and ?';
+
+    $replaced = str_replace_array('?', ['8:30', '9:00'], $string);
+
+    // The event will take place between 8:30 and 9:00
+
+<a name="method-str-replace-first"></a>
+#### `str_replace_first()` {#collection-method}
+
+The `str_replace_first()` function replaces the first occurrence of a given value in a string:
+
+    $replaced = str_replace_first('the', 'a', 'the quick brown fox jumps over the lazy dog');
+
+    // a quick brown fox jumps over the lazy dog
+
+<a name="method-str-replace-last"></a>
+#### `str_replace_last()` {#collection-method}
+
+The `str_replace_last()` function replaces the last occurrence of a given value in a string:
+
+    $replaced = str_replace_last('the', 'a', 'the quick brown fox jumps over the lazy dog');
+
+    // the quick brown fox jumps over a lazy dog
+
 <a name="method-str-singular"></a>
 #### `str_singular()` {#collection-method}
 
@@ -733,6 +807,10 @@ The `str_singular` function converts a string to its singular form. This functio
 
     // car
 
+    $singular = str_singular('children');
+
+    // child
+
 <a name="method-str-slug"></a>
 #### `str_slug()` {#collection-method}
 
@@ -741,6 +819,19 @@ The `str_slug` function generates a URL friendly "slug" from the given string:
     $title = str_slug('Laravel 5 Framework', '-');
 
     // laravel-5-framework
+
+<a name="method-str-start"></a>
+#### `str_start()` {#collection-method}
+
+The `str_start` function adds a single instance of the given value to a string if it does not already start with it:
+
+    $adjusted = str_start('this/string', '/');
+
+    // /this/string
+
+    $adjusted = str_start('/this/string/', '/');
+
+    // /this/string
 
 <a name="method-studly-case"></a>
 #### `studly_case()` {#collection-method}
@@ -869,10 +960,21 @@ The `abort_unless` function throws an HTTP exception if a given boolean expressi
 
     abort_unless(Auth::user()->isAdmin(), 403);
 
+<a name="method-app"></a>
+#### `app()` {#collection-method}
+
+The `app` function returns a [service container](/docs/{{version}}/container) instance:
+
+    $container = app();
+
+You may optionally pass a class or interface name to resolve its instance from the container:
+
+    $instance = app('HelpSpot\API');
+
 <a name="method-auth"></a>
 #### `auth()` {#collection-method}
 
-The `auth` function returns an authenticator instance. You may use it instead of the `Auth` facade for convenience:
+The `auth` function returns an [authenticator](/docs/{{version}}/authentication) instance. You may use it instead of the `Auth` facade for convenience:
 
     $user = auth()->user();
 
@@ -889,6 +991,13 @@ The `back()` function generates a redirect response to the user's previous locat
 The `bcrypt` function hashes the given value using Bcrypt. You may use it as an alternative to the `Hash` facade:
 
     $password = bcrypt('my-secret-password');
+
+<a name="method-broadcast"></a>
+#### `broadcast()` {#collection-method}
+
+The `broadcast` function [broadcasts](/docs/{{version}}/broadcasting) the given [event](/docs/{{version}}/events) to its listeners:
+
+    broadcast(new UserRegistered($user));
 
 <a name="method-cache"></a>
 #### `cache()` {#collection-method}
@@ -925,6 +1034,13 @@ The `config` helper may also be used to set configuration variables at runtime b
 
     config(['app.debug' => true]);
 
+<a name="method-cookie"></a>
+#### `cookie()` {#collection-method}
+
+The `cookie` function creates a new [cookie](/docs/{{version}}/requests#cookies) instance:
+
+    $cookie = cookie('name', 'value', $minutes);
+
 <a name="method-csrf-field"></a>
 #### `csrf_field()` {#collection-method}
 
@@ -955,9 +1071,16 @@ If you do not want to halt the execution of your script, use the `dump` function
 <a name="method-dispatch"></a>
 #### `dispatch()` {#collection-method}
 
-The `dispatch` function pushes a new job onto the Laravel [job queue](/docs/{{version}}/queues):
+The `dispatch` function pushes the given [job](/docs/{{version}}/queues#creating-jobs) onto the Laravel [job queue](/docs/{{version}}/queues):
 
     dispatch(new App\Jobs\SendEmails);
+
+<a name="method-dispatch-now"></a>
+#### `dispatch_now()` {#collection-method}
+
+The `dispatch_now` function runs the given [job](/docs/{{version}}/queues#creating-jobs) immediately and returns the value from its `handle` method:
+
+    $result = dispatch_now(new App\Jobs\SendEmails);
 
 <a name="method-env"></a>
 #### `env()` {#collection-method}
@@ -1043,6 +1166,13 @@ The `optional` function accepts any argument and allows you to access properties
 
     {!! old('name', optional($user)->name) !!}
 
+<a name="method-policy"></a>
+#### `policy()` {#collection-method}
+
+The `policy` method gets a [policy](/docs/{{version}}/authorization#creating-policies) instance for a given class:
+
+    $policy = policy(App\User::class);
+
 <a name="method-redirect"></a>
 #### `redirect()` {#collection-method}
 
@@ -1088,6 +1218,13 @@ You may also pass a second argument to the `rescue` function. This argument will
     }, function () {
         return $this->failure();
     });
+
+<a name="method-resolve"></a>
+#### `resolve()` {#collection-method}
+
+The `resolve` function resolves a given class or interface name to its instance from the [service container](/docs/{{version}}/container):
+
+    $instance = resolve('HelpSpot\API');
 
 <a name="method-response"></a>
 #### `response()` {#collection-method}
@@ -1148,6 +1285,27 @@ If no Closure is passed to the `tap` function, you may call any method on the gi
 The `today` function creates a new `Illuminate\Support\Carbon` instance for the current date:
 
     return today();
+
+<a name="method-throw-if"></a>
+#### `throw_if()` {#collection-method}
+
+The `throw_if` function throws the given exception if a given boolean expression evaluates to `true`:
+
+    throw_if(! Auth::user()->isAdmin(), AuthorizationException::class, 'You are not allowed to access this page');
+
+<a name="method-throw-unless"></a>
+#### `throw_unless()` {#collection-method}
+
+The `throw_unless` function throws the given exception if a given boolean expression evaluates to `false`:
+
+    throw_unless(Auth::user()->isAdmin(), AuthorizationException::class, 'You are not allowed to access this page');
+
+<a name="method-validator"></a>
+#### `validator()` {#collection-method}
+
+The `validator` function creates a new [validator](/docs/{{version}}/validation) instance with the given arguments. You may use it instead of the `Validator` facade for convenience:
+
+    $validator = validator($data, $rules, $messages);
 
 <a name="method-value"></a>
 #### `value()` {#collection-method}


### PR DESCRIPTION
#### Arrays

- Documents the missing `array_random()` function

#### Strings

- Documents the missing `preg_replace_array()`, `str_replace_array()`, `str_replace_first()`, `str_replace_last()` and `str_start()` functions
- Fixes the `str_limit()` position and improves its documentation mentioning the third argument (closes #3593). Also changed the example to better demonstrate that strings got trimmed when truncating.
- Documentation improvements to the `str_finish()` and `str_singular()` functions

#### Miscellaneous

- Documents the missing `app()`, `broadcast()`, `cookie()`, `dispatch_now()`, `policy()`, `resolve()`, `throw_if()`, `throw_unless()` and `validator()` functions
- Minor documentation improvements to the `auth()` and `dispatch()` functions