### PR TITLE
Include undocumented faker locale config option

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -92,6 +92,8 @@ Within the Closure, which serves as the factory definition, you may return the d
 
 You may also create additional factory files for each model for better organization. For example, you could create `UserFactory.php` and `CommentFactory.php` files within your `database/factories` directory. All of the files within the `factories` directory will automatically be loaded by Laravel.
 
+> {tip} You can set a Faker locale by adding `'faker_locale' => 'en_US',` to your `config/app.php` file.
+
 <a name="factory-states"></a>
 ### Factory States
 


### PR DESCRIPTION
This includes a tip for the undocumented faker locale config option.

There was a PR to include it in the default `laravel/laravel` here: https://github.com/laravel/laravel/pull/4161, but you closed it and suggested to just document it instead.

Solves https://github.com/laravel/docs/issues/3172