### PR TITLE
Add event fake documentation for times dispatched

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -79,6 +79,10 @@ As an alternative to mocking, you may use the `Event` facade's `fake` method to 
                 return $e->order->id === $order->id;
             });
 
+            // Assert an event was dispatched twice...
+            Event::assertDispatched(OrderShipped::class, 2);
+
+            // Assert an event was not dispatched...
             Event::assertNotDispatched(OrderFailedToShip::class);
         }
     }


### PR DESCRIPTION
Since Laravel version 5.5.28 you are able to assert how many times the event was dispatched. It's worth having it in a documentation.

As it is not available before 5.5.28, decided to put it in version 5.6.