### PR TITLE
Add electronic versions of the docs

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -3,6 +3,7 @@
     - [Upgrade Guide](/docs/{{version}}/upgrade)
     - [Contribution Guide](/docs/{{version}}/contributions)
     - [API Documentation](/api/{{version}})
+    - [Offline Documentation](/offline/{{version}})
 - ## Getting Started
     - [Installation](/docs/{{version}}/installation)
     - [Configuration](/docs/{{version}}/configuration)

--- a/offline.md
+++ b/offline.md
@@ -1,0 +1,7 @@
+# Offline documentation
+
+Laravel offers downloadable versions of this documentation in different formats, always up to date.
+
+<a href='https://laravel.com/offline-docs/5.6/laravel-docs-5.6.epub'>Epub Format</a>
+<a href='https://laravel.com/offline-docs/5.6/laravel-docs-5.6.pdf'>PDF Format</a>
+<a href='https://laravel.com/offline-docs/5.6/laravel-docs-5.6.mobi'>Mobi Format</a>


### PR DESCRIPTION
I think it'd be useful for many people to have electronic versions of the documentation. As for this pull request I add the docs for 5.6 in epub, mobi and pdf.

If accepted I can provide the source code to obtain these ebooks or even help directly with that. I'd also suggest too to add these docs to the old version of the docs, my program compiles them all too.