### PR TITLE
[5.7] Upped to the latest Homestead version (8.0.0 -> v8.0.1) 🙄

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -559,7 +559,7 @@ Next, you need to update the Homestead source code. If you cloned the repository
 
     git fetch
 
-    git checkout 8.0.0
+    git checkout v8.0.1
 
 These commands pull the latest Homestead code from the GitHub repository, fetches the latest tags, and then checks out the latest tagged release. You can find the latest stable release version on the [GitHub releases page](https://github.com/laravel/homestead/releases).
 

--- a/homestead.md
+++ b/homestead.md
@@ -107,7 +107,7 @@ You should check out a tagged version of Homestead since the `master` branch may
     cd ~/Homestead
 
     // Clone the desired release...
-    git checkout v7.20.0
+    git checkout v8.0.1
 
 Once you have cloned the Homestead repository, run the `bash init.sh` command from the Homestead directory to create the `Homestead.yaml` configuration file. The `Homestead.yaml` file will be placed in the Homestead directory:
 

--- a/homestead.md
+++ b/homestead.md
@@ -563,7 +563,7 @@ Next, you need to update the Homestead source code. If you cloned the repository
 
 These commands pull the latest Homestead code from the GitHub repository, fetches the latest tags, and then checks out the latest tagged release. You can find the latest stable release version on the [GitHub releases page](https://github.com/laravel/homestead/releases).
 
-If you have installed Homestead via your project's `composer.json` file, you should ensure your `composer.json` file contains `"laravel/homestead": "^7"` and update your dependencies:
+If you have installed Homestead via your project's `composer.json` file, you should ensure your `composer.json` file contains `"laravel/homestead": "^8"` and update your dependencies:
 
     composer update
 

--- a/homestead.md
+++ b/homestead.md
@@ -559,7 +559,7 @@ Next, you need to update the Homestead source code. If you cloned the repository
 
     git fetch
 
-    git checkout v8.0.0
+    git checkout 8.0.0
 
 These commands pull the latest Homestead code from the GitHub repository, fetches the latest tags, and then checks out the latest tagged release. You can find the latest stable release version on the [GitHub releases page](https://github.com/laravel/homestead/releases).
 


### PR DESCRIPTION
There is no tag called v8.0.0 on the git repo! 😿

https://github.com/laravel/homestead/tree/v8.0.0
https://github.com/laravel/homestead/tree/8.0.0