### PR TITLE
fixing the code example for Eloquent collections

### DIFF
--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -19,7 +19,7 @@ Of course, all collections also serve as iterators, allowing you to loop over th
 
 However, collections are much more powerful than arrays and expose a variety of map / reduce operations that may be chained using an intuitive interface. For example, let's remove all inactive models and gather the first name for each remaining user:
 
-    $users = App\User::where('active', 1)->get();
+    $users = App\User::all();
 
     $names = $users->reject(function ($user) {
         return $user->active === false;


### PR DESCRIPTION
In the example, users were filtered twice with the same criterion - once in query builder and then in reject collection method. Now only the filter using reject method is left.