### PR TITLE
Fix the typo

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -877,7 +877,7 @@ Within an event listener, you may access the `notifiable`, `notification`, and `
         // $event->channel
         // $event->notifiable
         // $event->notification
-        // $events->response
+        // $event->response
     }
 
 <a name="custom-channels"></a>


### PR DESCRIPTION
There was typo in
https://github.com/laravel/docs/pull/4716

Sorry about that.