### PR TITLE
[5.7] "Constraining Eager Loads" callout for unsupported eager load limit()

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -927,7 +927,7 @@ You may not always need every column from the relationships you are retrieving. 
 <a name="constraining-eager-loads"></a>
 ### Constraining Eager Loads
 
-Sometimes you may wish to eager load a relationship, but also specify additional query constraints for the eager loading query. Here's an example:
+Sometimes you may wish to eager load a relationship, but also specify additional query conditions for the eager loading query. Here's an example:
 
     $users = App\User::with(['posts' => function ($query) {
         $query->where('title', 'like', '%first%');
@@ -938,6 +938,8 @@ In this example, Eloquent will only eager load posts where the post's `title` co
     $users = App\User::with(['posts' => function ($query) {
         $query->orderBy('created_at', 'desc');
     }])->get();
+
+> {note} Query builder methods `limit()` and `take()` cannot be used when constraining eager loads. One database query is run to eager load a relation so the limited results will be for _all_ models, not _per_ model.
 
 <a name="lazy-eager-loading"></a>
 ### Lazy Eager Loading


### PR DESCRIPTION
The callout second sentence I came up with is kind of clunky so maybe we don't need the "why?" It's difficult to succinctly describe the groupwise-maximum query problem in a short warning alert.

This pull request covers issues:

* https://github.com/laravel/framework/issues/16217
* https://github.com/laravel/framework/issues/18014
* https://github.com/laravel/framework/issues/4835
* https://github.com/laravel/framework/issues/15585

Since 2014, GitHub issues have frequently been submitted to the framework with a misunderstanding that `limit()` can be used by:

* Eloquent relationships
* Eager load queries

The underlying issue is that developers don't realize these active record queries are not "regular"  queries since they must be built and run once to fetch many Eloquent models. So the `limit()` call applies to fetching relations for _all_ models and it doesn't run an SQL `LIMIT` _per_ model.

(Aside from not realizing the SQL being run) I think this confusion stems from these two phrases in the docs:

1. > specify additional query constraints for the eager loading query

   "Constraints" implies that SQL keywords `limit()` and `offset()` can be used.
2. > Of course, you may call _other query builder methods_

   This link to https://laravel.com/docs/5.7/queries implies all methods documented on that page can be used.

We can reduce developer confusion by:

* adjusting some grammar
  * For example, Rails docs uses the term "condition" instead of "constraint": https://guides.rubyonrails.org/active_record_querying.html#eager-loading-multiple-associations
  * although `orderBy()` still works and isn't a "condition".
* adding a callout to the "Eager Loading" section of the documentation to describe why `limit()` can't be called.

## Suggesting a 3rd-party package solution

To go an extra step, the docs can link to Composer package "staudenmeir/eloquent-eager-limit" that supports eager load `limit()` with more recent databases. To communicate this is not a sanctioned package in the Laravel ecosystem, the docs should be clear support for that solution is external.

---

> To call `limit()` while eager loading, some more recent database versions do support such groupwise-maximum database queries. Add the `staudenmeir/eloquent-eager-limit` dependency in your `composer.json` file and [follow package instructions](https://github.com/staudenmeir/eloquent-eager-limit#readme) to enable this feature. Issues and support for this package should be directed to its author.