### PR TITLE
Update - user_id field datatype in migration example

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -443,7 +443,7 @@ If you pass an array of columns into a method that drops indexes, the convention
 Laravel also provides support for creating foreign key constraints, which are used to force referential integrity at the database level. For example, let's define a `user_id` column on the `posts` table that references the `id` column on a `users` table:
 
     Schema::table('posts', function (Blueprint $table) {
-        $table->unsignedInteger('user_id');
+        $table->unsignedBigInteger('user_id');
 
         $table->foreign('user_id')->references('id')->on('users');
     });


### PR DESCRIPTION
The following commit in the 5.8 branch (https://github.com/laravel/laravel/commit/426df7a0e4d489439002cf99c37246aeebdc5327) changed the default migration type for the 'id' field on the users table migration to bigIncrements.

Trying to create a foreign key relationship to that field using the current 5.8 docs example fails due to the mismatched data type, and should perhaps instead read `$table->unsignedBigInteger('user_id');`