### PR TITLE
Change parameter instruction for 'insertGetId' PostgreSQL note. 

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -518,7 +518,7 @@ If the table has an auto-incrementing id, use the `insertGetId` method to insert
         ['email' => 'john@example.com', 'votes' => 0]
     );
 
-> {note} When using PostgreSQL the `insertGetId` method expects the auto-incrementing column to be named `id`. If you would like to retrieve the ID from a different "sequence", you may pass the sequence name as the second parameter to the `insertGetId` method.
+> {note} When using PostgreSQL the `insertGetId` method expects the auto-incrementing column to be named `id`. If you would like to retrieve the ID from a different "sequence", you may pass the column name as the second parameter to the `insertGetId` method.
 
 <a name="updates"></a>
 ## Updates


### PR DESCRIPTION
The current note for PostgreSQL states the sequence name should be passed as the second parameter if the desired sequence is attributed to a column named other than the expected 'id'. It is actually the _column_ name  that should be passed (i.e., 'column_name' _not_ 'column_name_id_seq'). 