### PR TITLE
Update helpers.md

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -955,7 +955,7 @@ The `str_start` function adds a single instance of the given value to a string i
 
     // /this/string
 
-    $adjusted = str_start('/this/string/', '/');
+    $adjusted = str_start('/this/string', '/');
 
     // /this/string
 


### PR DESCRIPTION
The example str_start('/this/string/', '/'); returns '/this/string/' and not '/this/string' as the comment suggests.
Either the comment or the code should be changed.
To be more consistent to the previous example (i.e. str_start('this/string', '/');) i suggest to change the code.