### PR TITLE
[5.7] Passport: add note about EncryptCookies middleware

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -651,6 +651,8 @@ When using this method of authentication, the default Laravel JavaScript scaffol
 
 > {note} If you are using a different JavaScript framework, you should make sure it is configured to send the `X-CSRF-TOKEN` and `X-Requested-With` headers with every outgoing request.
 
+> {note} The `CreateFreshApiToken` middleware requires the `EncryptCookies` middleware to be placed before it in order to function properly.
+
 <a name="events"></a>
 ## Events
 


### PR DESCRIPTION
The CreateFreshApiToken middleware cannot function without the EncryptCookies middleware being placed before it. Some people stumbled upon this so it might be better to explicitely note in the docs that it's a requirement.

https://github.com/laravel/passport/issues/484