### PR TITLE
Change Homestead NFS note to refer to Windows specifically

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -166,7 +166,7 @@ To enable [NFS](https://www.vagrantup.com/docs/synced-folders/nfs.html), you onl
           to: /home/vagrant/code
           type: "nfs"
 
-> {note} When using NFS, you should consider installing the [vagrant-winnfsd](https://github.com/winnfsd/vagrant-winnfsd) plug-in. This plug-in will maintain the correct user / group permissions for files and directories within the Homestead box.
+> {note} When using NFS on Windows, you should consider installing the [vagrant-winnfsd](https://github.com/winnfsd/vagrant-winnfsd) plug-in. This plug-in will maintain the correct user / group permissions for files and directories within the Homestead box.
 
 You may also pass any options supported by Vagrant's [Synced Folders](https://www.vagrantup.com/docs/synced-folders/basic_usage.html) by listing them under the `options` key:
 


### PR DESCRIPTION
Since this note refers specifically to something used on Windows, it should point that out to avoid confusion.