### PR TITLE
[5.6] Changed version of the package

### DIFF
--- a/socialite.md
+++ b/socialite.md
@@ -21,7 +21,7 @@ In addition to typical, form based authentication, Laravel also provides a simpl
 
 To get started with Socialite, use Composer to add the package to your project's dependencies:
 
-    composer require laravel/socialite
+    composer require laravel/socialite "^3.2.0"
 
 <a name="configuration"></a>
 ## Configuration


### PR DESCRIPTION
By default composer installs the last version of `Socialite`, now, the `Socialite's` last version is `4.0.1` and from `4.0.0` it requires Laravel 5.7 as minimum version, that's why guy which develops with Laravel 5.6 should install Socialite by saying that he wants last version which also requires Laravel 5.6, it's `3.2.0`