### PR TITLE
Add note about changes to template styles

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -257,7 +257,15 @@ PostgreSQL supports the float values `Infinity`, `-Infinity` and `NaN`. Prior to
 
 As of Laravel 5.7, these values will be cast to the corresponding PHP constants `INF`, `-INF`, and `NAN`.
 
-### Email Verification
+### Email
+
+#### Template Theme
+
+**Likelihood Of Impact: Low**
+
+If you have customized the default theme styles used for the email templates, you will need to re-publish and make your customizations again. The previous button colors have been renamed from 'blue', 'green', and 'red' to 'primary', 'success', and 'error' respectively.
+
+#### Verification
 
 **Likelihood Of Impact: Optional**
 


### PR DESCRIPTION
This adds a note about changes to the email templates which broke button styles for those who had customised the default stylesheet. This snagged me on a couple of projects, didn't realise it came from the 5.7 upgrade. Because there was already a heading for the email verification feature I merged these both under an email heading.

This addresses laravel/framework#25597.