### PR TITLE
Make it clear that Policies, once registered, need to be invoked via a Gate

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -176,8 +176,9 @@ Once the policy exists, it needs to be registered. The `AuthServiceProvider` inc
         public function boot()
         {
             $this->registerPolicies();
-
-            //
+            
+            // Define a gate that uses this policy
+            Gate::resource('posts', PostPolicy::class);
         }
     }
 


### PR DESCRIPTION
For someone new to Gates/Policies and reading these instructions, it's not clear that Policies need to be invoked via a Gate. 
This portion of the docs make it seem like you only need to register the Policy and it will work when used:

>>  "Registering a policy will instruct Laravel which policy to utilize when authorizing actions against a given model"

My edit suggests adding  `Gate::resource('posts', PostPolicy::class);` as an example usage of the registered Policy.

An alternative would be to link back to earlier in the notes where you address "Class@method style callback strings".