### PR TITLE
Add a description of Arr::add when the key exists and its value is null

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -202,6 +202,13 @@ The `Arr::add` method adds a given key / value pair to an array if the given key
     $array = Arr::add(['name' => 'Desk'], 'price', 100);
 
     // ['name' => 'Desk', 'price' => 100]
+    
+Or it updates the value corresponding to the given key of the array with the given value if the given key exists in the array and its corresponding value is `null`:
+
+
+    $array = array_add(['name' => 'Desk', 'price' => null], 'price', 100);
+
+    // ['name' => 'Desk', 'price' => 100]
 
 <a name="method-array-collapse"></a>
 #### `Arr::collapse()` {#collection-method}


### PR DESCRIPTION
Currently `Arr::add` is described as follows:

> The `Arr::add` method adds a given key / value pair to an array if the given key does not already exist in the array:

However, the value is updated when the key exists and the value is `null`.

```console
>>> Arr::add(['price' => null], 'price', 100)
=> [
     "price" => 100,
   ]
```

This PR adds a description of that case.

A PR has been submitted that corrects this behavior ([laravel/framework #12960](https://github.com/laravel/framework/pull/12960)), and at that time it was judged as 'Since this is a behavior change will hold off on this.'.

It would be difficult to make change that breaks backwards compatibility, so I think it would be better to have a description of this behavior.
