### PR TITLE
Expand new pivot code example

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -382,11 +382,11 @@ If you would like to define a custom model to represent the intermediate table o
         {
             if ($parent instanceof User) {
 
-                return \App\UserRole::fromRawAttributes($parent, $attributes, $table, $exists);
-			}
-            
-			return parent::newPivot($parent, $attributes, $table, $exists, $using);
-		}
+		return \App\UserRole::fromRawAttributes($parent, $attributes, $table, $exists);
+    	    }
+
+	    return parent::newPivot($parent, $attributes, $table, $exists, $using);
+  	}
     }
 
 When defining the `UserRole` model, we will extend the `Pivot` class:
@@ -404,8 +404,8 @@ When defining the `UserRole` model, we will extend the `Pivot` class:
         public function role()
         {
 
-			return $this->belongsTo('App\Role', 'role_id');
-		}
+		return $this->belongsTo('App\Role', 'role_id');
+	}
     }
 
 <a name="has-many-through"></a>

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -377,6 +377,16 @@ If you would like to define a custom model to represent the intermediate table o
         {
             return $this->belongsToMany('App\User')->using('App\UserRole');
         }
+        
+        public function newPivot(Model $parent, array $attributes, $table, $exists, $using = null)
+        {
+            if ($parent instanceof User) {
+
+                return \App\UserRole::fromRawAttributes($parent, $attributes, $table, $exists);
+			}
+            
+			return parent::newPivot($parent, $attributes, $table, $exists, $using);
+		}
     }
 
 When defining the `UserRole` model, we will extend the `Pivot` class:
@@ -389,7 +399,13 @@ When defining the `UserRole` model, we will extend the `Pivot` class:
 
     class UserRole extends Pivot
     {
-        //
+        protected $table = 'role_user';
+        
+        public function role()
+        {
+
+			return $this->belongsTo('App\Role', 'role_id');
+		}
     }
 
 <a name="has-many-through"></a>


### PR DESCRIPTION
This PR is put forward to clarify the method of overriding the `newPivot` method when creating a custom pivot table model. There are still a lot of **Laravel 4** example online that show a the old way of doing it. This has bitten a lot of developers i know really hard when surfing the internet for a **Laravel 5** example of how to correctly do this. I hope this PR serves to give developers a one-stop destination for a very lucid example right in the **Laravel 5* docs.

```php

// Old Way (Laravel 4)

public function newPivot(Model $parent, array $attributes, $table, $exists, $using = null){

			if($parent instanceof User){
                                // this thorws an error in L5 and righfully so
				return new Profile($parent, $attributes, $table, $exists); 
			}
			
                        return parent::newPivot($parent, $attributes, $table, $exists, $using);
}
```

```php

// New Way (Laravel 5)

public function newPivot(Model $parent, array $attributes, $table, $exists, $using = null){
			
                        if($parent instanceof User){
				return Profile::fromRawAttributes($parent, $attributes, $table, $exists);
			}

			return parent::newPivot($parent, $attributes, $table, $exists, $using);
}
```

Thanks 