### PR TITLE
[5.7] add Dusk link to Official Packages

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -78,6 +78,7 @@
     - [Mocking](/docs/{{version}}/mocking)
 - ## Official Packages
     - [Cashier](/docs/{{version}}/billing)
+    - [Dusk](/docs/{{version}}/dusk)
     - [Envoy](/docs/{{version}}/envoy)
     - [Horizon](/docs/{{version}}/horizon)
     - [Passport](/docs/{{version}}/passport)


### PR DESCRIPTION
I know it's already under the "Testing" section, but it is also an official package, and this could be an easier place for people to find the link