### PR TITLE
Update homestead default TLD to *.test

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -149,7 +149,7 @@ You may also pass any options supported by Vagrant's [Synced Folders](https://ww
 Not familiar with Nginx? No problem. The `sites` property allows you to easily map a "domain" to a folder on your Homestead environment. A sample site configuration is included in the `Homestead.yaml` file. Again, you may add as many sites to your Homestead environment as necessary. Homestead can serve as a convenient, virtualized environment for every Laravel project you are working on:
 
     sites:
-        - map: homestead.localhost
+        - map: homestead.test
           to: /home/vagrant/code/Laravel/public
 
 If you change the `sites` property after provisioning the Homestead box, you should re-run `vagrant reload --provision`  to update the Nginx configuration on the virtual machine.
@@ -158,11 +158,11 @@ If you change the `sites` property after provisioning the Homestead box, you sho
 
 You must add the "domains" for your Nginx sites to the `hosts` file on your machine. The `hosts` file will redirect requests for your Homestead sites into your Homestead machine. On Mac and Linux, this file is located at `/etc/hosts`. On Windows, it is located at `C:\Windows\System32\drivers\etc\hosts`. The lines you add to this file will look like the following:
 
-    192.168.10.10  homestead.localhost
+    192.168.10.10  homestead.test
 
 Make sure the IP address listed is the one set in your `Homestead.yaml` file. Once you have added the domain to your `hosts` file and launched the Vagrant box you will be able to access the site via your web browser:
 
-    http://homestead.localhost
+    http://homestead.test
 
 <a name="launching-the-vagrant-box"></a>
 ### Launching The Vagrant Box
@@ -190,7 +190,7 @@ Windows:
 
     vendor\\bin\\homestead make
 
-Next, run the `vagrant up` command in your terminal and access your project at `http://homestead.localhost` in your browser. Remember, you will still need to add an `/etc/hosts` file entry for `homestead.app` or the domain of your choice.
+Next, run the `vagrant up` command in your terminal and access your project at `http://homestead.test` in your browser. Remember, you will still need to add an `/etc/hosts` file entry for `homestead.app` or the domain of your choice.
 
 <a name="installing-mariadb"></a>
 ### Installing MariaDB
@@ -281,15 +281,15 @@ To connect to your MySQL or PostgreSQL database from your host machine's databas
 Once your Homestead environment is provisioned and running, you may want to add additional Nginx sites for your Laravel applications. You can run as many Laravel installations as you wish on a single Homestead environment. To add an additional site, simply add the site to your `Homestead.yaml` file:
 
     sites:
-        - map: homestead.localhost
+        - map: homestead.test
           to: /home/vagrant/code/Laravel/public
-        - map: another.localhost
+        - map: another.test
           to: /home/vagrant/code/another/public
 
 If Vagrant is not automatically managing your "hosts" file, you may need to add the new site to that file as well:
 
-    192.168.10.10  homestead.localhost
-    192.168.10.10  another.localhost
+    192.168.10.10  homestead.test
+    192.168.10.10  another.test
 
 Once the site has been added, run the `vagrant reload --provision` command from your Homestead directory.
 
@@ -299,7 +299,7 @@ Once the site has been added, run the `vagrant reload --provision` command from 
 Homestead supports several types of sites which allow you to easily run projects that are not based on Laravel. For example, we may easily add a Symfony application to Homestead using the `symfony2` site type:
 
     sites:
-        - map: symfony2.localhost
+        - map: symfony2.test
           to: /home/vagrant/code/Symfony/web
           type: symfony2
 
@@ -311,7 +311,7 @@ The available site types are: `apache`, `laravel` (the default), `proxy`, `silve
 You may add additional Nginx `fastcgi_param` values to your site via the `params` site directive. For example, we'll add a `FOO` parameter with a value of `BAR`:
 
     sites:
-        - map: homestead.localhost
+        - map: homestead.test
           to: /home/vagrant/code/Laravel/public
           params:
               - key: FOO
@@ -325,7 +325,7 @@ Laravel provides a convenient way to [schedule Cron jobs](/docs/{{version}}/sche
 If you would like the `schedule:run` command to be run for a Homestead site, you may set the `schedule` option to `true` when defining the site:
 
     sites:
-        - map: homestead.localhost
+        - map: homestead.test
           to: /home/vagrant/code/Laravel/public
           schedule: true
 
@@ -372,13 +372,13 @@ If you wish, you may forward additional ports to the Vagrant box, as well as spe
 
 Sometimes you may wish to share what you're currently working on with coworkers or a  client. Vagrant has a built-in way to support this via `vagrant share`; however, this will not work if you have multiple sites configured in your `Homestead.yaml` file.
 
-To solve this problem, Homestead includes its own `share` command. To get started, SSH into your Homestead machine via `vagrant ssh` and run `share homestead.localhost`. This will share the `homestead.localhost` site from your `Homestead.yaml` configuration file. Of course, you may substitute any of your other configured sites for `homestead.localhost`:
+To solve this problem, Homestead includes its own `share` command. To get started, SSH into your Homestead machine via `vagrant ssh` and run `share homestead.test`. This will share the `homestead.test` site from your `Homestead.yaml` configuration file. Of course, you may substitute any of your other configured sites for `homestead.test`:
 
-    share homestead.localhost
+    share homestead.test
 
 After running the command, you will see an Ngrok screen appear which contains the activity log and the publicly accessible URLs for the shared site. If you would like to specify a custom region, subdomain, or other Ngrok runtime option, you may add them to your `share` command:
 
-    share homestead.localhost -region=eu -subdomain=laravel
+    share homestead.test -region=eu -subdomain=laravel
 
 > {note} Remember, Vagrant is inherently insecure and you are exposing your virtual machine to the Internet when running the `share` command.
 
@@ -390,7 +390,7 @@ After running the command, you will see an Ngrok screen appear which contains th
 Homestead 6 introduced support for multiple versions of PHP on the same virtual machine. You may specify which version of PHP to use for a given site within your `Homestead.yaml` file. The available PHP versions are: "5.6", "7.0", and "7.1":
 
     sites:
-        - map: homestead.localhost
+        - map: homestead.test
           to: /home/vagrant/code/Laravel/public
           php: "5.6"
 


### PR DESCRIPTION
This was updated in `v6.5.0` because of https://github.com/laravel/homestead/issues/695