### PR TITLE
[5.7] Route name prefixes use the 'as' attribute in a group

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -294,6 +294,8 @@ The `name` method may be used to prefix each route name in the group with a give
         })->name('users');
     });
 
+> {note} The `name` method is an alias to the the `as` method. To specify a name prefix in a route group, use the `as` attribute.
+
 <a name="route-model-binding"></a>
 ## Route Model Binding
 


### PR DESCRIPTION
Counter-intuitive because all other methods represent equivalent attributes in a `Route::group` so this is worth mentioning. 