### PR TITLE
[5.7] Remove unused contributing file

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,3 +1,0 @@
-# Contribution Guidelines
-
-If you are submitting documentation for the **current stable release**, submit it to the corresponding branch. For example, documentation for Laravel 5.5 would be submitted to the `5.5` branch. Documentation intended for the next release of Laravel should be submitted to the `master` branch.


### PR DESCRIPTION
I couldn't find any usage for this file. I think it was used to link to from the docs repo but isn't anymore. We also now have a new contributions page.