### PR TITLE
[5.7] Remove ToC entry

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -4,7 +4,6 @@
 - [Bus Fake](#bus-fake)
 - [Event Fake](#event-fake)
     - [Scoped Event Fakes](#scoped-event-fakes)
-    - [Selective Event Fakes](#selective-event-fakes)
 - [Mail Fake](#mail-fake)
 - [Notification Fake](#notification-fake)
 - [Queue Fake](#queue-fake)


### PR DESCRIPTION
The anchor is removed at 9c52feafbd533269035e207240e78d53e35ae3f2