### PR TITLE
Use the word "delete" to improve searchability

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1095,7 +1095,7 @@ When attaching a relationship to a model, you may also pass an array of addition
 
     $user->roles()->attach($roleId, ['expires' => $expires]);
 
-Of course, sometimes it may be necessary to remove a role from a user. To remove a many-to-many relationship record, use the `detach` method. The `detach` method will remove the appropriate record out of the intermediate table; however, both models will remain in the database:
+Of course, sometimes it may be necessary to remove a role from a user. To remove a many-to-many relationship record, use the `detach` method. The `detach` method will delete the appropriate record out of the intermediate table; however, both models will remain in the database:
 
     // Detach a single role from the user...
     $user->roles()->detach($roleId);


### PR DESCRIPTION
The word "delete" isn't used anywhere on the page, so if you search the page for the word "delete" to look up how to delete a many-to-many relationship you won't find it.

This PR changes changes the word "remove" to "delete" so you can search for either "delete", "remove", or "detach" to find how to delete a many-to-many relationship.
