### PR TITLE
[5.8] Add #25517 and #25732 to upgrade guide 

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -35,6 +35,21 @@ The query builder will now return unquoted JSON values on MySQL/MariaDB. This ma
     
 As a result, the `->>` operator is no longer supported.
 
+#### MariaDB JSON Support 
+
+**Likelihood Of Impact: Very Low**
+
+The query builder will now support JSON queries on MariaDB. This changes the name of columns without an alias:
+
+    $user = User::select('options->language')->first();
+    dump($user->getAttributes());
+    
+    // Laravel 5.7...
+    ["`options`->'$."language"'" => "en"]
+    
+    // Laravel 5.8...
+    ["json_extract(`options`, \'$."language"\')" => "en"]
+
 ### Facades
 
 #### Facade Service Resolving

--- a/upgrade.md
+++ b/upgrade.md
@@ -15,6 +15,26 @@ Update your `laravel/framework` dependency to `5.8.*` in your `composer.json` fi
 
 Of course, don't forget to examine any 3rd party packages consumed by your application and verify you are using the proper version for Laravel 5.8 support.
 
+### Database
+
+#### Unquoted MySQL JSON Values
+
+**Likelihood Of Impact: Low**
+
+The query builder will now return unquoted JSON values on MySQL/MariaDB. This makes the behavior consistent with the other databases:
+
+    $value = DB::table('users')->value('options->language');
+    
+    dump($value);
+    
+    // Laravel 5.7...
+    '"en"'
+    
+    // Laravel 5.8...
+    'en'
+    
+As a result, the `->>` operator is no longer supported.
+
 ### Facades
 
 #### Facade Service Resolving


### PR DESCRIPTION
#4553:

 > Neither of these appear to require any action by the user during the upgrade process though? So why put them in the upgrade guide?

laravel/framework#25732:
If you are manually unquoting JSON values (`json_decode('"en"')`), this will no longer work.

laravel/framework#25517:
If you are accessing JSON values with ``$user->{'`options`->\'$."language"\''}``, this will no longer work.

---

Can you please not close PRs with a question? I and others find this disrespectful and discouraging. I understand that you don't read closed PRs, just leave the PR open for a day and give the contributor time to respond. Opening a new PR to answer a question is really not a pleasant and efficient way of communicating.