### PR TITLE
[5.7] Small note on hidden wildcard behaviour of data_get()

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -562,6 +562,17 @@ The `data_get` function also accepts a default value, which will be returned if 
 
     // 0
 
+This function also accepts wildcards which can target any key of the array or object. Along with the dot notation, this allows you to easily extract values that are located on a deeper level.
+
+    $data = [
+        'product-one' => ['name' => 'Desk 1', 'price' => 100],
+        'product-two' => ['name' => 'Desk 2', 'price' => 150],
+    ];
+
+    data_get($data, '*.name');
+
+    // ['Desk 1', 'Desk 2'];
+
 <a name="method-data-set"></a>
 #### `data_set()` {#collection-method}
 


### PR DESCRIPTION
This small addition to the docs makes note on the somewhat hidden feature of data_get() helper, namely that it, just as data_set(), accepts the * symbol as as wildcard selector. 

If this gets approved, I'll be happy to add this to the 5.5, 5.6 and master docs as well