### PR TITLE
[5.8] Fix directory name and clarify note further

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -383,7 +383,7 @@ Embedding inline images into your emails is typically cumbersome; however, Larav
         <img src="{{ $message->embed($pathToImage) }}">
     </body>
 
-> {note} `$message` variable is not available in markdown messages.
+> {note} `$message` variable is not available in plain-text messages because in general you don't want to put attachments in there.
 
 #### Embedding Raw Data Attachments
 


### PR DESCRIPTION
The rename is according to the clarification that this concerns the plain-text messages which corresponds with the directory rename we did earlier. I've also further clarified on *why* the $message variable isn't available for plain-text messages.