### PR TITLE
Update mapSpread Callback Parameters

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1026,8 +1026,8 @@ The `mapSpread` method iterates over the collection's items, passing each nested
 
     $chunks = $collection->chunk(2);
 
-    $sequence = $chunks->mapSpread(function ($odd, $even) {
-        return $odd + $even;
+    $sequence = $chunks->mapSpread(function ($even, $odd) {
+        return $even + $odd;
     });
 
     $sequence->all();


### PR DESCRIPTION
The mapSpread parameters takes the first value and then the second value, which is the even number 0, 2, 4, etc and the corresponding odd number 1, 3, 5, etc. This change corrects the parameters to correctly match to eliminate any possible confusion.