### PR TITLE
Note queue driver to use for Horizon

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -33,7 +33,7 @@ After installing Horizon, publish its assets using the `vendor:publish` Artisan 
 <a name="configuration"></a>
 ### Configuration
 
-After publishing Horizon's assets, its primary configuration file will be located at `config/horizon.php`. This configuration file allows you to configure your worker options and each configuration option includes a description of its purpose, so be sure to thoroughly explore this file.
+After publishing Horizon's assets, its primary configuration file will be located at `config/horizon.php`. This configuration file allows you to configure your worker options and each configuration option includes a description of its purpose, so be sure to thoroughly explore this file. Be sure to adjust your queue driver to `redis` in `config/queue.php` if you haven't already.
 
 #### Balance Options
 


### PR DESCRIPTION
This might have just been something silly I ran into, but after installing Horizon I wasn't sure which queue driver to use - totally forgetting that it ran on Redis. I had tried changing the queue driver to `horizon` and debugging why that didn't work. Thought it may be useful for the Horizon docs just to note that you use the `redis` queue driver when running Horizon.