### PR TITLE
[5.7] Horizon: removed PHP 7.1 requirement note

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -20,7 +20,7 @@ All of your worker configuration is stored in a single, simple configuration fil
 <a name="installation"></a>
 ## Installation
 
-> {note} Due to its usage of async process signals, Horizon requires PHP 7.1+. Secondly, you should ensure that your queue driver is set to `redis` in your `queue` configuration file.
+> {note} You should ensure that your queue driver is set to `redis` in your `queue` configuration file.
 
 You may use Composer to install Horizon into your Laravel project:
 


### PR DESCRIPTION
Since Laravel 5.7 already requires at least PHP 7.1.3, the note is redundant.