### PR TITLE
[5.7] Added missing htaccess authorization header handler

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -114,6 +114,9 @@ If the `.htaccess` file that ships with Laravel does not work with your Apache i
     Options +FollowSymLinks -Indexes
     RewriteEngine On
 
+    RewriteCond %{HTTP:Authorization} .
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]


### PR DESCRIPTION
This PR adds the authorization header handler for the alternative **.htaccess** in Web Server Configuration section at Installation page.

I found this rules must present especially for application that using Authorization header for their authentication feature.