### PR TITLE
env() - config:cache behaviour clarification

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -72,7 +72,7 @@ To give your application a speed boost, you should cache all of your configurati
 
 You should typically run the `php artisan config:cache` command as part of your production deployment routine. The command should not be run during local development as configuration options will frequently need to be changed during the course of your application's development.
 
-> {note} If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files.
+> {note} If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files, because after that command all `env()` calls will always return null.
 
 <a name="maintenance-mode"></a>
 ## Maintenance Mode

--- a/helpers.md
+++ b/helpers.md
@@ -1273,6 +1273,8 @@ The `env` function retrieves the value of an [environment variable](/docs/{{vers
     // Returns 'production' if APP_ENV is not set...
     $env = env('APP_ENV', 'production');
 
+> {note} After calling `config:cache` command during your deployment process, `env` function will always return null: you must call it only from within your configuration files.
+
 <a name="method-event"></a>
 #### `event()` {#collection-method}
 


### PR DESCRIPTION
[Reference](https://github.com/laravel/framework/issues/21727)

Docs is not exactly clear on which are the consequences of using the `env` helper other than within configuration file when launching `config:cache` command.
`env()` description doesn't even put a notice about this behaviour.

This PR adds some warnings and explanations