### PR TITLE
[5.7] Passport: client credentials scopes

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -448,7 +448,7 @@ Next, to use this grant type, you need to add the `CheckClientCredentials` middl
 
 Then, attach the middleware to a route:
 
-    Route::get('/user', function (Request $request) {
+    Route::get('/orders', function (Request $request) {
         ...
     })->middleware('client');
 

--- a/passport.md
+++ b/passport.md
@@ -452,6 +452,12 @@ Then, attach the middleware to a route:
         ...
     })->middleware('client');
 
+Then protect the route with specific scopes you can add a comma separated lists with the client middleware:
+
+    Route::get('/orders', function (Request $request) {
+        ...
+    })->middleware('client:check-status,your-scope');
+
 To retrieve a token using this grant type, make a request to the `oauth/token` endpoint:
 
     $guzzle = new GuzzleHttp\Client;


### PR DESCRIPTION
Should explain how a client credentials route can be protected by the client middleware and specific scopes.

It's also not very logic to use the user endpoint in this example because you're not making the request with an active user. It's a machine-to-machine request. Adjusted this as well.

https://github.com/laravel/passport/issues/501