### PR TITLE
Provide further instructions on MySQL 5.6 compatibility

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -410,7 +410,7 @@ Laravel uses the `utf8mb4` character set by default, which includes support for 
         Schema::defaultStringLength(191);
     }
 
-Alternatively, you may enable the `innodb_large_prefix` option for your database. Refer to your database's documentation for instructions on how to properly enable this option.
+You may also adjust your database configuration to adjust for the defaults made in MySQL 5.7. You would need to set `innodb_large_prefix = ON` and `innodb_file_format = Barracuda` in your database configuration. Also, the `row_format` would need to be set to `DYNAMIC`. One day to do this would be to set the `mysql` section in `config/database.php` to contain `'engine' => 'InnoDB ROW_FORMAT=DYNAMIC'`. This is simply intended to point you in the right direction, please refer to your database's documentation on how to properly enable this option.
 
 <a name="renaming-indexes"></a>
 ### Renaming Indexes


### PR DESCRIPTION
The primary issue with the existing documentation is that is starts the developer off with incomplete information. Presently, it sounds like setting the `innodb_large_prefix` setting on will do the trick, but it actually takes more than that. The new instructions provide the minimum configurations that will need to be adjusted in MySQL 5.6 in order to work properly.

This, I believe, is really the better way to go, especially if it's a local limitation and their production is running MySQL 5.7. This feels like it just fixes the issue, but in fact the prior instructions changes the character limit to 191. This opens the door to a bug that exists locally but not in production. That said, if it is being run in the app service provider then production gets the same limitation, but it's shame to limit MySQL 5.7 to 191 when it doesn't have to be.

Anyway, I hope the proposed changes make sense. Please let me know if there are any questions. 😄 