### PR TITLE
[5.8] Start method names for event subscribers with handle

### DIFF
--- a/events.md
+++ b/events.md
@@ -360,12 +360,12 @@ Event subscribers are classes that may subscribe to multiple events from within 
         /**
          * Handle user login events.
          */
-        public function onUserLogin($event) {}
+        public function handleUserLogin($event) {}
 
         /**
          * Handle user logout events.
          */
-        public function onUserLogout($event) {}
+        public function handleUserLogout($event) {}
 
         /**
          * Register the listeners for the subscriber.
@@ -376,12 +376,12 @@ Event subscribers are classes that may subscribe to multiple events from within 
         {
             $events->listen(
                 'Illuminate\Auth\Events\Login',
-                'App\Listeners\UserEventSubscriber@onUserLogin'
+                'App\Listeners\UserEventSubscriber@handleUserLogin'
             );
 
             $events->listen(
                 'Illuminate\Auth\Events\Logout',
-                'App\Listeners\UserEventSubscriber@onUserLogout'
+                'App\Listeners\UserEventSubscriber@handleUserLogout'
             );
         }
     }


### PR DESCRIPTION
To allow event auto discovery on subscribers you have to start the handlers with `handle*`. So this PR is to keep all event method names consistent. 