### PR TITLE
[5.7] Add an example of an exception being thrown

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -76,6 +76,8 @@ Below is an example of a valid Laravel documentation block. Note that the `@para
      * @param  \Closure|string|null  $concrete
      * @param  bool  $shared
      * @return void
+     *
+     * @throws \Exception
      */
     public function bind($abstract, $concrete = null, $shared = false)
     {


### PR DESCRIPTION
I know that the bind method doesn't thrown an actual exception, but an example is really helpful, because i didn't knew if the `@throws` directive has a new line before it.