### PR TITLE
correct config virtualbox use symbolic links Windows

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -533,5 +533,5 @@ By default, Homestead configures the `natdnshostresolver` setting to `on`. This 
 If symbolic links are not working properly on your Windows machine, you may need to add the following block to your `Vagrantfile`:
 
     config.vm.provider "virtualbox" do |v|
-        v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
+        v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/home/vagrant/code", "1"]
     end


### PR DESCRIPTION
The line where it sets the `VBoxInternal2/SharedFoldersEnableSymlinksCreate`  should also contain the path to the shared folder inside the VM. This is done in the last part where it originally says `/v-root`. 

The shared folder in Homestead is: `/home/vagrant/code`.

Therefore the correct config should be:

```
   config.vm.provider "virtualbox" do |v|
        v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/home/vagrant/code", "1"]
    end
```