### PR TITLE
Fix typo in code example

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -480,7 +480,7 @@ The `@error` directive may be used to quickly check if [validation error message
 
     <label for="title">Post Title</label>
 
-    <input type="text" class=@error('title') is-invalid @enderror">
+    <input type="text" class="@error('title') is-invalid @enderror">
 
     @error('title')
         <div class="alert alert-danger">{{ $message }}</div>


### PR DESCRIPTION
Fix typo in Validation Errors code example.

* Missing `"` (double quote)