### PR TITLE
[5.8] Note the change to bigIncrements in the default migration stub

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -271,6 +271,21 @@ As a result, the `->>` operator is no longer supported or necessary.
 
 As of Laravel 5.8 the [oldest supported SQLite version](https://github.com/laravel/framework/pull/25995) is SQLite 3.7.11. If you are using an older SQLite version, you should update it (SQLite 3.8.8+ is recommended).
 
+#### New ID columns are bigIncrements
+
+**Likelihood Of Impact: None**
+
+[As of Laravel 5.8](https://github.com/laravel/framework/pull/26454), any newly generated migrations will use the `bigIncrements` method for ID columns by default, where previous versions used to use the `increments` method.
+
+This will not affect any existing code in your project, but you should be aware when setting up foreign keys on new migrations that both columns involved will need to be the same type; a column created with the `increments` method can not reference a column created with the  `bigIncrements` method.
+
+    Schema::create('user_feedback', function (Blueprint $table) {
+        $table->bigIncrements('id');
+        $table->integer('user_id')->unsigned();
+        $table->foreign('user_id')->references('id')->on('users');
+        $table->string('body');
+    });
+
 <a name="eloquent"></a>
 ### Eloquent
 


### PR DESCRIPTION
The change the `bigIncrements` in the default migration stub may have not affected any existing code in a project, but it is a good change to note when upgrading an application and continuing to work on it.

In particular, [Povilas pointed out that foreign key references need to be of the same type](https://laraveldaily.com/be-careful-laravel-5-8-added-bigincrements-as-defaults/). This may be clear in hindsight but is a small enough change that people are likely to miss and need to be aware of for any future code they write in the project.