### PR TITLE
Change authorization token to snake case

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -416,7 +416,7 @@ Next, you should create a [service provider](/docs/{{version}}/providers) such a
         {
             Storage::extend('dropbox', function ($app, $config) {
                 $client = new DropboxClient(
-                    $config['authorizationToken']
+                    $config['authorization_token']
                 );
 
                 return new Filesystem(new DropboxAdapter($client));


### PR DESCRIPTION
Keys in all the default configuration files use snake case, so I just changed this code example to use snake case as well.