### PR TITLE
[5.8] Fixes in 5.8 Upgrade Guide about helpers

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -343,11 +343,11 @@ The session persistence logic has been [moved from the `terminate()` method to t
 <a name="string-and-array-helpers"></a>
 #### Prefer String And Array Classes Over Helpers
 
-**Likelihood Of Impact: Low**
+**Likelihood Of Impact: Medium**
 
 All `array_*` and `str_*` global helpers [have been deprecated](https://github.com/laravel/framework/pull/26898) and will be moved to an optional package in the future. You should use the `Illuminate\Support\Arr` and `Illuminate\Support\Str` methods directly.
 
-This impact of this change has been marked as `medium` since a future, opt-in package would prevent any breaking changes.
+The impact of this change has been marked as `medium` since a future, opt-in package would prevent any breaking changes.
 
 <a name="deferred-service-providers"></a>
 #### Deferred Service Providers


### PR DESCRIPTION
* Fixes a mistake from branch merge, where #4972 change got applied to a different section (as the original section no longer exists).
* Minor wording fix following up to [`0ae0791`](https://github.com/laravel/docs/commit/0ae07914f93a594ba723be1f9c1462c5feb133af#diff-e6fbd6eb4a701f2e57b69c2f4696dbaeR302).