### PR TITLE
Updated Codeship instructions

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1344,12 +1344,12 @@ To run Dusk tests on [Codeship](https://codeship.com), add the following command
     mkdir -p ./bootstrap/cache
     composer install --no-interaction --prefer-dist
     php artisan key:generate
+    nohup bash -c "php artisan serve 2>&1 &" && sleep 5
     php artisan dusk
     
 > {tip} If you need MySQL 5.7 on Codeship, add this code to the start of your setup commands:
 > ```
 > \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/mysql-5.7.sh | bash -s
-> export PATH=/home/rof/mysql-5.7.17/bin:$PATH
 > mysql --defaults-file="/home/rof/mysql-5.7.17/my.cnf" -u "${MYSQL_USER}" -p"${MYSQL_PASSWORD}" -e "create database development";
 > ```
 

--- a/dusk.md
+++ b/dusk.md
@@ -1346,12 +1346,6 @@ To run Dusk tests on [Codeship](https://codeship.com), add the following command
     php artisan key:generate
     nohup bash -c "php artisan serve 2>&1 &" && sleep 5
     php artisan dusk
-    
-> {tip} If you need MySQL 5.7 on Codeship, add this code to the start of your setup commands:
-> ```
-> \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/mysql-5.7.sh | bash -s
-> mysql --defaults-file="/home/rof/mysql-5.7.17/my.cnf" -u "${MYSQL_USER}" -p"${MYSQL_PASSWORD}" -e "create database development";
-> ```
 
 <a name="running-tests-on-heroku-ci"></a>
 ### Heroku CI

--- a/dusk.md
+++ b/dusk.md
@@ -1339,12 +1339,19 @@ If you are using CircleCI to run your Dusk tests, you may use this configuration
 
 To run Dusk tests on [Codeship](https://codeship.com), add the following commands to your Codeship project. Of course, these commands are a starting point and you are free to add additional commands as needed:
 
-    phpenv local 7.1
+    phpenv local 7.2
     cp .env.testing .env
-    composer install --no-interaction
-    nohup bash -c "./vendor/laravel/dusk/bin/chromedriver-linux 2>&1 &"
-    nohup bash -c "php artisan serve 2>&1 &" && sleep 5
+    mkdir -p ./bootstrap/cache
+    composer install --no-interaction --prefer-dist
+    php artisan key:generate
     php artisan dusk
+    
+> {tip} If you need MySQL 5.7 on Codeship, add this code to the start of your setup commands:
+> ```
+> \curl -sSL https://raw.githubusercontent.com/codeship/scripts/master/packages/mysql-5.7.sh | bash -s
+> export PATH=/home/rof/mysql-5.7.17/bin:$PATH
+> mysql --defaults-file="/home/rof/mysql-5.7.17/my.cnf" -u "${MYSQL_USER}" -p"${MYSQL_PASSWORD}" -e "create database development";
+> ```
 
 <a name="running-tests-on-heroku-ci"></a>
 ### Heroku CI


### PR DESCRIPTION
Updated setup commands for PHP 7.2 and minor build improvements.

Codeship already has ChromeDriver installed out of the box. See [here](https://documentation.codeship.com/basic/continuous-integration/browser-testing/#chromedriver)

MySQL 5.7 tip found from this blog post: [Testing with a MySQL 5.7 Database On Codeship](https://mattstauffer.com/blog/testing-with-a-mysql-5-7-database-on-codeship/)

Be sure to set environment variable `APP_URL` to `http://localhost:8000`.