### PR TITLE
[5.7] Extra mention for renaming QUEUE_DRIVER to QUEUE_CONNECTION

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -442,3 +442,5 @@ If you are implementing this interface, you should add this method to your imple
 ### Miscellaneous
 
 We also encourage you to view the changes in the `laravel/laravel` [GitHub repository](https://github.com/laravel/laravel). While many of these changes are not required, you may wish to keep these files in sync with your application. Some of these changes will be covered in this upgrade guide, but others, such as changes to configuration files or comments, will not be. You can easily view the changes with the [GitHub comparison tool](https://github.com/laravel/laravel/compare/5.6...master) and choose which updates are important to you.
+
+Note that the `QUEUE_DRIVER` environment variable has been renamed to `QUEUE_CONNECTION` as of Laravel 5.7. If you decide to copy over the new configuration files from the laravel/laravel repository as described above, make sure you update your `.env` file as well with this change. 


### PR DESCRIPTION
This is a question we see a lot at Laracasts. Although it shouldn't affect older application, unless you copy over the configuration files. However this is a mistake that is done a lot.

For more context see #4523

The documentation already describes that you need to look into the configuration files if you want to in the Miscellaneous section. So I can understand if this PR is not merged at all! However this is a mistake we see a lot so maybe we can help someone out here ;)