### PR TITLE
Add information on generating a private key

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -178,6 +178,8 @@ Once you have edited the `Homestead.yaml` to your liking, run the `vagrant up` c
 
 To destroy the machine, you may use the `vagrant destroy --force` command.
 
+> {note} If you get a message that says "Check your Homestead.yaml file, the path to your private key does not exist." when you run the `vagrant up` command, you need to generate a key. Run `ssh-keygen -t rsa -b 4096 -C "your_email@example.com"` and hit enter three times.
+
 <a name="per-project-installation"></a>
 ### Per Project Installation
 


### PR DESCRIPTION
Every time I've tried to install Homestead, I get the mentioned error the first time I try to run `vagrant up`. I then have to spend extra time trying to figure out how to create/add a private key. I'm not sure if they way I added the information is the best way and I'm sure it could use some polishing, but I think the information could help others like me not get confused.