### PR TITLE
[5.7] Make it clear that /vendor/mail/markdown refers to the plain text version of emails

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -411,7 +411,7 @@ You may export all of the Markdown mail components to your own application for c
 
     php artisan vendor:publish --tag=laravel-mail
 
-This command will publish the Markdown mail components to the `resources/views/vendor/mail` directory. The `mail` directory will contain a `html` and a `markdown` directory, each containing their respective representations of every available component. You are free to customize these components however you like.
+This command will publish the Markdown mail components to the `resources/views/vendor/mail` directory. The `mail` directory will contain a `html` and a `markdown` directory, each containing their respective representations of every available component. The components in the html directory are used to generate the HTML version of your email, and their counterparts in the markdown directory are used to generate the plain-text version. You are free to customize these components however you like.
 
 #### Customizing The CSS
 

--- a/mail.md
+++ b/mail.md
@@ -411,7 +411,7 @@ You may export all of the Markdown mail components to your own application for c
 
     php artisan vendor:publish --tag=laravel-mail
 
-This command will publish the Markdown mail components to the `resources/views/vendor/mail` directory. The `mail` directory will contain a `html` and a `markdown` directory, each containing their respective representations of every available component. The components in the html directory are used to generate the HTML version of your email, and their counterparts in the markdown directory are used to generate the plain-text version. You are free to customize these components however you like.
+This command will publish the Markdown mail components to the `resources/views/vendor/mail` directory. The `mail` directory will contain a `html` and a `markdown` directory, each containing their respective representations of every available component. The components in the `html` directory are used to generate the HTML version of your email, and their counterparts in the `markdown` directory are used to generate the plain-text version. You are free to customize these components however you like.
 
 #### Customizing The CSS
 


### PR DESCRIPTION
The clarification that 'markdown' directory refers to plain text version of emails is also applicable to 5.5!

After the discussion [here](https://github.com/laravel/framework/issues/23076) it appears 5.6+ docs were updated, but 5.5 weren't.  LTS is still first recourse for me at least at this time.