### PR TITLE
Update contributions.md

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -46,7 +46,7 @@ Informal discussion regarding bugs, new features, and implementation of existing
 <a name="which-branch"></a>
 ## Which Branch?
 
-**All** bug fixes should be sent to the latest stable branch or to the [current LTS branch](/docs/5.5/releases). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
+**All** bug fixes should be sent to the latest stable branch or to the [current LTS branch](/docs/{{version}}/releases#support-policy). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
 
 **Minor** features that are **fully backwards compatible** with the current Laravel release may be sent to the latest stable branch.
 


### PR DESCRIPTION
revert #4545.

the point of the link isn't to link to the LTS documentation, it's to link to the releases page, so people can see what the status of each version is.

I think it's a poor and confusing user experience for the links to be switching docs versions on the user.

I've also added the anchor of `#support-policy` this time, so it's more direct.