### PR TITLE
Remove return statement from closure validation example

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1116,7 +1116,7 @@ If you only need the functionality of a custom rule once throughout your applica
             'max:255',
             function($attribute, $value, $fail) {
                 if ($value === 'foo') {
-                    return $fail($attribute.' is invalid.');
+                    $fail($attribute.' is invalid.');
                 }
             },
         ],


### PR DESCRIPTION
Doesn't actually make a functional difference, but I think having it there is a bit misleading and can make the reader think they need to return the result of calling `$fail(...)` for the rule to work properly.