### PR TITLE
[5.8] Add breaking change of irregular plural model names to upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -190,6 +190,25 @@ As of Laravel 5.8 the [oldest supported SQLite version](https://github.com/larav
 
 ### Eloquent
 
+#### Model names ending with a word with an irregular plural
+
+**Likelihood of Impact: Medium**
+
+As of Laravel 5.8, multi-word model names, ending in a word with an irregular plural [are now correctly pluralized](https://github.com/laravel/framework/pull/26421).
+
+For example:
+```php
+// Laravel 5.7...
+App\Feedback.php -> feedback (correctly pluralized)
+App\UserFeedback.php -> user_feedbacks (incorrectly pluralized)
+
+// Laravel 5.8
+App\Feedback.php -> feedback (correctly pluralized)
+App\UserFeedback.php -> user_feedback (correctly pluralized)
+```
+
+If you had a model that was incorrectly pluralized you will need to either add a new migration that renames the table to the new, correct form. Or you can define the old table name in your model using the `$table` property.
+
 #### The `loadCount` Method
 
 **Likelihood Of Impact: Low**


### PR DESCRIPTION
I noticed [this breaking change](https://github.com/laravel/framework/pull/26421) was missing from the upgrade guide. This PR contains a quick draft of the breaking change and how to fix it.