### PR TITLE
[5.7] Add note about failed_jobs table to Horizon docs

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -34,6 +34,11 @@ After installing Horizon, publish its assets using the `horizon:install` Artisan
 
     php artisan horizon:install
 
+You may also want to install the `failed_jobs` table which Laravel will use to store any [failed jobs](/docs/{{version}}/queues#dealing-with-failed-jobs):
+
+    php artisan queue:failed-table
+    php artisan migrate
+
 <a name="configuration"></a>
 ### Configuration
 


### PR DESCRIPTION
A lot of people (including myself) have run into the problem where they'd install Horizon by following the install instructions of it but then forget to install the failed_jobs table so they get exceptions thrown when Laravel attempts to save failed jobs in the database. It's good idea to include these install instructions in the Horizon docs because they're pretty complementary.

Fixes https://github.com/laravel/docs/issues/4782