### PR TITLE
[5.7] Add whereJsonLength() queries

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -469,7 +469,7 @@ The query above will produce the following SQL:
 <a name="json-where-clauses"></a>
 ### JSON Where Clauses
 
-Laravel also supports querying JSON column types on databases that provide support for JSON column types. Currently, this includes MySQL 5.7, PostgreSQL, and SQL Server 2016. To query a JSON column, use the `->` operator:
+Laravel also supports querying JSON column types on databases that provide support for JSON column types. Currently, this includes MySQL 5.7, PostgreSQL, SQL Server 2016, and SQLite 3.9.0 (with the [JSON1 extension](https://www.sqlite.org/json1.html)). To query a JSON column, use the `->` operator:
 
     $users = DB::table('users')
                     ->where('options->language', 'en')
@@ -479,7 +479,7 @@ Laravel also supports querying JSON column types on databases that provide suppo
                     ->where('preferences->dining->meal', 'salad')
                     ->get();
                     
-You may use `whereJsonContains` to query JSON arrays:
+You may use `whereJsonContains` to query JSON arrays (not supported on SQLite):
                     
     $users = DB::table('users')
                     ->whereJsonContains('options->languages', 'en')

--- a/queries.md
+++ b/queries.md
@@ -614,7 +614,7 @@ Of course, in addition to inserting records into the database, the query builder
 <a name="updating-json-columns"></a>
 ### Updating JSON Columns
 
-When updating a JSON column, you should use `->` syntax to access the appropriate key in the JSON object. This operation is only supported on databases that support JSON columns:
+When updating a JSON column, you should use `->` syntax to access the appropriate key in the JSON object. This operation is only supported on MySQL 5.7+:
 
     DB::table('users')
                 ->where('id', 1)

--- a/queries.md
+++ b/queries.md
@@ -490,6 +490,16 @@ MySQL and PostgreSQL support `whereJsonContains` with multiple values:
     $users = DB::table('users')
                     ->whereJsonContains('options->languages', ['en', 'de'])
                     ->get();                    
+                    
+You may use `whereJsonLength` to query JSON arrays by their length:
+                    
+    $users = DB::table('users')
+                    ->whereJsonLength('options->languages', 0)
+                    ->get();
+
+    $users = DB::table('users')
+                    ->whereJsonLength('options->languages', '>', 1)
+                    ->get();
 
 <a name="ordering-grouping-limit-and-offset"></a>
 ## Ordering, Grouping, Limit, & Offset


### PR DESCRIPTION
Adds `Builder::whereJsonLength()`: https://github.com/laravel/framework/pull/25047
Also ports #4452 and #4453 to 5.7.

Regarding your [comment](https://github.com/laravel/framework/pull/25047#issuecomment-419103913):
AFAICS, the documentation already covers all the available JSON methods. Am I missing something?

Can you change the default branch to 5.7?