### PR TITLE
Updating valet install instructions

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -67,6 +67,7 @@ Both Valet and Homestead are great choices for configuring your Laravel developm
 <div class="content-list" markdown="1">
 - Install or update [Homebrew](http://brew.sh/) to the latest version using `brew update`.
 - Install PHP 7.2 using Homebrew via `brew install php@7.2`.
+- Install [Composer](https://getcomposer.org) if you haven't already
 - Install Valet with Composer via `composer global require laravel/valet`. Make sure the `~/.composer/vendor/bin` directory is in your system's "PATH".
 - Run the `valet install` command. This will configure and install Valet and DnsMasq, and register Valet's daemon to launch when your system starts.
 </div>


### PR DESCRIPTION
Current Valet installation instructions mention installing Homebrew and PHP, but make no mention of installing Composer before instructing the user to use composer. Adding a line with a link to Composer.