### PR TITLE
[5.7] Improve view composer documentation

### DIFF
--- a/views.md
+++ b/views.md
@@ -104,7 +104,7 @@ Occasionally, you may need to share a piece of data with all views that are rend
 
 View composers are callbacks or class methods that are called when a view is rendered. If you have data that you want to be bound to a view each time that view is rendered, a view composer can help you organize that logic into a single location.
 
-For this example, let's register the view composers within a [service provider](/docs/{{version}}/providers). We'll use the `View` facade to access the underlying `Illuminate\Contracts\View\Factory` contract implementation. Remember, Laravel does not include a default directory for view composers. You are free to organize them however you wish. For example, you could create an `app/Http/ViewComposers` directory:
+For this example, let's register the view composers within a [service provider](/docs/{{version}}/providers). We'll use the `View` facade to access the underlying `Illuminate\Contracts\View\Factory` contract implementation. Remember, Laravel does not include a default directory for view composers. You are free to organize them however you wish. For example, you could create an `app/Http/View/Composers` directory:
 
     <?php
 
@@ -113,7 +113,7 @@ For this example, let's register the view composers within a [service provider](
     use Illuminate\Support\Facades\View;
     use Illuminate\Support\ServiceProvider;
 
-    class ComposerServiceProvider extends ServiceProvider
+    class ViewServiceProvider extends ServiceProvider
     {
         /**
          * Register bindings in the container.
@@ -124,7 +124,7 @@ For this example, let's register the view composers within a [service provider](
         {
             // Using class based composers...
             View::composer(
-                'profile', 'App\Http\ViewComposers\ProfileComposer'
+                'profile', 'App\Http\View\Composers\ProfileComposer'
             );
 
             // Using Closure based composers...
@@ -150,7 +150,7 @@ Now that we have registered the composer, the `ProfileComposer@compose` method w
 
     <?php
 
-    namespace App\Http\ViewComposers;
+    namespace App\Http\View\Composers;
 
     use Illuminate\View\View;
     use App\Repositories\UserRepository;
@@ -198,7 +198,7 @@ You may attach a view composer to multiple views at once by passing an array of 
 
     View::composer(
         ['profile', 'dashboard'],
-        'App\Http\ViewComposers\MyViewComposer'
+        'App\Http\View\Composers\MyViewComposer'
     );
 
 The `composer` method also accepts the `*` character as a wildcard, allowing you to attach a composer to all views:
@@ -211,4 +211,4 @@ The `composer` method also accepts the `*` character as a wildcard, allowing you
 
 View **creators** are very similar to view composers; however, they are executed immediately after the view is instantiated instead of waiting until the view is about to render. To register a view creator, use the `creator` method:
 
-    View::creator('profile', 'App\Http\ViewCreators\ProfileCreator');
+    View::creator('profile', 'App\Http\View\Creators\ProfileCreator');


### PR DESCRIPTION
This adds a new subdirectory to the view composer example to be complementatry with the view creators below. Adds for a much nicer directory structure than the separate directories with the View prefix.

It also renames the service provider from `ComposerServiceProvider` to `ViewServiceProvider` to prevent confusion with the ambiguous "Composer" naming. Besides that it also doesn't hints that way that the service provider would be for composers only but for creators as well.