### PR TITLE
Clarify possible parameters to the `before` rule

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -597,12 +597,12 @@ Stop running validation rules after the first validation failure.
 <a name="rule-before"></a>
 #### before:_date_
 
-The field under validation must be a value preceding the given date. The dates will be passed into the PHP `strtotime` function.
+The field under validation must be a value preceding the given date. The dates will be passed into the PHP `strtotime` function. As with the [`after`](#rule-after) rule, the name of another field in the dataset under validation may be supplied as the value of `date`.
 
 <a name="rule-before-or-equal"></a>
 #### before\_or\_equal:_date_
 
-The field under validation must be a value preceding or equal to the given date. The dates will be passed into the PHP `strtotime` function.
+The field under validation must be a value preceding or equal to the given date. The dates will be passed into the PHP `strtotime` function. As with the [`after`](#rule-after) rule, the name of another field in the dataset under validation may be supplied as the value of `date`.
 
 <a name="rule-between"></a>
 #### between:_min_,_max_


### PR DESCRIPTION
A user visiting the docs and clicking directly to [the `before` rule](https://laravel.com/docs/5.7/validation#rule-before) wouldn't know that you can also pass another field name as a parameter to `before`, as it's only mentioned in the `after` rule section. This PR fixes that.