### PR TITLE
[5.8] fix cache.headers middleware reference and params

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -69,7 +69,7 @@ Or, you may use the `withHeaders` method to specify an array of headers to be ad
 
 Laravel includes a `cache.headers` middleware, which may be used to quickly set the `Cache-Control` header for a group of routes. If `etag` is specified in the list of directives, an MD5 hash of the response content will automatically be set as the ETag identifier:
 
-    Route::middleware('cache-control:public,max-age=2628000;etag')->group(function() {
+    Route::middleware('cache.headers:public;max_age=2628000;etag')->group(function() {
         Route::get('privacy', function () {
             // ...
         });


### PR DESCRIPTION
updated correct reference for registered `cache.headers` MiddleWare
per https://github.com/laravel/laravel/blob/3001f3c6e232ba7ce2ecdbdfe6e43b4c64ee05ad/app/Http/Kernel.php#L57

swap options delimiter to `;` vs `,` 
per explode method https://github.com/laravel/framework/blob/5.8/src/Illuminate/Http/Middleware/SetCacheHeaders.php#L49

swap `max-age` to `max_age` option 
per https://github.com/symfony/http-foundation/blob/v4.2.5/Response.php#L932