### PR TITLE
Array instead of string for multiple route middleware

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -130,7 +130,7 @@ You may also assign multiple middleware to the route:
 
     Route::get('/', function () {
         //
-    })->middleware('first', 'second');
+    })->middleware(['first', 'second']);
 
 When assigning middleware, you may also pass the fully qualified class name:
 


### PR DESCRIPTION
Route->middleware() accepts array when assigning multiple middlewares.