### PR TITLE
[5.7] Fix typo in mail section

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -380,7 +380,7 @@ Embedding inline images into your emails is typically cumbersome; however, Larav
     <body>
         Here is an image:
 
-        <img src="{{ $message->embed($pathToFile) }}">
+        <img src="{{ $message->embed($pathToImage) }}">
     </body>
 
 > {note} `$message` variable is not available in markdown messages.


### PR DESCRIPTION
fixing typo in mail section. So it's logical to be $pathToImage not a $pathToFile because it's ```<img>``` tag