### PR TITLE
[5.7] Targets Algolia PHP Client V1

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -71,7 +71,7 @@ Once you have configured a queue driver, set the value of the `queue` option in 
 
 When using the Algolia driver, you should configure your Algolia `id` and `secret` credentials in your `config/scout.php` configuration file. Once your credentials have been configured, you will also need to install the Algolia PHP SDK via the Composer package manager:
 
-    composer require algolia/algoliasearch-client-php
+    composer require algolia/algoliasearch-client-php:^1.27
 
 <a name="configuration"></a>
 ## Configuration


### PR DESCRIPTION
@julienbourdeau , It's about to release Algolia PHP Client V2 which is not supported **yet** by Scout.