### PR TITLE
update from 5.2.45 to 5.3

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -777,6 +777,8 @@ The `Illuminate\Foundation\Providers\ArtisanServiceProvider` should be removed f
 
 The `Illuminate\Routing\ControllerServiceProvider` should be removed from your service provider list in your `app.php` configuration file.
 
+The `Illuminate\Bus\BusServiceProvider`, `App\Providers\BusServiceProvider` and `App\Providers\ConfigServiceProvider` should be removed from your service provider list in your `app.php` configuration file. Also `app/Providers/BusServiceProvider.php` and `app/Providers/ConfigServiceProvider.php` should be deleted since those are no longer used.
+
 ### Sessions
 
 Because of changes to the authentication system, any existing sessions will be invalidated when you upgrade to Laravel 5.2.


### PR DESCRIPTION
I was getting the following error:

    [Symfony\Component\Debug\Exception\FatalThrowableError]         
    Call to undefined method Illuminate\Bus\Dispatcher::mapUsing()  

I had to do remove these providers in order to upgrade to 5.3