### PR TITLE
[5.5] Add note for using withCount together with select

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -758,6 +758,8 @@ You may also alias the relationship count result, allowing multiple counts on th
 
     echo $posts[0]->pending_comments_count;
 
+> {note} In case of specifying columns selected for your model (using for example `select`) use `withCount` after specifying those columns. Otherwise generated query might be invalid and you might also get invalid counts of related models.
+
 <a name="eager-loading"></a>
 ## Eager Loading
 


### PR DESCRIPTION
As showed in https://github.com/laravel/framework/issues/24797 there is a problem when `withCount` is used before `select`. So as suggested I've added this as note to documentation.