### PR TITLE
[5.7] Keep the route naming convention consistent

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -557,7 +557,7 @@ Sometimes you may wish to capture the HTML content of a mailable without sending
 
 When designing a mailable's template, it is convenient to quickly preview the rendered mailable in your browser like a typical Blade template. For this reason, Laravel allows you to return any mailable directly from a route Closure or controller. When a mailable is returned, it will be rendered and displayed in the browser, allowing you to quickly preview its design without needing to send it to an actual email address:
 
-    Route::get('/mailable', function () {
+    Route::get('mailable', function () {
         $invoice = App\Invoice::find(1);
 
         return new App\Mail\InvoicePaid($invoice);


### PR DESCRIPTION
In [Preview Mailables In the Browser](https://laravel.com/docs/5.7/mail#previewing-mailables-in-the-browser) the `Route::get('/mailable'` has slash before mailable, but in other places in the documentation, the slash does not exist. 

e.g. https://laravel.com/docs/5.7/routing#named-routes
```
Route::get('user/profile', function () {
    //
})->name('profile');
```