### PR TITLE
Added v5.8 upgrade note about moving the `add` method to base Collection

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -188,6 +188,14 @@ The `firstWhere` method signature [has changed](https://github.com/laravel/frame
      */
     public function firstWhere($key, $operator = null, $value = null);
 
+#### The `add` Method
+
+**Likelihood Of Impact: Very Low**
+
+The `add` method [has been moved](https://github.com/laravel/framework/pull/27082) from Eloquent to the base collection. If you were extending `Illuminate\Support\Collection` and the extended class has an `add` method, make sure the method signature matches its parent:
+
+    public function add($item);
+
 <a name="console"></a>
 ### Console
 


### PR DESCRIPTION
This PR adds a new possible BC for the v5.8 upgrade guide.

Moving the (undocumented) `add()` method to the base collection class in laravel/framework#27082 may cause a BC, eg. artkonekt/menu#3, vanilophp/framework#39