### PR TITLE
[5.7] Clarify chunkById

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -116,8 +116,9 @@ If you need to update records that will change the result of your chunk query, y
 
     DB::table('users')->where('active', false)->chunkById(100, function ($users) {
         foreach ($users as $user) {
-            $user->active = true;
-            $user->save();
+            DB::table('users')
+                ->where('id', $user->id)
+                ->update(['active' => true]);
         }
     });
 

--- a/queries.md
+++ b/queries.md
@@ -112,11 +112,12 @@ You may stop further chunks from being processed by returning `false` from the `
         return false;
     });
 
-Since you will often be ordering chunked results by the primary key, you may use the `chunkById` method as a shortcut:
+If you need to update records that will change the result of your chunk query, you can use `chunkById` to paginate the results based on the primary key. Otherwise this could lead to records being skipped.
 
-    DB::table('users')->chunkById(100, function ($users) {
+    DB::table('users')->where('active', false)->chunkById(100, function ($users) {
         foreach ($users as $user) {
-            //
+            $user->active = true;
+            $user->save();
         }
     });
 


### PR DESCRIPTION
`chunkById()` is not just a shortcut for `orderBy('id')->chunk()`. This clarifies the use-case and potential dangers of `chunk` when changing records inside the chunk.