### PR TITLE
Fix Laravel Dusk composer require for Laravel 5.4

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -409,7 +409,7 @@ In order to allow Laravel to autoload any new tests you generate using the Larav
 
 First install the `laravel/browser-kit-testing` package:
 
-    composer require laravel/browser-kit-testing="1.*" --dev
+    composer require --dev laravel/browser-kit-testing "1.*"
 
 Once the package has been installed, create a copy of your `tests/TestCase.php` file and save it to your `tests` directory as `BrowserKitTestCase.php`. Then, modify the file to extend the `Laravel\BrowserKitTesting\TestCase` class. Once you have done this, you should have two base test classes in your `tests` directory: `TestCase.php` and `BrowserKitTestCase.php`. In order for your `BrowserKitTestCase` class to be properly loaded, you may need to add it to your `composer.json` file:
 
@@ -459,7 +459,7 @@ Once you have created this class, make sure to update all of your tests to exten
 
 If you would like to install Laravel Dusk into an application that has been upgraded from Laravel 5.3, first install it via Composer:
 
-    composer require --dev laravel/dusk
+    composer require --dev laravel/dusk "1.*"
 
 Next, you will need to create a `CreatesApplication` trait in your `tests` directory. This trait is responsible for creating fresh application instances for test cases. The trait should look like the following:
 


### PR DESCRIPTION
Laravel Dusk is now under stable `2.*` and is not compatible with Laravel `5.4.*` so we need to specify what version we want to use when installing Dusk while upgrading from Laravel 5.3 to 5.4.