### PR TITLE
[5.8] Note the silently breaking changes in phpdotenv

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -502,6 +502,29 @@ New behavior:
 
     dump(env('APP_ENV')); // local
 
+#### Environment file values
+
+**Likelihood Of Impact: Low**
+
+The [phpdotenv](https://github.com/vlucas/phpdotenv) package that is used to parse .env files has had a major version upgrade, which may impact the results returned from the `env` helper Notably, the `#` character in an unquoted value will now be commented out, instead of part of the value itself.
+
+Previous behavior:
+
+    ENV_VALUE=foo#bar
+    env('ENV_VALUE'); // foo#bar
+
+New behavior:
+
+    ENV_VALUE=foo#bar
+    env('ENV_VALUE'); // foo
+
+The solution for this is to wrap the environment values in quotes:
+
+    ENV_VALUE="foo#bar"
+    env('ENV_VALUE'); // foo#bar
+
+There are some other uncommon cases where a descriptive error may be thrown upon loading the environment file. You can read more about these in the [phpdotenv upgrade guide](https://github.com/vlucas/phpdotenv/blob/master/UPGRADING.md)
+
 <a name="testing"></a>
 ### Testing
 


### PR DESCRIPTION
I noticed [a thread come up on Laracasts](https://laracasts.com/discuss/channels/laravel/beware-in-env-files) that points out how the upgrade to the phpdotenv library in 5.8 may silently break applications if the environment file has an unquoted hashtag character in it.

This PR notes the breaking change and points to the phpdotenv upgrade guide for other (non-silent) changes that may break an upgrading application.