### PR TITLE
[5.8] Add Valet Log

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -296,9 +296,9 @@ If you would like to define a custom Valet driver for a single application, crea
 Command  | Description
 ------------- | -------------
 `valet forget` | Run this command from a "parked" directory to remove it from the parked directory list.
-`valet log` | Returns a list of logs from services used within Valet for viewing.
+`valet log` | Display a list of logs written by Valet's services.
 `valet paths` | View all of your "parked" paths.
 `valet restart` | Restart the Valet daemon.
 `valet start` | Start the Valet daemon.
 `valet stop` | Stop the Valet daemon.
-`valet uninstall` | Uninstall the Valet daemon entirely.
+`valet uninstall` | Uninstall the Valet daemon.

--- a/valet.md
+++ b/valet.md
@@ -301,3 +301,4 @@ Command  | Description
 `valet start` | Start the Valet daemon.
 `valet stop` | Stop the Valet daemon.
 `valet uninstall` | Uninstall the Valet daemon entirely.
+`valet log` | Returns a list of logs from services used within Valet for viewing.

--- a/valet.md
+++ b/valet.md
@@ -296,9 +296,9 @@ If you would like to define a custom Valet driver for a single application, crea
 Command  | Description
 ------------- | -------------
 `valet forget` | Run this command from a "parked" directory to remove it from the parked directory list.
+`valet log` | Returns a list of logs from services used within Valet for viewing.
 `valet paths` | View all of your "parked" paths.
 `valet restart` | Restart the Valet daemon.
 `valet start` | Start the Valet daemon.
 `valet stop` | Stop the Valet daemon.
 `valet uninstall` | Uninstall the Valet daemon entirely.
-`valet log` | Returns a list of logs from services used within Valet for viewing.

--- a/valet.md
+++ b/valet.md
@@ -296,7 +296,7 @@ If you would like to define a custom Valet driver for a single application, crea
 Command  | Description
 ------------- | -------------
 `valet forget` | Run this command from a "parked" directory to remove it from the parked directory list.
-`valet log` | Display a list of logs written by Valet's services.
+`valet log` | View a list of logs which are written written by Valet's services.
 `valet paths` | View all of your "parked" paths.
 `valet restart` | Restart the Valet daemon.
 `valet start` | Start the Valet daemon.


### PR DESCRIPTION
Adds brief documentation to the new `valet log` feature added in [Valet 2.3.0](https://github.com/laravel/valet/releases/tag/v2.3.0).

https://github.com/laravel/valet/pull/757

![Screen Shot 2019-04-17 at 4 29 32 PM](https://user-images.githubusercontent.com/17038330/56322330-5ab96480-612e-11e9-95c0-dff2796daa6d.png)
