### PR TITLE
[5.2] Update upgrade.md

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -53,6 +53,25 @@ The `loginPath()` method has been removed from `Illuminate\Foundation\Auth\Authe
 
 The `Illuminate\Auth\Access\UnauthorizedException` has been renamed to `Illuminate\Auth\Access\AuthorizationException`. This is unlikely to affect your application if you are not manually catching this exception.
 
+#### The `AuthorizesResources` Trait
+
+You should add the `AuthorizesResources` trait to your `app/Http/Controllers/Controller.php` file.
+
+    <?php
+
+    namespace App\Http\Controllers;
+
+    use Illuminate\Foundation\Bus\DispatchesJobs;
+    use Illuminate\Routing\Controller as BaseController;
+    use Illuminate\Foundation\Validation\ValidatesRequests;
+    use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+    use Illuminate\Foundation\Auth\Access\AuthorizesResources;
+
+    class Controller extends BaseController
+    {
+        use AuthorizesRequests, AuthorizesResources, DispatchesJobs, ValidatesRequests;
+    }
+
 ### Collections
 
 #### Eloquent Base Collections


### PR DESCRIPTION
Resolves #4372.

If a developer at the time (like in my case) had originally built their app with `5.1 LTS` and then later upgraded their app to `5.2` using this documentation, they will miss the change that happened to the `app/Http/Controllers/Controller.php` file which this PR addresses. Specifically, adding the `AuthorizesResources` trait.

If the developer was using the **Automatically Determining Policy Methods** feature, then they'll encounter unexpected results. Specifically, when authorizing a method name that is in the missing resource map located in the missing trait, e.g. `show`. Without the resource map authorization looks for a `show` method on the policy. With the resource map it would look for a `view` method on the policy. In `5.3` the `AuthorizesResources` and `AuthorizesRequests` traits are merged which breaks apps that missed the addition of this trait in `5.2` because they may have developed policies while missing a resource map.