### PR TITLE
Documents the keys being preserved in `Collection#reverse`

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1335,15 +1335,23 @@ For the inverse of the `reject` method, see the [`filter`](#method-filter) metho
 <a name="method-reverse"></a>
 #### `reverse()` {#collection-method}
 
-The `reverse` method reverses the order of the collection's items:
+The `reverse` method reverses the order of the collection's items, preserving the original keys:
 
-    $collection = collect([1, 2, 3, 4, 5]);
+    $collection = collect(['a', 'b', 'c', 'd', 'e']);
 
     $reversed = $collection->reverse();
 
     $reversed->all();
 
-    // [5, 4, 3, 2, 1]
+    /*
+        [
+            4 => 'e',
+            3 => 'd',
+            2 => 'c',
+            1 => 'b',
+            0 => 'a',
+        ]
+    */
 
 <a name="method-search"></a>
 #### `search()` {#collection-method}


### PR DESCRIPTION
Following on from the discussion on [laravel/internals](https://github.com/laravel/internals/issues/859), `collections.md` now documents that the keys are also reversed with `Collection#reverse`