### PR TITLE
Explain how to enable whisper() when using Pusher

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -581,7 +581,11 @@ You may listen for the join event via Echo's `listen` method:
 <a name="client-events"></a>
 ## Client Events
 
-Sometimes you may wish to broadcast an event to other connected clients without hitting your Laravel application at all. This can be particularly useful for things like "typing" notifications, where you want to alert users of your application that another user is typing a message on a given screen. To broadcast client events, you may use Echo's `whisper` method:
+Sometimes you may wish to broadcast an event to other connected clients without hitting your Laravel application at all. This can be particularly useful for things like "typing" notifications, where you want to alert users of your application that another user is typing a message on a given screen.
+
+> {tip} While using [Pusher](https://pusher.com), the option to send `Client Events` need to be enabled in the `App Settings` section of your application [dashboard](https://dashboard.pusher.com/)
+
+To broadcast client events, you may use Echo's `whisper` method:
 
     Echo.private('chat')
         .whisper('typing', {


### PR DESCRIPTION
Hello !

Overall, the Broadcasting documentation is using Pusher to explain most of the configuration. A small section is saying to use whisper() to exchange directly between connecteds peers, but in order to do that with Pusher, you need to allow it manually in your App Settings, otherwise it would fail silently, except from the Debug Console on the Pusher Dashboard.

Explaining that would be nice.