### PR TITLE
Include run-time modification of $appends

### DIFF
--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -145,6 +145,14 @@ After creating the accessor, add the attribute name to the `appends` property on
         protected $appends = ['is_admin'];
     }
 
+or add properties at run-time:
+
+    $user->append("is_admin")->toArray();
+    
+or override the whole list:
+
+    $user->setAppends(["is_admin"]);
+
 Once the attribute has been added to the `appends` list, it will be included in both the model's array and JSON representations. Attributes in the `appends` array will also respect the `visible` and `hidden` settings configured on the model.
 
 <a name="date-serialization"></a>


### PR DESCRIPTION
It's not obvious from the current documentation that you can alter the `$appends` list at run time on a single instance without having to include them in the model class.  This just adds a couple of examples of how to do it.