### PR TITLE
Added warning message for --sleep

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -552,6 +552,8 @@ When jobs are available on the queue, the worker will keep processing jobs with 
 
     php artisan queue:work --sleep=3
 
+> {note} The `--sleep` value should always be at least several seconds shorter than the `--timeout` value (default 60 seconds if not set). This will ensure that the child queue process isn't mistakenly being marked as frozen and removed.
+
 <a name="supervisor-configuration"></a>
 ## Supervisor Configuration
 


### PR DESCRIPTION
I had `--sleep=60` in my Supervisor config and this caused an issue that stopped my worker after 1 minute. I didn't know about `--timeout` and that it doesn't see a "sleeping" process as an active worker.
I hope by adding this little warning I can save other people the time of debugging this issue.
Also made a blog post about the issue: [DEV.to](https://dev.to/glennmen/debugging-laravel-queue-sleeper-21hn)

I also am not sure what the target branch should be, because older versions could also benefit from this warning message. I was working on a Laravel 5.7 project when I had this issue.