### PR TITLE
Add documentation for installing Telescope on Sub-Folder Laravel Installs

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -83,7 +83,7 @@ For sub-folder installs of Laravel, the `asset()` has difficulty rendering paths
 
     use Illuminate\Support\Facades\View;
 	
-	/**
+    /**
      * Bootstrap any Telescope services.
      *
      * @return void
@@ -99,7 +99,7 @@ For sub-folder installs of Laravel, the `asset()` has difficulty rendering paths
         });
 		
         parent::boot();
-	}
+    }
     
     
 

--- a/telescope.md
+++ b/telescope.md
@@ -77,6 +77,32 @@ After running `telescope:install`, you should remove the `TelescopeServiceProvid
         }
     }
 
+### Sub-Folder Laravel Installs
+
+For sub-folder installs of Laravel, the `asset()` has difficulty rendering paths correctly. You will need to add the following in the `boot` method of your `app/Providers/TelescopeServiceProvider.php` file.
+
+    use Illuminate\Support\Facades\View;
+	
+	/**
+     * Bootstrap any Telescope services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        View::composer(['telescope::layout'], function ($view) {
+            $view->with('telescopeScriptVariables', [ 
+                'path' => 'YOUR-URL-STRING-HERE/' . config('telescope.path'),  
+                'timezone' => config('app.timezone'), 
+                'recording' => ! cache('telescope:pause-recording'), 
+            ]);
+        });
+		
+        parent::boot();
+	}
+    
+    
+
 <a name="configuration"></a>
 ### Configuration
 


### PR DESCRIPTION
This PR adds to the docs the clarity for users looking to use Telescope in their sub-folder projects. Before you could not have a sub-folder instance and have telescope. Sites like /admin or /app as their root would not be able to call the telescope-api routes correctly. 