### PR TITLE
Update text for naming resource route parameters

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -226,15 +226,15 @@ By default, all resource controller actions have a route name; however, you can 
 <a name="restful-naming-resource-route-parameters"></a>
 ### Naming Resource Route Parameters
 
-By default, `Route::resource` will create the route parameters for your resource routes based on the "singularized" version of the resource name. You can easily override this on a per resource basis by passing `parameters` in the options array. The `parameters` array should be an associative array of resource names and parameter names:
+By default, `Route::resource` will create the route parameters for your resource routes based on the "singularized" version of the resource name. You can easily override this on a per resource basis by using the `parameters` method. The array passed into the `parameters` method should be an associative array of resource names and parameter names:
 
-    Route::resource('user', 'AdminUserController')->parameters([
-        'user' => 'admin_user'
+    Route::resource('users', 'AdminUserController')->parameters([
+        'users' => 'admin_user'
     ]);
 
  The example above generates the following URIs for the resource's `show` route:
 
-    /user/{admin_user}
+    /users/{admin_user}
 
 <a name="restful-localizing-resource-uris"></a>
 ### Localizing Resource URIs


### PR DESCRIPTION
The text was still referring to the options array that was replaced by fluent declarations with 0fa66a2f4c5da8b04279b840b0567d08df87b8bd
Also, I changed the resource name in the example code for easier understanding of how renaming parameters works. Some people (including me) found the previous resource name to be confusing: https://github.com/laravel/framework/issues/19477