### PR TITLE
list optional software

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -47,8 +47,9 @@ Homestead runs on any Windows, Mac, or Linux system, and includes the Nginx web 
 - PHP 7.0
 - PHP 5.6
 - Nginx
+- Apache (optional)
 - MySQL
-- MariaDB
+- MariaDB (optional)
 - Sqlite3
 - PostgreSQL
 - Composer
@@ -57,6 +58,7 @@ Homestead runs on any Windows, Mac, or Linux system, and includes the Nginx web 
 - Memcached
 - Beanstalkd
 - Mailhog
+- Elasticsearch (optional)
 - ngrok
 </div>
 

--- a/homestead.md
+++ b/homestead.md
@@ -47,9 +47,9 @@ Homestead runs on any Windows, Mac, or Linux system, and includes the Nginx web 
 - PHP 7.0
 - PHP 5.6
 - Nginx
-- Apache (optional)
+- Apache (Optional)
 - MySQL
-- MariaDB (optional)
+- MariaDB (Optional)
 - Sqlite3
 - PostgreSQL
 - Composer
@@ -58,7 +58,7 @@ Homestead runs on any Windows, Mac, or Linux system, and includes the Nginx web 
 - Memcached
 - Beanstalkd
 - Mailhog
-- Elasticsearch (optional)
+- Elasticsearch (Optional)
 - ngrok
 </div>
 


### PR DESCRIPTION
apache is not installed by default, only if the user designates one of their sites as "apache".

mariadb is optional, and must be specified in the `Homestead.yaml` file

elasticsearch is optional, and must be specified in the `Homestead.yaml` file