### PR TITLE
Add note about specifying an index name

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -801,7 +801,7 @@ The `str_before` function returns everything before the given value in a string:
 <a name="method-str-contains"></a>
 #### `str_contains()` {#collection-method}
 
-The `str_contains` function determines if the given string contains the given value:
+The `str_contains` function determines if the given string contains the given value (case sensitive):
 
     $contains = str_contains('This is my name', 'my');
 
@@ -812,7 +812,6 @@ You may also pass an array of values to determine if the given string contains a
     $contains = str_contains('This is my name', ['my', 'foo']);
 
     // true
-This method is case sensitive.
 
 <a name="method-str-finish"></a>
 #### `str_finish()` {#collection-method}

--- a/helpers.md
+++ b/helpers.md
@@ -812,6 +812,7 @@ You may also pass an array of values to determine if the given string contains a
     $contains = str_contains('This is my name', ['my', 'foo']);
 
     // true
+This method is case sensitive.
 
 <a name="method-str-finish"></a>
 #### `str_finish()` {#collection-method}

--- a/migrations.md
+++ b/migrations.md
@@ -381,6 +381,8 @@ Laravel will automatically generate a reasonable index name, but you may pass a 
 
 #### Available Index Types
 
+Each index method accepts an optional second argument to specify the name of the index. If omitted, the name will be derived from the names of the table and column(s).
+
 Command  |  Description
 -------  |  -----------
 `$table->primary('id');`  |  Adds a primary key.


### PR DESCRIPTION
It wasn't clear that you can specify a name when creating an index.  This is important for migrations, so you can use the same name when dropping it in the `down()` method.