### PR TITLE
[5.7] Use default pivot table name

### DIFF
--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -499,7 +499,7 @@ In addition to conditionally including relationship information in your resource
         return [
             'id' => $this->id,
             'name' => $this->name,
-            'expires_at' => $this->whenPivotLoaded('role_users', function () {
+            'expires_at' => $this->whenPivotLoaded('role_user', function () {
                 return $this->pivot->expires_at;
             }),
         ];


### PR DESCRIPTION
The example wouldn't work with a standard `$this->belongsToMany(Role::class)` relationship.