### PR TITLE
[5.8] Added clarity on rate limiting for queues

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -420,7 +420,7 @@ However, you may also define the maximum number of seconds a job should be allow
 <a name="rate-limiting"></a>
 ### Rate Limiting
 
-> {note} This feature requires that your application can interact with a [Redis server](/docs/{{version}}/redis).
+> {note} This feature requires that your application uses Redis as the queue driver.
 
 If your application interacts with Redis, you may throttle your queued jobs by time or concurrency. This feature can be of assistance when your queued jobs are interacting with APIs that are also rate limited.
 


### PR DESCRIPTION
Unfortunately throttling does not work when using `sync` as the queue driver, only when using `redis`.  The documentation was incorrectly written in a way that gave the impression that merely having a `redis` connection is sufficient.