### PR TITLE
[5.7] Explain issues of dispatching jobs from tinker.

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -195,6 +195,8 @@ Once you have written your job class, you may dispatch it using the `dispatch` m
         }
     }
 
+> {note} The `dispatch` method depends on garbage collection to place the job on the queue. Therefore, when using Artisan `tinker` REPL in particular, you should use `Bus::dispatch` or `Queue::push` instead.
+
 <a name="delayed-dispatching"></a>
 ### Delayed Dispatching
 


### PR DESCRIPTION
I wasted half a day wondering why dispatching jobs wasn't working as expected. Turned out it was a combination of using tinker and the fact that `dispatch` method uses garbage collection to put jobs on the queue.

I filed [this bug](https://github.com/laravel/tinker/issues/59#event-1937877824), which was closed, because [two](https://github.com/laravel/tinker/issues/28) [other](https://github.com/laravel/tinker/issues/30) where already filed concerning the same problem. Many people are wasting their time when faced with this problem, so it would make sense to document that "known subtlety" (citing Graham here).

Thanks.