### PR TITLE
[5.7] Document passing the Echo client as an option

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -469,6 +469,16 @@ When creating an Echo instance that uses the `pusher` connector, you may also sp
         encrypted: true
     });
 
+You may also instead of binding the Pusher or Socket.IO client to the window, pass the client to the config object:
+
+    const client = require('pusher-js');
+
+    window.Echo = new Echo({
+        broadcaster: 'pusher',
+        key: 'your-pusher-key',
+        client: client
+    });
+
 <a name="listening-for-events"></a>
 ### Listening For Events
 


### PR DESCRIPTION
It wasn't clear that you can also instead of binding the client to the window, pass it as a config option. In some situations this may be desired. See https://github.com/laravel/echo/issues/29 for more info.