### PR TITLE
bcmath require only  for telescope project.

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -20,6 +20,12 @@ Laravel Telescope is an elegant debug assistant for the Laravel framework. Teles
 
 > {note} Telescope requires Laravel 5.7.7+.
 
+in addition to laravel requirements you will need to make sure your server meets the following requirement:
+
+    bcmath PHP Extension
+
+
+
 You may use Composer to install Telescope into your Laravel project:
 
     composer require laravel/telescope

--- a/telescope.md
+++ b/telescope.md
@@ -23,9 +23,7 @@ Laravel Telescope is an elegant debug assistant for the Laravel framework. Teles
 in addition to laravel requirements you will need to make sure your server meets the following requirement:
 
     bcmath PHP Extension
-
-
-
+    
 You may use Composer to install Telescope into your Laravel project:
 
     composer require laravel/telescope


### PR DESCRIPTION
alternative to  https://github.com/laravel/docs/pull/4757 it can be added only  for telescope project.
separated   from Laravel  requireds exts list.