### PR TITLE
Update example for Route Name Prefixes

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -271,7 +271,7 @@ The `name` method may be used to prefix each route name in the group with a give
     Route::name('admin.')->group(function () {
         Route::get('users', function () {
             // Route assigned name "admin.users"...
-        });
+        })->name('users');
     });
 
 <a name="route-model-binding"></a>


### PR DESCRIPTION
Example for Route Name Prefixes:
```
Route::name('admin.')->group(function () {
    Route::get('users', function () {
        // Route assigned name "admin.users"...
    });
});
```
The route in example actually hasn't `admin.users` name, because it isn't assigned explicitly.
I think it can confuse some people, because from the example they could think that name of a route is automatically assigned by url.