### PR TITLE
[5.7] Hash::check verifyAlgorithm is now optionally

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -360,9 +360,9 @@ The `readStream` and `writeStream` methods [have been added to the `Illuminate\C
 
 #### `Hash:check` Method
 
-**Likelihood Of Impact: Low**
+**Likelihood Of Impact: None**
 
-The `check` method now checks if the algorithm of the hash matches the configured algorithm.
+The `check` method now **optionally** checks if the algorithm of the hash matches the configured algorithm.
 
 ### Mail
 


### PR DESCRIPTION
As of https://github.com/laravel/framework/commit/5fd4b899cc42d266fab34ee2d5f92fb47ca34fd0 the verification is now optionally.

If this notice in the upgrade guide is now no longer needed maybe consider reverting  6e02201e2c4858ed31d4a5a21fa4d0bb37cb60cd.