### PR TITLE
Explicitly define Passport version to use

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -42,7 +42,7 @@ Laravel already makes it easy to perform authentication via traditional login fo
 
 To get started, install Passport via the Composer package manager:
 
-    composer require laravel/passport
+    composer require laravel/passport=~4.0
 
 The Passport service provider registers its own database migration directory with the framework, so you should migrate your database after registering the provider. The Passport migrations will create the tables your application needs to store clients and access tokens:
 


### PR DESCRIPTION
If one was to use `composer require laravel/passport` per the original docs, Composer would grab 5.0, which requires Laravel ~5.6.