### PR TITLE
[5.6] remove part year in cron method

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -95,7 +95,7 @@ Of course, there are a variety of schedules you may assign to your task:
 
 Method  | Description
 ------------- | -------------
-`->cron('* * * * * *');`  |  Run the task on a custom Cron schedule
+`->cron('* * * * *');`  |  Run the task on a custom Cron schedule
 `->everyMinute();`  |  Run the task every minute
 `->everyFiveMinutes();`  |  Run the task every five minutes
 `->everyTenMinutes();`  |  Run the task every ten minutes


### PR DESCRIPTION
With the upgrade from component mtdowling/cron-expression to dragonmantank/cron-expression the part year of the Cron was obsolete.