### PR TITLE
Added a note about retrieving cookies via a facade

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -273,6 +273,10 @@ All cookies created by the Laravel framework are encrypted and signed with an au
 
     $value = $request->cookie('name');
 
+Alternatively, you can use the `Cookie` facade:
+
+    Cookie::get('name');
+
 #### Attaching Cookies To Responses
 
 You may attach a cookie to an outgoing `Illuminate\Http\Response` instance using the `cookie` method. You should pass the name, value, and number of minutes the cookie should be considered valid to this method:


### PR DESCRIPTION
Good to know, you don't need to use a `Request` object, to retrieve cookies.