### PR TITLE
[5.7] Fix nginx starter config

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -48,7 +48,7 @@ If you are deploying your application to a server that is running Nginx, you may
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
             fastcgi_pass unix:/var/run/php/php7.1-fpm.sock;
             fastcgi_index index.php;
-            include fastcgi_params;
+            include fastcgi.conf;
         }
 
         location ~ /\.(?!well-known).* {


### PR DESCRIPTION
To make the nginx config work out of the box, you need to import `fastcgi.conf` instead of `fastcgi_params`