### PR TITLE
[5.8] Update telescope version in documentation

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -38,7 +38,7 @@ Laravel Telescope is an elegant debug assistant for the Laravel framework. Teles
 <a name="installation"></a>
 ## Installation
 
-> {note} Telescope requires Laravel 5.7.7+.
+> {note} Telescope requires Laravel 5.8+.
 
 You may use Composer to install Telescope into your Laravel project:
 


### PR DESCRIPTION
Currently I'm trying to add Telescope to my Laravel 5.7.28 app. The documentation says that it needs to be at least 5.7.7. However, this doesn't work as it 5.8+.

I've updated the documentation according that it only supports versions 5.8+ 

https://github.com/laravel/telescope/blob/2.0/composer.json#L19

![image](https://user-images.githubusercontent.com/5346497/55492136-fe871880-5636-11e9-8edd-33b2e830be34.png)
