### PR TITLE
[5.7] Remove note about sharing secure valet sites

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -169,8 +169,6 @@ To share a site, navigate to the site's directory in your terminal and run the `
 
 To stop sharing your site, hit `Control + C` to cancel the process.
 
-> {note} `valet share` does not currently support sharing sites that have been secured using the `valet secure` command.
-
 <a name="custom-valet-drivers"></a>
 ## Custom Valet Drivers
 


### PR DESCRIPTION
`valet share` now supports secured sites. https://github.com/laravel/valet/pull/630