### PR TITLE
Add clarifications in description of array_sort_recoursive

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -460,19 +460,21 @@ You may also sort the array by the results of the given Closure:
 <a name="method-array-sort-recursive"></a>
 #### `array_sort_recursive()` {#collection-method}
 
-The `array_sort_recursive` function recursively sorts an array using the `sort` function:
+The `array_sort_recursive` function recursively sorts an array using the `sort` function for numeric subarrays and `ksort` for associative subarrays:
 
     $array = [
         ['Roman', 'Taylor', 'Li'],
         ['PHP', 'Ruby', 'JavaScript'],
+        ['one' => 1, 'two' => 2, 'three' => 3],
     ];
 
     $sorted = array_sort_recursive($array);
 
     /*
         [
+            [JavaScript, PHP, Ruby],
+            ['one' => 1, 'three' => 3, 'two' => 2],
             ['Li', 'Roman', 'Taylor'],
-            ['JavaScript', 'PHP', 'Ruby'],
         ]
     */
 


### PR DESCRIPTION
Default `array_sort_recoursive` realisation use `Illuminate\Support\Arr::sortRecursive` to sort input array.

`Illuminate\Support\Arr::sortRecursive` implement sorting using `ksort` for assoc and `sort` for numeric subarrays:

```php
    /**
     * Recursively sort an array by keys and values.
     *
     * @param  array  $array
     * @return array
     */
    public static function sortRecursive($array)
    {
        foreach ($array as &$value) {
            if (is_array($value)) {
                $value = static::sortRecursive($value);
            }
        }

        if (static::isAssoc($array)) {
            ksort($array);
        } else {
            sort($array);
        }

        return $array;
    }
```

But old description of `array_sort_recoursive` contains information only about `sort` usage. I was confused at first time and create my own helper to sort assoc array recursive. Letter I open source code and found `ksort` usage inside `array_sort_recoursive`. 

This MR was created to prevent another developers confusion of incorrect description.