### PR TITLE
[5.7] Update exception report() snippet to match actual code

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -45,7 +45,7 @@ For example, if you need to report different types of exceptions in different wa
             //
         }
 
-        return parent::report($exception);
+        parent::report($exception);
     }
 
 > {tip} Instead of making a lot of `instanceof` checks in your `report` method, consider using [reportable exceptions](/docs/{{version}}/errors#renderable-exceptions)


### PR DESCRIPTION
In `App\Exceptions\Handler.php`, the `report()` method does not return.

https://github.com/laravel/laravel/blob/d1db3cd089d6e9f81a4c8a65d401939f85cbbd5c/app/Exceptions/Handler.php#L29-L38