### PR TITLE
Add note about mass assignment during seeding

### DIFF
--- a/seeding.md
+++ b/seeding.md
@@ -44,6 +44,8 @@ As an example, let's modify the default `DatabaseSeeder` class and add a databas
         }
     }
 
+> {note} Mass Assignment protection is disabled during seeding.
+
 <a name="using-model-factories"></a>
 ### Using Model Factories
 


### PR DESCRIPTION
Today I learned, after some struggle, that mass assignment protection is disabled during seeding. It might be useful to add a note somewhere in the docs about it.

I'm submitting another PR, adding the same note in the `Eloquent` section, so you can chose the best place to add the note in case you judge it pertinent. 