### PR TITLE
[5.7] Fix SCRIPT_FILENAME can be no present on fcgi nginx params

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -47,6 +47,7 @@ If you are deploying your application to a server that is running Nginx, you may
         location ~ \.php$ {
             fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
             fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
             include fastcgi_params;
         }
 


### PR DESCRIPTION
Hi! I added Laravel to my deployment workflow.

To keep it simple, I get nginx conf on documentation and... White page with status code 200.

On some distribution, ```include fastcgi_params;``` is not enough, ```SCRIPT_FILENAME``` is not include in ```/etc/nginx/fastcgi_params```, Ubuntu 18.04 in my case. This parameter is required for fcgi to correctly pass filename path to PHP FPM. So, I add it to documentation. We can use ```$document_root``` instead of ```$realpath_root``` but it offers better support for symlinks when modern deployment.