### PR TITLE
[5.8] Remove string from the comment

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -932,7 +932,7 @@ Once your notification channel class has been defined, you may return the class 
          * Get the notification channels.
          *
          * @param  mixed  $notifiable
-         * @return array|string
+         * @return array
          */
         public function via($notifiable)
         {


### PR DESCRIPTION
`via($notifiable)` must return an array. Otherwise, it will get `Invalid argument supplied for foreach()` error.