### PR TITLE
Feature/names

### DIFF
--- a/urls.md
+++ b/urls.md
@@ -92,13 +92,13 @@ To verify that an incoming request has a valid signature, you should call the `h
 
     use Illuminate\Http\Request;
 
-    Route::post('/unsubscribe/{user}', function (Request $request) {
+    Route::get('/unsubscribe/{user}', function (Request $request) {
         if (! $request->hasValidSignature()) {
             abort(401);
         }
 
         // ...
-    });
+    })->name('unsubscribe')
 
 Alternatively, you may assign the `Illuminate\Routing\Middleware\ValidateSignature` middleware to the route. If it is not already present, you should assign this middleware a key in your HTTP kernel's `routeMiddleware` array:
 
@@ -117,7 +117,7 @@ Once you have registered the middleware in your kernel, you may attach it to a r
 
     Route::post('/unsubscribe/{user}', function (Request $request) {
         // ...
-    })->middleware('signed');
+    })->name('unsubscribe')->middleware('signed');
 
 <a name="urls-for-controller-actions"></a>
 ## URLs For Controller Actions

--- a/urls.md
+++ b/urls.md
@@ -98,7 +98,7 @@ To verify that an incoming request has a valid signature, you should call the `h
         }
 
         // ...
-    })->name('unsubscribe')
+    })->name('unsubscribe');
 
 Alternatively, you may assign the `Illuminate\Routing\Middleware\ValidateSignature` middleware to the route. If it is not already present, you should assign this middleware a key in your HTTP kernel's `routeMiddleware` array:
 


### PR DESCRIPTION
Unless I'm mistaken, when calling `signedRoute` you are passing it the name of a route. In the examples the route definitions aren't given a name so they wouldn't work as expected. This adds the missing name, but it also changes the route to being `GET` instead. I get that realistically an unsubscribe route wouldn't actually be a `GET` request, but I feel it's a little clearer given the context of generating a signed URL that's likely going to be visited directly as a `GET` request.