### PR TITLE
Updating example docblock return type

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -158,7 +158,7 @@ The `ShouldBroadcast` interface requires our event to define a `broadcastOn` met
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return array
+     * @return \Illuminate\Broadcasting\PrivateChannel
      */
     public function broadcastOn()
     {


### PR DESCRIPTION
Changed as people may copy and paste the example with an incorrect docblock.