### PR TITLE
Improved consistency when declaring unsigned integer columns

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -59,7 +59,7 @@ Before using Cashier, we'll also need to [prepare the database](/docs/{{version}
 
     Schema::create('subscriptions', function ($table) {
         $table->increments('id');
-        $table->integer('user_id');
+        $table->unsignedInteger('user_id');
         $table->string('name');
         $table->string('stripe_id');
         $table->string('stripe_plan');
@@ -137,7 +137,7 @@ Before using Cashier, we'll need to [prepare the database](/docs/{{version}}/mig
 
     Schema::create('subscriptions', function ($table) {
         $table->increments('id');
-        $table->integer('user_id');
+        $table->unsignedInteger('user_id');
         $table->string('name');
         $table->string('braintree_id');
         $table->string('braintree_plan');

--- a/migrations.md
+++ b/migrations.md
@@ -433,7 +433,7 @@ If you pass an array of columns into a method that drops indexes, the convention
 Laravel also provides support for creating foreign key constraints, which are used to force referential integrity at the database level. For example, let's define a `user_id` column on the `posts` table that references the `id` column on a `users` table:
 
     Schema::table('posts', function (Blueprint $table) {
-        $table->integer('user_id')->unsigned();
+        $table->unsignedInteger('user_id');
 
         $table->foreign('user_id')->references('id')->on('users');
     });


### PR DESCRIPTION
Given edits to #4191 by @taylorotwell I assumed it would help to keep any fk columns to uint primary keys using the short-hand syntax of
``` php
    $table->unsignedInteger('user_id');
```
rather than
``` php
    $table->integer('user_id')->unsigned();
```