### PR TITLE
[5.4] Improve Dusk installation on Windows

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -40,7 +40,7 @@ Laravel Dusk provides an expressive, easy-to-use browser automation and testing 
 
 To get started, you should add the `laravel/dusk` Composer dependency to your project:
 
-    composer require --dev laravel/dusk:^1.0
+    composer require --dev laravel/dusk:"^1.0"
 
 Once Dusk is installed, you should register the `Laravel\Dusk\DuskServiceProvider` service provider. You should register the provider within the `register` method of your `AppServiceProvider` in order to limit the environments in which Dusk is available, since it exposes the ability to log in as other users:
 


### PR DESCRIPTION
In unquoted version numbers the [Windows batch ignores the caret](https://github.com/composer/composer/issues/5151).
As a result Composer only receives `1.0` and installs `1.0.0` (instead of `1.1.1`).