### PR TITLE
improve documentation on queues

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -506,6 +506,7 @@ Supervisor configuration files are typically stored in the `/etc/supervisor/conf
 
     [program:laravel-worker]
     process_name=%(program_name)s_%(process_num)02d
+    directory=/path/to/laravel/project
     command=php /home/forge/app.com/artisan queue:work sqs --sleep=3 --tries=3
     autostart=true
     autorestart=true


### PR DESCRIPTION
in my project there was an error without this  because php would not
been able to finde .env file of my project and get to use default settings. 