### PR TITLE
Fix Passport token expiry

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -164,7 +164,7 @@ When deploying Passport to your production servers for the first time, you will 
 <a name="token-lifetimes"></a>
 ### Token Lifetimes
 
-By default, Passport issues long-lived access tokens that never need to be refreshed. If you would like to configure a shorter token lifetime, you may use the `tokensExpireIn` and `refreshTokensExpireIn` methods. These methods should be called from the `boot` method of your `AuthServiceProvider`:
+By default, Passport issues long-lived access tokens that expire after 1 year. If you would like to configure a shorter token lifetime, you may use the `tokensExpireIn` and `refreshTokensExpireIn` methods. These methods should be called from the `boot` method of your `AuthServiceProvider`:
 
     /**
      * Register any authentication / authorization services.


### PR DESCRIPTION
Passport tokens no longer last forever. They expire after 1 year.

I found the PR where this change was made (although it doesnt say why): https://github.com/laravel/passport/commit/5a69318d810b4c99373d163b220c9808ad868261

Closes https://github.com/laravel/docs/issues/3049