### PR TITLE
[5.7] Use consistent package titles

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1,4 +1,4 @@
-# Browser Tests (Laravel Dusk)
+# Laravel Dusk
 
 - [Introduction](#introduction)
 - [Installation](#installation)

--- a/envoy.md
+++ b/envoy.md
@@ -1,4 +1,4 @@
-# Envoy Task Runner
+# Laravel Envoy
 
 - [Introduction](#introduction)
     - [Installation](#installation)


### PR DESCRIPTION
All the other package documentation have this convention so let's keep using the same one everywhere. I believe it should be clear from the docs itself what they're about without having to explicitly mention it in the titles.

Passport title was renamed here: https://github.com/laravel/docs/pull/4995