### PR TITLE
Use PostResource for conditional relationships example

### DIFF
--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -184,7 +184,7 @@ If you would like to include related resources in your response, you may add the
             'id' => $this->id,
             'name' => $this->name,
             'email' => $this->email,
-            'posts' => Post::collection($this->posts),
+            'posts' => PostResource::collection($this->posts),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];


### PR DESCRIPTION
The example on conditional relationships for resources uses:

```php
Post::collection()
```

Instead of the resource class which is used throughout the other examples.
```php
PostResource::collection()
```
