### PR TITLE
[5.7] Clarify libraries and Lumen support policy

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -16,7 +16,7 @@ Paradigm shifting releases are separated by many years and represent fundamental
 <a name="support-policy"></a>
 ## Support Policy
 
-For LTS releases, such as Laravel 5.5, bug fixes are provided for 2 years and security fixes are provided for 3 years. These releases provide the longest window of support and maintenance. For general releases, bug fixes are provided for 6 months and security fixes are provided for 1 year.
+For LTS releases, such as Laravel 5.5, bug fixes are provided for 2 years and security fixes are provided for 3 years. These releases provide the longest window of support and maintenance. For general releases, bug fixes are provided for 6 months and security fixes are provided for 1 year. For all additional libraries and Lumen we only support the latest releases.
 
 | Version | Release | Bug Fixes Until | Security Fixes Until |
 | --- | --- | --- | --- |


### PR DESCRIPTION
To clarify that the Lumen and other libraries support policy differs from the framework one. Added this to prevent any confusion.