### PR TITLE
[5.7] Update Mailgun region config key to endpoint

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -48,7 +48,7 @@ If you are not using the "US" [Mailgun region](https://documentation.mailgun.com
     'mailgun' => [
         'domain' => 'your-mailgun-domain',
         'secret' => 'your-mailgun-key',
-        'region' => 'api.eu.mailgun.net',
+        'endpoint' => 'api.eu.mailgun.net',
     ],
 
 #### SparkPost Driver


### PR DESCRIPTION
As per [MailgunTransport driver](https://github.com/laravel/framework/blob/b18c2535fcdaa69d83309ac4524a9a6b1a6850f2/src/Illuminate/Mail/TransportManager.php#L116) the `region` should actually be called `endpoint`.
Apologies for the mixup earlier.