### PR TITLE
[5.6] Add more detailed documentation about Event::fakeFor method

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -88,7 +88,7 @@ As an alternative to mocking, you may use the `Event` facade's `fake` method to 
     }
 
 > {note} After calling `Event::fake()`, no event listeners will be executed. So, if your tests use model factories that rely on events, such as creating a UUID during a model's `creating` event, you should call `Event::fake()` **after** using your factories.
-Another option would be to use `Event::fakeFor()` to prevent event listeners from being executed only during the given callback.
+Another option would be to use `Event::fakeFor()` to prevent event listeners from being executed only during the given callback and keeping the original listeners before and after this call.
 
 <a name="mail-fake"></a>
 ## Mail Fake

--- a/mocking.md
+++ b/mocking.md
@@ -3,6 +3,7 @@
 - [Introduction](#introduction)
 - [Bus Fake](#bus-fake)
 - [Event Fake](#event-fake)
+    - [Partial faking](#event-partial-faking)
 - [Mail Fake](#mail-fake)
 - [Notification Fake](#notification-fake)
 - [Queue Fake](#queue-fake)
@@ -88,7 +89,44 @@ As an alternative to mocking, you may use the `Event` facade's `fake` method to 
     }
 
 > {note} After calling `Event::fake()`, no event listeners will be executed. So, if your tests use model factories that rely on events, such as creating a UUID during a model's `creating` event, you should call `Event::fake()` **after** using your factories.
-Another option would be to use `Event::fakeFor()` to prevent event listeners from being executed only during the given callback and keeping the original listeners before and after this call.
+
+<a name="event-partial-faking"></a>
+### Partial faking
+
+If you want to prevent event listeners from being executed for only a specific part of your test, you can use the `fakeFor` method. This method will reset the original listeners after the callback. When using the `fakeFor`, assertions made after the code inside the callback:
+
+    <?php
+
+    namespace Tests\Feature;
+
+    use App\Order;
+    use Tests\TestCase;
+    use App\Events\OrderCreated;
+    use Illuminate\Support\Facades\Event;
+    use Illuminate\Foundation\Testing\RefreshDatabase;
+    use Illuminate\Foundation\Testing\WithoutMiddleware;
+
+    class ExampleTest extends TestCase
+    {
+        /**
+         * Test order process.
+         */
+        public function testOrderProcess()
+        {
+            $order = Event::fakeFor(function () {
+                // Events are faked and observers will not run ...
+                $order = factory(Order::class)->create();
+
+                // Assert an event was dispatched ...
+                Event::assertDispatched(OrderCreated::class);
+
+                return $order;
+            });
+
+            // Events are dispatched as normal and observers will run ...
+            $order->update([...]);
+        }
+    }
 
 <a name="mail-fake"></a>
 ## Mail Fake

--- a/mocking.md
+++ b/mocking.md
@@ -88,6 +88,7 @@ As an alternative to mocking, you may use the `Event` facade's `fake` method to 
     }
 
 > {note} After calling `Event::fake()`, no event listeners will be executed. So, if your tests use model factories that rely on events, such as creating a UUID during a model's `creating` event, you should call `Event::fake()` **after** using your factories.
+Another option would be to use `Event::fakeFor()` to prevent event listeners from being executed only during the given callback.
 
 <a name="mail-fake"></a>
 ## Mail Fake


### PR DESCRIPTION
Add documentation about the Event::fakeFor method and that it can be used to fake the events for only a part of your test.

Instead of only one sentence as in #4334 it's now described in more detail.