### PR TITLE
Update migrations.md

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -41,6 +41,8 @@ The `--table` and `--create` options may also be used to indicate the name of th
 
     php artisan make:migration add_votes_to_users_table --table=users
 
+> Note: the name used for the migration must match the class name used for the miration. It would be CreateUsersTable and AddVotesToUsersTable respetively. 
+
 If you would like to specify a custom output path for the generated migration, you may use the `--path` option when executing the `make:migration` command. The given path should be relative to your application's base path.
 
 <a name="migration-structure"></a>


### PR DESCRIPTION
It isn't very clear that the migration name must match the file name. I made a migration via the command line called `resources` and edited the class name to be `CreateResource` and it kept complaining that the the class `Resources` was not found.