### PR TITLE
[WIP] Better Socket.io instructions

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -95,9 +95,15 @@ If you are going to pair the Redis broadcaster with a Socket.IO server, you will
 
     <script src="//{{ Request::getHost() }}:6001/socket.io/socket.io.js"></script>
 
-Next, you will need to instantiate Echo with the `socket.io` connector and a `host`.
+Add the following to your NPM dependancy:
+
+    npm add socket.io-client
+
+Next, you will need to instantiate Echo with the `socket.io` connector and a `host`. 
 
     import Echo from "laravel-echo"
+
+    window.io = require('socket.io-client');
 
     window.Echo = new Echo({
         broadcaster: 'socket.io',

--- a/broadcasting.md
+++ b/broadcasting.md
@@ -91,11 +91,7 @@ When the Redis broadcaster publishes an event, it will be published on the event
 
 #### Socket.IO
 
-If you are going to pair the Redis broadcaster with a Socket.IO server, you will need to include the Socket.IO JavaScript client library in your application's `head` HTML element. When the Socket.IO server is started, it will automatically expose the client JavaScript library at a standard URL. For example, if you are running the Socket.IO server on the same domain as your web application, you may access the client library like so:
-
-    <script src="//{{ Request::getHost() }}:6001/socket.io/socket.io.js"></script>
-
-Add the following to your NPM dependancy:
+If you are going to pair the Redis broadcaster with a Socket.IO server, you will need to include the Socket.IO JavaScript client library in your application. Add the following to your NPM dependency:
 
     npm add socket.io-client
 


### PR DESCRIPTION
This is an attempt to solve https://github.com/laravel/docs/issues/3173

Essentially there are some concerns that the default example in the docs for Socket.IO has the potential to cause a complete failure of all your JS scripts if the socket.io is not available for any reason (i.e. an outage). So if the server is not running (for any reason) then the JS is not available, and the whole thing falls apart, but brings down the rest of your unrelated JS scripting with it.

The advice from @barryvdh and @kkomelin is to modify the example to make it more robust to failures.

I've put **[WIP]** as I want to get confirmation from @barryvdh and/or @kkomelin that this PR solves their concerns first