### PR TITLE
[5.7] Cache has does not return false is value is false

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -124,7 +124,7 @@ You may even pass a `Closure` as the default value. The result of the `Closure` 
 
 #### Checking For Item Existence
 
-The `has` method may be used to determine if an item exists in the cache. This method will return `false` if the value is `null` or `false`:
+The `has` method may be used to determine if an item exists in the cache. This method will return `false` if the value is `null`:
 
     if (Cache::has('key')) {
         //


### PR DESCRIPTION
When a `Cache::has` is performed, false is a valid value to have according to the PSR-16 spec. This is also the current behavior in the framework so the docs aren't correct at the moment.

Reported here: https://github.com/laravel/framework/issues/27630