### PR TITLE
[Homestead] Note new Zend Framework site types

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -328,7 +328,7 @@ Homestead supports several types of sites which allow you to easily run projects
           to: /home/vagrant/code/Symfony/web
           type: "symfony2"
 
-The available site types are: `apache`, `laravel` (the default), `proxy`, `silverstripe`, `statamic`, `symfony2`, and `symfony4`.
+The available site types are: `apache`, `apigility`, `expressive`, `laravel` (the default), `proxy`, `silverstripe`, `statamic`, `symfony2`, `symfony4`, and `zf`.
 
 <a name="site-parameters"></a>
 #### Site Parameters


### PR DESCRIPTION
Adds "apigility", "expressive", and "zf" to the list of available site types for Homestead.