### PR TITLE
Add note about specifying an index name

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -349,6 +349,8 @@ You may drop multiple columns from a table by passing an array of column names t
 
 #### Available Command Aliases
 
+Each index method accepts an optional second argument to specify the name of the index. If omitted, the name will be derived from the names of the table and column(s).
+
 Command  |  Description
 -------  |  -----------
 `$table->dropRememberToken();`  |  Drop the `remember_token` column.


### PR DESCRIPTION
It wasn't clear that you can specify a name when creating an index. This is important for migrations, so you can use the same name when dropping it in the down() method. (Originally #4044)