### PR TITLE
[5.7] Passport: document integer column for user identification

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -48,6 +48,8 @@ The Passport service provider registers its own database migration directory wit
 
     php artisan migrate
 
+> {note} By default, Passport makes use of an integer column to save the `user_id` associations. If your application makes use of something else to identify the user (say UUIDs) then you should overwrite the default Passport migrations as descrived below.
+
 > {note} If you are not going to use Passport's default migrations, you should call the `Passport::ignoreMigrations` method in the `register` method of your `AppServiceProvider`. You may export the default migrations using `php artisan vendor:publish --tag=passport-migrations`.
 
 Next, you should run the `passport:install` command. This command will create the encryption keys needed to generate secure access tokens. In addition, the command will create "personal access" and "password grant" clients which will be used to generate access tokens:


### PR DESCRIPTION
I can't even begin to count the amount of times I encountered issues with people not realizing the user ids are saved as integers. I think an explicit note to the docs is appropriate to make people aware that user ids will be saved as integers and that they can overwrite the migrations for this is they want to. Hopefully this will solve future issues and mistakes.