### PR TITLE
[5.7] Fixed incorrect link to sorting middleware

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -6,7 +6,7 @@
     - [Global Middleware](#global-middleware)
     - [Assigning Middleware To Routes](#assigning-middleware-to-routes)
     - [Middleware Groups](#middleware-groups)
-    - [Sorting Middleware](sorting-middleware)
+    - [Sorting Middleware](#sorting-middleware)
 - [Middleware Parameters](#middleware-parameters)
 - [Terminable Middleware](#terminable-middleware)
 


### PR DESCRIPTION
Fixes incorrect link introduced in https://github.com/laravel/docs/commit/4144497c5bdfc2b537bd8d8bd79ad699998ce0ca (missing hash symbol). Without it, the link points to a 404.