### PR TITLE
[5.4] Add missing concat documentation

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -225,7 +225,7 @@ The `combine` method combines the keys of the collection with the values of anot
 <a name="method-concat"></a>
 #### `concat()` {#collection-method}
  
-The `concat` method appends the given `array` or collection values into the end of the collection, ignoring any existing keys in the given items:
+The `concat` method appends the given `array` or collection values onto the end of the collection, ignoring any existing keys in the given items:
  
     $collection = collect(['John Doe']);
  

--- a/collections.md
+++ b/collections.md
@@ -53,6 +53,7 @@ For the remainder of this documentation, we'll discuss each method available on 
 [chunk](#method-chunk)
 [collapse](#method-collapse)
 [combine](#method-combine)
+[concat](#method-concat)
 [contains](#method-contains)
 [containsStrict](#method-containsstrict)
 [count](#method-count)
@@ -220,6 +221,19 @@ The `combine` method combines the keys of the collection with the values of anot
     $combined->all();
 
     // ['name' => 'George', 'age' => 29]
+
+<a name="method-concat"></a>
+#### `concat()` {#collection-method}
+ 
+The `concat` method appends the given `array` or collection values into the end of the collection, ignoring any existing keys in the given items:
+ 
+    $collection = collect(['John Doe']);
+ 
+    $concatenated = $collection->concat(['Jane Doe'])->concat(['name' => 'Johnny Doe']);
+ 
+    $concatenated->all();
+ 
+    // ['John Doe', 'Jane Doe', 'Johnny Doe'] 
 
 <a name="method-contains"></a>
 #### `contains()` {#collection-method}


### PR DESCRIPTION
Refs [5.5]. https://github.com/laravel/docs/commit/ceaf4b1dd155b6d9d50cb979e54d7dc4f50e1b14