### PR TITLE
Fix the command name used in the console test example

### DIFF
--- a/console-tests.md
+++ b/console-tests.md
@@ -33,7 +33,7 @@ You may test this command with the following test which utilizes the `expectsQue
      */
     public function test_console_command()
     {
-        $this->artisan('laracon')
+        $this->artisan('question')
              ->expectsQuestion('What is your name?', 'Taylor Otwell')
              ->expectsQuestion('Which language do you program in?', 'PHP')
              ->expectsOutput('Your name is Taylor Otwell and you program in PHP.')

--- a/releases.md
+++ b/releases.md
@@ -120,7 +120,7 @@ You may test this command with the following test which utilizes the `expectsQue
      */
     public function test_console_command()
     {
-        $this->artisan('laracon')
+        $this->artisan('question')
              ->expectsQuestion('What is your name?', 'Taylor Otwell')
              ->expectsQuestion('Which language do you program in?', 'PHP')
              ->expectsOutput('Your name is Taylor Otwell and you program in PHP.')


### PR DESCRIPTION
Fix the command name used in the console test example code to match the name of the example command specified above.