### PR TITLE
[5.7] Fixed js path in Mix.md

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -298,7 +298,7 @@ The `version` method will automatically append a unique hash to the filenames of
 
 After generating the versioned file, you won't know the exact file name. So, you should use Laravel's global `mix` function within your [views](/docs/{{version}}/views) to load the appropriately hashed asset. The `mix` function will automatically determine the current name of the hashed file:
 
-    <script src="{{ mix('/assets/js/app.js') }}"></script>
+    <script src="{{ mix('/js/app.js') }}"></script>
 
 Because versioned files are usually unnecessary in development, you may instruct the versioning process to only run during `npm run production`:
 


### PR DESCRIPTION
app.js refers to the wrong path