### PR TITLE
Replaced recommended plugin for NFS

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -152,7 +152,7 @@ To enable [NFS](https://www.vagrantup.com/docs/synced-folders/nfs.html), you onl
           to: /home/vagrant/code
           type: "nfs"
 
-> {note} When using NFS, you should consider installing the [vagrant-bindfs](https://github.com/gael-ian/vagrant-bindfs) plug-in. This plug-in will maintain the correct user / group permissions for files and directories within the Homestead box.
+> {note} When using NFS, you should consider installing the [vagrant-winnfsd](https://github.com/winnfsd/vagrant-winnfsd) plug-in. This plug-in will maintain the correct user / group permissions for files and directories within the Homestead box.
 
 You may also pass any options supported by Vagrant's [Synced Folders](https://www.vagrantup.com/docs/synced-folders/basic_usage.html) by listing them under the `options` key:
 


### PR DESCRIPTION
The documentation of the recommended plug-in `vagrant-bindfs` states that it is necessary to make additional settings in the `VagrantFile` file.
This is a problem when updating `Homestead`, because every time you will need to re-add this setting, which you can just forget.
The proposed plugin `vagrant-winnfsd` does not require additional configuration settings. You just need to install it and specify parameter `type: "nfs"`. That's it.