### PR TITLE
Fix confusing queue example

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -124,7 +124,6 @@ Job classes are very simple, normally containing only a `handle` method which is
     namespace App\Jobs;
 
     use App\Podcast;
-    use App\AudioProcessor;
     use Illuminate\Bus\Queueable;
     use Illuminate\Queue\SerializesModels;
     use Illuminate\Queue\InteractsWithQueue;
@@ -151,10 +150,10 @@ Job classes are very simple, normally containing only a `handle` method which is
         /**
          * Execute the job.
          *
-         * @param  AudioProcessor  $processor
+         * @param  Podcast  $podcast
          * @return void
          */
-        public function handle(AudioProcessor $processor)
+        public function handle(Podcast  $podcast)
         {
             // Process uploaded podcast...
         }
@@ -552,7 +551,6 @@ You may define a `failed` method directly on your job class, allowing you to per
 
     use Exception;
     use App\Podcast;
-    use App\AudioProcessor;
     use Illuminate\Bus\Queueable;
     use Illuminate\Queue\SerializesModels;
     use Illuminate\Queue\InteractsWithQueue;
@@ -578,10 +576,10 @@ You may define a `failed` method directly on your job class, allowing you to per
         /**
          * Execute the job.
          *
-         * @param  AudioProcessor  $processor
+         * @param  Podcast  $podcast
          * @return void
          */
-        public function handle(AudioProcessor $processor)
+        public function handle(Podcast  $podcast)
         {
             // Process uploaded podcast...
         }


### PR DESCRIPTION
I believe the input arguments need to be the same between the construct and handle functions.