### PR TITLE
Add GitLab CI to Laravel Dusk

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1319,7 +1319,6 @@ To run your Dusk tests on Travis CI, we will need to use the "sudo-enabled" Ubun
     script:
        - php artisan dusk
 
-
 <a name="running-tests-on-gitlab-ci"></a>
 ### GitLab CI
 

--- a/dusk.md
+++ b/dusk.md
@@ -1322,7 +1322,7 @@ To run your Dusk tests on Travis CI, we will need to use the "sudo-enabled" Ubun
 <a name="running-tests-on-gitlab-ci"></a>
 ### GitLab CI
 
-To run Dusk tests on [GitLab CI](https://about.gitlab.com/features/gitlab-ci-cd/), add the following to `.gitlab-ci.yml`. 
+To run Dusk tests on [GitLab CI](https://about.gitlab.com/features/gitlab-ci-cd/), add the following to your `.gitlab-ci.yml` file:
 
 	stages:
   	  - test

--- a/dusk.md
+++ b/dusk.md
@@ -36,6 +36,7 @@
     - [Codeship](#running-tests-on-codeship)
     - [Heroku CI](#running-tests-on-heroku-ci)
     - [Travis CI](#running-tests-on-travis-ci)
+    - [GitLab CI](#running-tests-on-gitlab-ci)
 
 <a name="introduction"></a>
 ## Introduction
@@ -1317,3 +1318,27 @@ To run your Dusk tests on Travis CI, we will need to use the "sudo-enabled" Ubun
 
     script:
        - php artisan dusk
+
+
+<a name="running-tests-on-gitlab-ci"></a>
+### GitLab CI
+
+To run Dusk tests on [GitLab CI](https://about.gitlab.com/features/gitlab-ci-cd/), add the following to `.gitlab-ci.yml`. 
+
+	stages:
+  	  - test
+	
+	browser_test:
+	  image: laratools/ci:7.2
+	  stage: test
+	  before_script:
+	    - composer install --prefer-dist --no-interaction --no-suggest
+	    - cp .env.testing .env
+	    - nohup php artisan serve &
+	  script:
+	    - php artisan dusk
+	  artifacts:
+	    paths:
+	      - ./tests/Browser/screenshots
+	      - ./tests/Browser/console
+	    expire_in: 7 days


### PR DESCRIPTION
A lot of users are using Gitlab CI as it is a free and powerful CI. Ive added the missing GitLab CI example for Dusk testing. 