### PR TITLE
Correct count field name

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -734,7 +734,7 @@ You may use "dot" notation to execute a query against a nested relationship. For
 <a name="counting-related-models"></a>
 ### Counting Related Models
 
-If you want to count the number of results from a relationship without actually loading them you may use the `withCount` method, which will place a `{relation}_count` column on your resulting models. For example:
+If you want to count the number of results from a relationship without actually loading them you may use the `withCount` method, which will place a `{related_table_name}_count` column on your resulting models. For example:
 
     $posts = App\Post::withCount('comments')->get();
 


### PR DESCRIPTION
"relation" here is ambiguous. The related count field name isn't {relationship}_count, or even {related_model}_count, it seems to be {related_table_name}_count. In my case according to the docs it should have been productVariants_count, but it's actually product_variants_count.
Am I missing some subtlety here?