### PR TITLE
[5.7] Document AnonymousNotifiable Usage in Mocking

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -236,7 +236,7 @@ You may use the `Notification` facade's `fake` method to prevent notifications f
                 [$user], AnotherNotification::class
             );
             
-            // Assert a notification was sent when Notification::route() was used...
+            // Assert a notification was sent via Notification::route() method...
             Notification::assertSentTo(
                 new AnonymousNotifiable, OrderShipped::class
             );            

--- a/mocking.md
+++ b/mocking.md
@@ -238,7 +238,7 @@ You may use the `Notification` facade's `fake` method to prevent notifications f
             
             // Assert a notification was sent when Notification::route() was used...
             Notification::assertSentTo(
-                new AnonymousNotifiable(), OrderShipped::class
+                new AnonymousNotifiable, OrderShipped::class
             );            
         }
     }

--- a/mocking.md
+++ b/mocking.md
@@ -206,6 +206,7 @@ You may use the `Notification` facade's `fake` method to prevent notifications f
     use Tests\TestCase;
     use App\Notifications\OrderShipped;
     use Illuminate\Support\Facades\Notification;
+    use Illuminate\Notifications\AnonymousNotifiable;
     use Illuminate\Foundation\Testing\RefreshDatabase;
     use Illuminate\Foundation\Testing\WithoutMiddleware;
 
@@ -234,6 +235,11 @@ You may use the `Notification` facade's `fake` method to prevent notifications f
             Notification::assertNotSentTo(
                 [$user], AnotherNotification::class
             );
+            
+            // Assert a notification was sent when Notification::route() was used...
+            Notification::assertSentTo(
+                new AnonymousNotifiable(), OrderShipped::class
+            );            
         }
     }
 


### PR DESCRIPTION
In 5.5 `AnonymousNotifiable` has been added (laravel/framework#21379). However, the feature never made it into the documentation.
Maybe someone wants to push that change also to the `5.5`, `5.6` and `master` branches.

