### PR TITLE
[5.7] add whereBetween method

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -165,6 +165,7 @@ For the remainder of this documentation, we'll discuss each method available on 
 [whenEmpty](#method-whenempty)
 [whenNotEmpty](#method-whennotempty)
 [where](#method-where)
+[whereBetween](#method-wherebetween)
 [whereStrict](#method-wherestrict)
 [whereIn](#method-wherein)
 [whereInStrict](#method-whereinstrict)
@@ -2105,6 +2106,31 @@ The `where` method filters the collection by a given key / value pair:
     */
 
 The `where` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`whereStrict`](#method-wherestrict) method to filter using "strict" comparisons.
+
+<a name="method-wherebetween"></a>
+#### `whereBetween()` {#collection-method}
+
+The `whereBetween` method filters the collection within a given range:
+
+    $collection = collect([
+        ['product' => 'Desk', 'price' => 200],
+        ['product' => 'Chair', 'price' => 80],
+        ['product' => 'Bookcase', 'price' => 150],
+        ['product' => 'Pencil', 'price' => 30],
+        ['product' => 'Door', 'price' => 100],
+    ]);
+
+    $filtered = $collection->whereBetween('price', [100, 200]);
+
+    $filtered->all();
+
+    /*
+        [
+            ['product' => 'Desk', 'price' => 200],
+            ['product' => 'Bookcase', 'price' => 150],
+            ['product' => 'Door', 'price' => 100],
+        ]
+    */
 
 <a name="method-wherestrict"></a>
 #### `whereStrict()` {#collection-method}


### PR DESCRIPTION
This PR adds documentation to the `whereBetween` collection method which was introduced in PR [26888](https://github.com/laravel/framework/pull/26888)