### PR TITLE
Mention unsigned columns for foreign keys

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -440,6 +440,8 @@ If you pass an array of columns into a method that drops indexes, the convention
 
 Laravel also provides support for creating foreign key constraints, which are used to force referential integrity at the database level. For example, let's define a `user_id` column on the `posts` table that references the `id` column on a `users` table:
 
+> {note} Local columns must have the same `signed` or `unsigned` signature as the foreign column they are indexing. Laravel's `increment` column type defaults to `unsigned`, so take care to create your local key as `unsigned` as well.
+
     Schema::table('posts', function (Blueprint $table) {
         $table->unsignedInteger('user_id');
 


### PR DESCRIPTION
Ran into an issue where I had just created an `integer` column for my foreign key and it took me a bit of work to figure out why it wasn't working. Hopefully this will save someone else a few minutes. 

Also, not sure if this is mysql specific, if so maybe this isn't relevant for everyone. 