### PR TITLE
[5.7] Updated atomic lock code example

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -222,9 +222,8 @@ The `get` method also accepts a Closure. After the Closure is executed, Laravel 
 
 If the lock is not available at the moment you request it, you may instruct Laravel to wait for a specified number of seconds. If the lock can not be acquired within the specified time limit, an `Illuminate\Contracts\Cache\LockTimeoutException` will be thrown:
 
-    if (Cache::lock('foo', 10)->block(5)) {
-        // Lock acquired after waiting maximum of 5 seconds...
-    }
+    Cache::lock('foo', 10)->block(5);
+    // Lock acquired after waiting maximum of 5 seconds...
 
     Cache::lock('foo', 10)->block(5, function () {
         // Lock acquired after waiting maximum of 5 seconds...


### PR DESCRIPTION
The return value of blocking for an atomic lock is always going to be true, so it is not necessary to wrap it in an `if` statement