### PR TITLE
Clarify release note pivot events

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -127,7 +127,7 @@ However, this can become cumbersome and repetitive if you are specifying the sam
 
 ### Intermediate Table / Pivot Model Events
 
-In previous versions of Laravel, [Eloquent model events](https://laravel.com/docs/5.8/eloquent#events) were not dispatched when attaching, detaching, or syncing custom intermediate table / "pivot" models of a many-to-many relationship. When using [custom intermediate table models](/docs/{{version}}/eloquent-relationships#defining-custom-intermediate-table-models) in Laravel 5.8, the applicable model events will now be dispatched.
+In previous versions of Laravel, [Eloquent model events](/docs/{{version}}/eloquent#events) were not dispatched when attaching, detaching, or syncing custom intermediate table / "pivot" models of a many-to-many relationship. When using [custom intermediate table models](/docs/{{version}}/eloquent-relationships#defining-custom-intermediate-table-models) in Laravel 5.8, the applicable model events will now be dispatched.
 
 ### Artisan Call Improvements
 

--- a/releases.md
+++ b/releases.md
@@ -127,7 +127,7 @@ However, this can become cumbersome and repetitive if you are specifying the sam
 
 ### Intermediate Table / Pivot Model Events
 
-In previous versions of Laravel, Eloquent model events were not dispatched when attaching, detaching, or syncing custom intermediate table / "pivot" models of a many-to-many relationship. When using [custom intermediate table models](/docs/{{version}}/eloquent-relationships#defining-custom-intermediate-table-models) in Laravel 5.8, these events will now be dispatched.
+In previous versions of Laravel, Eloquent model events(e.g. saving, saved, updated, etc.) were not dispatched when attaching, detaching, or syncing custom intermediate table / "pivot" models of a many-to-many relationship. When using [custom intermediate table models](/docs/{{version}}/eloquent-relationships#defining-custom-intermediate-table-models) in Laravel 5.8, the applicable model events will now be dispatched.
 
 ### Artisan Call Improvements
 

--- a/releases.md
+++ b/releases.md
@@ -127,7 +127,7 @@ However, this can become cumbersome and repetitive if you are specifying the sam
 
 ### Intermediate Table / Pivot Model Events
 
-In previous versions of Laravel, Eloquent model events(e.g. saving, saved, updated, etc.) were not dispatched when attaching, detaching, or syncing custom intermediate table / "pivot" models of a many-to-many relationship. When using [custom intermediate table models](/docs/{{version}}/eloquent-relationships#defining-custom-intermediate-table-models) in Laravel 5.8, the applicable model events will now be dispatched.
+In previous versions of Laravel, [Eloquent model events](https://laravel.com/docs/5.8/eloquent#events) were not dispatched when attaching, detaching, or syncing custom intermediate table / "pivot" models of a many-to-many relationship. When using [custom intermediate table models](/docs/{{version}}/eloquent-relationships#defining-custom-intermediate-table-models) in Laravel 5.8, the applicable model events will now be dispatched.
 
 ### Artisan Call Improvements
 


### PR DESCRIPTION
## Issue
In the release notes section, Intermediate Table/Pivot Model Events, the wording was the source of some confusion. An [issue](https://github.com/laravel/framework/issues/28050) was posted on the laravel/framework repo which stated that the user expected there to be new 'syncing', 'detaching', and 'attaching' events available in Laravel 5.8.

## Before
> In previous versions of Laravel, **Eloquent model events were not dispatched when attaching, detaching, or syncing custom intermediate table / "pivot" models** of a many-to-many relationship. **When using custom intermediate table models in Laravel 5.8, these events will now be dispatched.**

## Changes
- A documentation link was added to the reference to "Eloquent model events", to clarify which events will be dispatched.
- The phrase "these events will now be dispatched" is changed to "the applicable model events will now be dispatched.".

Hopefully these small changes will help clarify this new functionality.