### PR TITLE
[5.8] Add missing use in Str::endsWith

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -867,6 +867,8 @@ You may also pass an array of values to determine if the given string contains a
 
 The `Str::endsWith` method determines if the given string ends with the given value:
 
+    use Illuminate\Support\Str;
+
     $result = Str::endsWith('This is my name', 'name');
 
     // true


### PR DESCRIPTION
Every code block has the use statement expect in Str::endsWith.