### PR TITLE
[5.7] Add some method to Eloquent collections

### DIFF
--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -115,6 +115,7 @@ All Eloquent collections extend the base [Laravel collection](/docs/{{version}}/
 [shift](/docs/{{version}}/collections#method-shift)
 [shuffle](/docs/{{version}}/collections#method-shuffle)
 [slice](/docs/{{version}}/collections#method-slice)
+[some](/docs/{{version}}/collections#method-some)
 [sort](/docs/{{version}}/collections#method-sort)
 [sortBy](/docs/{{version}}/collections#method-sortby)
 [sortByDesc](/docs/{{version}}/collections#method-sortbydesc)


### PR DESCRIPTION
Just realized, I missed adding the some method to the Eloquent collections page besides the collections page per laravel/framework#26376