### PR TITLE
Fixed typo in code example for @error directive

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -164,7 +164,7 @@ You may also use the `@error` [Blade](/docs/{{version}}/blade) directive to quic
 
     <label for="title">Post Title</label>
 
-    <input type="text" class=@error('title') is-invalid @enderror">
+    <input type="text" class="@error('title') is-invalid @enderror">
 
     @error('title')
         <div class="alert alert-danger">{{ $message }}</div>


### PR DESCRIPTION
Added a missing quotation mark in the code example.