### PR TITLE
[5.7] Add note for method increment on null value

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -678,6 +678,8 @@ You may also specify additional columns to update during the operation:
 
     DB::table('users')->increment('votes', 1, ['name' => 'John']);
 
+> {tip} This does not work if the value of column is null, be sure to set a numeric default value for your columns.
+
 <a name="deletes"></a>
 ## Deletes
 


### PR DESCRIPTION
I think we should add a note for the issue https://github.com/laravel/framework/issues/23954, Query Builder methods `increment`, `decrement` will not work if value of column is null.