### PR TITLE
Add docs about the @append Blade directive

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -79,6 +79,7 @@ When defining a child view, use the Blade `@extends` directive to specify which 
 In this example, the `sidebar` section is utilizing the `@@parent` directive to append (rather than overwriting) content to the layout's sidebar. The `@@parent` directive will be replaced by the content of the layout when the view is rendered.
 
 > {tip} Contrary to the previous example, this `sidebar` section ends with `@endsection` instead of `@show`. The `@endsection` directive will only define a section while `@show` will define and **immediately yield** the section.
+In the previous example, `@section` together with `@parent` may be combined to `@append`.
 
 Blade views may be returned from routes using the global `view` helper:
 


### PR DESCRIPTION
Prevent confusion about default Blade directives, see [this issue](https://github.com/laravel/docs/issues/4302).

An alternative might be to add a small section about the different Blade directives (endsection, show, append, yield) and also mention `@stop` as alias of `@endsection`. 
Not sure about this as using `@stop` might also be discouraged, so let me know if you'd like me to write it this way.