### PR TITLE
[5.7] Remove fastcgi_split_path_info from nginx config

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -45,7 +45,6 @@ If you are deploying your application to a server that is running Nginx, you may
         error_page 404 /index.php;
 
         location ~ \.php$ {
-            fastcgi_split_path_info ^(.+\.php)(/.+)$;
             fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
             fastcgi_index index.php;
             include fastcgi_params;


### PR DESCRIPTION
Hello @taylorotwell!

You've probably missed my previous PR's (https://github.com/laravel/docs/pull/4847) comments, let me summarize to create a whole picture.


## `fastcgi_split_path_info`
### What is purpose of the `fastcgi_split_path_info` nginx directive?
It constructs the `$fastcgi_path_info` variable from the given regex (with exactly 2 capture groups).
Most widely used value is `^(.+\.php)(/.+)$`. ([nginx docs](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_split_path_info))

### What is effect of using `fastcgi_split_path_info`?
The `$fastcgi_path_info` value will be set to the processed path's portion after the `.php` extension.
Example: `https://laravel.com/test.php/foo/bar` => `/foor/bar`.

### How can I use the `$fastcgi_path_info` variable?
Now we may have some value assigned to `$fastcgi_path_info`, but we have to pass it to PHP via the `PATH_INFO` variable (the default `/etc/nginx/fastcgi_params` file does not handle it).
The standard way to do that: `fastcgi_param PATH_INFO $fastcgi_path_info`.

### What is prerequisite of using `fastcgi_split_path_info`?
Since the only use-case is getting the substring (routing) after the `.php` file, we have to create a location block which handles such paths.
Most widely used location block to do that:
```nginx
location ~ [^/]\.php(/|$) {
    ...
}
```

### Should I use the `fastcgi_split_path_info`?
Only if you have to deal with `/index.php/foo/bar` style routes (or `slash arguments` as [Moodle calls it](https://docs.moodle.org/36/en/Using_slash_arguments)).
Typical applications which require it: [Moodle](https://docs.moodle.org/33/en/Nginx#Nginx), older Joomla!, [Drupal](https://www.nginx.com/resources/wiki/start/topics/recipes/drupal/) (only update route), [Magento](https://github.com/magento/magento2/blob/2.3/nginx.conf.sample) (only update route) or any legacy stuff.
Some applications which support it: [Symfony](https://symfony.com/doc/current/setup/web_server_configuration.html#nginx) (note the `internal` directive), [Slim](https://www.slimframework.com/docs/v3/start/web-servers.html#nginx-configuration) (note the missing `$`)
Some applications which don't support it: [Yii 2](https://www.yiiframework.com/doc/guide/2.0/en/start-installation#recommended-nginx-configuration), [Zend](https://www.nginx.com/resources/wiki/start/topics/recipes/zend/), [CodeIgniter](https://www.nginx.com/resources/wiki/start/topics/recipes/codeigniter/), [CakePHP](https://book.cakephp.org/3.0/en/installation.html#nginx), [WordPress](https://codex.wordpress.org/Nginx#General_WordPress_rules)

### Can I see some example?
Example reques `#1`: `https://laravel.com/test.php`
- without `fastcgi_split_path_info`:
  - `$fastcgi_script_name`: `/test.php`
  - `$fastcgi_path_info`: `no value`
- with `fastcgi_split_path_info` (value: `^(.+\.php)(/.+)$`):
  - `$fastcgi_script_name`: `/test.php`
  - `$fastcgi_path_info`: `no value`

Example request `#2`: `https://laravel.com/test.php/foo/bar`
- without `fastcgi_split_path_info`:
  - `$fastcgi_script_name`: `/test.php/foo/bar`
  - `$fastcgi_path_info`: `no value`
- with `fastcgi_split_path_info` (value: `^(.+\.php)(/.+)$`):
  - `$fastcgi_script_name`: `/test.php`
  - `$fastcgi_path_info`: `/foo/bar`


## `fastcgi_split_path_info` × Laravel
### What's the issue with nginx configuration?
The [Deployment documentation of Laravel](https://laravel.com/docs/5.7/deployment) suggests the following nginx PHP location block:
```nginx
location ~ \.php$ {
    fastcgi_split_path_info ^(.+\.php)(/.+)$;
    fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
    fastcgi_index index.php;
    include fastcgi_params;
}
```
Issues:
1. The location regex restricts the processed path to end with `.php` (e.g. `/test.php`), so it won't process a route with slash arguments (e.g. `/test.php/foo/bar`).
2. If only the `.php$` paths will be processed the there is no point of using `fastcgi_split_path_info`.
3. Even if we are using the `fastcgi_split_path_info` directive, the generated `$fastcgi_path_info` (without value in this case) isn't used anywhere.


## Solutions
### `#1` Get rid of `fastcgi_split_path_info`
The most obvious way to handle this anomaly is removing the `fastcgi_split_path_info` directive, as I suggested in this PR.
The final location block would be:
```nginx
location ~ \.php$ {
    fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
    fastcgi_index index.php;
    include fastcgi_params;
}
```

### `#2` Allow slash arguments
Another way to make the configuration useful is extending the location regex to: `[^/]\.php(/|$)`
The final location block would be:
```nginx
location ~ [^/]\.php(/|$) {
    fastcgi_split_path_info ^(.+\.php)(/.+)$;
    fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
    fastcgi_index index.php;
    include fastcgi_params;
}
```

### (`#3` Hybrid solution)
Laravel's `Illuminate\Http\Request` class extends `Symfony\Component\HttpFoundation\Request` class, which handles the `PATH_INFO` variable if present, but also can construct it from the url. We can get rid of `fastcgi_split_path_info` directive (since we currently do not pass the `PATH_INFO` variable to PHP) and allow the slash arguments processing location regex.
```nginx
location ~ [^/]\.php(/|$) {
    fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
    fastcgi_index index.php;
    include fastcgi_params;
}
```

Thanks for reading this.
What do you think @taylorotwell?

P.S. Sorry for the duplicate PR.