### PR TITLE
Clarify passing password to attempt method, fixes #3642

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -218,7 +218,7 @@ We will access Laravel's authentication services via the `Auth` [facade](/docs/{
         }
     }
 
-The `attempt` method accepts an array of key / value pairs as its first argument. The values in the array will be used to find the user in your database table. So, in the example above, the user will be retrieved by the value of the `email` column. If the user is found, the hashed password stored in the database will be compared with the hashed `password` value passed to the method via the array. If the two hashed passwords match an authenticated session will be started for the user.
+The `attempt` method accepts an array of key / value pairs as its first argument. The values in the array will be used to find the user in your database table. So, in the example above, the user will be retrieved by the value of the `email` column. If the user is found, the hashed password stored in the database will be compared with the hashed `password` value passed to the method via the array. You should pass the password to the `attempt` method without hashing it yourself. If the two hashed passwords match an authenticated session will be started for the user.
 
 The `attempt` method will return `true` if authentication was successful. Otherwise, `false` will be returned.
 


### PR DESCRIPTION
I added the sentence `You should pass the password to the `attempt` method without hashing it yourself` to clarify the issue mentioned in #3642 