### PR TITLE
[5.5] Improved migrations documentation

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -83,7 +83,6 @@ Within both of these methods you may use the Laravel schema builder to expressiv
         }
     }
 
-
 <a name="running-migrations"></a>
 ## Running Migrations
 
@@ -212,59 +211,61 @@ Of course, the schema builder contains a variety of column types that you may sp
 
 Command  | Description
 ------------- | -------------
-`$table->bigIncrements('id');`  |  Incrementing ID (primary key) using a "UNSIGNED BIG INTEGER" equivalent.
-`$table->bigInteger('votes');`  |  BIGINT equivalent for the database.
-`$table->binary('data');`  |  BLOB equivalent for the database.
-`$table->boolean('confirmed');`  |  BOOLEAN equivalent for the database.
-`$table->char('name', 4);`  |  CHAR equivalent with a length.
-`$table->date('created_at');`  |  DATE equivalent for the database.
-`$table->dateTime('created_at');`  |  DATETIME equivalent for the database.
-`$table->dateTimeTz('created_at');`  |  DATETIME (with timezone) equivalent for the database.
-`$table->decimal('amount', 5, 2);`  |  DECIMAL equivalent with a precision and scale.
-`$table->double('column', 15, 8);`  |  DOUBLE equivalent with precision, 15 digits in total and 8 after the decimal point.
-`$table->enum('choices', ['foo', 'bar']);` | ENUM equivalent for the database.
-`$table->float('amount', 8, 2);`  |  FLOAT equivalent for the database, 8 digits in total and 2 after the decimal point.
-`$table->geometry('column');`  | GEOMETRY equivalent for the database.
-`$table->geometryCollection('column');`  | GEOMETRYCOLLECTION equivalent for the database.
-`$table->increments('id');`  |  Incrementing ID (primary key) using a "UNSIGNED INTEGER" equivalent.
-`$table->integer('votes');`  |  INTEGER equivalent for the database.
-`$table->ipAddress('visitor');`  |  IP address equivalent for the database.
-`$table->json('options');`  |  JSON equivalent for the database.
-`$table->jsonb('options');`  |  JSONB equivalent for the database.
-`$table->lineString('column');`  |  LINESTRING equivalent for the database.
-`$table->longText('description');`  |  LONGTEXT equivalent for the database.
-`$table->macAddress('device');`  |  MAC address equivalent for the database.
-`$table->mediumIncrements('id');`  |  Incrementing ID (primary key) using a "UNSIGNED MEDIUM INTEGER" equivalent.
-`$table->mediumInteger('numbers');`  |  MEDIUMINT equivalent for the database.
-`$table->mediumText('description');`  |  MEDIUMTEXT equivalent for the database.
-`$table->morphs('taggable');`  |  Adds unsigned INTEGER `taggable_id` and STRING `taggable_type`.
-`$table->multiLineString('column');`  |  MULTILINESTRING equivalent for the database.
-`$table->multiPoint('column');`  |  MULTIPOINT equivalent for the database.
-`$table->multiPolygon('column');`  |  MULTIPOLYGON equivalent for the database.
-`$table->nullableMorphs('taggable');`  |  Nullable versions of the `morphs()` columns.
-`$table->nullableTimestamps();`  |  Nullable versions of the `timestamps()` columns.
-`$table->point('column');`  | POINT equivalent for the database.
-`$table->polygon('column');`  | POLYGON equivalent for the database.
-`$table->rememberToken();`  |  Adds `remember_token` as VARCHAR(100) NULL.
-`$table->smallIncrements('id');`  |  Incrementing ID (primary key) using a "UNSIGNED SMALL INTEGER" equivalent.
-`$table->smallInteger('votes');`  |  SMALLINT equivalent for the database.
-`$table->softDeletes();`  |  Adds nullable `deleted_at` column for soft deletes.
-`$table->string('email');`  |  VARCHAR equivalent column.
-`$table->string('name', 100);`  |  VARCHAR equivalent with a length.
-`$table->text('description');`  |  TEXT equivalent for the database.
-`$table->time('sunrise');`  |  TIME equivalent for the database.
-`$table->timeTz('sunrise');`  |  TIME (with timezone) equivalent for the database.
-`$table->timestamp('added_on');`  |  TIMESTAMP equivalent for the database.
-`$table->timestampTz('added_on');`  |  TIMESTAMP (with timezone) equivalent for the database.
-`$table->timestamps();`  |  Adds nullable `created_at` and `updated_at` columns.
-`$table->timestampsTz();`  |  Adds nullable `created_at` and `updated_at` (with timezone) columns.
-`$table->tinyInteger('numbers');`  |  TINYINT equivalent for the database.
-`$table->unsignedBigInteger('votes');`  |  Unsigned BIGINT equivalent for the database.
-`$table->unsignedInteger('votes');`  |  Unsigned INT equivalent for the database.
-`$table->unsignedMediumInteger('votes');`  |  Unsigned MEDIUMINT equivalent for the database.
-`$table->unsignedSmallInteger('votes');`  |  Unsigned SMALLINT equivalent for the database.
-`$table->unsignedTinyInteger('votes');`  |  Unsigned TINYINT equivalent for the database.
-`$table->uuid('id');`  |  UUID equivalent for the database.
+`$table->bigIncrements('id');`  |  Auto-incrementing UNSIGNED BIGINT (primary key) equivalent column.
+`$table->bigInteger('votes');`  |  BIGINT equivalent column.
+`$table->binary('data');`  |  BLOB equivalent column.
+`$table->boolean('confirmed');`  |  BOOLEAN equivalent column.
+`$table->char('name', 100);`  |  CHAR equivalent column with a optional length.
+`$table->date('created_at');`  |  DATE equivalent column.
+`$table->dateTime('created_at');`  |  DATETIME equivalent column.
+`$table->dateTimeTz('created_at');`  |  DATETIME (with timezone) equivalent column.
+`$table->decimal('amount', 8, 2);`  |  DECIMAL equivalent column with a precision (total digits) and scale (decimal digits).
+`$table->double('amount', 8, 2);`  |  DOUBLE equivalent column with a precision (total digits) and scale (decimal digits).
+`$table->enum('level', ['easy', 'hard']);`  |  ENUM equivalent column.
+`$table->float('amount', 8, 2);`  |  FLOAT equivalent column with a precision (total digits) and scale (decimal digits).
+`$table->geometry('positions');`  |  GEOMETRY equivalent column.
+`$table->geometryCollection('positions');`  |  GEOMETRYCOLLECTION equivalent column.
+`$table->increments('id');`  |  Auto-incrementing UNSIGNED INTEGER (primary key) equivalent column.
+`$table->integer('votes');`  |  INTEGER equivalent column.
+`$table->ipAddress('visitor');`  |  IP address equivalent column.
+`$table->json('options');`  |  JSON equivalent column.
+`$table->jsonb('options');`  |  JSONB equivalent column.
+`$table->lineString('positions');`  |  LINESTRING equivalent column.
+`$table->longText('description');`  |  LONGTEXT equivalent column.
+`$table->macAddress('device');`  |  MAC address equivalent column.
+`$table->mediumIncrements('id');`  |  Auto-incrementing UNSIGNED MEDIUMINT (primary key) equivalent colum.
+`$table->mediumInteger('votes');`  |  MEDIUMINT equivalent column.
+`$table->mediumText('description');`  |  MEDIUMTEXT equivalent column.
+`$table->morphs('taggable');`  |  Adds `taggable_id` UNSIGNED INTEGER and `taggable_type` VARCHAR equivalent columns.
+`$table->multiLineString('positions');`  |  MULTILINESTRING equivalent column.
+`$table->multiPoint('positions');`  |  MULTIPOINT equivalent column.
+`$table->multiPolygon('positions');`  |  MULTIPOLYGON equivalent column.
+`$table->nullableMorphs('taggable');`  |  Adds nullable versions of `morphs()` columns.
+`$table->nullableTimestamps();`  |  Adds nullable versions of `timestamps()` columns.
+`$table->point('position');`  |  POINT equivalent column.
+`$table->polygon('positions');`  |  POLYGON equivalent column.
+`$table->rememberToken();`  |  Adds a nullable `remember_token` VARCHAR(100) equivalent column.
+`$table->smallIncrements('id');`  |  Auto-incrementing UNSIGNED SMALLINT (primary key) equivalent column.
+`$table->smallInteger('votes');`  |  SMALLINT equivalent column.
+`$table->softDeletes();`  |  Adds a nullable `deleted_at` TIMESTAMP equivalent column for soft deletes.
+`$table->softDeletesTz();`  |  Adds a nullable `deleted_at` TIMESTAMP (with timezone) equivalent column for soft deletes.
+`$table->string('name', 100);`  |  VARCHAR equivalent column with a optional length.
+`$table->text('description');`  |  TEXT equivalent column.
+`$table->time('sunrise');`  |  TIME equivalent column.
+`$table->timeTz('sunrise');`  |  TIME (with timezone) equivalent column.
+`$table->timestamp('added_on');`  |  TIMESTAMP equivalent column.
+`$table->timestampTz('added_on');`  |  TIMESTAMP (with timezone) equivalent column.
+`$table->timestamps();`  |  Adds nullable `created_at` and `updated_at` TIMESTAMP equivalent columns.
+`$table->timestampsTz();`  |  Adds nullable `created_at` and `updated_at` TIMESTAMP (with timezone) equivalent columns.
+`$table->tinyIncrements('id');`  |  Auto-incrementing UNSIGNED TINYINT (primary key) equivalent column.
+`$table->tinyInteger('votes');`  |  TINYINT equivalent column.
+`$table->unsignedBigInteger('votes');`  |  UNSIGNED BIGINT equivalent column.
+`$table->unsignedDecimal('amount', 8, 2);`  |  UNSIGNED DECIMAL equivalent column with a precision (total digits) and scale (decimal digits).
+`$table->unsignedInteger('votes');`  |  UNSIGNED INTEGER equivalent column.
+`$table->unsignedMediumInteger('votes');`  |  UNSIGNED MEDIUMINT equivalent column.
+`$table->unsignedSmallInteger('votes');`  |  UNSIGNED SMALLINT equivalent column.
+`$table->unsignedTinyInteger('votes');`  |  UNSIGNED TINYINT equivalent column.
+`$table->uuid('id');`  |  UUID equivalent column.
 
 <a name="column-modifiers"></a>
 ### Column Modifiers
@@ -279,16 +280,19 @@ Below is a list of all the available column modifiers. This list does not includ
 
 Modifier  | Description
 ------------- | -------------
-`->after('column')`  |  Place the column "after" another column (MySQL Only)
-`->comment('my comment')`  |  Add a comment to a column (MySQL Only)
+`->after('column')`  |  Place the column "after" another column (MySQL)
+`->autoIncrement()`  |  Set INTEGER columns as auto-increment (primary key)
+`->charset('utf8')`  |  Specify a character set for the column (MySQL)
+`->collation('utf8_unicode_ci')`  |  Specify a collation for the column (MySQL/SQL Server)
+`->comment('my comment')`  |  Add a comment to a column (MySQL)
 `->default($value)`  |  Specify a "default" value for the column
-`->first()`  |  Place the column "first" in the table (MySQL Only)
+`->first()`  |  Place the column "first" in the table (MySQL)
 `->nullable($value = true)`  |  Allows (by default) NULL values to be inserted into the column
-`->storedAs($expression)`  |  Create a stored generated column (MySQL Only)
-`->unsigned()`  |  Set `integer` columns to `UNSIGNED`
-`->virtualAs($expression)`  |  Create a virtual generated column (MySQL Only)
+`->storedAs($expression)`  |  Create a stored generated column (MySQL)
+`->unsigned()`  |  Set INTEGER columns as UNSIGNED (MySQL)
+`->useCurrent()`  |  Set TIMESTAMP columns to use CURRENT_TIMESTAMP as default value
+`->virtualAs($expression)`  |  Create a virtual generated column (MySQL)
 
-<a name="changing-columns"></a>
 <a name="modifying-columns"></a>
 ### Modifying Columns
 
@@ -314,7 +318,6 @@ We could also modify a column to be nullable:
 
 > {note} The following column types can not be "changed": char, double, enum, mediumInteger, timestamp, tinyInteger, ipAddress, json, jsonb, macAddress, mediumIncrements, morphs, nullableMorphs, nullableTimestamps, softDeletes, timeTz, timestampTz, timestamps, timestampsTz, unsignedMediumInteger, unsignedTinyInteger, uuid.
 
-<a name="renaming-columns"></a>
 #### Renaming Columns
 
 To rename a column, you may use the `renameColumn` method on the Schema builder. Before renaming a column, be sure to add the `doctrine/dbal` dependency to your `composer.json` file:
@@ -356,24 +359,23 @@ Alternatively, you may create the index after defining the column. For example:
 
     $table->unique('email');
 
-You may even pass an array of columns to an index method to create a compound index:
+You may even pass an array of columns to an index method to create a compound (or composite) index:
 
     $table->index(['account_id', 'created_at']);
 
 Laravel will automatically generate a reasonable index name, but you may pass a second argument to the method to specify the name yourself:
 
-    $table->index('email', 'my_index_name');
+    $table->unique('email', 'unique_email');
 
 #### Available Index Types
 
 Command  | Description
 ------------- | -------------
-`$table->primary('id');`  |  Add a primary key.
-`$table->primary(['first', 'last']);`  |  Add composite keys.
-`$table->unique('email');`  |  Add a unique index.
-`$table->unique('state', 'my_index_name');`  |  Add a custom index name.
-`$table->unique(['first', 'last']);`  |  Add a composite unique index.
-`$table->index('state');`  |  Add a basic index.
+`$table->primary('id');`  |  Adds a primary key.
+`$table->primary(['id', 'parent_id']);`  |  Adds composite keys.
+`$table->unique('email');`  |  Adds a unique index.
+`$table->index('state');`  |  Adds a plain index.
+`$table->spatialIndex('location');`  |  Adds a spatial index. (MySQL)
 
 #### Index Lengths & MySQL / MariaDB
 


### PR DESCRIPTION
[Preview](https://github.com/paulofreitas/laravel-docs/blob/improved-migrations/migrations.md)

### Added

- Added 3 missing column type methods: `softDeletesTz()`, `tinyIncrements()` and `unsignedDecimal()`
- Added 4 missing column modifier methods: `autoIncrement()`, `charset()`, `collation()` and `useCurrent()`
- Added 1 missing index type method: `spatialIndex()`

### Changed

- Changed `$table->char()` and `$table->string()` column types commands descriptions to state the column length is optional
- Fixed `$table->morphs()` column type command description to state the `taggable_type` column uses a VARCHAR column type
- Changed `->unsigned()` column modifier command description to state it is also MySQL only
- Overall command descriptions rewording with **lots** of small improvements
- Improved some commands arguments to improve the consistency with other examples
- Reordered methods in *Modifying Columns* note and added 10 missing unsupported methods

### Removed

- The *Creating Indexes* section already demonstrates that every index type method could be used to create composite indexes and/or custom-named indexes, so I've removed some examples from the *Available Index Types* table to avoid having to demonstrate all indexes creation variations
- Removed 2 unused link anchors