### PR TITLE
[5.7] Corrected description of data_set

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -604,7 +604,7 @@ This function also accepts wildcards and will set values on the target according
         ]
     */
 
-By default, any existing values are overwritten. If you wish to only set a value if it doesn't exist, you may pass `false` as the third argument:
+By default, any existing values are overwritten. If you wish to only set a value if it doesn't exist, you may pass `false` as the fourth argument:
 
     $data = ['products' => ['desk' => ['price' => 100]]];
 


### PR DESCRIPTION
The function `data_set` was incorrectly saying that the third argument is the overwrite argument; when in fact it is the fourth.