### PR TITLE
Fix wrong example of envoy servers declaration

### DIFF
--- a/envoy.md
+++ b/envoy.md
@@ -39,7 +39,7 @@ You may also use Composer to keep your Envoy installation up to date. Issuing th
 
 All of your Envoy tasks should be defined in an `Envoy.blade.php` file in the root of your project. Here's an example to get you started:
 
-    @servers(['web' => ['user@192.168.1.1']])
+    @servers(['web' => 'user@192.168.1.1'])
 
     @task('foo', ['on' => 'web'])
         ls -la


### PR DESCRIPTION
The current example throws an array to string conversion error, but everything works fine with this change. So I guess it is a doc error.

I know this is a very small change for a pull request, so maybe there is some place to report such errors ?

Thank you.