### PR TITLE
Added example for custom column name for unique method with Rule class

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -963,6 +963,10 @@ To instruct the validator to ignore the user's ID, we'll use the `Rule` class to
         ],
     ]);
 
+You can specify the custom column name as the second parameter of the `unique` method:
+
+    'email' => Rule::unique('users', 'email_address')
+    
 If your table uses a primary key column name other than `id`, you may specify the name of the column when calling the `ignore` method:
 
     'email' => Rule::unique('users')->ignore($user->id, 'user_id')


### PR DESCRIPTION
The first idea that came into my mind on how to specify a custom column name using the Rule class was to write:
`'email' => Rule::unique('users,<custom_name>')`.
This caused an error:
`(ErrorException(code: 0): Undefined offset: 1 at /var/www/html/vendor/laravel/framework/src/Illuminate/Validation/Concerns/ValidatesAttributes.php:795`.
After sometime I discovered it should be passed as a second parameter to the unique method. I believe it would be nice to have this information in the documentation.