### PR TITLE
[5.6] Clarify custom Cashier webhook controller route declaration

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -468,6 +468,13 @@ Cashier automatically handles subscription cancellation on failed charges, but i
         }
     }
 
+You also need to update your route file to point to your new Cashier controller:
+
+    Route::post(
+        'stripe/webhook',
+        '\App\Http\Controllers\WebhookController@handleWebhook'
+    );
+
 <a name="handling-failed-subscriptions"></a>
 ### Failed Subscriptions
 

--- a/billing.md
+++ b/billing.md
@@ -468,7 +468,7 @@ Cashier automatically handles subscription cancellation on failed charges, but i
         }
     }
 
-You should also update your `routes/web.php` file with a route to your new Cashier controller:
+Next, define a route to your Cashier controller within your `routes/web.php` file:
 
     Route::post(
         'stripe/webhook',

--- a/billing.md
+++ b/billing.md
@@ -468,7 +468,7 @@ Cashier automatically handles subscription cancellation on failed charges, but i
         }
     }
 
-You also need to update your route file to point to your new Cashier controller:
+You should also update your `routes/web.php` file with a route to your new Cashier controller:
 
     Route::post(
         'stripe/webhook',


### PR DESCRIPTION
Clarify the requirement to switch the router to point to your custom Cashier controller rather than the package one.

Closes https://github.com/laravel/docs/issues/3387