### PR TITLE
Update SparkPost API endpoint EU example

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -55,8 +55,8 @@ If necessary, you may also configure which [API endpoint](https://developers.spa
     'sparkpost' => [
         'secret' => 'your-sparkpost-key',
         'options' => [
-            'endpoint' => 'https://api.eu.sparkpost.com/api/v1',
-        ]
+            'endpoint' => 'https://api.eu.sparkpost.com/api/v1/transmissions',
+        ],
     ],
 
 #### SES Driver


### PR DESCRIPTION
The example API endpoint is missing `/transmissions`. Default also uses this: https://github.com/laravel/framework/blob/c8682e11b9f0e153654ff5c2a3ad9f8b2dca56d1/src/Illuminate/Mail/Transport/SparkPostTransport.php#L146