### PR TITLE
Add docs for the `is()` method of the eloquent model class

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -13,6 +13,7 @@
     - [Updates](#updates)
     - [Mass Assignment](#mass-assignment)
     - [Other Creation Methods](#other-creation-methods)
+- [Comparing Models](#comparing-models)
 - [Deleting Models](#deleting-models)
     - [Soft Deleting](#soft-deleting)
     - [Querying Soft Deleted Models](#querying-soft-deleted-models)
@@ -412,6 +413,17 @@ You may also come across situations where you want to update an existing model o
         ['departure' => 'Oakland', 'destination' => 'San Diego'],
         ['price' => 99]
     );
+
+<a name="comparing-models"></a>
+## Comparing Models
+
+You may come across situations where you want to compare two objects of the same model. It can be useful to determine if both the model objects refer the same record in the database or not. Laravel provides an `is()` method to do it in a neat way:
+
+    // an example usecase
+
+    if (auth()->user()->is($post->user)) {
+        //
+    }
 
 <a name="deleting-models"></a>
 ## Deleting Models


### PR DESCRIPTION
- This PR adds the missing documentation for the [is()](https://github.com/laravel/framework/blob/5.5/src/Illuminate/Database/Eloquent/Model.php#L1071) method that was added to the `Model` class in Laravel 5.3.