### PR TITLE
Update upgrade.md for Foreign keys in SQLite

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -217,6 +217,14 @@ Prior to Laravel 5.7, the `PDO_DBLIB` driver was used as the default SQL Server 
 
 If neither of these drivers are available, Laravel will use the `PDO_DBLIB` driver.
 
+#### Foreign keys in SQLite
+
+**Likelihood Of Impact: Medium**
+
+SQLite does not support dropping foreign keys. Using the `dropForeign` method on a table now throws an exception. Generally, this should be considered a bug fix; however, it is listed as a breaking change out of caution.
+
+If you run your migrations on multiple types of databases, consider using `DB::getDriverName()` in your migrations to skip unsupported foreign key methods for SQLite, or override the Blueprint methods to suit your needs.
+
 ### Debug
 
 #### Dumper Classes


### PR DESCRIPTION
See https://github.com/laravel/framework/issues/25475.

I think this (currently undocumented) breaking change is a good decision overall.

But I also think it would be a good addition to explicitly mention in the upgrade guide for 5.7, as the impact can be quite significant and unexpected.

One scenario where this heavily affects the upgrade process is when you use:

* MySQL as your main database
* in-memory SQLite as your testing database
* have functional tests using the `refreshDatabase` trait, 
* and have migrations which drop foreign keys. 
