### PR TITLE
[5.6] Inclue cache config warning for deployment

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -77,6 +77,8 @@ When deploying your application to production, you should make sure that you run
 
 This command will combine all of Laravel's configuration files into a single, cached file, which greatly reduces the number of trips the framework must make to the filesystem when loading your configuration values.
 
+> {note} If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded and all calls to the `env` function will return `null`.
+
 <a name="optimizing-route-loading"></a>
 ### Optimizing Route Loading
 


### PR DESCRIPTION
Add a warning about using `env()` during `cache:config` for the deployment section.

This is already mentioned in the configuration page, but it could/is easily missed by people who only read the deployment section.