### PR TITLE
Removing true flag for deleteFileAfterSend

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -228,7 +228,7 @@ The `download` method may be used to generate a response that forces the user's 
 
     return response()->download($pathToFile, $name, $headers);
 
-    return response()->download($pathToFile)->deleteFileAfterSend(true);
+    return response()->download($pathToFile)->deleteFileAfterSend();
 
 > {note} Symfony HttpFoundation, which manages file downloads, requires the file being downloaded to have an ASCII file name.
 


### PR DESCRIPTION
Symfony no longer requires the true flag for deleteFileAfterSend and defaults to true since 4.1