### PR TITLE
[5.7] Telescope Docs: Add Migration Customisation documentation

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -2,6 +2,7 @@
 
 - [Introduction](#introduction)
 - [Installation](#installation)
+    - [Migration Customization](#migration-customization)
     - [Configuration](#configuration)
     - [Data Pruning](#data-pruning)
 - [Dashboard Authorization](#dashboard-authorization)
@@ -76,6 +77,11 @@ After running `telescope:install`, you should remove the `TelescopeServiceProvid
             $this->app->register(TelescopeServiceProvider::class);
         }
     }
+
+<a name="migration-customization"></a>
+### Migration Customization
+
+If you are not going to use Telescope's default migrations, you should call the `Telescope::ignoreMigrations` method in the `register` method of your `AppServiceProvider`. You may export the default migrations using `php artisan vendor:publish --tag=telescope-migrations`.
 
 <a name="configuration"></a>
 ### Configuration


### PR DESCRIPTION
A recent PR, in the https://github.com/laravel/telescope project, has been made so that users can customise their use and publishing of database migrations for the Telescope package.

Please see https://github.com/laravel/telescope/pull/530

https://github.com/laravel/telescope/issues/525