### PR TITLE
[5.6] Add warning about timezones and daylight saving

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -9,6 +9,7 @@
     - [Preventing Task Overlaps](#preventing-task-overlaps)
     - [Running Tasks On One Server](#running-tasks-on-one-server)
     - [Maintenance Mode](#maintenance-mode)
+    - [Timezones](#timezones)
 - [Task Output](#task-output)
 - [Task Hooks](#task-hooks)
 
@@ -205,6 +206,17 @@ To indicate that the task should run on only one server, use the `onOneServer` m
 Laravel's scheduled tasks will not run when Laravel is in [maintenance mode](/docs/{{version}}/configuration#maintenance-mode), since we don't want your tasks to interfere with any unfinished maintenance you may be performing on your server. However, if you would like to force a task to run even in maintenance mode, you may use the `evenInMaintenanceMode` method:
 
     $schedule->command('emails:send')->evenInMaintenanceMode();
+
+<a name="timezones"></a>
+### Timezones
+
+You have the ability to set the scheduled task to run at a specific time in a given timezone.
+
+    $schedule->command('report:generate')
+             ->timezone('America/New_York')
+             ->at('02:00')
+    
+> {note} Care needs to be taken when using scheduled tasks and timezones which have daylight savings. When the daylight saving changes occur, your scheduled command might run twice, or not at all. It is recommended to avoid timezone scheduling whenever possible, or to consider what effects a daylight saving change will have on your scheduled command.
 
 <a name="task-output"></a>
 ## Task Output


### PR DESCRIPTION
Add a warning about using timezones and scheduled commands.

This is not unique to Laravel - it is really a fundamental flaw of cron itself. The `cron-expression` library gets "issues" all the time about commands skipping or running twice during daylight saving changes - but the issue is a fundamental one about intention, so the best option is just use UTC.

Closes https://github.com/laravel/docs/issues/3198