### PR TITLE
L5.5 minimum PHP version 7.0.0 -> 7.1.0

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -11,7 +11,7 @@
 
 ### PHP
 
-Laravel 5.5 requires PHP 7.0.0 or higher.
+Laravel 5.5 requires PHP 7.1.0 or higher.
 
 ### Updating Dependencies
 


### PR DESCRIPTION
Due to use of typehinted nullable type parameter in Symfony\Component\Translation\Translator constructor