### PR TITLE
[5.7] Add information about environments method

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -182,6 +182,14 @@ The `skip` method may be seen as the inverse of `when`. If the `skip` method ret
 
 When using chained `when` methods, the scheduled command will only execute if all `when` conditions return `true`.
 
+#### Environment Constraints
+
+The `environments` method may be used to execute tasks only on certain environments. Only if the current environment matches the given environment or the list of environments the task will be executed.
+
+    $schedule->command('emails:send')
+                        ->daily()
+                        ->environments(['staging', 'production']);
+
 <a name="timezones"></a>
 ### Timezones
 

--- a/scheduling.md
+++ b/scheduling.md
@@ -151,6 +151,7 @@ Method  | Description
 `->saturdays();`  |  Limit the task to Saturday
 `->between($start, $end);`  |  Limit the task to run between start and end times
 `->when(Closure);`  |  Limit the task based on a truth test
+`->environments($env);`  |  Limit the task to be only executed on a certain environment
 
 #### Between Time Constraints
 


### PR DESCRIPTION
This will add information about the `environments` method that allows to limit execution of a scheduled task to a specific environment.