### PR TITLE
remove incorrect version

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -46,7 +46,7 @@ Informal discussion regarding bugs, new features, and implementation of existing
 <a name="which-branch"></a>
 ## Which Branch?
 
-**All** bug fixes should be sent to the latest stable branch or to the current LTS branch (5.6). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
+**All** bug fixes should be sent to the latest stable branch or to the [current LTS branch](/docs/{{version}}/releases). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
 
 **Minor** features that are **fully backwards compatible** with the current Laravel release may be sent to the latest stable branch.
 


### PR DESCRIPTION
the current LTS is 5.5, not 5.6.

This PR removes the value, and links to the 'releases' page, so we don't have to keep updating it, and people can look if they'd like.