### PR TITLE
Csrf disabled in tests

### DIFF
--- a/csrf.md
+++ b/csrf.md
@@ -51,6 +51,8 @@ Typically, you should place these kinds of routes outside of the `web` middlewar
             'http://example.com/foo/*',
         ];
     }
+    
+> {tip} When running tests the CSRF Middleware is disabled.
 
 <a name="csrf-x-csrf-token"></a>
 ## X-CSRF-TOKEN

--- a/http-tests.md
+++ b/http-tests.md
@@ -67,6 +67,8 @@ You may use the `withHeaders` method to customize the request's headers before i
         }
     }
 
+> {tip} When running tests the CSRF Middleware is disabled.
+
 <a name="session-and-authentication"></a>
 ## Session / Authentication
 


### PR DESCRIPTION
I know you dont want too many tips/notes - but I'm not sure it warrents a full paragraph to explain it?

But the fact that CSRF protection is disabled in unit tests is not mentioned anywhere in the docs, so we probably should document it in both the "csrf" and "testing" sections.