### PR TITLE
[5.6] Requirement for Braintree and InvoiceFor

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -585,6 +585,13 @@ The invoice will be charged immediately against the user's credit card. The `inv
         'custom-option' => $value,
     ]);
 
+If you are using Braintree you *must* include a `description` field for the Braintree API:
+
+    $user->invoiceFor('One Time Fee', 500, [
+        'description' => 'your invoice description here',
+    ]);
+
+
 > {note} The `invoiceFor` method will create a Stripe invoice which will retry failed billing attempts. If you do not want invoices to retry failed charges, you will need to close them using the Stripe API after the first failed charge.
 
 <a name="invoices"></a>

--- a/billing.md
+++ b/billing.md
@@ -585,7 +585,7 @@ The invoice will be charged immediately against the user's credit card. The `inv
         'custom-option' => $value,
     ]);
 
-If you are using Braintree you *must* include a `description` field for the Braintree API:
+If you are using Braintree as your billing provider, you must include a `description` option when calling the `invoiceFor` method:
 
     $user->invoiceFor('One Time Fee', 500, [
         'description' => 'your invoice description here',


### PR DESCRIPTION
Document requirement for inclusion of `description` when using Braintree and `InvoiceFor()`

Closes https://github.com/laravel/docs/issues/3709