### PR TITLE
LTS version corrected

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -46,7 +46,7 @@ Informal discussion regarding bugs, new features, and implementation of existing
 <a name="which-branch"></a>
 ## Which Branch?
 
-**All** bug fixes should be sent to the latest stable branch or to the current LTS branch (5.6). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
+**All** bug fixes should be sent to the latest stable branch or to the current LTS branch (5.5). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
 
 **Minor** features that are **fully backwards compatible** with the current Laravel release may be sent to the latest stable branch.
 


### PR DESCRIPTION
Current LTS version is 5.5 according to https://laravel.com/docs/5.6/releases#support-policy
I believe the same issue exists in branches 5.7 and master too.