### PR TITLE
Fixed typo in testing.md

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -7,7 +7,7 @@
 <a name="introduction"></a>
 ## Introduction
 
-Laravel is built with testing in mind. In fact, support for testing with PHPUnit is included out of the box and a `phpunit.xml` file is already setup for your application. The framework also ships with convenient helper methods that allow you to expressively test your applications.
+Laravel is built with testing in mind. In fact, support for testing with PHPUnit is included out of the box and a `phpunit.xml` file is already set up for your application. The framework also ships with convenient helper methods that allow you to expressively test your applications.
 
 By default, your application's `tests` directory contains two directories: `Feature` and `Unit`. Unit tests are tests that focus on a very small, isolated portion of your code. In fact, most unit tests probably focus on a single method. Feature tests may test a larger portion of your code, including how several objects interact with each other or even a full HTTP request to a JSON endpoint.
 


### PR DESCRIPTION
Fixed a typo where a `setup` _noun_ has been used instead of the `set up` _verb_.