### PR TITLE
[5.6] No callable array syntax for action() in 5.6

### DIFF
--- a/urls.md
+++ b/urls.md
@@ -126,12 +126,6 @@ The `action` function generates a URL for the given controller action. You do no
 
     $url = action('HomeController@index');
 
-You may also reference actions with a "callable" array syntax:
-
-    use App\Http\Controllers\HomeController;
-
-    $url = action([HomeController::class, 'index']);
-
 If the controller method accepts route parameters, you may pass them as the second argument to the function:
 
     $url = action('UserController@profile', ['id' => 1]);


### PR DESCRIPTION
action() doesn't support callable array syntax in 5.6. This feature is 5.7+ only.