### PR TITLE
Add note to passport docs

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -507,6 +507,8 @@ To restrict access to the route to specific scopes you may provide a comma-delim
         ...
     })->middleware('client:check-status,your-scope');
 
+> {note} When protecting routes with the `client` middleware, make sure you are using `client` instead of the `auth` middleware.
+
 ### Retrieving Tokens
 
 To retrieve a token using this grant type, make a request to the `oauth/token` endpoint:


### PR DESCRIPTION
This PR adds the following note to the Client Credentials Grant section of the Passport documentation:

> {note} When protecting routes with the `client` middleware, make sure you are using `client` instead of the `auth` middleware.

This just caught me out (I was using both auth and client) and could have been avoided if docs made it a bit more clear. 

Not sure if its best to add it here or in the Protecting Routes section.