### PR TITLE
Fix explanation of automatic foreign key detection in 'One to many' relationship block

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -225,7 +225,7 @@ Once the relationship has been defined, we can retrieve the `Post` model for a `
 
     echo $comment->post->title;
 
-In the example above, Eloquent will try to match the `post_id` from the `Comment` model to an `id` on the `Post` model. Eloquent determines the default foreign key name by examining the name of the relationship method and suffixing the method name with `_id`. However, if the foreign key on the `Comment` model is not `post_id`, you may pass a custom key name as the second argument to the `belongsTo` method:
+In the example above, Eloquent will try to match the `post_id` from the `Comment` model to an `id` on the `Post` model. Eloquent determines the default foreign key name by examining the name of the relationship method and suffixing the method name with a `_` followed by the name of the primary key column. However, if the foreign key on the `Comment` model is not `post_id`, you may pass a custom key name as the second argument to the `belongsTo` method:
 
     /**
      * Get the post that owns the comment.


### PR DESCRIPTION
- If the owning model uses a primary key other than `id`, let's say the `Post` model from the given example uses `uuid` as the primary key, then the current explanation will result in an error.
- The current explanation says it will prefix it with `_id` (hardcoded) i.e. doing `$post->comments` will look for `post_id` in comments table, but instead it will look for `post_uuid`. 