### PR TITLE
[5.6] Update lifecycle.md

### DIFF
--- a/lifecycle.md
+++ b/lifecycle.md
@@ -2,6 +2,8 @@
 
 - [Introduction](#introduction)
 - [Lifecycle Overview](#lifecycle-overview)
+    - [HTTP Lifecycle](#http-lifecycle)
+    - [Console Lifecycle](#console-lifecycle)
 - [Focus On Service Providers](#focus-on-service-providers)
 
 <a name="introduction"></a>
@@ -14,21 +16,35 @@ The goal of this document is to give you a good, high-level overview of how the 
 <a name="lifecycle-overview"></a>
 ## Lifecycle Overview
 
-### First Things
+There are two entry points to your application. `http` which come via your web server, and `console` which come via the `artisan` command.
 
-The entry point for all requests to a Laravel application is the `public/index.php` file. All requests are directed to this file by your web server (Apache / Nginx) configuration. The `index.php` file doesn't contain much code. Rather, it is a starting point for loading the rest of the framework.
+<a name="http-lifecycle"></a>
+### HTTP Lifecycle
+
+The entry point for all HTTP requests to a Laravel application is the `public/index.php` file. HTTP requests are directed to this file by your web server (Apache / Nginx) configuration. The `index.php` file doesn't contain much code. Rather, it is a starting point for loading the rest of the framework.
 
 The `index.php` file loads the Composer generated autoloader definition, and then retrieves an instance of the Laravel application from `bootstrap/app.php` script. The first action taken by Laravel itself is to create an instance of the application / [service container](/docs/{{version}}/container).
 
-### HTTP / Console Kernels
-
-Next, the incoming request is sent to either the HTTP kernel or the console kernel, depending on the type of request that is entering the application. These two kernels serve as the central location that all requests flow through. For now, let's just focus on the HTTP kernel, which is located in `app/Http/Kernel.php`.
+Next, the incoming request is sent to the HTTP kernel located at `app/Http/Kernel.php`.
 
 The HTTP kernel extends the `Illuminate\Foundation\Http\Kernel` class, which defines an array of `bootstrappers` that will be run before the request is executed. These bootstrappers configure error handling, configure logging, [detect the application environment](/docs/{{version}}/configuration#environment-configuration), and perform other tasks that need to be done before the request is actually handled.
 
 The HTTP kernel also defines a list of HTTP [middleware](/docs/{{version}}/middleware) that all requests must pass through before being handled by the application. These middleware handle reading and writing the [HTTP session](/docs/{{version}}/session), determining if the application is in maintenance mode, [verifying the CSRF token](/docs/{{version}}/csrf), and more.
 
 The method signature for the HTTP kernel's `handle` method is quite simple: receive a `Request` and return a `Response`. Think of the Kernel as being a big black box that represents your entire application. Feed it HTTP requests and it will return HTTP responses.
+
+<a name="console-lifecycle"></a>
+### Console Lifecylce
+
+Every time you run `php artisan` you are starting a console request to the Laravel application.
+
+The `artisan` file loads the Composer generated autoloader definition, and then retrieves an instance of the Laravel application from `bootstrap/app.php` script. The first action taken by Laravel itself is to create an instance of the application / [service container](/docs/{{version}}/container).
+
+Next, the incoming request is sent to the Console kernel located at `app/Console/Kernel.php`.
+
+The Console kernel extends the `Illuminate\Foundation\Console\Kernel` class, which defines an array of `bootstrappers` that will be run before the request is executed. These bootstrappers configure error handling, configure logging, [detect the application environment](/docs/{{version}}/configuration#environment-configuration), and perform other tasks that need to be done before the request is actually handled.
+
+Artian will then attempt to match your request to a [registered command](/docs/{{version}}/artisan), and `run()` that command.
 
 #### Service Providers
 


### PR DESCRIPTION
The lifecycle documentation can be a little confusing. It currently says

> The entry point for all requests to a Laravel application is the `public/index.php` file

but we know this is not true for console requests. This is a first pass to clarify the two entry points to any Laravel application.

Closes https://github.com/laravel/docs/issues/3841