### PR TITLE
[5.7] Fix read & write connections example code

### DIFF
--- a/database.md
+++ b/database.md
@@ -50,10 +50,10 @@ To see how read / write connections should be configured, let's look at this exa
 
     'mysql' => [
         'read' => [
-            'host' => ['192.168.1.1'],
+            'host' => '192.168.1.1',
         ],
         'write' => [
-            'host' => ['196.168.1.2'],
+            'host' => '196.168.1.2',
         ],
         'sticky'    => true,
         'driver'    => 'mysql',


### PR DESCRIPTION
Now we have a problem with read & write example code,if we use array in config/database.php we get an two errors.

```
1   ErrorException::("Array to string conversion")
 2   Illuminate\Foundation\Bootstrap\HandleExceptions::handleError("Array to string conversion", "/var/www/project_example/vendor/laravel/framework/src/Illuminate/Database/Connectors/MySqlConnector.php")
      /var/www/project_example/vendor/laravel/framework/src/Illuminate/Database/Connectors/MySqlConnector.php:133
```
