### PR TITLE
remove one hash tag to fix broken link

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -393,7 +393,7 @@ As previously discussed, some actions like `create` may not require a model inst
 
 #### Authorizing Resource Controllers
 
-If you are utilizing [resource controllers](/docs/{{version}}/controllers##resource-controllers), you may make use of the `authorizeResource` method in the controller's constructor. This method will attach the appropriate `can` middleware definition to the resource controller's methods.
+If you are utilizing [resource controllers](/docs/{{version}}/controllers#resource-controllers), you may make use of the `authorizeResource` method in the controller's constructor. This method will attach the appropriate `can` middleware definition to the resource controller's methods.
 
 The `authorizeResource` method accepts the model's class name as its first argument, and the name of the route / request parameter that will contain the model's ID as its second argument:
 


### PR DESCRIPTION
Incorrect indexing for resource controllers documentation. By removing one # tag the link redirects to correct location.