### PR TITLE
[5.7] Update the User Factory definition

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -84,6 +84,7 @@ When testing, you may need to insert a few records into your database before exe
         return [
             'name' => $faker->name,
             'email' => $faker->unique()->safeEmail,
+            'email_verified_at' => now(),
             'password' => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
             'remember_token' => str_random(10),
         ];


### PR DESCRIPTION
This PR adds the new `email_verified_at` to the User Factory example.

https://github.com/laravel/laravel/blob/f9cf7ff1c834bd918a21930288d12d04e0f15a00/database/factories/UserFactory.php#L18-L22