### PR TITLE
Add warning for Saved & Updated method will not fire in case of mass update

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -732,6 +732,9 @@ Eloquent models fire several events, allowing you to hook into the following poi
 
 The `retrieved` event will fire when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will fire. If a model already existed in the database and the `save` method is called, the `updating` / `updated` events will fire. However, in both cases, the `saving` / `saved` events will fire.
 
+> {note} When issuing a mass update via Eloquent, the `saved` and `updated` model events will not be fired for the updated models. This is because the models are never actually retrieved when issuing a mass update.
+
+
 To get started, define a `$dispatchesEvents` property on your Eloquent model that maps various points of the Eloquent model's lifecycle to your own [event classes](/docs/{{version}}/events):
 
     <?php


### PR DESCRIPTION
We have this warning (Saved & Updated method will not fire in case of mass update) in updates section.
But its a Event related note/warning, I think it should (also) be in Events section so its hard to miss it, for someone whose looking for reference.