### PR TITLE
mix.inProduction() is not a function

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -305,7 +305,7 @@ Because versioned files are usually unnecessary in development, you may instruct
 
     mix.js('resources/assets/js/app.js', 'public/js');
 
-    if (mix.inProduction()) {
+    if (mix.inProduction) {
         mix.version();
     }
 


### PR DESCRIPTION
`npm run production fails` 
with
`TypeError: mix.inProduction is not a function`