### PR TITLE
[5.7] PostgreSQL column comments are supported also

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -287,7 +287,7 @@ Modifier  |  Description
 `->autoIncrement()`  |  Set INTEGER columns as auto-increment (primary key)
 `->charset('utf8')`  |  Specify a character set for the column (MySQL)
 `->collation('utf8_unicode_ci')`  |  Specify a collation for the column (MySQL/SQL Server)
-`->comment('my comment')`  |  Add a comment to a column (MySQL)
+`->comment('my comment')`  |  Add a comment to a column (MySQL/PostgreSQL)
 `->default($value)`  |  Specify a "default" value for the column
 `->first()`  |  Place the column "first" in the table (MySQL)
 `->nullable($value = true)`  |  Allows (by default) NULL values to be inserted into the column


### PR DESCRIPTION
There is an implementation for the PostgreSQL column comments in 
Illuminate\Database\Schema\Grammars\PostgresGrammar::compileComment() 
see https://github.com/laravel/framework/blob/5.7/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php#L380