### PR TITLE
Removed "with name" for clearer prose

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -67,7 +67,7 @@ When passing a multi-word model name to the `authorizeResource` method, the resu
 
 #### The `before` Policy Method
 
-The `before` method of a policy class will not be called if the class doesn't contain a method with name matching the name of the ability being checked.
+The `before` method of a policy class will not be called if the class doesn't contain a method matching the name of the ability being checked.
 
 ### Cache
 


### PR DESCRIPTION
  - The previous version seemed like it could use the article
    "a" between "with" and "name", but this version reads a little
    cleaner. "This method matches that name" is the same as saying
    "this method's name matches that method's name".