### PR TITLE
update elasticsearch notes

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -212,14 +212,16 @@ If you prefer to use MariaDB instead of MySQL, you may add the `mariadb` option 
 <a name="installing-elasticsearch"></a>
 ### Installing Elasticsearch
 
-To install Elasticsearch, add the `elasticsearch` option to your `Homestead.yaml` file. The default installation will create a cluster named 'homestead' and allocate it 2GB of memory. You should never give Elasticsearch more than half of the operating system's memory, so make sure your Homestead machine has at least 4GB of memory:
+Add the `elasticsearch` option to your `Homestead.yaml` file and specify a supported version. The default installation will create a cluster named 'homestead'. You should never give Elasticsearch more than half of the operating system's memory, so make sure your Homestead machine has at least twice the Elasticsearch allocation.
 
     box: laravel/homestead
     ip: "192.168.10.10"
     memory: 4096
     cpus: 4
     provider: virtualbox
-    elasticsearch: true
+    elasticsearch: 6
+    
+Please reference the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current) to customize your configuration.
 
 <a name="aliases"></a>
 ### Aliases


### PR DESCRIPTION
recently added support for ES6 to Homestead (https://github.com/laravel/homestead/commit/2d5f1b6f27b3d53082cb42c4450485f6860818ab)

since we support multiple versions now, tried to make the docs a little more generic

- new code allows you to specify a version. currently v5 and v6 supported.
- current users with a 'true' value will fallback to v5, so no breaking change
- added link to current ES configuration docs
- v5 defaults to 2GB, and v6 defaults to 1GB of memory, so I had to remove the hard coded values.