### PR TITLE
[5.7] Document replicate method

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -227,13 +227,10 @@ You can replicate models using the `replicate` method. The `replicate` method wi
 
     $flight = App\Flight::first();
 
-    $flight->id; // 1
     $flight->plane; // "Concorde"
 
     $replicatedFlight = $flight->replicate();
-    $replicatedFlight->save();
 
-    $replicatedFlight->id; // 2
     $replicatedFlight->plane; // "Concorde"
 
 You can ignore certain attributes which you don't want to replicate by passing an array of ignored attributes:
@@ -243,7 +240,6 @@ You can ignore certain attributes which you don't want to replicate by passing a
     $flight->plane; // "Concorde"
 
     $replicatedFlight = $flight->replicate(['plane']);
-    $replicatedFlight->save();
 
     $replicatedFlight->plane; // null
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -221,6 +221,34 @@ The `refresh` method will re-hydrate the existing model using fresh data from th
 
     $flight->number; // "FR 900"
 
+#### Replicating Models
+
+You can replicate models using the `replicate` method. The `replicate` method will return a new instance of an unsaved model. The existing model instance will not be affected:
+
+    $flight = App\Flight::first();
+
+    $flight->id; // 1
+    $flight->plane; // "Concorde"
+
+    $replicatedFlight = $flight->replicate();
+    $replicatedFlight->save();
+
+    $replicatedFlight->id; // 2
+    $replicatedFlight->plane; // "Concorde"
+
+You can ignore certain attributes which you don't want to replicate by passing an array of ignored attributes:
+
+    $flight = App\Flight::first();
+
+    $flight->plane; // "Concorde"
+
+    $replicatedFlight = $flight->replicate(['plane']);
+    $replicatedFlight->save();
+
+    $replicatedFlight->plane; // null
+
+> {note} When replicated models which have attributes set because of the `withCount` or `storedAs` properties, you'll have to unset these first before saving. Otherwise an exception will be thrown when the model is attempted to be saved as these attributes don't exist in your database table.
+
 <a name="collections"></a>
 ### Collections
 


### PR DESCRIPTION
I wasn't super sure where to put this. It doesn't really belong under the "Retrieving Models" section but couldn't figure out a good alternative. The method itself in the `Model` class is right below the `refresh` method so this might not be the worst place.

This also comes with an important gotcha note about replicating models with their `$withCount` and `$storedAs` properties set.

See https://github.com/laravel/framework/issues/26562