### PR TITLE
Remove line about how 0 removes entries when using the Cache Facade

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -182,6 +182,8 @@ The `add` method will only add the item to the cache if it does not already exis
 
     Cache::add('key', 'value', $seconds);
 
+> {note} Using a duration of 0 seconds is handled differently by the underlying cache stores and does not immediately expire the stored value.
+
 #### Storing Items Forever
 
 The `forever` method may be used to store an item in the cache permanently. Since these items will not expire, they must be manually removed from the cache using the `forget` method:
@@ -197,9 +199,7 @@ You may remove items from the cache using the `forget` method:
 
     Cache::forget('key');
 
-You may also remove items by providing a zero or negative TTL:
-
-    Cache::put('key', 'value', 0);
+You may also remove items by providing a negative TTL:
 
     Cache::put('key', 'value', -5);
 


### PR DESCRIPTION
The handling of a duration of 0 seconds is vastly different among storage implementations.

These drivers store values forever:
- [ApcStore](https://github.com/laravel/framework/blob/bf7076f9a325a65770aa802d6014993422eb8f6c/src/Illuminate/Cache/ApcStore.php#L97)
- [ArrayStore](https://github.com/laravel/framework/blob/bf7076f9a325a65770aa802d6014993422eb8f6c/src/Illuminate/Cache/ArrayStore.php#L102)
- [FileStore](https://github.com/laravel/framework/blob/bf7076f9a325a65770aa802d6014993422eb8f6c/src/Illuminate/Cache/FileStore.php#L121)
- [MemcachedStore](https://github.com/laravel/framework/blob/bf7076f9a325a65770aa802d6014993422eb8f6c/src/Illuminate/Cache/MemcachedStore.php#L178)

These stores actually expire the value immediately:
- [DatabaseStore](https://github.com/laravel/framework/blob/bf7076f9a325a65770aa802d6014993422eb8f6c/src/Illuminate/Cache/DatabaseStore.php#L100)
- [DynamoDbStore](https://github.com/laravel/framework/blob/bf7076f9a325a65770aa802d6014993422eb8f6c/src/Illuminate/Cache/DynamoDbStore.php#L459)
- [RedisStore](https://github.com/laravel/framework/blob/bf7076f9a325a65770aa802d6014993422eb8f6c/src/Illuminate/Cache/RedisStore.php#L93) (value will be cached for 1 second)