### PR TITLE
Specify that only Arrayable objects are converted into arrays

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1826,7 +1826,7 @@ The `toArray` method converts the collection into a plain PHP `array`. If the co
         ]
     */
 
-> {note} `toArray` also converts all of the collection's nested objects to an array. If you want to get the raw underlying array, use the [`all`](#method-all) method instead.
+> {note} `toArray` also converts all of the collection's nested objects that are an instance of `Arrayable` to an array. If you want to get the raw underlying array without converting `Arrayable` objects into arrays, use the [`all`](#method-all) method instead.
 
 <a name="method-tojson"></a>
 #### `toJson()` {#collection-method}

--- a/collections.md
+++ b/collections.md
@@ -1826,7 +1826,7 @@ The `toArray` method converts the collection into a plain PHP `array`. If the co
         ]
     */
 
-> {note} `toArray` also converts all of the collection's nested objects that are an instance of `Arrayable` to an array. If you want to get the raw underlying array without converting `Arrayable` objects into arrays, use the [`all`](#method-all) method instead.
+> {note} `toArray` also converts all of the collection's nested objects that are an instance of `Arrayable` to an array. If you want to get the raw underlying array, use the [`all`](#method-all) method instead.
 
 <a name="method-tojson"></a>
 #### `toJson()` {#collection-method}


### PR DESCRIPTION
Resolves https://github.com/laravel/framework/issues/27722.

The docs say that

> toArray also converts all of the collection's nested objects to an array. If you want to get the raw underlying array, use the all method instead.

which isn't exactly right. It converts only `Arrayable` objects to arrays. stdObjects can be converted into arrays too but aren't, because they are not `instanceof Arrayable`.

Feel free to improve the formulation of the note, I couldn't think of a better way to write it.