### PR TITLE
Added a note about accessing cookies via a facade

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -273,6 +273,10 @@ All cookies created by the Laravel framework are encrypted and signed with an au
 
     $value = $request->cookie('name');
 
+Alternatively, you can use the `Cookie` facade:
+
+    Cookie::get('name');
+
 #### Attaching Cookies To Responses
 
 You may attach a cookie to an outgoing `Illuminate\Http\Response` instance using the `cookie` method. You should pass the name, value, and number of minutes the cookie should be considered valid to this method:
@@ -286,6 +290,14 @@ The `cookie` method also accepts a few more arguments which are used less freque
     return response('Hello World')->cookie(
         'name', 'value', $minutes, $path, $domain, $secure, $httpOnly
     );
+
+Alternatively, you can use the `Cookie` facade to queue cookies. The `queue` method accepts both a `Cookie` instance or a list of arguments to create one:
+
+    Cookie::queue(Cookie::make('name', 'value', $minutes));
+
+    Cookie::queue('name', 'value', $minutes);
+
+These cookies will be attached to the response on its creation.
 
 #### Generating Cookie Instances
 

--- a/responses.md
+++ b/responses.md
@@ -77,6 +77,14 @@ The `cookie` method also accepts a few more arguments which are used less freque
 
     ->cookie($name, $value, $minutes, $path, $domain, $secure, $httpOnly)
 
+Alternatively, you can use the `Cookie` facade to queue cookies. The `queue` method accepts both a `Cookie` instance or a list of arguments to create one:
+
+    Cookie::queue(Cookie::make('name', 'value', $minutes));
+
+    Cookie::queue('name', 'value', $minutes);
+
+These cookies will be attached to the response on its creation.
+
 <a name="cookies-and-encryption"></a>
 #### Cookies & Encryption
 


### PR DESCRIPTION
As per your request in #3724.

---

I have added this info, because it took me quite a while to figure out how to attach cookies from a Service Provider not accessing `Response` object.

[And](https://stackoverflow.com/questions/40405822/set-a-cookie-in-laravel-5-without-response) [it's](https://stackoverflow.com/questions/22345442/how-to-set-cookie-without-response-in-laravel) [not](https://stackoverflow.com/questions/31516762/how-to-set-cookies-in-laravel-5-independently-inside-controller) [only](https://laracasts.com/discuss/channels/laravel/make-and-get-cookies?page=1) [me](https://laracasts.com/discuss/channels/general-discussion/cookies-how-to-set-and-get-cookies-in-laravel-51).
