### PR TITLE
Add another note about mass assignment during seeding

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -349,6 +349,8 @@ If you already have a model instance, you may use the `fill` method to populate 
 
     $flight->fill(['name' => 'Flight 22']);
 
+> {note} Mass Assignment protection is disabled during seeding.
+
 #### Guarding Attributes
 
 While `$fillable` serves as a "white list" of attributes that should be mass assignable, you may also choose to use `$guarded`. The `$guarded` property should contain an array of attributes that you do not want to be mass assignable. All other attributes not in the array will be mass assignable. So, `$guarded` functions like a "black list". Of course, you should use either `$fillable` or `$guarded` - not both. In the example below, all attributes **except for `price`** will be mass assignable:


### PR DESCRIPTION
Ref #3887 

> Today I learned, after some struggle, that mass assignment protection is disabled during seeding. It might be useful to add a note somewhere in the docs about it.

I submitted another PR, adding the same note in the Seeding section, so you can chose the best place to add the note in case you judge it pertinent.