### PR TITLE
[>= 5.6] Clarify the usage of the :count placeholder

### DIFF
--- a/localization.md
+++ b/localization.md
@@ -133,6 +133,10 @@ You may even create more complex pluralization rules which specify translation s
 
     'apples' => '{0} There are none|[1,19] There are some|[20,*] There are many',
 
+If you want to display the exact value that was used to evaluate the pluralizated translation strings you may use the pre-defined `:count` placeholder.
+
+    'apples' => '{0} There are none|{1} There is one|[2,*] There are :count',
+
 After defining a translation string that has pluralization options, you may use the `trans_choice` function to retrieve the line for a given "count". In this example, since the count is greater than one, the plural form of the translation string is returned:
 
     echo trans_choice('messages.apples', 10);


### PR DESCRIPTION
There was no documentation of the default placeholder `:count` that you can use during localization. This caused confusion with the existing placeholder attribute documentation as users were thinking that they need to provide the value to `trans_choice()` twice in order to display the exact value that caused the pluralization to take effect.

Confusion that was caused: https://github.com/laravel/ideas/issues/1300
The feature is implemented in here: 
https://github.com/laravel/framework/blob/5.6/src/Illuminate/Translation/Translator.php#L210

It may be a good idea to merge this change not only in the 5.6 branch but also in the 5.7 and master as it's not documented in there as well.