### PR TITLE
Update dusk.md

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -365,6 +365,8 @@ The `attach` method may be used to attach a file to a `file` input element. Like
 
     $browser->attach('photo', __DIR__.'/photos/me.png');
 
+> {note} The attach function requires the `ZIP PHP Extension` to be enabled on your server.
+
 <a name="using-the-keyboard"></a>
 ### Using The Keyboard
 


### PR DESCRIPTION
The dusk attach function requires the `ZIP PHP Extension`.

The other option was to be put in the server requirements section - and mention it is just for dusk - but I think that might be confusing?

Closes the last comment here https://github.com/laravel/docs/issues/2397 (ignore the rest of the issue ticket - that is wrong).