### PR TITLE
[5.8] Link to notifications page for relevant drivers

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -195,7 +195,7 @@ If you would like to manually define the tags for one of your queueable objects,
 <a name="notifications"></a>
 ## Notifications
 
-> **Note:** Before using notifications, you should add the `guzzlehttp/guzzle` Composer package to your project. When configuring Horizon to send SMS notifications, you should also review the [prerequisites for the Nexmo notification driver](https://laravel.com/docs/{{version}}/notifications#sms-notifications).
+> **Note:** When configuring Horizon to send Slack or SMS notifications, you should also review the [prerequisites for the relevant notification driver](https://laravel.com/docs/{{version}}/notifications).
 
 If you would like to be notified when one of your queues has a long wait time, you may use the `Horizon::routeMailNotificationsTo`, `Horizon::routeSlackNotificationsTo`, and `Horizon::routeSmsNotificationsTo` methods. You may call these methods from your application's `HorizonServiceProvider`:
 

--- a/horizon.md
+++ b/horizon.md
@@ -195,7 +195,7 @@ If you would like to manually define the tags for one of your queueable objects,
 <a name="notifications"></a>
 ## Notifications
 
-> **Note:** When configuring Horizon to send Slack or SMS notifications, you should also review the [prerequisites for the relevant notification driver](https://laravel.com/docs/{{version}}/notifications).
+> **Note:** When configuring Horizon to send Slack or SMS notifications, you should review the [prerequisites for the relevant notification driver](https://laravel.com/docs/{{version}}/notifications).
 
 If you would like to be notified when one of your queues has a long wait time, you may use the `Horizon::routeMailNotificationsTo`, `Horizon::routeSlackNotificationsTo`, and `Horizon::routeSmsNotificationsTo` methods. You may call these methods from your application's `HorizonServiceProvider`:
 


### PR DESCRIPTION
As the Slack and Nexmo drivers have now been broken out into separate packages, the note in the Horizon docs should prompt developers to look at the notifications docs in order to hook either of these up.