### PR TITLE
[5.3] Illuminate\Auth\Middleware\Authenticate renamed middleware

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -379,6 +379,10 @@ Once this route middleware has been registered, you should add it to the `api` m
         'bindings',
     ],
 
+#### Authenticate Middleware
+
+The `App\Http\Middleware\Authenticate` middleware has been renamed to `Illuminate\Auth\Middleware\Authenticate`.
+
 ### Notifications
 
 #### Installation


### PR DESCRIPTION
This resolves #3001. [I used Github Compare feature to assert that](https://github.com/laravel/laravel/compare/5.2...5.3#diff-b3af398d5ac2670049a1f17f4683c03eR48).