### PR TITLE
Added link to 'view composer' page from  'providers' page

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -61,7 +61,7 @@ This service provider only defines a `register` method, and uses that method to 
 <a name="the-boot-method"></a>
 ### The Boot Method
 
-So, what if we need to register a view composer within our service provider? This should be done within the `boot` method. **This method is called after all other service providers have been registered**, meaning you have access to all other services that have been registered by the framework:
+So, what if we need to register a [view composer](/docs/{{version}}/views#view-composers) within our service provider? This should be done within the `boot` method. **This method is called after all other service providers have been registered**, meaning you have access to all other services that have been registered by the framework:
 
     <?php
 


### PR DESCRIPTION
Was a bit confused about "View composer" when was reading about
the "The Boot Method" from page https://laravel.com/docs/5.6/providers#writing-service-providers

Hopefully this small change will make it more clear

