### PR TITLE
Added documentation for apiResources array

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -196,6 +196,13 @@ When declaring a resource route, you may specify a subset of actions the control
 When declaring resource routes that will be consumed by APIs, you will commonly want to exclude routes that present HTML templates such as `create` and `edit`. For convenience, you may use the `apiResource` method to automatically exclude these two routes:
 
     Route::apiResource('photo', 'PhotoController');
+    
+You may register many API resource controllers at once by passing an array to the `apiResources` method:
+
+    Route::apiResources([
+        'photos' => 'PhotoController',
+        'posts' => 'PostController'
+    ]);
 
 <a name="restful-naming-resource-routes"></a>
 ### Naming Resource Routes


### PR DESCRIPTION
With Laravel Framework PR 21956, apiResources is now a function that can accept an array of controllers. This commit documents that functionality.
https://github.com/laravel/framework/commit/44680ec4f3d71b0064e3a416525d176cf613a92b