### PR TITLE
[5.7] Added note for default preserving keys on reverse collection

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1455,6 +1455,8 @@ The `reverse` method reverses the order of the collection's items, preserving th
         ]
     */
 
+The returned reversed collection will preserve keys by default. If you do not wish to preserve the original keys, you can use the [`values`](#method-values) method to reindex them.
+
 <a name="method-search"></a>
 #### `search()` {#collection-method}
 


### PR DESCRIPTION
This PR adds the note that the reverse function on a collection does preserve keys by default and suggests a method to not preserve the keys.