### PR TITLE
[5.7] Rename the folder scss to sass in upgrade docs

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -55,7 +55,7 @@ For new Laravel 5.7 applications, the assets directory that contains the scripts
 However, if you wish to make this change, you should move all files from the `resources/assets/*` directory up one level:
 
 - From `resources/assets/js/*` to `resources/js/*`
-- From `resources/assets/scss/*` to `resources/scss/*`
+- From `resources/assets/sass/*` to `resources/sass/*`
 
 Then, update any reference to the old directories in your `webpack.mix.js` file:
 


### PR DESCRIPTION
There is an issue with folder name in docs where in one line the folder is called scss and in webpack.mix.js it is called sass and also in the laravel project it is called sass.