### PR TITLE
Fixed typo

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -340,7 +340,7 @@ The `count` method returns the total number of items in the collection:
 <a name="method-countBy"></a>
 #### `countBy()` {#collection-method}
 
-The `countBy` method counts the occurences of values in the collection. By default, the method counts the occurrences of every element:
+The `countBy` method counts the occurrences of values in the collection. By default, the method counts the occurrences of every element:
 
     $collection = collect([1, 2, 2, 2, 3]);
 


### PR DESCRIPTION
Aside from just being a typo, it's also inconsistent with how the same word is spelt in the next sentence.