### PR TITLE
Fix URL::temporarySignedRoute usage example

### DIFF
--- a/urls.md
+++ b/urls.md
@@ -83,7 +83,7 @@ If you would like to generate a temporary signed route URL that expires, you may
     use Illuminate\Support\Facades\URL;
 
     return URL::temporarySignedRoute(
-        'unsubscribe', now()->addMinutes(30), ['user' => 1]
+        'unsubscribe', ['user' => 1], now()->addMinutes(30)
     );
 
 #### Validating Signed Route Requests


### PR DESCRIPTION
Fix URL::temporarySignedRoute usage example to match method signature