### PR TITLE
laravel/installer v2 requires ext-zip

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -29,6 +29,7 @@ However, if you are not using Homestead, you will need to make sure your server 
 - Ctype PHP Extension
 - JSON PHP Extension
 - BCMath PHP Extension
+- Zip PHP Extension *required by laravel/installer v2*
 </div>
 
 <a name="installing-laravel"></a>


### PR DESCRIPTION
work logs

```
$ composer global require laravel/installer
Changed current directory to /home/xxxxxxx/.composer
Using version ^2.0 for laravel/installer
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - laravel/installer v2.0.1 requires ext-zip * -> the requested PHP extension zip is missing from your system.
    - laravel/installer v2.0.0 requires ext-zip * -> the requested PHP extension zip is missing from your system.
    - Installation request for laravel/installer ^2.0 -> satisfiable by laravel/installer[v2.0.0, v2.0.1].

```