### PR TITLE
[5.8] Sort required php extensions by alphabetical order

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -21,14 +21,14 @@ However, if you are not using Homestead, you will need to make sure your server 
 
 <div class="content-list" markdown="1">
 - PHP >= 7.1.3
-- OpenSSL PHP Extension
-- PDO PHP Extension
-- Mbstring PHP Extension
-- Tokenizer PHP Extension
-- XML PHP Extension
+- BCMath PHP Extension
 - Ctype PHP Extension
 - JSON PHP Extension
-- BCMath PHP Extension
+- Mbstring PHP Extension
+- OpenSSL PHP Extension
+- PDO PHP Extension
+- Tokenizer PHP Extension
+- XML PHP Extension
 </div>
 
 <a name="installing-laravel"></a>


### PR DESCRIPTION
For easier inspection when run `php -m` command