### PR TITLE
[5.6] Update docs about methods whose type-hinted dependencies get injected via the DIC

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -54,7 +54,7 @@ After generating your command, you should fill in the `signature` and `descripti
 
 > {tip} For greater code reuse, it is good practice to keep your console commands light and let them defer to application services to accomplish their tasks. In the example below, note that we inject a service class to do the "heavy lifting" of sending the e-mails.
 
-Let's take a look at an example command. Note that we are able to inject any dependencies we need into the command's constructor. The Laravel [service container](/docs/{{version}}/container) will automatically inject all dependencies type-hinted in the constructor:
+Let's take a look at an example command. Note that we are able to inject any dependencies we need into the command's constructor (or in the `handle` method). The Laravel [service container](/docs/{{version}}/container) will automatically inject all dependencies type-hinted in the constructor (or in the `handle` method):
 
     <?php
 

--- a/middleware.md
+++ b/middleware.md
@@ -32,9 +32,25 @@ This command will place a new `CheckAge` class within your `app/Http/Middleware`
     namespace App\Http\Middleware;
 
     use Closure;
+    use Illuminate\Routing\Redirector;
 
     class CheckAge
     {
+        /**
+         * @var Redirector
+         */
+        private $redirector;
+
+        /**
+         * @param  Redirector $redirector
+         * @return void
+         */
+        public function __construct(Redirector $redirector)
+        {
+            // Dependencies automatically resolved by the service container...
+            $this->redirector = $redirector;
+        }
+        
         /**
          * Handle an incoming request.
          *
@@ -45,7 +61,7 @@ This command will place a new `CheckAge` class within your `app/Http/Middleware`
         public function handle($request, Closure $next)
         {
             if ($request->age <= 200) {
-                return redirect('home');
+                return $this->redirector->to('home');
             }
 
             return $next($request);
@@ -55,6 +71,8 @@ This command will place a new `CheckAge` class within your `app/Http/Middleware`
 As you can see, if the given `age` is less than or equal to `200`, the middleware will return an HTTP redirect to the client; otherwise, the request will be passed further into the application. To pass the request deeper into the application (allowing the middleware to "pass"), call the `$next` callback with the `$request`.
 
 It's best to envision middleware as a series of "layers" HTTP requests must pass through before they hit your application. Each layer can examine the request and even reject it entirely.
+
+> {tip} All middleware are resolved via the [service container](/docs/{{version}}/container), so you may type-hint any dependencies you need within a middleware's constructor.
 
 ### Before & After Middleware
 

--- a/seeding.md
+++ b/seeding.md
@@ -46,6 +46,8 @@ As an example, let's modify the default `DatabaseSeeder` class and add a databas
         }
     }
 
+> {tip} You may type-hint any dependencies you need within the `run` method and they will be resolved via the [service container](/docs/{{version}}/container).
+
 <a name="using-model-factories"></a>
 ### Using Model Factories
 

--- a/validation.md
+++ b/validation.md
@@ -216,6 +216,9 @@ So, how are the validation rules evaluated? All you need to do is type-hint the 
 
 If validation fails, a redirect response will be generated to send the user back to their previous location. The errors will also be flashed to the session so they are available for display. If the request was an AJAX request, a HTTP response with a 422 status code will be returned to the user including a JSON representation of the validation errors.
 
+
+> {tip} You may type-hint any dependencies you need within the `rules` method and they will be resolved via the [service container](/docs/{{version}}/container).
+
 #### Adding After Hooks To Form Requests
 
 If you would like to add an "after" hook to a form request, you may use the `withValidator` method. This method receives the fully constructed validator, allowing you to call any of its methods before the validation rules are actually evaluated:
@@ -269,6 +272,8 @@ If you plan to have authorization logic in another part of your application, ret
     {
         return true;
     }
+
+> {tip} You may type-hint any dependencies you need within the `authorize` method and they will be resolved via the [service container](/docs/{{version}}/container).
 
 <a name="customizing-the-error-messages"></a>
 ### Customizing The Error Messages


### PR DESCRIPTION
There are some instances in the framework where some methods get called via the container and any type-hinted dependencies in those methods get automatically injected, but the docs were missing mentions of some of those methods.