### PR TITLE
Improve Dusk installation on Windows

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -46,7 +46,7 @@ Laravel Dusk provides an expressive, easy-to-use browser automation and testing 
 
 To get started, you should add the `laravel/dusk` Composer dependency to your project:
 
-    composer require --dev laravel/dusk:^2.0
+    composer require --dev laravel/dusk:"^2.0"
 
 Once Dusk is installed, you should register the `Laravel\Dusk\DuskServiceProvider` service provider. Typically, this will be done automatically via Laravel's automatic service provider registration.
 


### PR DESCRIPTION
In unquoted version numbers the [Windows batch ignores the caret](https://github.com/composer/composer/issues/5151).
As a result Composer only receives `2.0` and installs `2.0.0` (instead of `2.0.14`).