### PR TITLE
[5.2] Definitive fix for markdown issue

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -16,7 +16,7 @@ The Laravel framework has a few system requirements. Of course, all of these req
 However, if you are not using Homestead, you will need to make sure your server meets the following requirements:
 
 <div class="content-list" markdown="1">
-- PHP `>= 5.5.9` & `< 7.2.0`
+- PHP >= 5.5.9 & &lt; 7.2.0
 - OpenSSL PHP Extension
 - PDO PHP Extension
 - Mbstring PHP Extension

--- a/installation.md
+++ b/installation.md
@@ -16,7 +16,7 @@ The Laravel framework has a few system requirements. Of course, all of these req
 However, if you are not using Homestead, you will need to make sure your server meets the following requirements:
 
 <div class="content-list" markdown="1">
-- PHP >= 5.5.9 & &lt; 7.2.0
+- PHP version between 5.5.9 - 7.1.*
 - OpenSSL PHP Extension
 - PDO PHP Extension
 - Mbstring PHP Extension


### PR DESCRIPTION
I've personally tested this on a cloned Laravel.com website with the docs.

I dont know what it is about a single `<` - but it totally breaks the markdown parser, even if wrapped in code blocks. (good to be mindful of in any future PRs we see).

The use of the HTML symbol code for `<` solves it and displays correctly (on my local server).