### PR TITLE
Fixed date validation not accepting relative dates

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -666,7 +666,7 @@ The field under validation must have a matching field of `foo_confirmation`. For
 <a name="rule-date"></a>
 #### date
 
-The field under validation must be a valid non-relative date according to the `strtotime` PHP function.
+The field under validation must be a valid, non-relative date according to the `strtotime` PHP function.
 
 <a name="rule-date-equals"></a>
 #### date_equals:_date_

--- a/validation.md
+++ b/validation.md
@@ -666,7 +666,7 @@ The field under validation must have a matching field of `foo_confirmation`. For
 <a name="rule-date"></a>
 #### date
 
-The field under validation must be a valid date according to the `strtotime` PHP function.
+The field under validation must be a valid non-relative date according to the `strtotime` PHP function.
 
 <a name="rule-date-equals"></a>
 #### date_equals:_date_


### PR DESCRIPTION
The date validation does not accept _any_ value that `strtotime` understands, as it does `date_parse` with `check_date` afterwards. 
There was an issue for this, but was closed, although I could reproduce it.
https://github.com/laravel/docs/issues/2542

`app('validator')->make(['foo' => 'yesterday'], ['foo' => ['date']])->validate()`

edit: Fixed typo