### PR TITLE
Fix namespace issue

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -325,7 +325,7 @@ You may also use HTTP Basic Authentication without setting a user identifier coo
 
     <?php
 
-    namespace Illuminate\Auth\Middleware;
+    namespace App\Http\Middleware;
 
     use Illuminate\Support\Facades\Auth;
 


### PR DESCRIPTION
This middleware class is created locally with the 'artisan make:middleware' command. Existing namespace yields error: 
`"Cannot declare class Illuminate\Auth\Middleware\AuthenticateOnceWithBasicAuth, because the name is already in use in \app\Http\Middleware\AuthenticateOnceWithBasicAuth.php"`