### PR TITLE
[5.3] Fix upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -129,7 +129,7 @@ In prior versions of Laravel, when registering custom Blade directives using the
 
 Laravel 5.3 includes significant improvements to [event broadcasting](/docs/{{version}}/broadcasting). You should add the new `BroadcastServiceProvider` to your `app/Providers` directory by [grabbing a fresh copy of the source from GitHub](https://raw.githubusercontent.com/laravel/laravel/5.3/app/Providers/BroadcastServiceProvider.php). Once you have defined the new service provider, you should add it to the `providers` array of your `config/app.php` configuration file.
 
-Then add the new `broadcasting.php` to your `app/config` directory by [grabbing a fresh copy of the source from GitHub](https://raw.githubusercontent.com/laravel/laravel/5.3/config/broadcasting.php)
+Next, add the new `broadcasting.php` configuration file to your `app/config` directory by [grabbing a fresh copy of the source from GitHub](https://raw.githubusercontent.com/laravel/laravel/5.3/config/broadcasting.php).
 
 ### Cache
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -129,6 +129,8 @@ In prior versions of Laravel, when registering custom Blade directives using the
 
 Laravel 5.3 includes significant improvements to [event broadcasting](/docs/{{version}}/broadcasting). You should add the new `BroadcastServiceProvider` to your `app/Providers` directory by [grabbing a fresh copy of the source from GitHub](https://raw.githubusercontent.com/laravel/laravel/5.3/app/Providers/BroadcastServiceProvider.php). Once you have defined the new service provider, you should add it to the `providers` array of your `config/app.php` configuration file.
 
+Then add the new `broadcasting.php` to your `app/config` directory by [grabbing a fresh copy of the source from GitHub](https://raw.githubusercontent.com/laravel/laravel/5.3/config/broadcasting.php)
+
 ### Cache
 
 #### Extension Closure Binding & `$this`


### PR DESCRIPTION
I know this upgrade guide is quite old now - but there are at least two open issues relating to an error in the guide.

This PR tells people to pull in the config file for broadcasting, which is now set to `"null"` - so should prevent any issues after upgrading.

Solves https://github.com/laravel/docs/issues/2583 and https://github.com/laravel/docs/issues/2586