### PR TITLE
[5.7] Clarify Horizon balance default

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -47,7 +47,7 @@ After publishing Horizon's assets, its primary configuration file will be locate
 
 #### Balance Options
 
-Horizon allows you to choose from three balancing strategies: `simple`, `auto`, and `false`. The `simple` strategy, which is the default, splits incoming jobs evenly between processes:
+Horizon allows you to choose from three balancing strategies: `simple`, `auto`, and `false`. The `simple` strategy, which is the default in the config file, splits incoming jobs evenly between processes:
 
     'balance' => 'simple',
 


### PR DESCRIPTION
At the moment it seemed as the simple balance strategy is the default strategy even if you leave it away but this isn't the case. Adding these words will make it clear that simple is only the default in the config file itself.

Ref.: https://github.com/laravel/horizon/issues/507