### PR TITLE
[5.8] Mark environment changes as high impact change

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -8,7 +8,7 @@
 <div class="content-list" markdown="1">
 - [Cache TTL In Seconds](#cache-ttl-in-seconds)
 - [Cache Lock Safety Improvements](#cache-lock-safety-improvements)
-- [Environment](#environment)
+- [Environment Variable Parsing](#environment-variable-parsing)
 - [Markdown File Directory Change](#markdown-file-directory-change)
 - [Nexmo / Slack Notification Channels](#nexmo-slack-notification-channels)
 </div>
@@ -328,8 +328,8 @@ The `deleted_at` property [will now be automatically casted](https://github.com/
 
 The `getForeignKey` and `getQualifiedForeignKey` methods of the `BelongsTo` relationship have been renamed to `getForeignKeyName` and `getQualifiedForeignKeyName` respectively, making the method names consistent with the other relationships offered by Laravel.
 
-<a name="#environment"></a>
-### Environment
+<a name="#environment-variable-parsing"></a>
+### Environment Variable Parsing
 
 **Likelihood Of Impact: High**
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -8,6 +8,7 @@
 <div class="content-list" markdown="1">
 - [Cache TTL In Seconds](#cache-ttl-in-seconds)
 - [Cache Lock Safety Improvements](#cache-lock-safety-improvements)
+- [Environment](#environment)
 - [Markdown File Directory Change](#markdown-file-directory-change)
 - [Nexmo / Slack Notification Channels](#nexmo-slack-notification-channels)
 </div>
@@ -327,9 +328,10 @@ The `deleted_at` property [will now be automatically casted](https://github.com/
 
 The `getForeignKey` and `getQualifiedForeignKey` methods of the `BelongsTo` relationship have been renamed to `getForeignKeyName` and `getQualifiedForeignKeyName` respectively, making the method names consistent with the other relationships offered by Laravel.
 
+<a name="#environment"></a>
 ### Environment
 
-**Likelihood Of Impact: Low**
+**Likelihood Of Impact: High**
 
 The [phpdotenv](https://github.com/vlucas/phpdotenv) package that is used to parse `.env` files has released a new major version, which may impact the results returned from the `env` helper. Specifically, the `#` character in an unquoted value will now be considered a comment instead of part of the value:
 


### PR DESCRIPTION
Since the newly updated vlucas/phpdotenv library has some pretty significant changes it might be wanted to mark this as a high impact change.

See https://github.com/laravel/framework/issues/27850 & https://laracasts.com/discuss/channels/laravel/beware-in-env-files