### PR TITLE
[5.7] Remove notion of manually registering service providers

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -49,8 +49,6 @@ To get started, you should add the `laravel/dusk` Composer dependency to your pr
 
     composer require --dev laravel/dusk
 
-Once Dusk is installed, you should register the `Laravel\Dusk\DuskServiceProvider` service provider. Typically, this will be done automatically via Laravel's automatic service provider registration.
-
 > {note} If you are manually registering Dusk's service provider, you should **never** register it in your production environment, as doing so could lead to arbitrary users being able to authenticate with your application.
 
 After installing the Dusk package, run the `dusk:install` Artisan command:

--- a/passport.md
+++ b/passport.md
@@ -45,7 +45,7 @@ To get started, install Passport via the Composer package manager:
 
     composer require laravel/passport
 
-The Passport service provider registers its own database migration directory with the framework, so you should migrate your database after registering the provider. The Passport migrations will create the tables your application needs to store clients and access tokens:
+The Passport service provider registers its own database migration directory with the framework, so you should migrate your database after installing the package. The Passport migrations will create the tables your application needs to store clients and access tokens:
 
     php artisan migrate
 


### PR DESCRIPTION
Since pre-Laravel 5.5 releases aren't supported anymore we can safely remove notions about manually registering service providers. This is still documented if people need to refer to it: https://laravel.com/docs/5.7/providers#registering-providers