### PR TITLE
[5.7] Change community Socialite drivers website URL

### DIFF
--- a/socialite.md
+++ b/socialite.md
@@ -15,7 +15,7 @@
 
 In addition to typical, form based authentication, Laravel also provides a simple, convenient way to authenticate with OAuth providers using [Laravel Socialite](https://github.com/laravel/socialite). Socialite currently supports authentication with Facebook, Twitter, LinkedIn, Google, GitHub, GitLab and Bitbucket.
 
-> {tip} Adapters for other platforms are listed at the community driven [Socialite Providers](https://socialiteproviders.github.io/) website.
+> {tip} Adapters for other platforms are listed at the community driven [Socialite Providers](https://socialiteproviders.netlify.com/) website.
 
 <a name="upgrading-socialite"></a>
 ## Upgrading Socialite


### PR DESCRIPTION
This PR updates the Socialite documentation to point to the new Netlify-hosted website for the Socialite Drivers community site.