### PR TITLE
[5.8] Added explanation how to eager load "has many" relationships. 

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -997,11 +997,15 @@ To eager load nested relationships, you may use "dot" syntax. For example, let's
 
 #### Eager Loading Specific Columns
 
-You may not always need every column from the relationships you are retrieving. For this reason, Eloquent allows you to specify which columns of the relationship you would like to retrieve:
+You may not always need every column from the relationships you are retrieving. For this reason, Eloquent allows you to specify which columns of the relationship you would like to retrieve. For "has one" relationships:
 
-    $users = App\Book::with('author:id,name')->get();
+    $books = App\Book::with('author:id,name')->get();
 
 > {note} When using this feature, you should always include the `id` column in the list of columns you wish to retrieve.
+
+For "has many" relations you need specify both `id` and `foreign_key`
+
+    $books = App\Book::with('chapter:id,book_id,name')->get();
 
 <a name="constraining-eager-loads"></a>
 ### Constraining Eager Loads


### PR DESCRIPTION
Added explanation how to eager load "has many" relationships. Including just "id" as the current document claims does not work with "has many" relationships leaving users scratching their heads. I didn't not test eager loading other types of relationships but I assume the same would be true there as well.