### PR TITLE
Improved Socket.IO section of the Driver Prerequisites

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -91,13 +91,15 @@ When the Redis broadcaster publishes an event, it will be published on the event
 
 #### Socket.IO
 
-If you are going to pair the Redis broadcaster with a Socket.IO server, you will need to include the Socket.IO JavaScript client library in your application's `head` HTML element. When the Socket.IO server is started, it will automatically expose the client JavaScript library at a standard URL. For example, if you are running the Socket.IO server on the same domain as your web application, you may access the client library like so:
+If you are going to pair the Redis broadcaster with a Socket.IO server, you will need to include the Socket.IO JavaScript client library in your application. You may install it via the NPM package manager:
 
-    <script src="//{{ Request::getHost() }}:6001/socket.io/socket.io.js"></script>
+    npm install --save socket.io-client
 
 Next, you will need to instantiate Echo with the `socket.io` connector and a `host`.
 
     import Echo from "laravel-echo"
+    
+    window.io = require('socket.io-client');
 
     window.Echo = new Echo({
         broadcaster: 'socket.io',


### PR DESCRIPTION
## Problem/Motivation

_As a followup for this issue https://github.com/laravel/docs/issues/3173._

Laravel Echo Server can become a single point of failure for the entire Laravel app if we include Socket.IO library as currently described in [the official Laravel documentation](https://laravel.com/docs/broadcasting#driver-prerequisites):

```html
<script src="//{{ Request::getHost() }}:6001/socket.io/socket.io.js"></script>
```

In other words, if Laravel Echo Server stops working, then all JS code of the app will stop functioning with the following error:

> Uncaught ReferenceError: io is not defined

## Proposed Resolution

Include the Socket.IO client into the JS build process as a dependency instead of consuming the library, provided by Laravel Echo Server, by link.

An additional improvement has been requested for the Laravel Echo client here https://github.com/laravel/echo/issues/173#issuecomment-366495063

## Tests

Tested by the PR author locally. No issues have been discovered with this approach.

## Related Issues

- https://github.com/laravel/docs/issues/3173
- https://github.com/tlaverdure/laravel-echo-server/issues/132
- https://github.com/laravel/docs/pull/4098
- https://github.com/laravel/echo/issues/173

Thanks.