### PR TITLE
[5.8] docs(eloquent observers): method order

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -877,16 +877,6 @@ To register an observer, use the `observe` method on the model you wish to obser
     class AppServiceProvider extends ServiceProvider
     {
         /**
-         * Bootstrap any application services.
-         *
-         * @return void
-         */
-        public function boot()
-        {
-            User::observe(UserObserver::class);
-        }
-
-        /**
          * Register the service provider.
          *
          * @return void
@@ -894,5 +884,15 @@ To register an observer, use the `observe` method on the model you wish to obser
         public function register()
         {
             //
+        }
+
+        /**
+         * Bootstrap any application services.
+         *
+         * @return void
+         */
+        public function boot()
+        {
+            User::observe(UserObserver::class);
         }
     }


### PR DESCRIPTION
I've been debugging my app for an hour trying to figure out why my observer isn't working, the problem was that I placed the `User::observe(UserObserver::class);` in the `register` method  instead of the `boot` method, in the docs the `register` method in placed below the `boot` method which causes confusion because it doesn't follow the Laravel generated order.