### PR TITLE
Added info about Valet community forks.

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -18,6 +18,8 @@
 
 Valet is a Laravel development environment for Mac minimalists. No Vagrant, no `/etc/hosts` file. You can even share your sites publicly using local tunnels. _Yeah, we like it too._
 
+> {tip} If you're not using Mac, you can check community-driven forks of Valet for [Linux](https://github.com/cpriego/valet-linux) and [Windows](https://github.com/cpriego/valet-linux).
+
 Laravel Valet configures your Mac to always run [Nginx](https://www.nginx.com/) in the background when your machine starts. Then, using [DnsMasq](https://en.wikipedia.org/wiki/Dnsmasq), Valet proxies all requests on the `*.dev` domain to point to sites installed on your local machine.
 
 In other words, a blazing fast Laravel development environment that uses roughly 7 MB of RAM. Valet isn't a complete replacement for Vagrant or Homestead, but provides a great alternative if you want flexible basics, prefer extreme speed, or are working on a machine with a limited amount of RAM.


### PR DESCRIPTION
For a long time, I assumed that Valet was only something for Mac users, until one day I saw someone mentioning Valet forks in comments on Laracasts. I think plenty of other people may also be missing out on Valet, as the very first sentence tells you it's only for Mac. I haven't tried personally the one for Windows, but Linux fork works great in my experience.