### PR TITLE
[5.6] Collection's partition method: add example result

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1227,6 +1227,14 @@ The `partition` method may be combined with the `list` PHP function to separate 
         return $i < 3;
     });
 
+    $underThree->all();
+
+    // [1, 2]
+
+    $aboveThree->all();
+
+    // [3, 4, 5, 6]
+
 <a name="method-pipe"></a>
 #### `pipe()` {#collection-method}
 


### PR DESCRIPTION
Resubmission of https://github.com/laravel/docs/pull/4263
______
Adding the example result to `partition` method on Collection.

Currently, it's documented with this description and example:
> The `partition` method may be combined with the `list` PHP function to separate elements that pass a given truth test from those that do not:

    $collection = collect([1, 2, 3, 4, 5, 6]);

    list($underThree, $aboveThree) = $collection->partition(function ($i) {
        return $i < 3;
    });

And that's it. This PR will add the results of the example:

``` php
$underThree->all();

// [1, 2]

$aboveThree->all();

// [3, 4, 5, 6]
```