### PR TITLE
[5.8] Document change in behaviour as routes are now throttled on a domain level

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -374,7 +374,7 @@ If the user approves the authorization request, they will be redirected back to 
 
 This `/oauth/token` route will return a JSON response containing `access_token`, `refresh_token`, and `expires_in` attributes. The `expires_in` attribute contains the number of seconds until the access token expires.
 
-> {tip} Like the `/oauth/authorize` route, the `/oauth/token` route is defined for you by the `Passport::routes` method. There is no need to manually define this route. By default, this route is throttled using the settings of the `ThrottleRequests` middleware.
+> {tip} Like the `/oauth/authorize` route, the `/oauth/token` route is defined for you by the `Passport::routes` method. There is no need to manually define this route. By default, this route is throttled using the settings of the `ThrottleRequests` middleware. Other route throttler settings may override these settings.
 
 <a name="refreshing-tokens"></a>
 ### Refreshing Tokens

--- a/routing.md
+++ b/routing.md
@@ -401,6 +401,16 @@ Laravel includes a [middleware](/docs/{{version}}/middleware) to rate limit acce
         });
     });
 
+
+> {note} the given throttle settings apply on a domain-level globally and not on a per-route/group basis. So for example, if you have multiple routes that define throttle settings:
+
+```
+Route::get('users')->middleware('throttle:6,10');
+Route::get('posts')->middleware('throttle:10,5);
+```
+
+Whichever route loaded first will take priority and use those throttle threshold settings. You can change this behaviour by extending `Illuminate\Routing\Middleware\ThrottleRequests` and overriding the `resolveRequestSignature` method.
+
 #### Dynamic Rate Limiting
 
 You may specify a dynamic request maximum based on an attribute of the authenticated `User` model. For example, if your `User` model contains a `rate_limit` attribute, you may pass the name of the attribute to the `throttle` middleware so that it is used to calculate the maximum request count:


### PR DESCRIPTION
Since PR https://github.com/laravel/framework/pull/19807 which changed the throttlers request signature, routes are now throttled at a domain level and not on a per-route/group basis. This is a major breaking change and so I've been suggested by @driesvints to send a PR to the docs to explain this behaviour change.

I personally believe this change is unintentional, as the docs explain you can have different throttle settings per route, but it seems this is no longer the case so it should be documented.

The original PR also meant you can no longer have different throttle settings for [api/web requests](https://github.com/laravel/laravel/blob/v5.8.3/app/Http/Kernel.php#L41), which Laravel uses out the box.

See here for more info: https://github.com/laravel/framework/issues/28323
