### PR TITLE
Add full path to policy

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -60,7 +60,7 @@ Gates may also be defined using a `Class@method` style callback string, like con
     {
         $this->registerPolicies();
 
-        Gate::define('update-post', 'PostPolicy@update');
+        Gate::define('update-post', 'App\Policies\PostPolicy@update');
     }
 
 #### Resource Gates


### PR DESCRIPTION
Unless the full path to the policy is used in the Class@method style callback string an exception is thrown.

This may be implied here but because the gate definitions under the resource gates below show the full path, the description may be confusing.