### PR TITLE
Fix inconsistent Passport versions

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -56,7 +56,7 @@ In addition, if you are using the following first-party Laravel packages, you sh
 
 <div class="content-list" markdown="1">
 - Dusk (Upgrade To `^3.0`)
-- Passport (Upgrade To `^5.0`)
+- Passport (Upgrade To `^6.0`)
 - Scout (Upgrade To `^4.0`)
 </div>
 


### PR DESCRIPTION
As described in laravel/passport#755, the current upgrade guide is confusing and prior to the notice about Passport 6.0.7 it wasn't clear if Passport 6 is compatible with Laravel 5.6.