### PR TITLE
[5.6] Update required PHP extensions

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -26,6 +26,8 @@ However, if you are not using Homestead, you will need to make sure your server 
 - Mbstring PHP Extension
 - Tokenizer PHP Extension
 - XML PHP Extension
+- Ctype PHP Extension
+- JSON PHP Extension
 </div>
 
 <a name="installing-laravel"></a>


### PR DESCRIPTION
Closes https://github.com/laravel/docs/issues/3982

I checked, and these extensions are not included in some default PHP builds (such as FreeBSD etc)