### PR TITLE
[5.3] Update requirements to show does not support PHP7.2

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -18,7 +18,7 @@ The Laravel framework has a few system requirements. Of course, all of these req
 However, if you are not using Homestead, you will need to make sure your server meets the following requirements:
 
 <div class="content-list" markdown="1">
-- PHP >= 5.6.4
+- PHP `>= 5.6.4` & `< 7.2.0`
 - OpenSSL PHP Extension
 - PDO PHP Extension
 - Mbstring PHP Extension


### PR DESCRIPTION
Laravel 5.3 has known issues with PHP7.2 that are not being resolved - so we should doument the fact it is not supported.

Example of unsupportedd PHP7.2 function in Laravel 5.3 that was closed: https://github.com/laravel/framework/issues/22843