### PR TITLE
Fix issue with policy blade example code

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -330,13 +330,13 @@ When writing Blade templates, you may wish to display a portion of the page only
 
     @can('update', $post)
         <!-- The Current User Can Update The Post -->
-    @elsecan('create', $post)
+    @elsecan('create', App\Post::class)
         <!-- The Current User Can Create New Post -->
     @endcan
 
     @cannot('update', $post)
         <!-- The Current User Can't Update The Post -->
-    @elsecannot('create', $post)
+    @elsecannot('create', App\Post::class)
         <!-- The Current User Can't Create New Post -->
     @endcannot
 


### PR DESCRIPTION
This PR fixes two small errors in example code for using policies in blade templates.

Since `create` doesn't require a model instance, `App\Post::class` should be passed into the `@cannot` directive's second parameter, instead of `$post`.

Let me know if you have any questions. Thanks!