### PR TITLE
[5.8] Stripe and Braintree Documentation

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -68,14 +68,14 @@ First, require the Cashier package for Stripe with Composer:
 
 Before using Cashier, we'll also need to [prepare the database](/docs/{{version}}/migrations). We need to add several columns to your `users` table and create a new `subscriptions` table to hold all of our customer's subscriptions:
 
-    Schema::table('users', function ($table) {
+    Schema::table('users', function (Blueprint $table) {
         $table->string('stripe_id')->nullable()->collation('utf8mb4_bin');
         $table->string('card_brand')->nullable();
         $table->string('card_last_four', 4)->nullable();
         $table->timestamp('trial_ends_at')->nullable();
     });
 
-    Schema::create('subscriptions', function ($table) {
+    Schema::create('subscriptions', function (Blueprint $table) {
         $table->bigIncrements('id');
         $table->unsignedBigInteger('user_id');
         $table->string('name');

--- a/braintree.md
+++ b/braintree.md
@@ -74,7 +74,7 @@ The discount amount configured in the Braintree control panel can be any value y
 
 Before using Cashier, we'll need to [prepare the database](/docs/{{version}}/migrations). We need to add several columns to your `users` table and create a new `subscriptions` table to hold all of our customer's subscriptions:
 
-    Schema::table('users', function ($table) {
+    Schema::table('users', function (Blueprint $table) {
         $table->string('braintree_id')->nullable();
         $table->string('paypal_email')->nullable();
         $table->string('card_brand')->nullable();
@@ -82,7 +82,7 @@ Before using Cashier, we'll need to [prepare the database](/docs/{{version}}/mig
         $table->timestamp('trial_ends_at')->nullable();
     });
 
-    Schema::create('subscriptions', function ($table) {
+    Schema::create('subscriptions', function (Blueprint $table) {
         $table->increments('id');
         $table->unsignedInteger('user_id');
         $table->string('name');


### PR DESCRIPTION
Stripe and Braintree Documentation reflects the Blueprint in the migrations examples thus the examples are consistent with the default users migration that is created with a new Laravel 5.8 installation and when a new migration is created using the **php artisan make:migration** command