### PR TITLE
[5.7] Remove white line for throws annotation

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -77,7 +77,6 @@ Below is an example of a valid Laravel documentation block. Note that the `@para
      * @param  \Closure|string|null  $concrete
      * @param  bool  $shared
      * @return void
-     *
      * @throws \Exception
      */
     public function bind($abstract, $concrete = null, $shared = false)


### PR DESCRIPTION
This isn't enforced anymore at the moment and the updated way is used more than the previous one.