### PR TITLE
[5.7] Clarify foreign key constraint usage for SQlite

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -452,7 +452,7 @@ You may also specify the desired action for the "on delete" and "on update" prop
           ->references('id')->on('users')
           ->onDelete('cascade');
 
-To drop a foreign key, you may use the `dropForeign` method. Foreign key constraints use the same naming convention as indexes. So, we will concatenate the table name and the columns in the constraint then suffix the name with "_foreign":
+To drop a foreign key, you may use the `dropForeign` method. Foreign key constraints use the same naming convention as indexes. So, we will concatenate the table name and the columns in the constraint then suffix the name with "\_foreign":
 
     $table->dropForeign('posts_user_id_foreign');
 

--- a/migrations.md
+++ b/migrations.md
@@ -465,3 +465,9 @@ You may enable or disable foreign key constraints within your migrations by usin
     Schema::enableForeignKeyConstraints();
 
     Schema::disableForeignKeyConstraints();
+
+For SQLite you need to enable foreign key constraints with every connection, for example in the `boot` method of your `AppServiceProvider` or a `setUp` method in your `TestCase`:
+
+    if (\DB::connection() instanceof \Illuminate\Database\SQLiteConnection) {
+        \Schema::enableForeignKeyConstraints();
+    }


### PR DESCRIPTION
When using SQLite enabling foreign key constraints in a migration has no
effect.

I also fixed an unescaped underscore, hope that's okay. :)