### PR TITLE
Remove "php artisan optimize" from composer.json

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -45,9 +45,7 @@ Passing `null` to the `Arr::wrap` method will now return an empty array.
 
 #### The `optimize` Command
 
-The previously deprecated `optimize` Artisan command has been removed. With recent improvements to PHP itself including the OPcache, the `optimize` command no longer provides any relevant performance benefit.
-
-You should remove `php artisan optimize` from your `composer.json` scripts.
+The previously deprecated `optimize` Artisan command has been removed. With recent improvements to PHP itself including the OPcache, the `optimize` command no longer provides any relevant performance benefit. Therefore, you may remove `php artisan optimize` from the `scripts` within your `composer.json` file.
 
 ### Blade
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -47,6 +47,8 @@ Passing `null` to the `Arr::wrap` method will now return an empty array.
 
 The previously deprecated `optimize` Artisan command has been removed. With recent improvements to PHP itself including the OPcache, the `optimize` command no longer provides any relevant performance benefit.
 
+You should remove `php artisan optimize` from your `composer.json` scripts.
+
 ### Blade
 
 #### HTML Entity Encoding


### PR DESCRIPTION
Small reminder to remove the optimize command from composer scripts (post-install-cmd & post-update-cmd).