### PR TITLE
[5.6] Clarify mail html and markdown directories.

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -412,7 +412,7 @@ You may export all of the Markdown mail components to your own application for c
 
     php artisan vendor:publish --tag=laravel-mail
 
-This command will publish the Markdown mail components to the `resources/views/vendor/mail` directory. The `mail` directory will contain a `html` and a `markdown` directory, each containing their respective representations of every available component. You are free to customize these components however you like.
+This command will publish the Markdown mail components to the `resources/views/vendor/mail` directory. The `mail` directory will contain a `html` and a `markdown` directory, each containing their respective representations of every available component. The components in the `html` directory are used to generate the HTML version of your email, and their counterparts in the `markdown` directory are used to generate the plain-text version. You are free to customize these components however you like.
 
 #### Customizing The CSS
 


### PR DESCRIPTION
Clarify the purpose of `mail/html` and `mail/markdown` directories. There seems quite a bit of confusion around this, and I believe the amended wording would help alleviate this.

I had to find https://github.com/laravel/framework/issues/17970#issuecomment-324159935 to discover this, and that took me quite a bit of digging!