### PR TITLE
Update Echo options for pusher in broadcasting.js

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -75,7 +75,9 @@ When using Pusher and [Laravel Echo](#installing-laravel-echo), you should speci
 
     window.Echo = new Echo({
         broadcaster: 'pusher',
-        key: 'your-pusher-key'
+        key: 'your-pusher-key',
+        cluster: 'eu',
+        encrypted: true
     });
 
 #### Redis


### PR DESCRIPTION
Hi!

I've made little update to `broadcasting.js` based on [Pusher tutorial to build chat app with Laravel](https://blog.pusher.com/how-to-build-a-laravel-chat-app-with-pusher/).

```
import Echo from "laravel-echo"

window.Echo = new Echo({
    broadcaster: 'pusher',
    key: 'xxxxxxxxxxxxxxxxxxxx',
    cluster: 'eu',
    encrypted: true
});
```

Without `cluster` option, Pusher throws errors like:

`Pusher: You should always specify a cluster when connecting. See: https://pusher.com/docs/javascript_quick_start`

`Pusher: Error: {"type":"WebSocketError","error":{"type":"PusherError","data":{"code":4001,"message":"Did you forget to specify the cluster when creating the Pusher instance?  App key [app-key] does not exist in this cluster."}}}`
