### PR TITLE
Adjust validation rule language to avoid confusion

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -724,12 +724,12 @@ The field under validation must not be empty when it is present.
 <a name="rule-gt"></a>
 #### gt:_field_
 
-The given _field_ must be greater than the field under validation. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the `size` rule.
+The field under validation must be greater than the given _field_. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the `size` rule.
 
 <a name="rule-gte"></a>
 #### gte:_field_
 
-The given _field_ must be greater than or equal to the field under validation. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the `size` rule.
+The field under validation must be greater than or equal to the given _field_. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the `size` rule.
 
 <a name="rule-image"></a>
 #### image
@@ -781,12 +781,12 @@ The field under validation must be a valid JSON string.
 <a name="rule-lt"></a>
 #### lt:_field_
 
-The given _field_ must be less than the field under validation. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the `size` rule.
+The field under validation must be less than the given _field_. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the `size` rule.
 
 <a name="rule-lte"></a>
 #### lte:_field_
 
-The given _field_ must be less than or equal to the field under validation. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the `size` rule.
+The field under validation must be less than or equal to the given _field_. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the `size` rule.
 
 <a name="rule-max"></a>
 #### max:_value_


### PR DESCRIPTION
The text for the new comparison validation rules `gt`, `gte`, `lt` & `lte` make it seem like the supplied `field` parameter's value should actually be greater/less/equal to the field being validated. The source code confirms that the field being validated should be greater/less/equal to the supplied field parameter's value.