### PR TITLE
Update deployment.md

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -48,6 +48,7 @@ If you are deploying your application to a server that is running Nginx, you may
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
             fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
             fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             include fastcgi_params;
         }
 


### PR DESCRIPTION
Without `fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;` in the `location ~ \.php$` block, I am getting a blank page on Docker. No error in the nginx error logs, `127.0.0.1 -  16/Dec/2018:16:11:42 +0000 "- " 200` is returned.

My Dockerfile
```
FROM php:7.3-fpm

RUN apt-get update && apt-get install -y nginx \
    supervisor \
    git \
    zip \
    libfreetype6-dev \
    libjpeg62-turbo-dev \
    && docker-php-ext-install pdo_mysql \
    && docker-php-ext-install bcmath \
    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
    && docker-php-ext-install gd

COPY supervisord.conf /etc/supervisord.conf

RUN rm /etc/nginx/sites-enabled/default
COPY default.conf /etc/nginx/conf.d/default.conf

WORKDIR /var/www/laravel

COPY . .
RUN chgrp -R www-data storage bootstrap/cache \
    && chmod -R ug+rwx storage bootstrap/cache

RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer

RUN composer install --optimize-autoloader --no-dev \
    && php artisan key:generate \
    && php artisan config:cache \
    && php artisan route:cache

EXPOSE 80

ENTRYPOINT ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisord.conf"]
```