### PR TITLE
Remove pseudo-scientific slogan

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -10,7 +10,7 @@
 <a name="installation"></a>
 ## Installation
 
-> {video} Are you a visual learner? Laracasts provides a [free, thorough introduction to Laravel](http://laravelfromscratch.com) for newcomers to the framework. It's a great place to start your journey.
+> {video} Laracasts provides a [free, thorough introduction to Laravel](http://laravelfromscratch.com) for newcomers to the framework. It's a great place to start your journey.
 
 <a name="server-requirements"></a>
 ### Server Requirements


### PR DESCRIPTION
There is no empirical evidence for the existence of learning types.

Brief summary: https://en.wikipedia.org/wiki/Learning_styles#Criticism
APS paper: https://doi.org/10.1111/j.1539-6053.2009.01038.x

This question is present in branches 5.4, 5.5, 5.6, master.

I was thinking of a better alternative, but couldn't come up with anything useful. Overall I think this little advert is fine without an introductory question.