### PR TITLE
[5.5] Document Auth::basic throwing exception instead of returning Response

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -321,7 +321,7 @@ If you are using PHP FastCGI, HTTP Basic authentication may not work correctly o
 <a name="stateless-http-basic-authentication"></a>
 ### Stateless HTTP Basic Authentication
 
-You may also use HTTP Basic Authentication without setting a user identifier cookie in the session, which is particularly useful for API authentication. To do so, [define a middleware](/docs/{{version}}/middleware) that calls the `onceBasic` method. If no response is returned by the `onceBasic` method, the request may be passed further into the application:
+You may also use HTTP Basic Authentication without setting a user identifier cookie in the session, which is particularly useful for API authentication. To do so, [define a middleware](/docs/{{version}}/middleware) that calls the `onceBasic` method. If no exception is thrown by the `onceBasic` method, the request may be passed further into the application:
 
     <?php
 
@@ -340,7 +340,8 @@ You may also use HTTP Basic Authentication without setting a user identifier coo
          */
         public function handle($request, $next)
         {
-            return Auth::onceBasic() ?: $next($request);
+            Auth::onceBasic();            
+            return $next($request);
         }
 
     }

--- a/upgrade.md
+++ b/upgrade.md
@@ -98,7 +98,7 @@ When passing a multi-word model name to the `authorizeResource` method, the resu
 
 #### The `basic` and `onceBasic` Methods
 
-`Auth::basic` and `Auth::onceBasic` now throw an `UnauthorizedHTTPException` rather than returning a `Response` when authentication fails. By default, this will still result in a 401 response being sent to the client. However, if your application logic checked the return value of `Auth::basic` in order to return a custom response or implement other behavior on authentication failure, you will now need to handle the `UnauthorizedHTTPException` instead, either in a `catch` block or in your application's exception handler.
+`Auth::basic` and `Auth::onceBasic` now throw `\Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException` rather than returning a `Response` when authentication fails. By default, this will still result in a 401 response being sent to the client. However, if your application logic checked the return value of `Auth::basic` in order to return a custom response or implement other behavior on authentication failure, you will now need to handle the `UnauthorizedHttpException` instead, either in a `catch` block or in your application's exception handler.
 
 #### The `before` Policy Method
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -96,6 +96,10 @@ With recent improvements to PHP op-code caching, the `optimize` Artisan command 
 
 When passing a multi-word model name to the `authorizeResource` method, the resulting route segment will now be "snake" case, matching the behavior of resource controllers.
 
+#### The `basic` and `onceBasic` Methods
+
+`Auth::basic` and `Auth::onceBasic` now throw an `UnauthorizedHTTPException` rather than returning a `Response` when authentication fails. By default, this will still result in a 401 response being sent to the client. However, if your application logic checked the return value of `Auth::basic` in order to return a custom response or implement other behavior on authentication failure, you will now need to handle the `UnauthorizedHTTPException` instead, either in a `catch` block or in your application's exception handler.
+
 #### The `before` Policy Method
 
 The `before` method of a policy class will not be called if the class doesn't contain a method matching the name of the ability being checked.


### PR DESCRIPTION
See https://github.com/laravel/framework/issues/27633.