### PR TITLE
Remove an unnecessary to fix Markdown syntax.

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1235,7 +1235,7 @@ If you are using CircleCI 1.0 to run your Dusk tests, you may use this configura
         override:
             - php artisan dusk
 
- #### CircleCI 2.0
+#### CircleCI 2.0
 
  If you are using CircleCI 2.0 to run your Dusk tests, you may add these steps to your build:
 


### PR DESCRIPTION
It's a nitspick but there was an unnecessary space in front of `####`. so I removed it to make syntax valid.