### PR TITLE
Update container.md

### DIFF
--- a/container.md
+++ b/container.md
@@ -208,7 +208,7 @@ If some of your class' dependencies are not resolvable via the container, you ma
 <a name="automatic-injection"></a>
 #### Automatic Injection
 
-Alternatively, and importantly, you may "type-hint" the dependency in the constructor of a class that is resolved by the container, including [controllers](/docs/{{version}}/controllers), [event listeners](/docs/{{version}}/events), [queue jobs](/docs/{{version}}/queues), [middleware](/docs/{{version}}/middleware), and more. In practice, this is how most of your objects should be resolved by the container.
+Alternatively, and importantly, you may "type-hint" the dependency in the constructor (or handle() method for queue jobs) of a class that is resolved by the container, including [controllers](/docs/{{version}}/controllers), [event listeners](/docs/{{version}}/events), [queue jobs](/docs/{{version}}/queues), [middleware](/docs/{{version}}/middleware), and more. In practice, this is how most of your objects should be resolved by the container.
 
 For example, you may type-hint a repository defined by your application in a controller's constructor. The repository will automatically be resolved and injected into the class:
 


### PR DESCRIPTION
Added clarification that for queue jobs dependencies are not injected into the constructor, but must be injected into the handle() method.