### PR TITLE
Update bootstrap/autoload.php

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -15,7 +15,28 @@ Update your `laravel/framework` dependency to `5.4.*` in your `composer.json` fi
 
 #### Removing Compiled Services File
 
-If it exists, you may delete the `bootstrap/cache/compiled.php` file. It is no longer used by the framework.
+If it exists, you may delete the `bootstrap/cache/compiled.php` file. It is no longer used by the framework. 
+
+#### Update `bootstrap/autoload.php` File
+
+Now that we will no longer have the `bootstrap/cache/compiled.php` file, the following snippet of code is no longer needed and can be removed from `bootstrap/autoload.php`:
+
+    /*
+    |--------------------------------------------------------------------------
+    | Include The Compiled Class File
+    |--------------------------------------------------------------------------
+    |
+    | To dramatically increase your application's performance, you may use a
+    | compiled class file which contains all of the classes commonly used
+    | by a request. The Artisan "optimize" is used to create this file.
+    |
+    */
+
+    $compiledPath = __DIR__.'/cache/compiled.php';
+
+    if (file_exists($compiledPath)) {
+        require $compiledPath;
+    }
 
 #### Flushing The Cache
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -19,7 +19,7 @@ If it exists, you may delete the `bootstrap/cache/compiled.php` file. It is no l
 
 #### Update `bootstrap/autoload.php` File
 
-Now that we will no longer have the `bootstrap/cache/compiled.php` file, the following snippet of code is no longer needed and can be removed from `bootstrap/autoload.php`:
+Now that we no longer have the `bootstrap/cache/compiled.php` file, the following snippet can be removed from `bootstrap/autoload.php`:
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This pull request attempts to call attention to the fact that the bootstrap/cache/compiled.php file will never again exist, but the bootstrap/autoload.php file will still try to require it.

Because this change is in regards to some code in `bootstrap/autoload.php` checking the existence of a file (`compiled.php`) that the upgrade guide already instructs us to remove, it feels pertinent that it be mentioned to make sure no one inadvertently skips the removal of this bit also. Since we already have the users checking inside the `bootstrap` folder already, might as well have them do that too as part of the upgrade flow and save them from having to check that file with the comparison tool. 