### PR TITLE
Introduce the noProrate method in docs

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -312,6 +312,10 @@ Sometimes subscriptions are affected by "quantity". For example, your applicatio
 Alternatively, you may set a specific quantity using the `updateQuantity` method:
 
     $user->subscription('main')->updateQuantity(10);
+    
+To remove stripe's default [prorate](https://stripe.com/docs/subscriptions/upgrading-downgrading#understanding-proration) calculation you can use the `noProrate()` method:
+   
+    $user->subscription('main')->noProrate()->updateQuantity(10);
 
 For more information on subscription quantities, consult the [Stripe documentation](https://stripe.com/docs/subscriptions/quantities).
 


### PR DESCRIPTION
I was looking for a way to disable prorate in my update of quantity and found this. Couldn't find any docs about thought it would fit in nicely.