### PR TITLE
Response is also available in notification events

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -877,6 +877,7 @@ Within an event listener, you may access the `notifiable`, `notification`, and `
         // $event->channel
         // $event->notifiable
         // $event->notification
+        // $events->response
     }
 
 <a name="custom-channels"></a>


### PR DESCRIPTION
https://github.com/laravel/framework/blob/8699a622a31a139d4a6094973f169af7a0806f91/src/Illuminate/Notifications/Events/NotificationSent.php#L52

Response returned from API is also available inside Notification events