### PR TITLE
[5.7] Passport: document default token throttling

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -310,7 +310,7 @@ If the user approves the authorization request, they will be redirected back to 
 
 This `/oauth/token` route will return a JSON response containing `access_token`, `refresh_token`, and `expires_in` attributes. The `expires_in` attribute contains the number of seconds until the access token expires.
 
-> {tip} Like the `/oauth/authorize` route, the `/oauth/token` route is defined for you by the `Passport::routes` method. There is no need to manually define this route.
+> {tip} Like the `/oauth/authorize` route, the `/oauth/token` route is defined for you by the `Passport::routes` method. There is no need to manually define this route. It also uses the default settings of the ThrottleRequests middleware.
 
 <a name="refreshing-tokens"></a>
 ### Refreshing Tokens


### PR DESCRIPTION
Passport provides the route for token requests and by default uses the throttles middleware with its default settings. This was sometimes confusing to people who wondered why their requests were throttled by default.

https://github.com/laravel/passport/issues/506