### PR TITLE
Explicitly show that the code for order shipping needs to be written

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -106,6 +106,7 @@ You may use the `Mail` facade's `fake` method to prevent mail from being sent. Y
 
             // Perform order shipping...
 
+            // Assert that a message was sent with a correct order id...
             Mail::assertSent(OrderShipped::class, function ($mail) use ($order) {
                 return $mail->order->id === $order->id;
             });


### PR DESCRIPTION
Reading the code example it is not clear that the code for shipping the order needs to be written.

3 out of 4 assertions in the example have a comment right above them, describing what the assertion does.
The comment above the first assertion does not refer to the assertion itself, but instructs the reader to write the logic for shipping the order.

This may be quite misleading, as the reader may assume that `assertSent` method is responsible for performing the order shipping.