### PR TITLE
Improve docs for "optional" with second argument

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -1383,17 +1383,23 @@ The `old` function [retrieves](/docs/{{version}}/requests#retrieving-input) an [
 <a name="method-optional"></a>
 #### `optional()` {#collection-method}
 
-The `optional` function accepts any argument and allows you to access properties or call methods on that object. If the given object is `null`, properties and methods will return `null` instead of causing an error:
+The `optional` function accepts any argument and allows you to access properties on that object. If the given object is `null`, accessing a property will return `null` instead of causing an error:
 
     return optional($user->address)->street;
 
     {!! old('name', optional($user)->name) !!}
 
-The `optional` function also accepts a Closure as its second argument. The Closure will be invoked if the value provided as the first argument is not null:
+You can also call methods on the returned object. As with property access, if the given object is `null`, calling a method will return `null` instead of causing an error:
+
+    return optional($user)->getTwitterProfile();
+
+If the method you want to call is not actually on the object itself, you can pass a Closure to `optional` as its second argument:
 
     return optional(User::find($id), function ($user) {
-        return new DummyUser;
+        return TwitterApi::findUser($user->twitter_id);
     });
+
+If the given object is not `null`, the Closure will be called and its return value will be returned as is. If the given object is actually `null`, the Closure will not be called, and `optional` will return `null` instead of causing an error.
 
 <a name="method-policy"></a>
 #### `policy()` {#collection-method}


### PR DESCRIPTION
This is a different attempt at #4461.

### Short version

The current docs are misleading. It says that passing a Closure to `optional` will only call it **if the object is not `null`**, but the code example seems to imply that it will call the Closure **if the object actually _is_ `null`**.

This PR aims to clear that up.

### Longer version

We essentially have two entirely different signatures for the `optional` helper:

1. `maybeNullObject => Optional` - Calling `optional` with a single argument returns an instance of `Optional`, which allows you to access a property or call a method on the underlying object, noop-ing for when the first argument is actually `null`.

1. `(maybeNullObject , Closure) => maybeNullOtherObject` - Passing a Closure as the second argument changes the return value of `optional`. If the first argument is `null`, `optional` will return `null`. If the first argument is not `null`, `optional` will return whatever the Closure returns.

In essence, whichever version of `optional` you use, you're always protected against a single `null` value. If a Twitter profile is not actually returned, accessing properties on that will cause an error:

1. Passing a single argument to `optional`:

    ```php
    optional(User::find($id))->getTwitterProfile()->url; // throws

    class User
    {
        function getTwitterProfile()
        {
            // in some branch:
            return null;
        }
    }
    ```

1. Passing a Closure as the second argument to `optional`:

    ```php
    optional(User::find($id), function ($user) {
        return TwitterApi::findUser($user->twitter_id);
    })->url; // throws

    class TwitterApi
    {
        function findUser($twitterId)
        {
            // in some branch:
            return null;
        }
    }
    ```

For some reason, people were confused by this, thinking that `optional` should also protect you from accessing properties on the return value of the Closure, which doesn't really make sense.

I had [tweeted about this change](https://twitter.com/joseph_silber/status/981690994054828032) back when it was introduced, and people seem to have understood that example more clearly, so this PR adds it to the docs.