### PR TITLE
Replaced `providers` with `provides` in `optimize` section

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -41,7 +41,7 @@ Passing `null` to the `Arr::wrap` method will now return an empty array.
 
 #### The `optimize` Command
 
-The previously deprecated `optimize` Artisan command has been removed. With recent improvements to PHP itself including the OPcache, the `optimize` command no longer providers any relevant performance benefit.
+The previously deprecated `optimize` Artisan command has been removed. With recent improvements to PHP itself including the OPcache, the `optimize` command no longer provides any relevant performance benefit.
 
 ### Blade
 


### PR DESCRIPTION
### Original version:
> the `optimize` command no longer providers any relevant performance benefit.

### Fixed version:
> the `optimize` command no longer provides any relevant performance benefit.
---
`providers` seems to be a typo, I guess it should be `provides`.