### PR TITLE
[5.7] Make Eloquent events docs more clear

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -728,7 +728,7 @@ Sometimes you may need to determine if two models are the "same". The `is` metho
 <a name="events"></a>
 ## Events
 
-Eloquent models fire several events, allowing you to hook into the following points in a model's lifecycle: `retrieved`, `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`. Events allow you to easily execute code each time a specific model class is saved or updated in the database.
+Eloquent models fire several events, allowing you to hook into the following points in a model's lifecycle: `retrieved`, `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`. Events allow you to easily execute code each time a specific model class is saved or updated in the database. Each event receives the instance of the model through its constructor.
 
 The `retrieved` event will fire when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will fire. If a model already existed in the database and the `save` method is called, the `updating` / `updated` events will fire. However, in both cases, the `saving` / `saved` events will fire.
 
@@ -759,6 +759,8 @@ To get started, define a `$dispatchesEvents` property on your Eloquent model tha
             'deleted' => UserDeleted::class,
         ];
     }
+
+After defining and mapping your Eloquent events you can use [event listeners](https://laravel.com/docs/5.7/events#defining-listeners) to listen to them and perform related actions.
 
 <a name="observers"></a>
 ### Observers


### PR DESCRIPTION
It turns out that for newer users the docs on eloquent events aren't entirely clear on how to use them. These two small changes hopefully make them more clear.

See https://github.com/laravel/docs/issues/3915