### PR TITLE
Queries: note 'or' versions of various `where` functions

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -347,14 +347,14 @@ You may chain where constraints together as well as add `or` clauses to the quer
 
 #### Additional Where Clauses
 
-**whereBetween**
+**whereBetween / orWhereBetween**
 
 The `whereBetween` method verifies that a column's value is between two values:
 
     $users = DB::table('users')
                         ->whereBetween('votes', [1, 100])->get();
 
-**whereNotBetween**
+**whereNotBetween / orWhereNotBetween**
 
 The `whereNotBetween` method verifies that a column's value lies outside of two values:
 
@@ -362,7 +362,7 @@ The `whereNotBetween` method verifies that a column's value lies outside of two 
                         ->whereNotBetween('votes', [1, 100])
                         ->get();
 
-**whereIn / whereNotIn**
+**whereIn / whereNotIn / orWhereIn / orWhereNotIn**
 
 The `whereIn` method verifies that a given column's value is contained within the given array:
 
@@ -376,7 +376,7 @@ The `whereNotIn` method verifies that the given column's value is **not** contai
                         ->whereNotIn('id', [1, 2, 3])
                         ->get();
 
-**whereNull / whereNotNull**
+**whereNull / whereNotNull / orWhereNull / orWhereNotNull**
 
 The `whereNull` method verifies that the value of the given column is `NULL`:
 
@@ -422,7 +422,7 @@ The `whereTime` method may be used to compare a column's value against a specifi
                     ->whereTime('created_at', '=', '11:20:45')
                     ->get();
 
-**whereColumn**
+**whereColumn / orWhereColumn**
 
 The `whereColumn` method may be used to verify that two columns are equal:
 


### PR DESCRIPTION
There are 'or' versions of most 'where' functions (e.g. `orWhereNull`). Added these to the Query Builder page for the benefit of new developers who might otherwise not be aware of them. The current wording of the page makes it sound like there is only an `orWhere` function