### PR TITLE
[5.7] Add note about making Dusk binaries executable

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -65,6 +65,8 @@ If you had test failures the last time you ran the `dusk` command, you may save 
 
     php artisan dusk:fails
 
+> {note} It's important that the chromedriver binaries can by run so if you're experiencing issues with running Dusk make sure you make the binaries executable by running `chmod -R 0755 vendor/laravel/dusk/bin`.
+
 <a name="using-other-browsers"></a>
 ### Using Other Browsers
 


### PR DESCRIPTION
Sometimes when installed the binaries will have a different permission set than required. Often this is in combination with a virtual machine. Clarifying that these binaries need to be executable would help.

As reported here: https://github.com/laravel/dusk/issues/81