### PR TITLE
Changing UsersController to UserController

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -34,7 +34,7 @@ All Laravel routes are defined in your route files, which are located in the `ro
 
 For most applications, you will begin by defining routes in your `routes/web.php` file. The routes defined in `routes/web.php` may be accessed by entering the defined route's URL in your browser. For example, you may access the following route by navigating to `http://your-app.dev/user` in your browser:
 
-    Route::get('/user', 'UsersController@index');
+    Route::get('/user', 'UserController@index');
 
 Routes defined in the `routes/api.php` file are nested within a route group by the `RouteServiceProvider`. Within this group, the `/api` URI prefix is automatically applied so you do not need to manually apply it to every route in the file. You may modify the prefix and other route group options by modifying your `RouteServiceProvider` class.
 


### PR DESCRIPTION
I can see controller name is singular like UserController, PhotoController in all Laravel docs except this example. This is confusing.

If you don't want to change that, could you explain why? The thing is I'm working on naming conventions table, so I'd really like to know what controller naming conventions exist https://github.com/alexeymezenin/laravel-best-practices#follow-laravel-naming-conventions