### PR TITLE
[5.7] Document Scout search callbacks

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -334,15 +334,17 @@ When this configuration option is `true`, Scout will not remove soft deleted mod
 <a name="search-callbacks"></a>
 ### Search Callbacks
 
-If you really want to manipulate the search behavior of the engine you may use a callback as the second argument of the `search` method. This will allow you to thoroughly manipulate the search behavior.
+If you want to manipulate the search behavior of the engine you may use a callback as the second argument of the `search` method. This will allow you to thoroughly manipulate the search behavior. The below example shows you how you can use the callback to add geo locating to your search options before being passed to the Algolia search engine. Note that your engine needs to implement this behavior before you can use it.
 
-    App\Order::search('Star Trek', function ($engine, $query, $options) {
+    use AlgoliaSearch\Index;
+
+    App\Order::search('Star Trek', function (Index $algolia, string $query, array $options) {
         $options['body']['query']['bool']['filter']['geo_distance'] = [
             'distance' => '1000km',
             'location' => ['lat' => 36, 'lon' => 111],
         ];
 
-        return $engine->search($options);
+        return $algolia->search($query, $options);
     })->get();
 
 <a name="custom-engines"></a>

--- a/scout.md
+++ b/scout.md
@@ -19,6 +19,7 @@
     - [Where Clauses](#where-clauses)
     - [Pagination](#pagination)
     - [Soft Deleting](#soft-deleting)
+    - [Search Callbacks](#search-callbacks)
 - [Custom Engines](#custom-engines)
 
 <a name="introduction"></a>
@@ -329,6 +330,20 @@ When this configuration option is `true`, Scout will not remove soft deleted mod
     $orders = App\Order::onlyTrashed()->search('Star Trek')->get();
 
 > {tip} When a soft deleted model is permanently deleted using `forceDelete`, Scout will remove it from the search index automatically.
+
+<a name="search-callbacks"></a>
+### Search Callbacks
+
+If you really want to manipulate the search behavior of the engine you may use a callback as the second argument of the `search` method. This will allow you to thoroughly manipulate the search behavior.
+
+    App\Order::search('Star Trek', function ($engine, $query, $options) {
+        $options['body']['query']['bool']['filter']['geo_distance'] = [
+            'distance' => '1000km',
+            'location' => ['lat' => 36, 'lon' => 111],
+        ];
+
+        return $engine->search($options);
+    })->get();
 
 <a name="custom-engines"></a>
 ## Custom Engines


### PR DESCRIPTION
This will make it more clear how developers can manipulate the searching behavior. Think it's good to have this in the docs as most people didn't seem to know this was possible. The example might need some tweaking.