### PR TITLE
Updating the version of Homestead in homestead.md from v8.0.1 to v8.2.0

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -123,7 +123,7 @@ You should check out a tagged version of Homestead since the `master` branch may
     cd ~/Homestead
 
     // Clone the desired release...
-    git checkout v8.0.1
+    git checkout v8.2.0
 
 Once you have cloned the Homestead repository, run the `bash init.sh` command from the Homestead directory to create the `Homestead.yaml` configuration file. The `Homestead.yaml` file will be placed in the Homestead directory:
 
@@ -652,7 +652,7 @@ Next, you need to update the Homestead source code. If you cloned the repository
 
     git fetch
 
-    git checkout v8.0.1
+    git checkout v8.2.0
 
 These commands pull the latest Homestead code from the GitHub repository, fetches the latest tags, and then checks out the latest tagged release. You can find the latest stable release version on the [GitHub releases page](https://github.com/laravel/homestead/releases).
 


### PR DESCRIPTION
Answered a question in the Laravel Slack and noticed these versions were 2 minor releases behind.