### PR TITLE
Update testing.md

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -18,6 +18,8 @@ An `ExampleTest.php` file is provided in both the `Feature` and `Unit` test dire
 
 When running tests via `phpunit`, Laravel will automatically set the configuration environment to `testing` because of the environment variables defined in the `phpunit.xml` file. Laravel also automatically configures the session and cache to the `array` driver while testing, meaning no session or cache data will be persisted while testing.
 
+You may also create a `.env.testing` file. This file will override the `.env` file when running PHPUnit tests or executing Artisan commands with the `--env=testing` option.
+
 You are free to define other testing environment configuration values as necessary. The `testing` environment variables may be configured in the `phpunit.xml` file, but make sure to clear your configuration cache using the `config:clear` Artisan command before running your tests!
 
 <a name="creating-and-running-tests"></a>


### PR DESCRIPTION
The use of `.env.testing` is mention in the config section of the docs, but not in the testing section itself.

So just duplicating this paragraph to where people might also need it when looking for testing information.