### PR TITLE
add bail to the list of available validation rules

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -485,6 +485,7 @@ Below is a list of all available validation rules and their function:
 [Alpha Dash](#rule-alpha-dash)
 [Alpha Numeric](#rule-alpha-num)
 [Array](#rule-array)
+[Bail](#rule-bail)
 [Before (Date)](#rule-before)
 [Before Or Equal (Date)](#rule-before-or-equal)
 [Between](#rule-between)
@@ -579,6 +580,11 @@ The field under validation must be entirely alpha-numeric characters.
 #### array
 
 The field under validation must be a PHP `array`.
+
+<a name="rule-bail"></a>
+#### bail
+
+Stop running validation rules after the first validation failure.
 
 <a name="rule-before"></a>
 #### before:_date_


### PR DESCRIPTION
A quick poll of a few devs in one of the laravel chat channels showed that many people don't know about the bail rule because they never saw it in the list of available rules. This PR adds bail to the list of available rules. 