### PR TITLE
[5.7] Add note to job chaining when deleting

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -246,6 +246,8 @@ Job chaining allows you to specify a list of queued jobs that should be run in s
         new ReleasePodcast
     ])->dispatch();
 
+> {note} Deleting jobs using the `$this->delete()` method will not prevent chained jobs from being processed.
+
 #### Chain Connection & Queue
 
 If you would like to specify the default connection and queue that should be used for the chained jobs, you may use the `allOnConnection` and `allOnQueue` methods. These methods specify the queue connection and queue name that should be used unless the queued job is explicitly assigned a different connection / queue:


### PR DESCRIPTION
There was some confusion about why chained jobs were still fired after the original job was deleted but this is the intended behavior: https://github.com/laravel/framework/commit/b880ad19282db768718cfd1629ebbc41054daadc

Fixes https://github.com/laravel/framework/issues/26725