### PR TITLE
Adds the add() method to the 5.8 documentation

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -604,7 +604,7 @@ You may also call the `first` method with no arguments to get the first element 
 The `firstWhere` method returns the first element in the collection with the given key / value pair:
 
     $collection = collect([
-        ['name' => 'Regena', 'age' => 12],
+        ['name' => 'Regena', 'age' => null],
         ['name' => 'Linda', 'age' => 14],
         ['name' => 'Diego', 'age' => 23],
         ['name' => 'Linda', 'age' => 84],
@@ -619,6 +619,12 @@ You may also call the `firstWhere` method with an operator:
     $collection->firstWhere('age', '>=', 18);
 
     // ['name' => 'Diego', 'age' => 23]
+
+Similar to the [where](#method-where) method, you may pass one argument to get the first element that meets the where clause:
+
+    $collection->firstWhere('age');
+
+    // ['name' => 'Linda', 'age' => 14]
 
 <a name="method-flatmap"></a>
 #### `flatMap()` {#collection-method}

--- a/collections.md
+++ b/collections.md
@@ -68,6 +68,7 @@ For the remainder of this documentation, we'll discuss each method available on 
 
 <div id="collection-method-list" markdown="1">
 
+[add](#method-add)
 [all](#method-all)
 [average](#method-average)
 [avg](#method-avg)
@@ -191,8 +192,21 @@ For the remainder of this documentation, we'll discuss each method available on 
     }
 </style>
 
+<a name="method-add"></a>
+#### `add()` {#collection-method .first-collection-method}
+
+The `add` method appends an item to the collection:
+
+    $collection = collect([1, 2, 3, 4]);
+
+    $collection->add(5);
+
+    $collection->all();
+
+    // [1, 2, 3, 4, 5]
+
 <a name="method-all"></a>
-#### `all()` {#collection-method .first-collection-method}
+#### `all()` {#collection-method}
 
 The `all` method returns the underlying array represented by the collection:
 


### PR DESCRIPTION
Documents the newly moved add() method to the base collection class.

Per the pull request
[5.8] Move Collection::add() laravel/framework#27082