### PR TITLE
Add section explaining bootable traits

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -21,6 +21,7 @@
     - [Local Scopes](#local-scopes)
 - [Events](#events)
     - [Observers](#observers)
+- [Traits](#traits)
 
 <a name="introduction"></a>
 ## Introduction
@@ -818,7 +819,7 @@ To register an observer, use the `observe` method on the model you wish to obser
     }
 
 <a name="traits"></a>
-### Traits
+## Traits
 
 If a trait used in a model needs to apply scopes or listen for events, you may define a custom `boot` method in the trait that that is named `boot` followed by the trait's own name to avoid overriding the parent class's `boot` method. Eloquent will execute this like a regular boot method.
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -816,3 +816,18 @@ To register an observer, use the `observe` method on the model you wish to obser
             //
         }
     }
+
+<a name="traits"></a>
+### Traits
+
+If a trait used in a model needs to apply scopes or listen for events, you may define a custom `boot` method in the trait that that is named `boot` followed by the trait's own name to avoid overriding the parent class's `boot` method. Eloquent will execute this like a regular boot method.
+
+    trait HasSlug
+    {
+        public static function bootHasSlug()
+        {
+            static::saving(function ($model) {
+                $model->slug = str_slug($model->name, '-');
+            });
+        }
+    }


### PR DESCRIPTION
Add an explanation and example of how a trait for a model can register its own boot method as this functionality is currently undocumented.