### PR TITLE
Clarify groupBy docs

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -740,7 +740,7 @@ The `groupBy` method groups the collection's items by a given key:
         ]
     */
 
-In addition to passing a string `key`, you may also pass a callback. The callback should return the value you wish to key the group by:
+Instead of passing a string `key`, you may pass a callback. The callback should return the value you wish to key the group by:
 
     $grouped = $collection->groupBy(function ($item, $key) {
         return substr($item['account_id'], -3);


### PR DESCRIPTION
Callback for `groupBy` is passed instead of the string `key`, not in addition to it.