### PR TITLE
Add info about forget() accepting array argument

### DIFF
--- a/session.md
+++ b/session.md
@@ -177,9 +177,11 @@ If you need to keep your flash data around for several requests, you may use the
 <a name="deleting-data"></a>
 ### Deleting Data
 
-The `forget` method will remove a piece of data from the session. If you would like to remove all data from the session, you may use the `flush` method:
+The `forget` method will remove a piece (or multiple pieces if you pass an array) of data from the session. If you would like to remove all data from the session, you may use the `flush` method:
 
     $request->session()->forget('key');
+    
+    $request->session()->forget(['key1', 'key2']);
 
     $request->session()->flush();
 


### PR DESCRIPTION
A colleague of mine that's just starting with Laravel wasn't able to find it in the docs today.