### PR TITLE
fix typo in not_regex validation reule

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -846,7 +846,7 @@ The field under validation must not be included in the given list of values. The
 
 The field under validation must not match the given regular expression.
 
-Internally, this rule uses the PHP `preg_match` function. The pattern specified should obey the same formatting required by `preg_match` and thus also include valid delimiters. For example: `'email' => 'regex:/^.+@.+$/i'`.
+Internally, this rule uses the PHP `preg_match` function. The pattern specified should obey the same formatting required by `preg_match` and thus also include valid delimiters. For example: `'email' => 'not_regex:/^.+$/i'`.
 
 **Note:** When using the `regex` / `not_regex` patterns, it may be necessary to specify rules in an array instead of using pipe delimiters, especially if the regular expression contains a pipe character.
 


### PR DESCRIPTION
When you explained 'not_regex' rule , you gave an example no 'regex' rule. Just a simple mistake in typo