### PR TITLE
[5.7] Clarify conditional indexing for Scout

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -262,6 +262,17 @@ Sometimes you may need to only make a model searchable under certain conditions.
         return $this->isPublished();
     }
 
+Note that this is only applied when manipulating models through the `save` method, queries or relationships. Directly making models and collections searchable would still override this behavior.
+
+    // Applied to...
+    App\Order::where('price', '>', 100)->searchable();
+    $user->orders()->searchable();
+    $order->save();
+
+    // Not applied to...
+    $orders->searchable();
+    $order->searchable();
+
 <a name="searching"></a>
 ## Searching
 


### PR DESCRIPTION
Conditional indexing only applies when using the save method on a model, the query builder or relationships directly. This is because the behavior on models and collections directly is meant to "force" them to be applied and ignores the `shouldBeSearchable` method.

See discussion here: https://github.com/laravel/scout/issues/320

Fixes https://github.com/laravel/docs/issues/4813