### PR TITLE
Update redis.md - note about dispatching

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -214,6 +214,8 @@ First, let's setup a channel listener using the `subscribe` method. We'll place 
             });
         }
     }
+    
+> {note} With some versions of Redis you will not be able to dispatch jobs on the same connection that you are subscribed on. You will need to either subscribe using a new redis connection or dispatch on a different connection.
 
 Now we may publish messages to the channel using the `publish` method:
 


### PR DESCRIPTION
With some versions of reids you can run into an error along the lines of "-ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context" if you call `SomeJob::dispatch()` from within a `Redis::subscribe(...)` handler and if they are both running on the same redis connection. The subscribe connection can only be used for pubsub.

To fix this issue I introduced a new connection in `database.php` for redis pubsub and called `Redis::connection('pubsub')->subscribe(...)`