### PR TITLE
Fix release notes on Blade component aliases

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -144,13 +144,13 @@ If your Blade components are stored in a sub-directory, you may now alias them f
 
     Blade::component('components.alert', 'alert');
 
-Once the component has been aliased, you may render it using its alias:
+Once the component has been aliased, you may render it using a directive:
 
-    @component('alert')
+    @alert('alert', ['type' => 'danger'])
         You are not allowed to access this resource!
-    @endcomponent
+    @endalert
 
-Or, if the component has no additional slots, you may use the component's name as a Blade directive:
+You may omit the parameters of the component has no additional slots:
 
     @alert
         You are not allowed to access this resource!


### PR DESCRIPTION
The code in the current example isn't implemented. Updated the example to match the PR.

See https://github.com/laravel/framework/pull/23096