### PR TITLE
[5.6] Add csrf and method field to Blade docs

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -4,6 +4,9 @@
 - [Template Inheritance](#template-inheritance)
     - [Defining A Layout](#defining-a-layout)
     - [Extending A Layout](#extending-a-layout)
+- [Forms](#forms)
+    - [CSRF Field](#csrf-field)
+    - [Method Field](#method-field)
 - [Components & Slots](#components-and-slots)
 - [Displaying Data](#displaying-data)
     - [Blade & JavaScript Frameworks](#blade-and-javascript-frameworks)
@@ -85,6 +88,29 @@ Blade views may be returned from routes using the global `view` helper:
     Route::get('blade', function () {
         return view('child');
     });
+
+<a name="forms"></a>
+## Forms
+
+<a name="csrf-field"></a>
+### CSRF Field
+
+Anytime you define a HTML form in your application, you should include a hidden CSRF token field in the form so that [the CSRF protection](https://laravel.com/docs/5.7/csrf) middleware can validate the request. You may use the @csrf Blade directive to generate the token field:
+
+    <form method="POST" action="/profile">
+        @csrf
+        ...
+    </form>
+
+<a name="method-field"></a>
+### Method Field
+
+If you want to custimize the HTTP method for your form request, you can use the `@method` helper which will add a hidden field containing the HTTP method that's processed by Laravel's router. You will still need to indicate the `method` attribute on the form with `POST`.
+
+    <form method="POST" action="/profile">
+        @method('PUT')
+        ...
+    </form>
 
 <a name="components-and-slots"></a>
 ## Components & Slots


### PR DESCRIPTION
See https://github.com/laravel/docs/issues/4458

I copied the docs for the CSRF field from https://laravel.com/docs/5.7/csrf. I felt that it should also be present in the Blade docs but not sure if having the same docs in two places is wanted. Let me know if you want this differently.

Do you merge upstream as well? Otherwise I can send in another PR for the 5.7 branch.