### PR TITLE
Refactor method to checkout to the latest stable release

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -88,7 +88,7 @@ You should check out a tagged version of Homestead since the `master` branch may
     cd Homestead
 
     // Clone the desired release...
-    git checkout v6.3.0
+    git checkout $(git tag --list | tail -1)
 
 Once you have cloned the Homestead repository, run the `bash init.sh` command from the Homestead directory to create the `Homestead.yaml` configuration file. The `Homestead.yaml` file will be placed in the Homestead directory:
 


### PR DESCRIPTION
As pointed out in #3673 this removes the need of PRs that solely changes the homestead tag version.

It will now dynamically determine the latest release tag.

This syntax works well because the release cycle of homestead is linear, but in case that in the future parallel versions of homestead are released (like v6.3.x and v7.0.x at the same time) we can specify a pattern to scope them.

For example:

```
git checkout $(git tag --list v7.* | tail -1)
```