### PR TITLE
Fix typo in blade section

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -405,7 +405,7 @@ Property  | Description
 ------------- | -------------
 `$loop->index`  |  The index of the current loop iteration (starts at 0).
 `$loop->iteration`  |  The current loop iteration (starts at 1).
-`$loop->remaining`  |  The iteration remaining in the loop.
+`$loop->remaining`  |  The iterations remaining in the loop.
 `$loop->count`  |  The total number of items in the array being iterated.
 `$loop->first`  |  Whether this is the first iteration through the loop.
 `$loop->last`  |  Whether this is the last iteration through the loop.


### PR DESCRIPTION
Added an 's' to make 'iteration' plural, since it is about the number of iterations remaining.