### PR TITLE
Add information for overriding setUp and tearDown

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -482,6 +482,17 @@ The `defer` boolean property on the service provider which is/was used to indica
 <a name="testing"></a>
 ### Testing
 
+#### The `setUp` and `tearDown` methods
+
+**Likelihood Of Impact: Medium**
+
+The `setUp` and `tearDown` methods in Laravel's `Illuminate\Foundation\Testing\TestCase` now require a void return type:
+
+    protected function setUp(): void
+    protected function tearDown(): void
+    
+If you are overriding those methods in classes that extend from `Illuminate\Foundation\Testing\TestCase` make sure to update your methods signatures.    
+
 #### PHPUnit 8
 
 **Likelihood Of Impact: Optional**


### PR DESCRIPTION
Alttough I'm using PHPUnit 7.5.6 and PHP 7.2 when running tests I got PHP error that signatures don't match. There were updated in this commit https://github.com/laravel/framework/commit/8fc3a75b413267a30e41464d358c1d0714a6a186 so I believe we should add this to upgrade guide - it has impact also when users don't use PHPUnit 8