### PR TITLE
Move tip about 'htmlspecialchars' to first example

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -167,11 +167,12 @@ You may display the contents of the `name` variable like so:
 
     Hello, {{ $name }}.
 
+
+> {tip} Blade `{{ }}` statements are automatically sent through PHP's `htmlspecialchars` function to prevent XSS attacks.
+
 Of course, you are not limited to displaying the contents of the variables passed to the view. You may also echo the results of any PHP function. In fact, you can put any PHP code you wish inside of a Blade echo statement:
 
     The current UNIX timestamp is {{ time() }}.
-
-> {tip} Blade `{{ }}` statements are automatically sent through PHP's `htmlspecialchars` function to prevent XSS attacks.
 
 #### Displaying Unescaped Data
 


### PR DESCRIPTION
The docs currently display a tip and then immediately display a new section with the same text. This change displays the {tip} after the first example so that users can learn the information when it's relevant and keeps the text in the next section for users who skip the previous section.