### PR TITLE
Replace Slack webhook URL fake property with literal string

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -805,7 +805,7 @@ To route Slack notifications to the proper location, define a `routeNotification
          */
         public function routeNotificationForSlack($notification)
         {
-            return $this->slack_webhook_url;
+            return 'https://hooks.slack.com/services/...';
         }
     }
 


### PR DESCRIPTION
A member on the community Discord was confused with where to place their webhook URL.

This can be clearer by showing an example of the webhook URL inline, instead of a fake property that implies there's something else.