### PR TITLE
[5.7] Add assertNothingSent, assertNothingPushed

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -167,6 +167,9 @@ You may use the `Mail` facade's `fake` method to prevent mail from being sent. Y
         public function testOrderShipping()
         {
             Mail::fake();
+            
+            // Assert that no mailables were sent...
+            Mail::assertNothingSent();
 
             // Perform order shipping...
 

--- a/mocking.md
+++ b/mocking.md
@@ -269,6 +269,9 @@ As an alternative to mocking, you may use the `Queue` facade's `fake` method to 
         public function testOrderShipping()
         {
             Queue::fake();
+            
+            // Assert that no jobs were pushed...
+            Queue::assertNothingPushed();
 
             // Perform order shipping...
 

--- a/mocking.md
+++ b/mocking.md
@@ -218,6 +218,9 @@ You may use the `Notification` facade's `fake` method to prevent notifications f
         public function testOrderShipping()
         {
             Notification::fake();
+            
+            // Assert that no notifications were sent...
+            Notification::assertNothingSent();
 
             // Perform order shipping...
 


### PR DESCRIPTION
This PR adds missing documentation of [assertNothingSent and assertNothingPushed](https://github.com/laravel/framework/pull/20651) mock assertions.