### PR TITLE
[5.7] Add waitForDialog() to Dusk

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -461,7 +461,7 @@ Or, you may drag an element in a single direction:
 
 Dusk provides various methods to interact with JavaScript Dialogs:
 
-    // Wait for the dialog to appear:
+    // Wait for a dialog to appear:
     $browser->waitForDialog($seconds = null);
     
     // Assert that a dialog has been displayed and that its message matches the given value:

--- a/dusk.md
+++ b/dusk.md
@@ -461,6 +461,9 @@ Or, you may drag an element in a single direction:
 
 Dusk provides various methods to interact with JavaScript Dialogs:
 
+    // Wait for the dialog to appear:
+    $browser->waitForDialog($seconds = null);
+    
     // Assert that a dialog has been displayed and that its message matches the given value:
     $browser->assertDialogOpened('value');
 


### PR DESCRIPTION
This PR adds documentation for [waitForDialog()](https://github.com/laravel/dusk/blob/c30c8a01d35661e253a7d3ea7ae6a79faf3f8d92/src/Concerns/WaitsForElements.php#L193-L208) within Dusk JavaScript Dialog assertions.