### PR TITLE
[5.6] Add remember_token note for upgrading to 5.6.30

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -14,7 +14,7 @@ Laravel 5.6.30 is a security release of Laravel and is recommended as an immedia
 
 Laravel 5.6.30 disables all serialization / unserialization of cookie values. Since all Laravel cookies are encrypted and signed, cookie values are typically considered safe from client tampering. **However, if your application's encryption key is in the hands of a malicious party, that party could craft cookie values using the encryption key and exploit vulnerabilities inherent to PHP object serialization / unserialization, such as calling arbitrary class methods within your application.**
 
-Disabling serialization on all cookie values will invalidate all of your application's sessions and users will need to log into the application again. In addition, any other encrypted cookies your application is setting will have invalid values. For this reason, you may wish to add additional logic to your application to validate that your custom cookie values match an expected list of values; otherwise, you should discard them.
+Disabling serialization on all cookie values will invalidate all of your application's sessions and users will need to log into the application again (unless they have a `remember_token` set, in which case the user will be logged into a new session automatically). In addition, any other encrypted cookies your application is setting will have invalid values. For this reason, you may wish to add additional logic to your application to validate that your custom cookie values match an expected list of values; otherwise, you should discard them.
 
 #### Configuring Cookie Serialization
 


### PR DESCRIPTION
I've been testing upgrading an app and could not figure out how I was still logged in at first.