### PR TITLE
Fixes exception incompatibility

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -563,10 +563,10 @@ You may define a `failed` method directly on your job class, allowing you to per
         /**
          * The job failed to process.
          *
-         * @param  Exception  $exception
+         * @param \Exception $exception
          * @return void
          */
-        public function failed(Exception $exception)
+        public function failed(\Exception $exception)
         {
             // Send user notification of failure, etc...
         }


### PR DESCRIPTION
Without backslash the method failed throws a incompatibility error.

```
[2017-11-27 09:52:18] local.ERROR: Type error: Argument 1 passed to App\Jobs\MyJob::failed() must be an instance of App\Jobs\Exception, instance of AnotherException given, called in /home/user/project/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php on line 149 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: Argument 1 passed to App\\Jobs\\MyJob::failed() must be an instance of App\\Jobs\\Exception, instance of AnotherException given, called in /home/user/project/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php on line 149 at /home/user/project/app/Jobs/MyJob.php:102)
```