### PR TITLE
document withoutMiddleware to avoid disable route binding gotcha

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -3,6 +3,9 @@
 - [Introduction](#introduction)
     - [Customizing Request Headers](#customizing-request-headers)
 - [Session / Authentication](#session-and-authentication)
+- [Without Middleware](#without-middleware)
+    - [Disabling All Middleware](#disabling-all-middleware)
+    - [Disabling Specific Middleware](#disabling-specific-middleware)
 - [Testing JSON APIs](#testing-json-apis)
 - [Testing File Uploads](#testing-file-uploads)
 - [Available Assertions](#available-assertions)
@@ -106,6 +109,72 @@ Of course, one common use of the session is for maintaining state for the authen
 You may also specify which guard should be used to authenticate the given user by passing the guard name as the second argument to the `actingAs` method:
 
     $this->actingAs($user, 'api')
+
+<a name="without-middleware"></a>
+## Without Middleware
+
+Sometimes it is helpful to disable all middleware or only certain middlewares when writing your tests. Let's take a look at disabling all middleware via the provided trait first.
+
+<a name="disabling-all-middleware"></a>
+### Disabling All Middleware
+
+Simply use the `Illuminate\Foundation\Testing\WithoutMiddleware` trait inside your test class to disable middleware for all tests in the class. See below for why this may not be the best approach.
+
+    <?php
+
+    namespace Tests\Feature;
+
+    use Tests\TestCase;
+    use Illuminate\Foundation\Testing\RefreshDatabase;
+    use Illuminate\Foundation\Testing\WithoutMiddleware;
+
+    class ExampleTest extends TestCase
+    {
+        use WithoutMiddleware;
+
+        /**
+         * A basic test example.
+         *
+         * @return void
+         */
+        public function testBasicTest()
+        {
+            $response = $this->get('/');
+
+            $response->assertStatus(200);
+        }
+    }
+
+> {note} Disabling all middleware also disables route model binding. This means you will end up with models containing empty attributes in your tests which will likely result in broken tests. Bindings are substituted via `\Illuminate\Routing\Middleware\SubstituteBindings` which is itself a middleware and as such will not take effect when all middleware is disabled. For this reason it is recommended to specifically disable only certain middlewares.
+
+<a name="disabling-specific-middleware"></a>
+### Disabling Specific Middleware
+
+You can disable specific middleware by calling `$this->withoutMiddleware('your_custom_middleware')` inside of a test method. You may also pass an array of middlewares to disable. `$this->withoutMiddleware(['middleware_one', 'middleware_two'])`.
+
+    <?php
+
+    namespace Tests\Feature;
+
+    use Tests\TestCase;
+    use Illuminate\Foundation\Testing\RefreshDatabase;
+
+    class ExampleTest extends TestCase
+    {
+        /**
+         * A basic test example.
+         *
+         * @return void
+         */
+        public function testBasicTest()
+        {
+            $this->withoutMiddleware(['foo_middleware', 'bar_middleware']);
+
+            $response = $this->get('/');
+
+            $response->assertStatus(200);
+        }
+    }
 
 <a name="testing-json-apis"></a>
 ## Testing JSON APIs


### PR DESCRIPTION
It seems obvious now but it was very frustrating having the route binding disabled when disabling all middleware. Sometimes I like to start writing tests in a very basic way and not worrying about middleware at all until later. I do that now by only disabling specific middleware but this took me a bit to figure out. Other people have had the same issue.

https://github.com/laravel/framework/issues/16260

I would recommend just keeping the route binding middleware on when calling `withoutMiddleware` and then deleting this doc. Makes a lot more sense to me but others disagree. It should at least be documented if it's going to be that way.

