### PR TITLE
Added array for when assigning multiple Middleware

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -130,7 +130,7 @@ You may also assign multiple middleware to the route:
 
     Route::get('/', function () {
         //
-    })->middleware('first', 'second');
+    })->middleware(['first', 'second']);
 
 When assigning middleware, you may also pass the fully qualified class name:
 


### PR DESCRIPTION
Seems to have been a typo. It appears you need to wrap multiple Middleware assignments in an array. If you don't, the second assignment is seen as a parameter for the first.