### PR TITLE
Documents collections.md with 'preverseKeys' info for 'reverse()'

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1345,6 +1345,26 @@ The `reverse` method reverses the order of the collection's items:
 
     // [5, 4, 3, 2, 1]
 
+`reverse`, unlike PHP's [`array_reserve`](https://secure.php.net/manual/en/function.array-reverse.php), will preserve keys by default. Pass `false` if you do not want this behaviour:
+
+    $collection = collect(['a', 'b', 'c']);
+
+    $collection->reverse()->keys()->all();
+
+    // [2, 1, 0]
+
+    $collection->reverse(false)->keys()->all();
+
+    // [0, 1, 2]
+
+No matter which version is used, string keys are always preseved:
+
+    $collection = collect([0 => 'first', 1 => 'second', 'framework' => 'laravel']);
+
+    $collection->reverse(false)->all();
+
+    // ['framework' => 'laravel', 0 => 'second', 1 => 'first']
+
 <a name="method-search"></a>
 #### `search()` {#collection-method}
 


### PR DESCRIPTION
As mentioned on [laravel/internals here](https://github.com/laravel/internals/issues/859) this overload was added then removed in mid-August 2015. This PR documents another PR on [laravel/framework](https://github.com/laravel/framework/pull/21871) which enables the functionality again, however, this time the default is backward compatible with existing API `$preserveKeys = true`.