### PR TITLE
[5.8] Update password broker to be 'public'

### DIFF
--- a/passwords.md
+++ b/passwords.md
@@ -75,7 +75,7 @@ In your `auth.php` configuration file, you may configure multiple password "brok
      *
      * @return PasswordBroker
      */
-    protected function broker()
+    public function broker()
     {
         return Password::broker('name');
     }


### PR DESCRIPTION
Ever since it has been implemented in 5.3, the forgot/reset password `broker()` function has been `public`. Trying to override it with a `protected` method will throw an error:

https://github.com/laravel/framework/blob/5.3/src/Illuminate/Foundation/Auth/ResetsPasswords.php
https://github.com/laravel/framework/blob/5.3/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php

https://github.com/laravel/framework/blob/5.8/src/Illuminate/Foundation/Auth/ResetsPasswords.php
https://github.com/laravel/framework/blob/5.8/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php