### PR TITLE
[5.7] Fixing listening to other Namespaced events example

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -529,7 +529,7 @@ You may have noticed in the examples above that we did not specify the full name
 Alternatively, you may prefix event classes with a `.` when subscribing to them using Echo. This will allow you to always specify the fully-qualified class name:
 
     Echo.channel('orders')
-        .listen('.Namespace.Event.Class', (e) => {
+        .listen('.Namespace\\Event\\Class', (e) => {
             //
         });
 


### PR DESCRIPTION
I just had to deal with this yesterday. When using the example from the docs and writing it like `.Namespace.Event.Class` it does not ever get triggered, since the `format` method in `Echo` returns the event name as it is after removing the first dot:

```js
format(event: string): string {
        if (event.charAt(0) === '.' || event.charAt(0) === '\\') {
            return event.substr(1); // here the event with a `.` prefixed gets returned
        } else if (this.namespace) {
            event = this.namespace + '.' + event;
        }

        return event.replace(/\./g, '\\');
    }
```