### PR TITLE
Clarify that `this->option()` can throw with unexpected arguments

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -284,7 +284,7 @@ Options may be retrieved just as easily as arguments using the `option` method. 
     // Retrieve all options...
     $options = $this->options();
 
-If the argument or option does not exist, `null` will be returned.
+If the option or argument is not required and was omitted when invoking the command, `null` will be returned. However, asking for a name that is not defined in the command's signature will throw an error.
 
 <a name="prompting-for-input"></a>
 ### Prompting For Input


### PR DESCRIPTION
Hi,

I updated the documentation for what the `argument` and `option` methods do with an invalid name.  We ran into subtle bugs because we invoked `$this->option("debug")` in a trait we used in a number of commands.  From the documentation, we expected that this would just return null if a command didn't have a `debug` option, but instead it threw an error. (Since the function just delegates to the underlying Symphony Input, is the expected behavior, at least as the code is currently written.)
This PR adds a clarification to the docs to clearly explain this behavior.