### PR TITLE
Refer to `contains` at `has` to clarify how to determine value existence

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -820,6 +820,8 @@ The `has` method determines if a given key exists in the collection:
 
     // false
 
+Use [`contains`](#method-contains) to determine whether a collection contains a given value.
+
 <a name="method-implode"></a>
 #### `implode()` {#collection-method}
 


### PR DESCRIPTION
Idiomatically, `has` could just as well refer to a collection having a certain value. 
To redirect the user to the corresponding function, I've added a reference. 