### PR TITLE
Explain breaking change in component registration

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -151,6 +151,8 @@ The published components will be placed in your `resources/js/components` direct
         require('./components/passport/PersonalAccessTokens.vue').default
     );
 
+> {note} Prior to Laravel v5.7.19, appending `.default` when registering components results in a console error. An explanation for this change can be found in the [Laravel Mix v4.0.0 release notes](https://github.com/JeffreyWay/laravel-mix/releases/tag/v4.0.0) 
+
 After registering the components, make sure to run `npm run dev` to recompile your assets. Once you have recompiled your assets, you may drop the components into one of your application's templates to get started creating clients and personal access tokens:
 
     <passport-clients></passport-clients>


### PR DESCRIPTION
The current docs, when used with an L5.7 install lower than 5.7.19 will result in failed Vue component registration. More details and a reason are needed because Laravel-mix 4.0.0 contains a breaking change.