### PR TITLE
[master] Add a reminder to call parent::tearDown()

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -55,4 +55,4 @@ Once the test has been generated, you may define test methods as you normally wo
         }
     }
 
-> {note} If you define your own `setUp` or `tearDown` method within a test class, be sure to call the respective `parent::setUp()` or `parent::tearDown()`.
+> {note} If you define your own `setUp` / `tearDown` methods within a test class, be sure to call the respective `parent::setUp()` / `parent::tearDown()` methods on the parent class.

--- a/testing.md
+++ b/testing.md
@@ -55,4 +55,4 @@ Once the test has been generated, you may define test methods as you normally wo
         }
     }
 
-> {note} If you define your own `setUp` method within a test class, be sure to call `parent::setUp()`.
+> {note} If you define your own `setUp` or `tearDown` method within a test class, be sure to call the respective `parent::setUp()` or `parent::tearDown()`.


### PR DESCRIPTION
The existing documentation mentions the importance of calling `parent::setUp()` when defining your own `setUp` method, but it doesn't mention the same for the `tearDown` method.

It should probably be obvious, but I've forgotten it on a few occasions and the symptoms have always been far less obvious than when forgetting to call `parent::setUp()`. I think if it was documented, it might be easier to remember.