### PR TITLE
update driver to connection, command expects connection

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -386,7 +386,7 @@ Supervisor configuration files are typically stored in the `/etc/supervisor/conf
     redirect_stderr=true
     stdout_logfile=/home/forge/app.com/worker.log
 
-In this example, the `numprocs` directive will instruct Supervisor to run 8 `queue:work` processes and monitor all of them, automatically restarting them if they fail. Of course, you should change the `queue:work sqs` portion of the `command` directive to reflect your chosen queue driver.
+In this example, the `numprocs` directive will instruct Supervisor to run 8 `queue:work` processes and monitor all of them, automatically restarting them if they fail. Of course, you should change the `queue:work sqs` portion of the `command` directive to reflect your chosen queue connection.
 
 Once the configuration file has been created, you may update the Supervisor configuration and start the processes using the following commands:
 


### PR DESCRIPTION
The docs for Laravel 5.1 state to use the queue driver, however the command from https://github.com/illuminate/queue/blob/d5889a14dfc9890f3ff84dc350c6b6d77d1afa45/Console/WorkCommand.php is expecting a queue connection name as defined in config/queue.

This is confusing and caused our supervisor instance to error out with
```
InvalidArgumentException: No connector for [] in /var/www/sites/platform/releases/1332/vendor/laravel/framework/src/Illuminate/Queue/QueueManager.php:150
```