### PR TITLE
Add quotes to 'laravel-worker:*'

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -530,7 +530,7 @@ Once the configuration file has been created, you may update the Supervisor conf
 
     sudo supervisorctl update
 
-    sudo supervisorctl start laravel-worker:*
+    sudo supervisorctl start 'laravel-worker:*'
 
 For more information on Supervisor, consult the [Supervisor documentation](http://supervisord.org/index.html).
 


### PR DESCRIPTION
Absence of quotes causes zsh to misunderstand this command. See https://github.com/robbyrussell/oh-my-zsh/issues/31