### PR TITLE
[5.7] HTTP Tests: Add note about escaping content

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -442,6 +442,8 @@ Assert that the given strings are contained in order within the response:
 Assert that the given string is contained within the response text:
 
     $response->assertSeeText($value);
+    
+> {note} If you escape HTML special characters in your templates (this is the default behaviour for Blade), then you will need to escape the value before testing. E.g. `$response->assertSeeText(e($value));`
 
 <a name="assert-see-text-in-order"></a>
 #### assertSeeTextInOrder


### PR DESCRIPTION
When using `assertSeeText`, `assertSeeTextInOrder` or `assertDontSeeText` with Blade templates you need to escape content before testing to ensure you don't get any false negatives. This PR just adds a brief note to highlight that fact in the documentation.

See https://github.com/laravel/framework/pull/21389, https://github.com/laravel/framework/pull/19902 and https://github.com/laravel/framework/pull/26169 for reference.