### PR TITLE
[5.7] Document custom Echo auth endpoint

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -332,6 +332,14 @@ The `Broadcast::routes` method will automatically place its routes within the `w
 
     Broadcast::routes($attributes);
 
+[Laravel Echo](#installing-laravel-echo) is by default configured with the `/broadcasting/auth` route but can configure it with your own custom endpoint:
+
+    window.Echo = new Echo({
+        broadcaster: 'pusher',
+        key: 'your-pusher-key',
+        authEndpoint: '/custom/endpoint/auth'
+    });
+
 <a name="defining-authorization-callbacks"></a>
 ### Defining Authorization Callbacks
 


### PR DESCRIPTION
This config option was undocumented and some people were wondering how you could update Echo to use their own custom endpoint for authentication. See https://github.com/laravel/echo/issues/171