### PR TITLE
Rename resource name from `User` to `UserResource`

### DIFF
--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -21,7 +21,7 @@ When building an API, you may need a transformation layer that sits between your
 
 To generate a resource class, you may use the `make:resource` Artisan command. By default, resources will be placed in the `app/Http/Resources` directory of your application. Resources extend the `Illuminate\Http\Resources\Json\Resource` class:
 
-    php artisan make:resource User
+    php artisan make:resource UserResource
 
 #### Resource Collections
 
@@ -69,7 +69,7 @@ Before diving into all of the options available to you when writing resources, l
 Every resource class defines a `toArray` method which returns the array of attributes that should be converted to JSON when sending the response. Notice that we can access model properties directly from the `$this` variable. This is because a resource class will automatically proxy property and method access down to the underlying model for convenient access. Once the resource is defined, it may be returned from a route or controller:
 
     use App\User;
-    use App\Http\Resources\User as UserResource;
+    use App\Http\Resources\UserResource;
 
     Route::get('/user', function () {
         return new UserResource(User::find(1));
@@ -80,7 +80,7 @@ Every resource class defines a `toArray` method which returns the array of attri
 If you are returning a collection of resources or a paginated response, you may use the `collection` method when creating the resource instance in your route or controller:
 
     use App\User;
-    use App\Http\Resources\User as UserResource;
+    use App\Http\Resources\UserResource;
 
     Route::get('/user', function () {
         return UserResource::collection(User::all());
@@ -162,7 +162,7 @@ In essence, resources are simple. They only need to transform a given model into
 Once a resource has been defined, it may be returned directly from a route or controller:
 
     use App\User;
-    use App\Http\Resources\User as UserResource;
+    use App\Http\Resources\UserResource;
 
     Route::get('/user', function () {
         return new UserResource(User::find(1));
@@ -197,7 +197,7 @@ If you would like to include related resources in your response, you may simply 
 While resources translate a single model into an array, resource collections translate a collection of models into an array. It is not absolutely necessary to define a resource collection class for each one of your model types since all resources provide a `collection` method to generate an "ad-hoc" resource collection on the fly:
 
     use App\User;
-    use App\Http\Resources\User as UserResource;
+    use App\Http\Resources\UserResource;
 
     Route::get('/user', function () {
         return UserResource::collection(User::all());
@@ -584,7 +584,7 @@ You may also add top-level data when constructing resource instances in your rou
 As you have already read, resources may be returned directly from routes and controllers:
 
     use App\User;
-    use App\Http\Resources\User as UserResource;
+    use App\Http\Resources\UserResource;
 
     Route::get('/user', function () {
         return new UserResource(User::find(1));
@@ -593,7 +593,7 @@ As you have already read, resources may be returned directly from routes and con
 However, sometimes you may need to customize the outgoing HTTP response before it is sent to the client. There are two ways to accomplish this. First, you may chain the `response` method onto the resource. This method will return an `Illuminate\Http\Response` instance, allowing you full control of the response's headers:
 
     use App\User;
-    use App\Http\Resources\User as UserResource;
+    use App\Http\Resources\UserResource;
 
     Route::get('/user', function () {
         return (new UserResource(User::find(1)))


### PR DESCRIPTION
Hi, i've just rename resource name from `User` to `UserResource` >> `php artisan make:resource UserResource`.

I've rename it to avoid collision on model name so 
```
use App\Http\Resources\User as UserResource;
```
simply becomes to 
```
use App\Http\Resources\UserResource;
```
Sometimes some IDE misunderstanding which class have to import