### PR TITLE
Added instruction on how to make Tinker ClassAliasAutoloader work in …

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -27,6 +27,19 @@ Update your `laravel/framework` dependency to `5.5.*` in your `composer.json` fi
 
 Of course, don't forget to examine any 3rd party packages consumed by your application and verify you are using the proper version for Laravel 5.5 support.
 
+#### Tinker
+Laravel Tinker now allows you to omit namespaces when calling your application classes. By analyzing Composer's classmap file, Tinker will attempt to find a class in the App namespace and alias it automatically.
+This feature requires adding the following to the `config` section of composer.json and then running `composer dump-autoload`:
+```
+"config": {
+    ...
+    "sort-packages": true,
+    "optimize-autoloader": true
+}
+```
+
+#### Laravel Installer
+
 > {tip} If you commonly use the Laravel installer via `laravel new`, you should update your Laravel installer package using the `composer global update` command.
 
 #### Laravel Dusk


### PR DESCRIPTION
…upgraded projects.

I've also added a super short description of what the feature does, since I couldn't find anything official to link to. The only references I could find, are comments in laravel/tinker issues.

I'm not sure if "sort-packages": true could be omitted, but it's there in fresh 5.5 installs, so I threw it in just in case :)