### PR TITLE
Remove 2nd param from Event::listen callback

### DIFF
--- a/events.md
+++ b/events.md
@@ -58,7 +58,7 @@ Typically, events should be registered via the `EventServiceProvider` `$listen` 
     {
         parent::boot();
 
-        Event::listen('event.name', function ($foo, $bar) {
+        Event::listen('event.name', function ($data) {
             //
         });
     }


### PR DESCRIPTION
In a listener like the example provided (a non-wildcard listener), a 2nd parameter is not passed to the closure.