### PR TITLE
[5.7] Removed assets directory. Fixes #4520

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -683,7 +683,7 @@ The `resource_path` function returns the fully qualified path to the `resources`
 
     $path = resource_path();
 
-    $path = resource_path('assets/sass/app.scss');
+    $path = resource_path('sass/app.scss');
 
 <a name="method-storage-path"></a>
 #### `storage_path()` {#collection-method}


### PR DESCRIPTION
This PR removes the assets directory from the resource path helper example.