### PR TITLE
Add tip for where to place Horizon auth

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -51,6 +51,8 @@ Horizon exposes a dashboard at `/horizon`. By default, you will only be able to 
     Horizon::auth(function ($request) {
         // return true / false;
     });
+    
+> {tip} You can place the dashboard authentication in a location that fits your project best. One common option is to place it in the `boot()` section of your `App\Providers\AppServiceProvider` file.
 
 <a name="running-horizon"></a>
 ## Running Horizon


### PR DESCRIPTION
The open issue here https://github.com/laravel/docs/issues/3590 is a request on suggesting where to place the Horizon auth example.

I appreciate you probably left it vague to encourage people to place it where it is most suitable for their application - but the open issue has 20x +1's - which is _by far_ the most of any issue on the docs page ever, so it is clearly something that people want guidence on.

I've included a tip as a starting point...