### PR TITLE
Fix blade syntax error

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -141,7 +141,7 @@ If your Blade components are stored in a sub-directory, you may wish to alias th
 
 Once the component has been aliased, you may render it using a directive:
 
-    @alert('alert', ['type' => 'danger'])
+    @alert(['type' => 'danger'])
         You are not allowed to access this resource!
     @endalert
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,5 @@
 # Laravel Documentation
 
-You can find the online version of the Laravel documentation at [https://laravel.com/docs](https://laravel.com/docs)
-
 ## Contribution Guidelines
 
-If you are submitting documentation for the **current stable release**, submit it to the corresponding branch. For example, documentation for Laravel 5.6 would be submitted to the `5.6` branch. Documentation intended for the next release of Laravel should be submitted to the `master` branch.
+If you are submitting documentation for the **current stable release**, submit it to the corresponding branch. For example, documentation for Laravel 5.5 would be submitted to the `5.5` branch. Documentation intended for the next release of Laravel should be submitted to the `master` branch.

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # Laravel Documentation
 
+You can find the online version of the Laravel documentation at [https://laravel.com/docs](https://laravel.com/docs)
+
 ## Contribution Guidelines
 
-If you are submitting documentation for the **current stable release**, submit it to the corresponding branch. For example, documentation for Laravel 5.5 would be submitted to the `5.5` branch. Documentation intended for the next release of Laravel should be submitted to the `master` branch.
+If you are submitting documentation for the **current stable release**, submit it to the corresponding branch. For example, documentation for Laravel 5.6 would be submitted to the `5.6` branch. Documentation intended for the next release of Laravel should be submitted to the `master` branch.


### PR DESCRIPTION
This fixes a syntax error on the blade docs.

Tested on a new install of 5.6 and have verified.

Solves https://github.com/laravel/docs/issues/4081