### PR TITLE
Fix the wording of two sentences

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -53,7 +53,7 @@ Typically, you should declare collection macros in a [service provider](/docs/{{
 <a name="available-methods"></a>
 ## Available Methods
 
-For the remainder of this documentation, we'll discuss each method available on the `Collection` class. Remember, all of these methods may be chained to fluently manipulating the underlying array. Furthermore, almost every method returns a new `Collection` instance, allowing you to preserve the original copy of the collection when necessary:
+For the remainder of this documentation, we'll discuss each method available on the `Collection` class. Remember, all of these methods may be chained to fluently manipulate the underlying array. Furthermore, almost every method returns a new `Collection` instance, allowing you to preserve the original copy of the collection when necessary:
 
 <style>
     #collection-method-list > p {
@@ -760,7 +760,7 @@ In addition to passing a string `key`, you may also pass a callback. The callbac
         ]
     */
 
-Multiple grouping criteria may be passed as an array. Each array element will applied for the corresponding level within a multi-dimensional array:
+Multiple grouping criteria may be passed as an array. Each array element will be applied to the corresponding level within a multi-dimensional array:
 
     $data = new Collection([
         10 => ['user' => 1, 'skill' => 1, 'roles' => ['Role_1', 'Role_3']],


### PR DESCRIPTION
There are two sentences that need small changes to read a little more smoothly:

- "to fluently *manipulate* the underlying array" instead of "to fluently *manipulating* the underlying array"
- "Each array element *will be applied to* the corresponding level" instead of "Each array element *will applied for* the corresponding level"