### PR TITLE
"Trusting All Proxies": "**" is deprecated, use "*"

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -400,11 +400,11 @@ To solve this, you may use the `App\Http\Middleware\TrustProxies` middleware tha
 
 #### Trusting All Proxies
 
-If you are using Amazon AWS or another "cloud" load balancer provider, you may not know the IP addresses of your actual balancers. In this case, you may use `**` to trust all proxies:
+If you are using Amazon AWS or another "cloud" load balancer provider, you may not know the IP addresses of your actual balancers. In this case, you may use `*` to trust all proxies:
 
     /**
      * The trusted proxies for this application.
      *
      * @var array
      */
-    protected $proxies = '**';
+    protected $proxies = '*';


### PR DESCRIPTION
I was source diving fideloper's TrustedProxies package and found this:
```
        // Trust any IP address that calls us
        // `**` for backwards compatibility, but is depreciated
        if ($trustedIps === '*' || $trustedIps === '**') {
            return $this->setTrustedProxyIpAddressesToTheCallingIp($request);
        }
```
[see file on github](https://github.com/fideloper/TrustedProxy/blob/master/src/TrustProxies.php)

It looks like the package docs still make a distinction between the two, so probably don't need this - but figured I'd put it out there.