### PR TITLE
- Scheduling docs Homestead Configuring Cron Schedules linking

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -26,6 +26,8 @@ When using the scheduler, you only need to add the following Cron entry to your 
 
 This Cron will call the Laravel command scheduler every minute. When the `schedule:run` command is executed, Laravel will evaluate your scheduled tasks and runs the tasks that are due.
 
+If you are using Homestead for development. Scheduling for a site can be enabled by just adding an entry in the Homestead.yaml file. Please refer [Homestead Configuring Cron Schedules](/docs/{{version}}/homestead#configuring-cron-schedules)
+
 <a name="defining-schedules"></a>
 ## Defining Schedules
 


### PR DESCRIPTION
People referring the docs during development might not know that Homestead has an easy option for enabling scheduling. 
They might end up configuring CRON jobs in their Homestead box instead. This commit / doc block helps users know that there is an easy way in Homestead for enabling scheduling. 