### PR TITLE
[5.7] remove PHP mail driver

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -25,7 +25,7 @@
 <a name="introduction"></a>
 ## Introduction
 
-Laravel provides a clean, simple API over the popular [SwiftMailer](https://swiftmailer.symfony.com/) library with drivers for SMTP, Mailgun, SparkPost, Amazon SES, PHP's `mail` function, and `sendmail`, allowing you to quickly get started sending mail through a local or cloud based service of your choice.
+Laravel provides a clean, simple API over the popular [SwiftMailer](https://swiftmailer.symfony.com/) library with drivers for SMTP, Mailgun, SparkPost, Amazon SES, and `sendmail`, allowing you to quickly get started sending mail through a local or cloud based service of your choice.
 
 <a name="driver-prerequisites"></a>
 ### Driver Prerequisites


### PR DESCRIPTION
the PHP mail driver is no longer used. It is simply an alias for the sendmail driver.

the 'mail' driver will continue to work (for now), we just shouldn't document it to help avoid confusion.

with the current wording, the program may think the native PHP `mail()` function is still being used, which it is not.