### PR TITLE
JavaScript Dialog Methods

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -459,11 +459,13 @@ Or, you may drag an element in a single direction:
 <a name="javascript-dialogs"></a>
 ### JavaScript Dialogs
 
-The `assertDialogOpened` method may be used to assert that a JavaScript dialog has been displayed and that its message matches the given value:
+Dusk provides various methods to interact with JavaScript Dialogs:
 
+    // Assert that a dialog has been displayed and that its message matches the given value:
     $browser->assertDialogOpened('value');
 
-#### Closing a Dialog
+    // Type the given value in an open JavaScript prompt dialog:
+    $browser->typeInDialog('Hello World');
 
 To close an opened JavaScript Dialog, clicking the OK button:
 
@@ -481,7 +483,7 @@ Sometimes you may wish to perform several operations while scoping all of the op
     $browser->with('.table', function ($table) {
         $table->assertSee('Hello World')
               ->clickLink('Delete');
-    });
+    });s
 
 <a name="waiting-for-elements"></a>
 ### Waiting For Elements

--- a/dusk.md
+++ b/dusk.md
@@ -463,16 +463,6 @@ The `assertDialogOpened` method may be used to assert that a JavaScript dialog h
 
     $browser->assertDialogOpened('value');
 
-<a name="scoping-selectors"></a>
-### Scoping Selectors
-
-Sometimes you may wish to perform several operations while scoping all of the operations within a given selector. For example, you may wish to assert that some text exists only within a table and then click a button within that table. You may use the `with` method to accomplish this. All operations performed within the callback given to the `with` method will be scoped to the original selector:
-
-    $browser->with('.table', function ($table) {
-        $table->assertSee('Hello World')
-              ->clickLink('Delete');
-    });
-
 #### Closing a Dialog
 
 To close an opened JavaScript Dialog, clicking the OK button:
@@ -482,6 +472,16 @@ To close an opened JavaScript Dialog, clicking the OK button:
 To close an opened JavaScript Dialog, clicking the Cancel button (for a confirmation dialog only):
 
     $browser->dismissDialog();
+
+<a name="scoping-selectors"></a>
+### Scoping Selectors
+
+Sometimes you may wish to perform several operations while scoping all of the operations within a given selector. For example, you may wish to assert that some text exists only within a table and then click a button within that table. You may use the `with` method to accomplish this. All operations performed within the callback given to the `with` method will be scoped to the original selector:
+
+    $browser->with('.table', function ($table) {
+        $table->assertSee('Hello World')
+              ->clickLink('Delete');
+    });
 
 <a name="waiting-for-elements"></a>
 ### Waiting For Elements


### PR DESCRIPTION
- Moves the additional methods from within JavaScript dialogs to the proper location. I think this was accidentally moved under the Scoping Selectors section.
- Does some general cleanup as `assertDialogOpened()` is already mentioned in the assertions so it's shortened up and included within a code snipped, instead.
- Adds the [undocumented `typeInDialog` method](https://github.com/laravel/dusk/blob/5facdb15f5952ed28c711e89b30adce74fa388c7/src/Concerns/InteractsWithElements.php#L392-L403)

![screen shot 2019-01-25 at 4 30 43 pm](https://user-images.githubusercontent.com/17038330/51776516-30bc4d00-20bf-11e9-951f-291f4dc7f26f.png)
