### PR TITLE
add docs about homestead webservers

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -424,7 +424,7 @@ In addition, you may use any of the supported PHP versions via the CLI:
 <a name="web-servers"></a>
 ### Web Servers
 
-By default Homestead uses the Nginx web server, but can also install Apache if required. While both web servers can *exist* in Homestead at the same time, both cannot be *running* at the same time. The process to turn one off and then turn the other on is a little cumbersome, so the `flip` command is provided to make this process easier. `flip` will automatically determine which web server is running, shut it off, and then turn the other on. This makes Homestead a powerful virtual machine that can run all of your projects, no matter which web server they may require.
+By default Homestead uses the Nginx web server, but can also install Apache if specified as a site type. While both web servers can *exist* in Homestead at the same time, both cannot be *running* at the same time. The process to turn one off and then turn the other on is a little cumbersome, so the `flip` command is provided to make this process easier. `flip` will automatically determine which web server is running, shut it off, and then turn the other on. This makes Homestead a powerful virtual machine that can run all of your projects, no matter which web server they may require.
 
 <a name="network-interfaces"></a>
 ## Network Interfaces

--- a/homestead.md
+++ b/homestead.md
@@ -424,7 +424,11 @@ In addition, you may use any of the supported PHP versions via the CLI:
 <a name="web-servers"></a>
 ### Web Servers
 
-By default Homestead uses the Nginx web server, but can also install Apache if specified as a site type. While both web servers can *exist* in Homestead at the same time, both cannot be *running* at the same time. The process to turn one off and then turn the other on is a little cumbersome, so the `flip` command is provided to make this process easier. `flip` will automatically determine which web server is running, shut it off, and then turn the other on. This makes Homestead a powerful virtual machine that can run all of your projects, no matter which web server they may require.
+By default Homestead uses the Nginx web server, but can also install Apache if specified as a site type. While both web servers can *exist* in Homestead at the same time, both cannot be *running* at the same time. The process to turn one off and then turn the other on is cumbersome, so the `flip` command is provided to make this process easier. `flip` will automatically determine which web server is running, shut it off, and then turn the other on. This makes Homestead a powerful virtual machine that can run all of your projects, no matter which web server they may require. To use this command, SSH into your Homestead machine and run it on the command line.
+
+```sh
+flip
+```
 
 <a name="network-interfaces"></a>
 ## Network Interfaces

--- a/homestead.md
+++ b/homestead.md
@@ -20,6 +20,7 @@
     - [Ports](#ports)
     - [Sharing Your Environment](#sharing-your-environment)
     - [Multiple PHP Versions](#multiple-php-versions)
+    - [Web Servers](#web-servers)
 - [Network Interfaces](#network-interfaces)
 - [Updating Homestead](#updating-homestead)
 - [Provider Specific Settings](#provider-specific-settings)
@@ -419,6 +420,11 @@ In addition, you may use any of the supported PHP versions via the CLI:
     php7.0 artisan list
     php7.1 artisan list
     php7.2 artisan list
+    
+<a name="web-servers"></a>
+### Web Servers
+
+By default Homestead uses the Nginx web server, but can also install Apache if required. While both web servers can *exist* in Homestead at the same time, both cannot be *running* at the same time. The process to turn one off and then turn the other on is a little cumbersome, so the `flip` command is provided to make this process easier. `flip` will automatically determine which web server is running, shut it off, and then turn the other on. This makes Homestead a powerful virtual machine that can run all of your projects, no matter which web server they may require.
 
 <a name="network-interfaces"></a>
 ## Network Interfaces


### PR DESCRIPTION
some users have been noting recently that we don't document the ability to run both Nginx **and** Apache very well.

hopefully this makes things a little clearer, and documents the previously undocumented `flip` command.