### PR TITLE
Cron entry example for schedule:run relative to project path

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -24,7 +24,7 @@ Laravel's command scheduler allows you to fluently and expressively define your 
 
 When using the scheduler, you only need to add the following Cron entry to your server. If you do not know how to add Cron entries to your server, consider using a service such as [Laravel Forge](https://forge.laravel.com) which can manage the Cron entries for you:
 
-    * * * * * php /path-to-your-project/artisan schedule:run >> /dev/null 2>&1
+    * * * * * cd /path-to-your-project && php artisan schedule:run >> /dev/null 2>&1
 
 This Cron will call the Laravel command scheduler every minute. When the `schedule:run` command is executed, Laravel will evaluate your scheduled tasks and runs the tasks that are due.
 


### PR DESCRIPTION
Ran into an issue where running the cron with a similar format to the existing example caused scheduled console jobs to not work if they were scheduled commands because the call to `Application::formatCommandString()` within `Schedule::command()` appears to generate the command string assuming that the caller is already in the working directory of the project. eg: `php artisan some:command`.