### PR TITLE
[5.6] Update authorization.md

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -75,7 +75,7 @@ This is identical to manually defining the following Gate definitions:
     Gate::define('posts.update', 'PostPolicy@update');
     Gate::define('posts.delete', 'PostPolicy@delete');
 
-By default, the `view`, `create`, `update`, and `delete` abilities will be defined. You may override or add to the default abilities by passing an array as a third argument to the `resource` method. The keys of the array define the names of the abilities while the values define the method names. For example, the following code will create two new Gate definitions - `posts.image` and `posts.photo`:
+By default, the `view`, `create`, `update`, and `delete` abilities will be defined. You may override the default abilities by passing an array as a third argument to the `resource` method. The keys of the array define the names of the abilities while the values define the method names. For example, the following code will only create two new Gate definitions - `posts.image` and `posts.photo`:
 
     Gate::resource('posts', 'PostPolicy', [
         'image' => 'updateImage',


### PR DESCRIPTION
I found this part regarding Gate resource confusing, as it says you may "add or override" but after doing some tests and checking the source code I found the third argument does not add but instead *overrides* the default options.