### PR TITLE
valet installation additional composer step

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -67,7 +67,7 @@ Both Valet and Homestead are great choices for configuring your Laravel developm
 <div class="content-list" markdown="1">
 - Install or update [Homebrew](http://brew.sh/) to the latest version using `brew update`.
 - Install PHP 7.2 using Homebrew via `brew install homebrew/php/php72`.
-- Install Valet with Composer via `composer global require laravel/valet`. Make sure the `~/.composer/vendor/bin` directory is in your system's "PATH".
+- Install Valet with Composer via `composer global require laravel/valet`. Make sure the `~/.composer/vendor/bin` directory is in your system's "PATH" by running: `echo $PATH`. If it is not present then add it by running: `export PATH=$PATH:~/.composer/vendor/bin`.
 - Run the `valet install` command. This will configure and install Valet and DnsMasq, and register Valet's daemon to launch when your system starts.
 </div>
 


### PR DESCRIPTION
I found this step missing in my initial install of valet, it is not an obvious thing for beginners to understand what a $PATH is.