### PR TITLE
Clarify @json usage in element attributes

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -195,7 +195,7 @@ However, instead of manually calling `json_encode`, you may use the `@json` Blad
         var app = @json($array);
     </script>
 
-You may also find it useful for seeding Vue components or `data-*` attributes:
+The `@json` directive is also useful for seeding Vue components or `data-*` attributes:
 
     <example-component :some-prop='@json($array)'></example-component>
 

--- a/blade.md
+++ b/blade.md
@@ -195,6 +195,12 @@ However, instead of manually calling `json_encode`, you may use the `@json` Blad
         var app = @json($array);
     </script>
 
+You may also find it useful for seeding Vue components or `data-*` attributes:
+
+    <example-component :some-prop='@json($array)'></example-component>
+
+> {note} Using `@json` in element attributes requires that it be surrounded by single quotes.
+
 #### HTML Entity Encoding
 
 By default, Blade (and the Laravel `e` helper) will double encode HTML entities. If you would like to disable double encoding, call the `Blade::withoutDoubleEncoding` method from the `boot` method of your `AppServiceProvider`:


### PR DESCRIPTION
If I tried using double quotes instead of single quotes around `attr='@json'`, I'm sure somebody else will.