### PR TITLE
Added a note about attaching cookies via a facade

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -77,6 +77,14 @@ The `cookie` method also accepts a few more arguments which are used less freque
 
     ->cookie($name, $value, $minutes, $path, $domain, $secure, $httpOnly)
 
+Alternatively, you can use the `Cookie` facade to queue cookies. The `queue` method accepts both a `Cookie` instance or a list of arguments to create one:
+
+    Cookie::queue(Cookie::make('name', 'value', $minutes));
+
+    Cookie::queue('name', 'value', $minutes);
+
+These cookies will be attached to the response on its creation.
+
 <a name="cookies-and-encryption"></a>
 #### Cookies & Encryption
 


### PR DESCRIPTION
I have added this info, because it took me quite a while to figure out how to attach cookies from a Service Provider not accessing `Response` object.

[And](https://stackoverflow.com/questions/40405822/set-a-cookie-in-laravel-5-without-response) [it's](https://stackoverflow.com/questions/22345442/how-to-set-cookie-without-response-in-laravel) [not](https://stackoverflow.com/questions/31516762/how-to-set-cookies-in-laravel-5-independently-inside-controller) [only](https://laracasts.com/discuss/channels/laravel/make-and-get-cookies?page=1) [me](https://laracasts.com/discuss/channels/general-discussion/cookies-how-to-set-and-get-cookies-in-laravel-51).

Continuation in #3723.