### PR TITLE
[5.7] Clean up code blocks and indentations

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1342,30 +1342,30 @@ Once the component has been defined, we can easily select a date within the date
 
 If you are using CircleCI to run your Dusk tests, you may use this configuration file as a starting point. Like TravisCI, we will use the `php artisan serve` command to launch PHP's built-in web server:
 
-     version: 2
-     jobs:
-         build:
-             steps:
+    version: 2
+    jobs:
+        build:
+            steps:
                 - run: sudo apt-get install -y libsqlite3-dev
                 - run: cp .env.testing .env
                 - run: composer install -n --ignore-platform-reqs
                 - run: npm install
                 - run: npm run production
                 - run: vendor/bin/phpunit
-
+       
                 - run:
-                   name: Start Chrome Driver
-                   command: ./vendor/laravel/dusk/bin/chromedriver-linux
-                   background: true
-
+                    name: Start Chrome Driver
+                    command: ./vendor/laravel/dusk/bin/chromedriver-linux
+                    background: true
+       
                 - run:
-                   name: Run Laravel Server
-                   command: php artisan serve
-                   background: true
-
+                    name: Run Laravel Server
+                    command: php artisan serve
+                    background: true
+       
                 - run:
-                   name: Run Laravel Dusk Tests
-                   command: php artisan dusk
+                    name: Run Laravel Dusk Tests
+                    command: php artisan dusk
 
 <a name="running-tests-on-codeship"></a>
 ### Codeship

--- a/envoy.md
+++ b/envoy.md
@@ -54,7 +54,7 @@ You can force a script to run locally by specifying the server's IP address as `
 <a name="setup"></a>
 ### Setup
 
-Sometimes, you may need to execute some PHP code before executing your Envoy tasks. You may use the ```@setup``` directive to declare variables and do other general PHP work before any of your other tasks are executed:
+Sometimes, you may need to execute some PHP code before executing your Envoy tasks. You may use the `@setup` directive to declare variables and do other general PHP work before any of your other tasks are executed:
 
     @setup
         $now = new DateTime();

--- a/mail.md
+++ b/mail.md
@@ -285,32 +285,32 @@ Once the data has been passed to the `with` method, it will automatically be ava
 
 To add attachments to an email, use the `attach` method within the mailable class' `build` method. The `attach` method accepts the full path to the file as its first argument:
 
-        /**
-         * Build the message.
-         *
-         * @return $this
-         */
-        public function build()
-        {
-            return $this->view('emails.orders.shipped')
-                        ->attach('/path/to/file');
-        }
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->view('emails.orders.shipped')
+                    ->attach('/path/to/file');
+    }
 
 When attaching files to a message, you may also specify the display name and / or MIME type by passing an `array` as the second argument to the `attach` method:
 
-        /**
-         * Build the message.
-         *
-         * @return $this
-         */
-        public function build()
-        {
-            return $this->view('emails.orders.shipped')
-                        ->attach('/path/to/file', [
-                            'as' => 'name.pdf',
-                            'mime' => 'application/pdf',
-                        ]);
-        }
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->view('emails.orders.shipped')
+                    ->attach('/path/to/file', [
+                        'as' => 'name.pdf',
+                        'mime' => 'application/pdf',
+                    ]);
+    }
 
 #### Attaching Files from Disk
 
@@ -321,11 +321,11 @@ If you have stored a file on one of your [filesystem disks](/docs/{{version}}/fi
      *
      * @return $this
      */
-     public function build()
-     {
-        return $this->view('email.orders.shipped')
-                    ->attachFromStorage('/path/to/file');
-     }
+    public function build()
+    {
+       return $this->view('email.orders.shipped')
+                   ->attachFromStorage('/path/to/file');
+    }
 
 If necessary, you may specify the file's attachment name and additional options using the second and third arguments to the `attachFromStorage` method:
 
@@ -334,13 +334,13 @@ If necessary, you may specify the file's attachment name and additional options 
      *
      * @return $this
      */
-     public function build()
-     {
-        return $this->view('email.orders.shipped')
-                    ->attachFromStorage('/path/to/file', 'name.pdf', [
-                        'mime' => 'application/pdf'
-                    ]);
-     }
+    public function build()
+    {
+       return $this->view('email.orders.shipped')
+                   ->attachFromStorage('/path/to/file', 'name.pdf', [
+                       'mime' => 'application/pdf'
+                   ]);
+    }
 
 The `attachFromStorageDisk` method may be used if you need to specify a storage disk other than your default disk:
 
@@ -349,28 +349,28 @@ The `attachFromStorageDisk` method may be used if you need to specify a storage 
      *
      * @return $this
      */
-     public function build()
-     {
-        return $this->view('email.orders.shipped')
-                    ->attachFromStorageDisk('s3', '/path/to/file');
-     }
+    public function build()
+    {
+       return $this->view('email.orders.shipped')
+                   ->attachFromStorageDisk('s3', '/path/to/file');
+    }
 
 #### Raw Data Attachments
 
 The `attachData` method may be used to attach a raw string of bytes as an attachment. For example, you might use this method if you have generated a PDF in memory and want to attach it to the email without writing it to disk. The `attachData` method accepts the raw data bytes as its first argument, the name of the file as its second argument, and an array of options as its third argument:
 
-        /**
-         * Build the message.
-         *
-         * @return $this
-         */
-        public function build()
-        {
-            return $this->view('emails.orders.shipped')
-                        ->attachData($this->pdf, 'name.pdf', [
-                            'mime' => 'application/pdf',
-                        ]);
-        }
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->view('emails.orders.shipped')
+                    ->attachData($this->pdf, 'name.pdf', [
+                        'mime' => 'application/pdf',
+                    ]);
+    }
 
 <a name="inline-attachments"></a>
 ### Inline Attachments
@@ -400,20 +400,20 @@ If you already have a raw data string you wish to embed into an email template, 
 
 The `withSwiftMessage` method of the `Mailable` base class allows you to register a callback which will be invoked with the raw SwiftMailer message instance before sending the message. This gives you an opportunity to customize the message before it is delivered:
 
-        /**
-         * Build the message.
-         *
-         * @return $this
-         */
-        public function build()
-        {
-            $this->view('emails.orders.shipped');
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        $this->view('emails.orders.shipped');
 
-            $this->withSwiftMessage(function ($message) {
-                $message->getHeaders()
-                        ->addTextHeader('Custom-Header', 'HeaderValue');
-            });
-        }
+        $this->withSwiftMessage(function ($message) {
+            $message->getHeaders()
+                    ->addTextHeader('Custom-Header', 'HeaderValue');
+        });
+    }
 
 <a name="markdown-mailables"></a>
 ## Markdown Mailables

--- a/mix.md
+++ b/mix.md
@@ -167,7 +167,7 @@ Because Laravel Mix is built on top of Webpack, it's important to understand a f
 By default, Laravel Mix and Webpack will find `example.png`, copy it to your `public/images` folder, and then rewrite the `url()` within your generated stylesheet. As such, your compiled CSS will be:
 
     .example {
-      background: url(/images/example.png?d41d8cd98f00b204e9800998ecf8427e);
+        background: url(/images/example.png?d41d8cd98f00b204e9800998ecf8427e);
     }
 
 As useful as this feature may be, it's possible that your existing folder structure is already configured in a way you like. If this is the case, you may disable `url()` rewriting like so:

--- a/passport.md
+++ b/passport.md
@@ -833,22 +833,20 @@ When using this method of authentication, the default Laravel JavaScript scaffol
 
 Passport raises events when issuing access tokens and refresh tokens. You may use these events to prune or revoke other access tokens in your database. You may attach listeners to these events in your application's `EventServiceProvider`:
 
-```php
-/**
- * The event listener mappings for the application.
- *
- * @var array
- */
-protected $listen = [
-    'Laravel\Passport\Events\AccessTokenCreated' => [
-        'App\Listeners\RevokeOldTokens',
-    ],
+    /**
+     * The event listener mappings for the application.
+     *
+     * @var array
+     */
+    protected $listen = [
+        'Laravel\Passport\Events\AccessTokenCreated' => [
+            'App\Listeners\RevokeOldTokens',
+        ],
 
-    'Laravel\Passport\Events\RefreshTokenCreated' => [
-        'App\Listeners\PruneOldTokens',
-    ],
-];
-```
+        'Laravel\Passport\Events\RefreshTokenCreated' => [
+            'App\Listeners\PruneOldTokens',
+        ],
+    ];
 
 <a name="testing"></a>
 ## Testing

--- a/passwords.md
+++ b/passwords.md
@@ -94,4 +94,3 @@ You may easily modify the notification class used to send the password reset lin
     {
         $this->notify(new ResetPasswordNotification($token));
     }
-

--- a/providers.md
+++ b/providers.md
@@ -191,5 +191,4 @@ To defer the loading of a provider, set the `defer` property to `true` and defin
         {
             return [Connection::class];
         }
-
     }

--- a/queues.md
+++ b/queues.md
@@ -499,9 +499,9 @@ The `--once` option may be used to instruct the worker to only process a single 
 
 #### Processing All Queued Jobs & Then Exiting
 
- The `--stop-when-empty` option may be used to instruct the worker to process all jobs and then exit gracefully. This option can be useful when working Laravel queues within a Docker container if you wish to shutdown the container after the queue is empty:
+The `--stop-when-empty` option may be used to instruct the worker to process all jobs and then exit gracefully. This option can be useful when working Laravel queues within a Docker container if you wish to shutdown the container after the queue is empty:
 
-     php artisan queue:work --stop-when-empty
+    php artisan queue:work --stop-when-empty
 
 #### Resource Considerations
 

--- a/valet.md
+++ b/valet.md
@@ -90,11 +90,9 @@ If you need a database, try MySQL by running `brew install mysql@5.7` on your co
 
 Valet allows you to switch PHP versions using the `valet use php@version` command. Valet will install the specified PHP version via Brew if it is not already installed:
 
-```
-valet use php@7.2
-
-valet use php
-```
+    valet use php@7.2
+    
+    valet use php
 
 <a name="upgrading"></a>
 ### Upgrading


### PR DESCRIPTION
These changes remove some of the remaining old code block notations and fix a whole bunch of indentations. Some code blocks were unnecessary indented by one level.