### PR TITLE
The middleware terminate method descripton is misleading.

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -223,7 +223,7 @@ Middleware parameters may be specified when defining the route by separating the
 <a name="terminable-middleware"></a>
 ## Terminable Middleware
 
-Sometimes a middleware may need to do some work after the HTTP response has been sent to the browser. For example, the "session" middleware included with Laravel writes the session data to storage after the response has been sent to the browser. If you define a `terminate` method on your middleware, it will automatically be called after the response is sent to the browser.
+Sometimes a middleware may need to do some work after the HTTP response has been prepared to be send. For example, the "session" middleware included with Laravel writes the session data to storage after the response has been prepared to be sent to the browser. If you define a `terminate` method on your middleware, it will automatically be called after the response is prepared to be sent to the browser.
 
     <?php
 

--- a/middleware.md
+++ b/middleware.md
@@ -223,7 +223,7 @@ Middleware parameters may be specified when defining the route by separating the
 <a name="terminable-middleware"></a>
 ## Terminable Middleware
 
-Sometimes a middleware may need to do some work after the HTTP response has been prepared to be send. For example, the "session" middleware included with Laravel writes the session data to storage after the response has been prepared to be sent to the browser. If you define a `terminate` method on your middleware, it will automatically be called after the response is prepared to be sent to the browser.
+Sometimes a middleware may need to do some work after the HTTP response has been prepared to be sent. For example, the "session" middleware included with Laravel writes the session data to storage after the response has been prepared to be sent to the browser. If you define a `terminate` method on your middleware, it will automatically be called after the response is prepared to be sent to the browser.
 
     <?php
 


### PR DESCRIPTION
From the current version of docs you can think that something will be done on server side, after the browser will really receive the response from server. THIS IS NOT TRUE - if you will put e.g. sleep(10) in the middleware terminate method - you will see in the browser that you will have to wait those additional 10 second for the response from server to be received.

I've checked this using php artisan serve and also by running it on Apache 2.4 with php 7.2 installed.