### PR TITLE
Multiple versions of PHP now work on Apache

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -477,8 +477,6 @@ After running the command, you will see an Ngrok screen appear which contains th
 <a name="multiple-php-versions"></a>
 ### Multiple PHP Versions
 
-> {note} This feature is only compatible with Nginx.
-
 Homestead 6 introduced support for multiple versions of PHP on the same virtual machine. You may specify which version of PHP to use for a given site within your `Homestead.yaml` file. The available PHP versions are: "5.6", "7.0", "7.1" and "7.2" (the default):
 
     sites:


### PR DESCRIPTION
This pull request is the same as #4460, except that it only deletes the note which states that multiple versions of PHP only work on Nginx.

Confirmed to work on my own machine with a fresh install of Laravel 4.2 and PHP 5.6. See laravel/homesteadv7.11.0 and v7.14.2 for more details.

I can't find a way to merge this commit into 5.6 and 5.7 without more pull requests, so I just commit to master.