### PR TITLE
update the way seeders are called

### DIFF
--- a/seeding.md
+++ b/seeding.md
@@ -75,9 +75,11 @@ Within the `DatabaseSeeder` class, you may use the `call` method to execute addi
      */
     public function run()
     {
-        $this->call(UsersTableSeeder::class);
-        $this->call(PostsTableSeeder::class);
-        $this->call(CommentsTableSeeder::class);
+        $this->call([
+            UsersTableSeeder::class,
+            PostsTableSeeder::class,
+            CommentsTableSeeder::class,
+        ]);
     }
 
 <a name="running-seeders"></a>


### PR DESCRIPTION
according to this method https://github.com/laravel/framework/blob/5.5/src/Illuminate/Database/Seeder.php#L32, you can pass an array of classes to the `call` method.  looks like the system was setup to work this way, so let's use it in the docs.