### PR TITLE
[5.7] Paginator Instance Descriptions, Additional Methods

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -189,15 +189,17 @@ If you would like to designate a different file as the default pagination view, 
 
 Each paginator instance provides additional pagination information via the following methods:
 
-- `$results->count()`
-- `$results->currentPage()`
-- `$results->firstItem()`
-- `$results->hasMorePages()`
-- `$results->lastItem()`
-- `$results->lastPage() (Not available when using simplePaginate)`
-- `$results->nextPageUrl()`
-- `$results->onFirstPage()`
-- `$results->perPage()`
-- `$results->previousPageUrl()`
-- `$results->total() (Not available when using simplePaginate)`
-- `$results->url($page)`
+Method  |  Description
+-------  |  -----------
+`$results->count()`  |  Get the number of items for the current page.
+`$results->currentPage()`  |  Get the current page number.
+`$results->firstItem()`  |  Get the number of the first item in the slice.
+`$results->hasMorePages()`  |  Determine if there are enough items to split into multiple pages.
+`$results->lastItem()`  |  Get the number of the last item in the slice.
+`$results->lastPage()`  |  Get the page number of the last available page. (Not available when using simplePaginate)
+`$results->nextPageUrl()`  |  Get the URL for the next page.
+`$results->onFirstPage()`  |  Determine if the paginator is on the first page.
+`$results->perPage()`  |  The number of items to be shown per page.
+`$results->previousPageUrl()`  |  Get the URL for the previous page.
+`$results->total()`  |  Determine the total number of items in the data store. (Not available when using simplePaginate)`
+`$results->url($page)`  |  Get the URL for a given page number.

--- a/pagination.md
+++ b/pagination.md
@@ -195,11 +195,12 @@ Method  |  Description
 `$results->currentPage()`  |  Get the current page number.
 `$results->firstItem()`  |  Get the number of the first item in the slice.
 `$results->hasMorePages()`  |  Determine if there are enough items to split into multiple pages.
+`$results->isValidPageNumber($page)`  |  Determine if the given value is a valid page number.
 `$results->lastItem()`  |  Get the number of the last item in the slice.
 `$results->lastPage()`  |  Get the page number of the last available page. (Not available when using simplePaginate)
 `$results->nextPageUrl()`  |  Get the URL for the next page.
 `$results->onFirstPage()`  |  Determine if the paginator is on the first page.
 `$results->perPage()`  |  The number of items to be shown per page.
 `$results->previousPageUrl()`  |  Get the URL for the previous page.
-`$results->total()`  |  Determine the total number of items in the data store. (Not available when using simplePaginate)`
+`$results->total()`  |  Determine the total number of items in the data store. (Not available when using simplePaginate)
 `$results->url($page)`  |  Get the URL for a given page number.

--- a/pagination.md
+++ b/pagination.md
@@ -196,7 +196,6 @@ Method  |  Description
 `$results->firstItem()`  |  Get the number of the first item in the slice.
 `$results->getUrlRange($start, $end)`  |  Create a range of pagination URLs.
 `$results->hasMorePages()`  |  Determine if there are enough items to split into multiple pages.
-`$results->isValidPageNumber($page)`  |  Determine if the given value is a valid page number.
 `$results->lastItem()`  |  Get the number of the last item in the slice.
 `$results->lastPage()`  |  Get the page number of the last available page. (Not available when using simplePaginate)
 `$results->nextPageUrl()`  |  Get the URL for the next page.

--- a/pagination.md
+++ b/pagination.md
@@ -194,6 +194,7 @@ Method  |  Description
 `$results->count()`  |  Get the number of items for the current page.
 `$results->currentPage()`  |  Get the current page number.
 `$results->firstItem()`  |  Get the number of the first item in the slice.
+`$results->getUrlRange($start, $end)`  |  Create a range of pagination URLs.
 `$results->hasMorePages()`  |  Determine if there are enough items to split into multiple pages.
 `$results->isValidPageNumber($page)`  |  Determine if the given value is a valid page number.
 `$results->lastItem()`  |  Get the number of the last item in the slice.


### PR DESCRIPTION
This PR adds a table to supply descriptions to the Paginator Instance Methods and also adds two undocumented methods.

- Add Description to each of the paginator instance methods
- ~~Document [`isValidPageNumber()` Method](https://github.com/laravel/framework/blob/b6a325446d222309f6457c28e9cbb14e4465db9a/src/Illuminate/Pagination/AbstractPaginator.php#L117-L126)~~
- Document [`getUrlRange()` Method](https://github.com/laravel/framework/blob/b6a325446d222309f6457c28e9cbb14e4465db9a/src/Illuminate/Pagination/AbstractPaginator.php#L140-L152)