### PR TITLE
Clarifies events fired upon mail being sent

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -545,7 +545,7 @@ Finally, you may use a service like [Mailtrap](https://mailtrap.io) and the `smt
 <a name="events"></a>
 ## Events
 
-Laravel fires an event just before sending mail messages. Remember, this event is fired when the mail is *sent*, not when it is queued. You may register an event listener for this event in your `EventServiceProvider`:
+Laravel fires two events during the process of sending mail messages. Prior to a message being sent the `MessageSending` event is fired. After a message has been sent the `MessageSent` event is fired. Remember, these events are fired when the mail is being *sent*, not when it is queued. You may register an event listener for this event in your `EventServiceProvider`:
 
     /**
      * The event listener mappings for the application.
@@ -554,6 +554,9 @@ Laravel fires an event just before sending mail messages. Remember, this event i
      */
     protected $listen = [
         'Illuminate\Mail\Events\MessageSending' => [
+            'App\Listeners\LogSendingMessage',
+        ],
+        'Illuminate\Mail\Events\MessageSent' => [
             'App\Listeners\LogSentMessage',
         ],
     ];


### PR DESCRIPTION
Found the existing text to not be perfectly clear as to when the event was fired. Had to dive into the source. Hopefully this helps.