### PR TITLE
Update Requirements for Laravel 5.5 to PHP 7.1.3 (from 7.0.0)

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -20,7 +20,7 @@ The Laravel framework has a few system requirements. Of course, all of these req
 However, if you are not using Homestead, you will need to make sure your server meets the following requirements:
 
 <div class="content-list" markdown="1">
-- PHP >= 7.0.0
+- PHP >= 7.1.3
 - OpenSSL PHP Extension
 - PDO PHP Extension
 - Mbstring PHP Extension


### PR DESCRIPTION
From my experience, Laravel 5.5 requires a minimum of PHP 7.1.3 as `doctrine/instantiator` requires PHP 7.1, and `symfony/event-dispatcher` and `symfony/css-selector` require 7.1.3. Therefore, I'm submitting this PR to be reviewed. It's also possible that I'm doing something wrong which is causing this error to appear?

When I try to run `composer install` on a relatively vanilla Laravel 5.5 install, I get the following errors:

```
  Problem 1
    - Installation request for doctrine/inflector v1.3.0 -> satisfiable by doctrine/inflector[v1.3.0].
    - doctrine/inflector v1.3.0 requires php ^7.1 -> your PHP version (7.0.22) does not satisfy that requirement.
  Problem 2
    - Installation request for symfony/css-selector v4.0.3 -> satisfiable by symfony/css-selector[v4.0.3].
    - symfony/css-selector v4.0.3 requires php ^7.1.3 -> your PHP version (7.0.22) does not satisfy that requirement.
  Problem 3
    - Installation request for symfony/event-dispatcher v4.0.3 -> satisfiable by symfony/event-dispatcher[v4.0.3].
    - symfony/event-dispatcher v4.0.3 requires php ^7.1.3 -> your PHP version (7.0.22) does not satisfy that requirement.
  Problem 4
    - Installation request for doctrine/instantiator 1.1.0 -> satisfiable by doctrine/instantiator[1.1.0].
    - doctrine/instantiator 1.1.0 requires php ^7.1 -> your PHP version (7.0.22) does not satisfy that requirement.
  Problem 5
    - doctrine/inflector v1.3.0 requires php ^7.1 -> your PHP version (7.0.22) does not satisfy that requirement.
    - laravel/framework v5.5.31 requires doctrine/inflector ~1.1 -> satisfiable by doctrine/inflector[v1.3.0].
    - Installation request for laravel/framework v5.5.31 -> satisfiable by laravel/framework[v5.5.31].
```