### PR TITLE
Specify version for 5.5 installation.

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -54,7 +54,7 @@ Once installed, the `laravel new` command will create a fresh Laravel installati
 
 Alternatively, you may also install Laravel by issuing the Composer `create-project` command in your terminal:
 
-    composer create-project --prefer-dist laravel/laravel blog
+    composer create-project --prefer-dist laravel/laravel blog "5.5.*"
 
 #### Local Development Server
 


### PR DESCRIPTION
Since 5.6 is out now, 5.5 needs to be specified when creating a Laravel 5.5 project via Composer.