### PR TITLE
Rename HipChat link to Stride

### DIFF
--- a/envoy.md
+++ b/envoy.md
@@ -159,7 +159,6 @@ If you would like to be prompted for confirmation before running a given task on
     @endtask
 
 <a name="notifications"></a>
-<a name="hipchat-notifications"></a>
 ## Notifications
 
 <a name="slack"></a>
@@ -177,4 +176,3 @@ You may provide one of the following as the channel argument:
 - To send the notification to a channel: `#channel`
 - To send the notification to a user: `@user`
 </div>
-

--- a/queues.md
+++ b/queues.md
@@ -601,7 +601,7 @@ You may define a `failed` method directly on your job class, allowing you to per
 <a name="failed-job-events"></a>
 ### Failed Job Events
 
-If you would like to register an event that will be called when a job fails, you may use the `Queue::failing` method. This event is a great opportunity to notify your team via email or [HipChat](https://www.hipchat.com). For example, we may attach a callback to this event from the `AppServiceProvider` that is included with Laravel:
+If you would like to register an event that will be called when a job fails, you may use the `Queue::failing` method. This event is a great opportunity to notify your team via email or [Stride](https://www.stride.com). For example, we may attach a callback to this event from the `AppServiceProvider` that is included with Laravel:
 
     <?php
 


### PR DESCRIPTION
Before the PR, when clicking on HipChat (https://www.hipchat.com) in https://laravel.com/docs/5.6/queues#failed-job-events, we got redirected to https://www.stride.com, so the PR is here to rename the link and use Stride URL directly.
(another commit has been added afterwards to remove an unused HipChat anchor link in envoy documentation, here it is : https://laravel.com/docs/5.6/envoy#hipchat-notifications)