### PR TITLE
[5.8] Telescope use proper provider in local environment only code sample

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -62,7 +62,7 @@ If you plan to only use Telescope to assist your local development. You may inst
 
 After running `telescope:install`, you should remove the `TelescopeServiceProvider` service provider registration from your `app` configuration file. Instead, manually register the service provider in the `register` method of your `AppServiceProvider`:
 
-    use Laravel\Telescope\TelescopeServiceProvider;
+    use App\Providers\TelescopeServiceProvider;
 
     /**
      * Register any application services.


### PR DESCRIPTION
The `Laravel\Telescope\TelescopeServiceProvider` is already registered with auto package discovery. The provider that is added in `config/app.php` when you run `php artisan telescope:install` is the `App\Providers\TelescopeServiceProvider`. So this is the one that should be registered manually in this code sample.