### PR TITLE
BCMath require by telescope fix syntax/grammer

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -28,7 +28,7 @@ However, if you are not using Homestead, you will need to make sure your server 
 - XML PHP Extension
 - Ctype PHP Extension
 - JSON PHP Extension
-- Bcmath PHP Extension
+- BCMath PHP Extension
 </div>
 
 <a name="installing-laravel"></a>


### PR DESCRIPTION
OK 
Now I understanding the rules of Laravel Document :
I must to write it more accurate, so I  fix the grammar/syntax : 
we have to write: BCMath (respectively to : XML, JSON ,POO, OpenSSL)
and not  Bcmath 

sources(php.net):
https://secure.php.net/manual/en/book.bc.php
https://secure.php.net/manual/en/intro.bc.php
https://secure.php.net/manual/en/ref.bc.php