### PR TITLE
[5.7] Documents how to dispatch a job synchronously

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -8,6 +8,7 @@
     - [Class Structure](#class-structure)
 - [Dispatching Jobs](#dispatching-jobs)
     - [Delayed Dispatching](#delayed-dispatching)
+    - [Synchronous Dispatching](#synchronous-dispatching)
     - [Job Chaining](#job-chaining)
     - [Customizing The Queue & Connection](#customizing-the-queue-and-connection)
     - [Specifying Max Job Attempts / Timeout Values](#max-job-attempts-and-timeout)
@@ -235,6 +236,35 @@ If you would like to delay the execution of a queued job, you may use the `delay
     }
 
 > {note} The Amazon SQS queue service has a maximum delay time of 15 minutes.
+
+<a name="synchronous-dispatching"></a>
+### Synchronous Dispatching
+
+If you would like to dispatch a job immediately (synchronously) use the `dispatchNow` method instead of `dispatch` when dispatching a job. For example, let's specify that a job should be fired inside a Controller that is awaiting for its response to return it to the user:
+
+    <?php
+
+    namespace App\Http\Controllers;
+
+    use App\Jobs\ProcessPodcast;
+    use Illuminate\Http\Request;
+    use App\Http\Controllers\Controller;
+
+    class PodcastController extends Controller
+    {
+        /**
+         * Store a new podcast.
+         *
+         * @param  Request  $request
+         * @return Response
+         */
+        public function store(Request $request)
+        {
+            // Create podcast...
+
+            ProcessPodcast::dispatchNow($podcast);
+        }
+    }
 
 <a name="job-chaining"></a>
 ### Job Chaining


### PR DESCRIPTION
Sometimes people tend to believe that jobs only can be used asynchronously, how about to document that they can do more than they think with jobs?