### PR TITLE
Syntax error in selectRaw() query example

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -169,7 +169,7 @@ Instead of using `DB::raw`, you may also use the following methods to insert a r
 The `selectRaw` method can be used in place of `select(DB::raw(...))`. This method accepts an optional array of bindings as its second argument:
 
     $orders = DB::table('orders')
-                    ->selectRaw('price * ? as price_with_tax'), [1.0825])
+                    ->selectRaw('price * ? as price_with_tax', [1.0825])
                     ->get();
 
 #### `whereRaw / orWhereRaw`


### PR DESCRIPTION
Redundant closing parenthesis