### PR TITLE
Cron syntax only has 5 stars

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -94,7 +94,7 @@ Of course, there are a variety of schedules you may assign to your task:
 
 Method  | Description
 ------------- | -------------
-`->cron('* * * * * *');`  |  Run the task on a custom Cron schedule
+`->cron('* * * * *');`  |  Run the task on a custom Cron schedule
 `->everyMinute();`  |  Run the task every minute
 `->everyFiveMinutes();`  |  Run the task every five minutes
 `->everyTenMinutes();`  |  Run the task every ten minutes


### PR DESCRIPTION
6 stars are shown in the example and confuse readers.