### PR TITLE
[5.7] Remove fastcgi_split_path_info

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -45,7 +45,6 @@ If you are deploying your application to a server that is running Nginx, you may
         error_page 404 /index.php;
 
         location ~ \.php$ {
-            fastcgi_split_path_info ^(.+\.php)(/.+)$;
             fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
             fastcgi_index index.php;
             include fastcgi_params;


### PR DESCRIPTION
Currently nginx PHP location block is configured to handle requests with `.php` ending (`location ~ \.php$ {}`).
Still there is the widely used `fastcgi_split_path_info` directive included with the standard `^(.+\.php)(/.+)$;` value.
This statement doesn't make any sense, since there is nothing to split after `.php`.
As far as I know this should be used only in legacy routing systems: `index.php/foo/bar`.