### PR TITLE
Use notification argument in routing examples

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -254,9 +254,10 @@ When sending notifications via the `mail` channel, the notification system will 
         /**
          * Route notifications for the mail channel.
          *
+         * @param  \Illuminate\Notifications\Notification  $notification
          * @return string
          */
-        public function routeNotificationForMail()
+        public function routeNotificationForMail($notification)
         {
             return $this->email_address;
         }
@@ -622,9 +623,10 @@ When sending notifications via the `nexmo` channel, the notification system will
         /**
          * Route notifications for the Nexmo channel.
          *
+         * @param  \Illuminate\Notifications\Notification  $notification
          * @return string
          */
-        public function routeNotificationForNexmo()
+        public function routeNotificationForNexmo($notification)
         {
             return $this->phone;
         }
@@ -798,9 +800,10 @@ To route Slack notifications to the proper location, define a `routeNotification
         /**
          * Route notifications for the Slack channel.
          *
+         * @param  \Illuminate\Notifications\Notification  $notification
          * @return string
          */
-        public function routeNotificationForSlack()
+        public function routeNotificationForSlack($notification)
         {
             return $this->slack_webhook_url;
         }


### PR DESCRIPTION
In reference to laravel/framework#22289.

This isn't totally necessary but I think it's worth updating the notification examples to show that the notification is passed in as an argument to the method. In all the examples in the documentation it isn't actually used (and I presume for most use cases it won't be used either) but it would highlight the functionality to anyone that might need to use it.