### PR TITLE
make sense of the grouped wheres example

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -420,15 +420,17 @@ Sometimes you may need to create more advanced where clauses such as "where exis
 
     DB::table('users')
                 ->where('name', '=', 'John')
-                ->orWhere(function ($query) {
+                ->where(function ($query) {
                     $query->where('votes', '>', 100)
-                          ->where('title', '<>', 'Admin');
+                          ->orWhere('title', '=', 'Admin');
                 })
                 ->get();
 
-As you can see, passing a `Closure` into the `orWhere` method instructs the query builder to begin a constraint group. The `Closure` will receive a query builder instance which you can use to set the constraints that should be contained within the parenthesis group. The example above will produce the following SQL:
+As you can see, passing a `Closure` into the `where` method instructs the query builder to begin a constraint group. The `Closure` will receive a query builder instance which you can use to set the constraints that should be contained within the parenthesis group. The example above will produce the following SQL:
 
-    select * from users where name = 'John' or (votes > 100 and title <> 'Admin')
+    select * from users where name = 'John' and (votes > 100 or title = 'Admin')
+
+It is recommended to always group `orWhere` calls this way in order to avoid unexpected behaviour when querying models with global scopes applied.
 
 <a name="where-exists-clauses"></a>
 ### Where Exists Clauses


### PR DESCRIPTION
Existing paragraph use a bit odd example, in that `where` grouping doesn't make any difference. Replaced it with an example using `(.. or ..)` when it really matters. Also added note when this can be even more important, ie. along with **global scopes**.


When this is merged, I will also create PRs targeting 5.3-5.5, where this paragraph exists.