### PR TITLE
Fix PHP Doc Block on broadcasting.md

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -158,7 +158,7 @@ The `ShouldBroadcast` interface requires our event to define a `broadcastOn` met
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return array
+     * @return \Illuminate\Broadcasting\Channel|array
      */
     public function broadcastOn()
     {


### PR DESCRIPTION
Added `\Illuminate\Broadcasting\Channel` to the PHPDoc block under the `Broadcasting` > `Concept Overview` > `The ShouldBroadcast Interface` section.

It was a little bit confusing because the return type was array, but a channel was being returned.