### PR TITLE
Display correct RFC number

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -585,7 +585,7 @@ The `getPresenceVerifierFor` method of the `Illuminate\Validation\Validator` cla
 
 **Likelihood Of Impact: Very Low**
 
-The email validation rule now checks if the email is [RFC5630](https://tools.ietf.org/html/rfc6530) compliant, making the validation logic consistent with the logic used by SwiftMailer. In Laravel `5.7`, the `email` rule only verified that the email was [RFC822](https://tools.ietf.org/html/rfc822) compliant.
+The email validation rule now checks if the email is [RFC6530](https://tools.ietf.org/html/rfc6530) compliant, making the validation logic consistent with the logic used by SwiftMailer. In Laravel `5.7`, the `email` rule only verified that the email was [RFC822](https://tools.ietf.org/html/rfc822) compliant.
 
 Therefore, when using Laravel 5.8, emails that were previously incorrectly considered invalid will now be considered valid (e.g `hej@bär.se`).  Generally, this should be considered a bug fix; however, it is listed as a breaking change out of caution. [Please let us know if you encounter any issues surrounding this change](https://github.com/laravel/framework/pull/26503).
 


### PR DESCRIPTION
I guess RFC5630 was copied from the original PR https://github.com/laravel/framework/pull/26503

This corrects it to RFC6530 as per the link it goes to.