### PR TITLE
[5.7] Document encoded forward slashes

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -171,6 +171,8 @@ By default, the Laravel routing component allows all characters except `/`. You 
 
 Now when you submit a search with an encoded forward slash, it'll be decoded in the `$search` parameter.
 
+> {note} Please note that using encoded forward slashes is only possible for the last route segment.
+
 <a name="named-routes"></a>
 ## Named Routes
 

--- a/routing.md
+++ b/routing.md
@@ -160,6 +160,17 @@ Once the pattern has been defined, it is automatically applied to all routes usi
         // Only executed if {id} is numeric...
     });
 
+<a name="parameters-encoded-forward-slashes"></a>
+#### Encoded Forward Slashes
+
+By default, the Laravel routing component allows all characters except `/`. You must explicitly allow `/` to be part of your placeholder by specifying it with a `where` condition:
+
+    Route::get('search/{search}', function ($search) {
+        return $search;
+    })->where('search', '.*');
+
+Now when you submit a search with an encoded forward slash, it'll be decoded in the `$search` parameter.
+
 <a name="named-routes"></a>
 ## Named Routes
 


### PR DESCRIPTION
Documents the way https://github.com/laravel/framework/issues/22125 can be solved.

Similar to the docs in Symfony: https://symfony.com/doc/current/routing/slash_in_parameter.html