### PR TITLE
[5.7] Fix email verification

### DIFF
--- a/verification.md
+++ b/verification.md
@@ -26,7 +26,7 @@ To get started, verify that your `App\User` model implements the `Illuminate\Con
 
     class User extends Authenticatable implements MustVerifyEmail
     {
-        use MustVerifyEmail, Notifiable;
+        use Notifiable;
 
         // ...
     }


### PR DESCRIPTION
The `MustVerifyEmail` trait is already used by the parent class `Authenticatable`.

In `App\User`, `MustVerifyEmail` is the class alias for the contract. So using it as a trait would fail:

 > App\User cannot use Illuminate\Contracts\Auth\MustVerifyEmail - it is not a trait