### PR TITLE
[5.7] Update collection every() method documentation

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -517,6 +517,16 @@ The `every` method may be used to verify that all elements of a collection pass 
 
     // false
 
+If the collection is empty, `every` will return true:
+
+    $collection = collect([]);
+
+    $collection->every(function($value, $key) {
+        return $value > 2;
+    }
+
+    // true
+
 <a name="method-except"></a>
 #### `except()` {#collection-method}
 

--- a/collections.md
+++ b/collections.md
@@ -523,7 +523,7 @@ If the collection is empty, `every` will return true:
 
     $collection->every(function($value, $key) {
         return $value > 2;
-    }
+    });
 
     // true
 


### PR DESCRIPTION
The `every()` method returns true for empty collections which is not documented but should be, since it goes against what the description would lead most developers to believe. After discussion with a few developers, we decided at least a documentation change should be put in, since changing the behavior may break many apps who rely on this in the wild.