### PR TITLE
[5.2] Fix requirements markdown

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -16,7 +16,7 @@ The Laravel framework has a few system requirements. Of course, all of these req
 However, if you are not using Homestead, you will need to make sure your server meets the following requirements:
 
 <div class="content-list" markdown="1">
-- PHP >= 5.5.9 & < 7.2.0
+- PHP `>= 5.5.9` & `< 7.2.0`
 - OpenSSL PHP Extension
 - PDO PHP Extension
 - Mbstring PHP Extension


### PR DESCRIPTION
When we added the PHP 7.2 limit the other day - somehow that broke the markdown parsing?

This PR wraps the php versions in code blocks to solve the issue.

See screenshot:

![image](https://user-images.githubusercontent.com/1210658/36348452-55d42160-14c4-11e8-9829-ad51bebb0abf.png)
