### PR TITLE
[5.8] Update service provider code examples

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -605,7 +605,17 @@ The following example creates a `@datetime($var)` directive which formats a give
     class AppServiceProvider extends ServiceProvider
     {
         /**
-         * Perform post-registration booting of services.
+         * Register bindings in the container.
+         *
+         * @return void
+         */
+        public function register()
+        {
+            //
+        }
+
+        /**
+         * Bootstrap any application services.
          *
          * @return void
          */
@@ -614,16 +624,6 @@ The following example creates a `@datetime($var)` directive which formats a give
             Blade::directive('datetime', function ($expression) {
                 return "<?php echo ($expression)->format('m/d/Y H:i'); ?>";
             });
-        }
-
-        /**
-         * Register bindings in the container.
-         *
-         * @return void
-         */
-        public function register()
-        {
-            //
         }
     }
 
@@ -641,7 +641,7 @@ Programming a custom directive is sometimes more complex than necessary when def
     use Illuminate\Support\Facades\Blade;
 
     /**
-     * Perform post-registration booting of services.
+     * Bootstrap any application services.
      *
      * @return void
      */

--- a/cache.md
+++ b/cache.md
@@ -379,7 +379,17 @@ To register the custom cache driver with Laravel, we will use the `extend` metho
     class CacheServiceProvider extends ServiceProvider
     {
         /**
-         * Perform post-registration booting of services.
+         * Register bindings in the container.
+         *
+         * @return void
+         */
+        public function register()
+        {
+            //
+        }
+
+        /**
+         * Bootstrap any application services.
          *
          * @return void
          */
@@ -388,16 +398,6 @@ To register the custom cache driver with Laravel, we will use the `extend` metho
             Cache::extend('mongo', function ($app) {
                 return Cache::repository(new MongoStore);
             });
-        }
-
-        /**
-         * Register bindings in the container.
-         *
-         * @return void
-         */
-        public function register()
-        {
-            //
         }
     }
 

--- a/database.md
+++ b/database.md
@@ -168,6 +168,16 @@ If you would like to receive each SQL query executed by your application, you ma
     class AppServiceProvider extends ServiceProvider
     {
         /**
+         * Register any application services.
+         *
+         * @return void
+         */
+        public function register()
+        {
+            //
+        }
+
+        /**
          * Bootstrap any application services.
          *
          * @return void
@@ -179,16 +189,6 @@ If you would like to receive each SQL query executed by your application, you ma
                 // $query->bindings
                 // $query->time
             });
-        }
-
-        /**
-         * Register the service provider.
-         *
-         * @return void
-         */
-        public function register()
-        {
-            //
         }
     }
 

--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -324,16 +324,6 @@ If you would like to disable the wrapping of the outer-most resource, you may us
     class AppServiceProvider extends ServiceProvider
     {
         /**
-         * Perform post-registration booting of services.
-         *
-         * @return void
-         */
-        public function boot()
-        {
-            Resource::withoutWrapping();
-        }
-
-        /**
          * Register bindings in the container.
          *
          * @return void
@@ -341,6 +331,16 @@ If you would like to disable the wrapping of the outer-most resource, you may us
         public function register()
         {
             //
+        }
+
+        /**
+         * Bootstrap any application services.
+         *
+         * @return void
+         */
+        public function boot()
+        {
+            Resource::withoutWrapping();
         }
     }
 

--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -187,7 +187,17 @@ Laravel extends the [Carbon](https://github.com/briannesbitt/Carbon) date librar
     class AppServiceProvider extends ServiceProvider
     {
         /**
-         * Perform post-registration booting of services.
+         * Register bindings in the container.
+         *
+         * @return void
+         */
+        public function register()
+        {
+            //
+        }
+
+        /**
+         * Bootstrap any application services.
          *
          * @return void
          */
@@ -196,15 +206,5 @@ Laravel extends the [Carbon](https://github.com/briannesbitt/Carbon) date librar
             Carbon::serializeUsing(function ($carbon) {
                 return $carbon->format('U');
             });
-        }
-
-        /**
-         * Register bindings in the container.
-         *
-         * @return void
-         */
-        public function register()
-        {
-            //
         }
     }

--- a/eloquent.md
+++ b/eloquent.md
@@ -877,7 +877,7 @@ To register an observer, use the `observe` method on the model you wish to obser
     class AppServiceProvider extends ServiceProvider
     {
         /**
-         * Register the service provider.
+         * Register any application services.
          *
          * @return void
          */

--- a/filesystem.md
+++ b/filesystem.md
@@ -408,7 +408,17 @@ Next, you should create a [service provider](/docs/{{version}}/providers) such a
     class DropboxServiceProvider extends ServiceProvider
     {
         /**
-         * Perform post-registration booting of services.
+         * Register bindings in the container.
+         *
+         * @return void
+         */
+        public function register()
+        {
+            //
+        }
+
+        /**
+         * Bootstrap any application services.
          *
          * @return void
          */
@@ -421,16 +431,6 @@ Next, you should create a [service provider](/docs/{{version}}/providers) such a
 
                 return new Filesystem(new DropboxAdapter($client));
             });
-        }
-
-        /**
-         * Register bindings in the container.
-         *
-         * @return void
-         */
-        public function register()
-        {
-            //
         }
     }
 

--- a/packages.md
+++ b/packages.md
@@ -84,7 +84,7 @@ A service provider extends the `Illuminate\Support\ServiceProvider` class and co
 Typically, you will need to publish your package's configuration file to the application's own `config` directory. This will allow users of your package to easily override your default configuration options. To allow your configuration files to be published, call the `publishes` method from the `boot` method of your service provider:
 
     /**
-     * Perform post-registration booting of services.
+     * Bootstrap any application services.
      *
      * @return void
      */
@@ -125,7 +125,7 @@ You may also merge your own package configuration file with the application's pu
 If your package contains routes, you may load them using the `loadRoutesFrom` method. This method will automatically determine if the application's routes are cached and will not load your routes file if the routes have already been cached:
 
     /**
-     * Perform post-registration booting of services.
+     * Bootstrap any application services.
      *
      * @return void
      */
@@ -140,7 +140,7 @@ If your package contains routes, you may load them using the `loadRoutesFrom` me
 If your package contains [database migrations](/docs/{{version}}/migrations), you may use the `loadMigrationsFrom` method to inform Laravel how to load them. The `loadMigrationsFrom` method accepts the path to your package's migrations as its only argument:
 
     /**
-     * Perform post-registration booting of services.
+     * Bootstrap any application services.
      *
      * @return void
      */
@@ -157,7 +157,7 @@ Once your package's migrations have been registered, they will automatically be 
 If your package contains [translation files](/docs/{{version}}/localization), you may use the `loadTranslationsFrom` method to inform Laravel how to load them. For example, if your package is named `courier`, you should add the following to your service provider's `boot` method:
 
     /**
-     * Perform post-registration booting of services.
+     * Bootstrap any application services.
      *
      * @return void
      */
@@ -175,7 +175,7 @@ Package translations are referenced using the `package::file.line` syntax conven
 If you would like to publish your package's translations to the application's `resources/lang/vendor` directory, you may use the service provider's `publishes` method. The `publishes` method accepts an array of package paths and their desired publish locations. For example, to publish the translation files for the `courier` package, you may do the following:
 
     /**
-     * Perform post-registration booting of services.
+     * Bootstrap any application services.
      *
      * @return void
      */
@@ -196,7 +196,7 @@ Now, when users of your package execute Laravel's `vendor:publish` Artisan comma
 To register your package's [views](/docs/{{version}}/views) with Laravel, you need to tell Laravel where the views are located. You may do this using the service provider's `loadViewsFrom` method. The `loadViewsFrom` method accepts two arguments: the path to your view templates and your package's name. For example, if your package's name is `courier`, you would add the following to your service provider's `boot` method:
 
     /**
-     * Perform post-registration booting of services.
+     * Bootstrap any application services.
      *
      * @return void
      */
@@ -220,7 +220,7 @@ When you use the `loadViewsFrom` method, Laravel actually registers two location
 If you would like to make your views available for publishing to the application's `resources/views/vendor` directory, you may use the service provider's `publishes` method. The `publishes` method accepts an array of package view paths and their desired publish locations:
 
     /**
-     * Perform post-registration booting of services.
+     * Bootstrap any application services.
      *
      * @return void
      */
@@ -261,7 +261,7 @@ To register your package's Artisan commands with Laravel, you may use the `comma
 Your package may have assets such as JavaScript, CSS, and images. To publish these assets to the application's `public` directory, use the service provider's `publishes` method. In this example, we will also add a `public` asset group tag, which may be used to publish groups of related assets:
 
     /**
-     * Perform post-registration booting of services.
+     * Bootstrap any application services.
      *
      * @return void
      */
@@ -282,7 +282,7 @@ Now, when your package's users execute the `vendor:publish` command, your assets
 You may want to publish groups of package assets and resources separately. For instance, you might want to allow your users to publish your package's configuration files without being forced to publish your package's assets. You may do this by "tagging" them when calling the `publishes` method from a package's service provider. For example, let's use tags to define two publish groups in the `boot` method of a package service provider:
 
     /**
-     * Perform post-registration booting of services.
+     * Bootstrap any application services.
      *
      * @return void
      */

--- a/providers.md
+++ b/providers.md
@@ -165,7 +165,7 @@ To defer the loading of a provider, implement the `\Illuminate\Contracts\Support
     class RiakServiceProvider extends ServiceProvider implements DeferrableProvider
     {
         /**
-         * Register the service provider.
+         * Register any application services.
          *
          * @return void
          */

--- a/queues.md
+++ b/queues.md
@@ -690,7 +690,7 @@ If you would like to register an event that will be called when a job fails, you
     class AppServiceProvider extends ServiceProvider
     {
         /**
-         * Register the service provider.
+         * Register any application services.
          *
          * @return void
          */
@@ -768,6 +768,16 @@ Using the `before` and `after` methods on the `Queue` [facade](/docs/{{version}}
     class AppServiceProvider extends ServiceProvider
     {
         /**
+         * Register any application services.
+         *
+         * @return void
+         */
+        public function register()
+        {
+            //
+        }
+
+        /**
          * Bootstrap any application services.
          *
          * @return void
@@ -785,16 +795,6 @@ Using the `before` and `after` methods on the `Queue` [facade](/docs/{{version}}
                 // $event->job
                 // $event->job->payload()
             });
-        }
-
-        /**
-         * Register the service provider.
-         *
-         * @return void
-         */
-        public function register()
-        {
-            //
         }
     }
 

--- a/session.md
+++ b/session.md
@@ -247,7 +247,17 @@ Once your driver has been implemented, you are ready to register it with the fra
     class SessionServiceProvider extends ServiceProvider
     {
         /**
-         * Perform post-registration booting of services.
+         * Register bindings in the container.
+         *
+         * @return void
+         */
+        public function register()
+        {
+            //
+        }
+
+        /**
+         * Bootstrap any application services.
          *
          * @return void
          */
@@ -257,16 +267,6 @@ Once your driver has been implemented, you are ready to register it with the fra
                 // Return implementation of SessionHandlerInterface...
                 return new MongoSessionHandler;
             });
-        }
-
-        /**
-         * Register bindings in the container.
-         *
-         * @return void
-         */
-        public function register()
-        {
-            //
         }
     }
 

--- a/validation.md
+++ b/validation.md
@@ -1236,6 +1236,16 @@ Another method of registering custom validation rules is using the `extend` meth
     class AppServiceProvider extends ServiceProvider
     {
         /**
+         * Register any application services.
+         *
+         * @return void
+         */
+        public function register()
+        {
+            //
+        }
+
+        /**
          * Bootstrap any application services.
          *
          * @return void
@@ -1245,16 +1255,6 @@ Another method of registering custom validation rules is using the `extend` meth
             Validator::extend('foo', function ($attribute, $value, $parameters, $validator) {
                 return $value == 'foo';
             });
-        }
-
-        /**
-         * Register the service provider.
-         *
-         * @return void
-         */
-        public function register()
-        {
-            //
         }
     }
 

--- a/views.md
+++ b/views.md
@@ -79,6 +79,16 @@ Occasionally, you may need to share a piece of data with all views that are rend
     class AppServiceProvider extends ServiceProvider
     {
         /**
+         * Register any application services.
+         *
+         * @return void
+         */
+        public function register()
+        {
+            //
+        }
+
+        /**
          * Bootstrap any application services.
          *
          * @return void
@@ -86,16 +96,6 @@ Occasionally, you may need to share a piece of data with all views that are rend
         public function boot()
         {
             View::share('key', 'value');
-        }
-
-        /**
-         * Register the service provider.
-         *
-         * @return void
-         */
-        public function register()
-        {
-            //
         }
     }
 
@@ -116,7 +116,17 @@ For this example, let's register the view composers within a [service provider](
     class ViewServiceProvider extends ServiceProvider
     {
         /**
-         * Register bindings in the container.
+         * Register any application services.
+         *
+         * @return void
+         */
+        public function register()
+        {
+            //
+        }
+
+        /**
+         * Bootstrap any application services.
          *
          * @return void
          */
@@ -131,16 +141,6 @@ For this example, let's register the view composers within a [service provider](
             View::composer('dashboard', function ($view) {
                 //
             });
-        }
-
-        /**
-         * Register the service provider.
-         *
-         * @return void
-         */
-        public function register()
-        {
-            //
         }
     }
 


### PR DESCRIPTION
The order of the `register` and `boot` method was changed in https://github.com/laravel/laravel/pull/4921. The docs weren't updated, which caused this problem: https://github.com/laravel/docs/pull/5158.

This PR updates the order of the `register` and `boot` methods for all code examples in the docs. It also updates the docblock text to match the text [currently used by the framework.](https://github.com/laravel/laravel/blob/3995828c13ddca61dec45b8f9511a669cc90a15c/app/Providers/AppServiceProvider.php#L10)