### PR TITLE
[5.7] Document Dusk browser macros

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -230,6 +230,42 @@ The `maximize` method may be used to maximize the browser window:
 
     $browser->maximize();
 
+#### Browser Macros
+
+If you would like to define a custom method that you can re-use in a variety of your tests, you may use the `macro` method on the `Browser` class. For example, from a [service provider's](/docs/{{version}}/providers) `boot` method:
+
+    <?php
+
+    namespace App\Providers;
+
+    use Laravel\Dusk\Browser;
+    use Illuminate\Support\ServiceProvider;
+
+    class DuskServiceProvider extends ServiceProvider
+    {
+        /**
+         * Register the Dusk's browser macros.
+         *
+         * @return void
+         */
+        public function boot()
+        {
+            Browser::macro('scrollToElement', function ($element = null) {
+                $this->script("$('html, body').animate({ scrollTop: $('$element').offset().top }, 0);");
+
+                return $this;
+            });
+        }
+    }
+
+The `macro` function accepts a name as its first argument, and a Closure as its second. The macro's Closure will be executed when calling the macro name from a `Browser` implementation:
+
+    $this->browse(function ($browser) use ($user) {
+        $browser->visit('/pay')
+                ->scrollToElement('#credit-card-details')
+                ->assertSee('Enter Credit Card Details');
+    });
+
 <a name="authentication"></a>
 ### Authentication
 


### PR DESCRIPTION
I agree we shouldn't document every single macroable class out there but this is a pretty handy one for Dusk users. I closed quite a bit of issues where people asked for additional functionality on the Browser instance so if people were aware that it was macroable it could help them to customize it.