### PR TITLE
[5.7] Fixed errors in the Implicit Extensions description and example

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1245,11 +1245,11 @@ When creating a custom validation rule, you may sometimes need to define custom 
 
 #### Implicit Extensions
 
-By default, when an attribute being validated is not present or contains an empty value as defined by the [`required`](#rule-required) rule, normal validation rules, including custom extensions, are not run. For example, the [`unique`](#rule-unique) rule will not be run against a `null` value:
+By default, when an attribute being validated is not present or contains an empty string, normal validation rules, including custom extensions, are not run. For example, the [`unique`](#rule-unique) rule will not be run against an empty string:
 
-    $rules = ['name' => 'unique'];
+    $rules = ['name' => 'unique:users,name'];
 
-    $input = ['name' => null];
+    $input = ['name' => ''];
 
     Validator::make($input, $rules)->passes(); // true
 


### PR DESCRIPTION
I am studying Laravel and it tooks me a few days to complete the Validation paragraph, because I could not get a custom not implicit validation rule not to run when the corresponding attribute in the request contains the `null` value.

Finally, I realized that this part of the documentation is a bit inaccurate. According to the [`presentOrRuleIsImplicit`][1] function implementation, the rule does not run if the attribute is not present or is an empty string. This function does not treat nulls as empty values.
```php
protected function presentOrRuleIsImplicit($rule, $attribute, $value)
{
    if (is_string($value) && trim($value) === '') {
        return $this->isImplicit($rule);
    }
    return $this->validatePresent($attribute, $value) ||
           $this->isImplicit($rule);
}
```
I added the following test:
```php
public function testExplicitRulesWithNullValues() {
    $rules = ['name' => 'unique'];
    $input = ['name' => null];
    $trans = $this->getIlluminateArrayTranslator();
    
    $v = new Validator($trans, $input, $rules);
    $this->assertTrue($v->passes());
}
```
It provides the following error:

    1) Illuminate\Tests\Validation\ValidationValidatorTest::testExplicitRulesWithNullValues
    InvalidArgumentException: Validation rule unique requires at least 1 parameters.

    /usr/src/framework/src/Illuminate/Validation/Concerns/ValidatesAttributes.php:1691
    /usr/src/framework/src/Illuminate/Validation/Concerns/ValidatesAttributes.php:690
    /usr/src/framework/src/Illuminate/Validation/Validator.php:382
    /usr/src/framework/src/Illuminate/Validation/Validator.php:277
    /usr/src/framework/tests/Validation/ValidationValidatorTest.php:4294

This error means two things:
1. The rule runs. Functions in the *ValidatesAttributes.php* file would not be executed if the `isValidatable` function returned `False` ([check here][2]). Hence, it returned `True`.
2. The code in the example lacks required parameters. The example provided in the [`unique`][3] rule description is different: 
    >'email' => 'unique:connection.users,email_address'

I included corresponding changes in this pull request. Also, if I change the `presentOrRuleIsImplicit` function to check for the `null` value and make my test pass, other tests fail.
```php
if ($value === null || (is_string($value) && trim($value) === '')) {
```
For instance, the [`testNullable`][7] test fails because the [`string`][4], [`integer`][5], [`numeric`][6], etc., rules do not run as expected. Taking this into account, I conclude that this is a documentation rather than a framework bug. It is easier to fix the documentation, because corresponding changes in the framework can break existing applications.

[1]: https://github.com/laravel/framework/blob/292f685b36be86dc1aa132b9bb4c6690ce7665b8/src/Illuminate/Validation/Validator.php#L476
[2]: https://github.com/laravel/framework/blob/292f685b36be86dc1aa132b9bb4c6690ce7665b8/src/Illuminate/Validation/Validator.php#L372
[3]: https://laravel.com/docs/5.7/validation#rule-unique
[4]: https://laravel.com/docs/5.7/validation#rule-string
[5]: https://laravel.com/docs/5.7/validation#rule-integer
[6]: https://laravel.com/docs/5.7/validation#rule-numeric
[7]: https://github.com/laravel/framework/blob/292f685b36be86dc1aa132b9bb4c6690ce7665b8/tests/Validation/ValidationValidatorTest.php#L168