### PR TITLE
Update upgrade guide on TrustedProxies

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -194,6 +194,8 @@ The `$headers` property, which was previously an array, is now a bit property th
 
 For more information on the available `$headers` values, check out the full documentation on [trusting proxies](/docs/5.6/requests#configuring-trusted-proxies).
 
+You also need to remove `config/trustedproxy.php` file.
+
 ### Validation
 
 #### The `ValidatesWhenResolved` Interface


### PR DESCRIPTION
You need to remove `config/trustedproxy.php` in order to fix the issue on `Undefined class constant 'HEADER_CLIENT_IP'`.

Reference: [Stackoverflow](https://stackoverflow.com/a/48595052/4248425)

<img width="1634" alt="screen shot 2018-02-09 at 5 37 25 am" src="https://user-images.githubusercontent.com/10341422/35999607-58753d98-0d5b-11e8-8dcb-8aff3f1916ea.png">

This is due to upgrade from Symfony 3 to Symfony 4.
