### PR TITLE
Require dotenv in order to use environment variables

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -327,7 +327,12 @@ You may pass either a string (proxy) or object (BrowserSync settings) to this me
 <a name="environment-variables"></a>
 ## Environment Variables
 
-You may inject environment variables into Mix by prefixing a key in your `.env` file with `MIX_`:
+To inject environment variables into Mix first require the `dotenv` package (which is installed by Mix) at the top of `webpack.mix.js`:
+
+    let mix = require('laravel-mix');
+    require('dotenv').config();
+
+Then prefix keys in your `.env` file with `MIX_`:
 
     MIX_SENTRY_DSN_PUBLIC=http://example.com
 


### PR DESCRIPTION
In order to use environment variables in `webpack.mix.js` you have to require `dotenv` (ref: <https://github.com/JeffreyWay/laravel-mix/issues/1155>).

Documentation should reflect this (or `webpack.mix.js` that ships w/ Laravel should just include it?)