### PR TITLE
Add essential notes about Hyper-V

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -485,3 +485,31 @@ If symbolic are not working properly on your Windows machine, you may need to ad
     config.vm.provider "virtualbox" do |v|
         v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     end
+
+<a name="provider-specific-hyperv"></a>
+### Hyper-V
+
+#### Networking
+Take note that all of the network setup will be determined by the virtual switch you choose for the VM. 
+You will have the smoothest experience if your physical network adapter uses a typical ethernet connection and you choose the Default Virtual Switch, but a virtual switch on an external or internal network can also work with the right settings.
+Once everything is setup, you should be able to access the VM on the IP that was created for it.
+
+#### SMB Shares
+Homestead should choose SMB synced folders by default when using Hyper-V, but if you encounter trouble during mounting, these options might help:
+
+     options:
+            mount_options: ['vers=2.1', 'mfsymlinks']
+            
+The VM might have trouble mounting the folders unless a compatible SMB version is used. The `mfsymlinks` is to help make sure symbolic links work as expected.
+You can also decrease the amount of prompts if you run `vagrant up` in a command line window with admin privileges as well as add `smb_username` and `smb_password` settings.
+
+Also, if you have just one synced folder, map it to `/vagrant` to prevent an additional mapping to this path which could result in an error if `mount` has trouble adding additional folders.
+
+#### Useful Settings
+You may find some of the [Hyper-V specific settings](https://www.vagrantup.com/docs/hyperv/configuration.html) to be of use. For example, the VM name, CPUs and memory will need to be set inside the Vagrant file:
+
+    config.vm.provider "hyperv" do |h|
+       h.vmname = "My VM"
+       h.cpus = 2
+       h.memory = 2048
+    end


### PR DESCRIPTION
I think it would be to the documentation's great benefit to add a few more provider specific notes about Hyper-V. There are a handful of tips that are not very obvious to someone who just wants to get it up and running and I feel it is incumbent upon us to add only a little crucial information.

I wholly invite and greatly encourage help in paring this down or otherwise refining these recommendations.

Things would have gone much better for me initially if I had a more typical kind of network connection. I had a wifi adapter with a bridged network connection so things were working a little differently. Here are some of the resources I found that helped guide me towards a setup that finally worked:

- [Vagrant + Hyper-V (Windows 10 anniversary)](https://quotidian-ennui.github.io/blog/2016/08/17/vagrant-windows10-hyperv/)
- [Learning to Use Vagrant on Windows 10](https://blogs.technet.microsoft.com/virtualization/2017/07/06/vagrant-and-hyper-v-tips-and-tricks/)
- [Vagrant Hyper-V Configuration](https://www.vagrantup.com/docs/hyperv/configuration.html)

Thank you for your consideration.