### PR TITLE
Documents the new signature for the firstWhere method

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -606,7 +606,7 @@ You may also call the `firstWhere` method with an operator:
 
     // ['name' => 'Diego', 'age' => 23]
 
-Similar to the [where](#method-where) method, you may pass one argument to get the first element that meets the where clause:
+Like the [where](#method-where) method, you may pass one argument to the `firstWhere` method. In this scenario, the `firstWhere` method will return the first item where the given item key's value is "truthy":
 
     $collection->firstWhere('age');
 

--- a/collections.md
+++ b/collections.md
@@ -590,7 +590,7 @@ You may also call the `first` method with no arguments to get the first element 
 The `firstWhere` method returns the first element in the collection with the given key / value pair:
 
     $collection = collect([
-        ['name' => 'Regena', 'age' => 12],
+        ['name' => 'Regena', 'age' => null],
         ['name' => 'Linda', 'age' => 14],
         ['name' => 'Diego', 'age' => 23],
         ['name' => 'Linda', 'age' => 84],
@@ -605,6 +605,12 @@ You may also call the `firstWhere` method with an operator:
     $collection->firstWhere('age', '>=', 18);
 
     // ['name' => 'Diego', 'age' => 23]
+
+Similar to the [where](#method-where) method, you may pass one argument to get the first element that meets the where clause:
+
+    $collection->firstWhere('age');
+
+    // ['name' => 'Linda', 'age' => 14]
 
 <a name="method-flatmap"></a>
 #### `flatMap()` {#collection-method}


### PR DESCRIPTION
Keeping in sync with the new signature of the firstWhere method laravel/framework#26261, this pull request adds a new example of how it can be used to find the first element that meets the where clause.