### PR TITLE
[5.7] Correct Mail set locale code snippet

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -617,10 +617,10 @@ If you have mailable classes that you want to always be queued, you may implemen
 
 Laravel allows you to send mailables in a locale other than the current language, and will even remember this locale if the mail is queued.
 
-To accomplish this, the `Illuminate\Mail\Mailable` class offers a `locale` method to set the desired language. The application will change into this locale when the mailable is being formatted and then revert back to the previous locale when formatting is complete:
+To accomplish this, the `Mail` facade offers a `locale` method to set the desired language. The application will change into this locale when the mailable is being formatted and then revert back to the previous locale when formatting is complete:
 
-    Mail::to($request->user())->send(
-        (new OrderShipped($order))->locale('es')
+    Mail::to($request->user())->locale('es')->send(
+        new OrderShipped($order)
     );
 
 ### User Preferred Locales


### PR DESCRIPTION
Fixes: https://github.com/laravel/framework/issues/27023

The documented mailable localization example:

```php
Mail::to($request->user())->send(
    (new OrderShipped($order))->locale('es')
);
```

would always be sent using the default locale since `PendingMail@fill()` overrides 'es' with the `PendingMail` default value which is `null`.

`Mail::to($request->user())->locale('es')` should instead be used to set the locale through the mail service.

There may have been confusion since https://github.com/laravel/framework/pull/25752 started allowing this call for a `Notification`:

```php
$user->notify((new OrderConfirmation($order))->locale('en'))
```

since there is no intermediate object to assign a locale to.