### PR TITLE
[5.4] Change upgrade guide to mention makeWith

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -133,6 +133,8 @@ Binding classes into the container with leading slashes is no longer supported. 
 
 The container's `make` method no longer accepts a second array of parameters. This feature typically indicates a code smell. Typically, you can always construct the object in another way that is more intuitive.
 
+If must continue to pass an array of parameters - you can switch to `makeWith()`.
+
 #### Resolving Callbacks
 
 The container's `resolving` and `afterResolving` method now must be provided a class name or binding key as the first argument to the method:

--- a/upgrade.md
+++ b/upgrade.md
@@ -133,7 +133,7 @@ Binding classes into the container with leading slashes is no longer supported. 
 
 The container's `make` method no longer accepts a second array of parameters. This feature typically indicates a code smell. Typically, you can always construct the object in another way that is more intuitive.
 
-If must continue to pass an array of parameters - you can switch to `makeWith()`.
+If must continue to pass an array of parameters, you may use the `makeWith` method.
 
 #### Resolving Callbacks
 


### PR DESCRIPTION
The current 5.3 -> 5.4 upgrade guide talks about the changes to `make()`.

There was `makeWith()` introduced in `5.4.16` - so we can include that as a pathway during the upgrades now.

Solves https://github.com/laravel/docs/issues/3250