### PR TITLE
Correct path to where Vue components are publish

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -128,7 +128,7 @@ To publish the Passport Vue components, use the `vendor:publish` Artisan command
 
     php artisan vendor:publish --tag=passport-components
 
-The published components will be placed in your `resources/assets/js/components` directory. Once the components have been published, you should register them in your `resources/assets/js/app.js` file:
+The published components will be placed in your `resources/js/components` directory. Once the components have been published, you should register them in your `resources/js/app.js` file:
 
     Vue.component(
         'passport-clients',


### PR DESCRIPTION
This was rectified in this [commit](https://github.com/laravel/passport/commit/36b24818056af18f6e4abe8494575e5390932beb#diff-7d570a80af9eec02aabf44ca6696fa07)

But the [documentation](https://laravel.com/docs/master/passport#frontend-quickstart) was never updated;

It's still reading...

> The published components will be placed in your `resources/assets/js/components` directory. Once the components have been published, you should register them in your  `resources/assets/js/app.js file`.

Instead of...

> The published components will be placed in your `resources/js/components` directory. Once the components have been published, you should register them in your  `resources/js/app.js` file.