### PR TITLE
[5.7] Add missing use in Str::endsWith

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -815,6 +815,8 @@ The `e` function runs PHP's `htmlspecialchars` function with the `double_encode`
 
 The `Str::endsWith` method determines if the given string ends with the given value:
 
+    use Illuminate\Support\Str;
+
     $result = Str::endsWith('This is my name', 'name');
 
     // true


### PR DESCRIPTION
Every code block has the use statement expect in Str::endsWith.
