### PR TITLE
Use private channel to use whisper methods

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -531,14 +531,14 @@ You may listen for the join event via Echo's `listen` method:
 
 Sometimes you may wish to broadcast an event to other connected clients without hitting your Laravel application at all. This can be particularly useful for things like "typing" notifications, where you want to alert users of your application that another user is typing a message on a given screen. To broadcast client events, you may use Echo's `whisper` method:
 
-    Echo.channel('chat')
+    Echo.private('chat')
         .whisper('typing', {
             name: this.user.name
         });
 
 To listen for client events, you may use the `listenForWhisper` method:
 
-    Echo.channel('chat')
+    Echo.private('chat')
         .listenForWhisper('typing', (e) => {
             console.log(e.name);
         });


### PR DESCRIPTION
I came across this issue when the code in the docs wasn't working for me, I would get this error in the console.

```
Uncaught TypeError: Echo.channel(...).whisper is not a function
```

I saw in tlaverdure/laravel-echo-server#127 that `whisper` can only be used for private channels, so this updates the docs to indicate as such.