### PR TITLE
[5.8] Id for labels added in @error directive

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -480,7 +480,7 @@ The `@error` directive may be used to quickly check if [validation error message
 
     <label for="title">Post Title</label>
 
-    <input type="text" class="@error('title') is-invalid @enderror">
+    <input id="title" type="text" class="@error('title') is-invalid @enderror">
 
     @error('title')
         <div class="alert alert-danger">{{ $message }}</div>

--- a/validation.md
+++ b/validation.md
@@ -164,7 +164,7 @@ You may also use the `@error` [Blade](/docs/{{version}}/blade) directive to quic
 
     <label for="title">Post Title</label>
 
-    <input type="text" class="@error('title') is-invalid @enderror">
+    <input id="title" type="text" class="@error('title') is-invalid @enderror">
 
     @error('title')
         <div class="alert alert-danger">{{ $message }}</div>


### PR DESCRIPTION
The `for="title"` in labels missing the `id="title"` in inputs.