### PR TITLE
Add return $this in set mutator

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -83,6 +83,8 @@ To define a mutator, define a `setFooAttribute` method on your model where `Foo`
         public function setFirstNameAttribute($value)
         {
             $this->attributes['first_name'] = strtolower($value);
+            
+            return $this;
         }
     }
 


### PR DESCRIPTION
While chaining methods, we end up with unable to call method save on null (when $this is not returned from mutator).

\App\Model::find(1)->setAttribute('first_name','laravel')->save();