### PR TITLE
Update mix versioning

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -292,12 +292,12 @@ When copying a directory, the `copy` method will flatten the directory's structu
 
 Many developers suffix their compiled assets with a timestamp or unique token to force browsers to load the fresh assets instead of serving stale copies of the code. Mix can handle this for you using the `version` method.
 
-The `version` method will automatically append a unique hash to the filenames of all compiled files, allowing for more convenient cache busting:
+The `version` method will automatically generate an md5 of the file's contents for all compiled files, and apply it as a query string allowing for more convenient cache busting:
 
     mix.js('resources/assets/js/app.js', 'public/js')
        .version();
 
-After generating the versioned file, you won't know the exact file name. So, you should use Laravel's global `mix` function within your [views](/docs/{{version}}/views) to load the appropriately hashed asset. The `mix` function will automatically determine the current name of the hashed file:
+To use the versioned assets, you need to use Laravel's global `mix` function within your [views](/docs/{{version}}/views) to load the hashed asset. The `mix` function will automatically append the appropriately query string from `mix-manifest.json` to each asset's filename:
 
     <link rel="stylesheet" href="{{ mix('/css/app.css') }}">
 


### PR DESCRIPTION
Update mix versioning docs according to `laravel-mix` `v1.0.0` which now uses query-string versioning rather than hashed filenames.