### PR TITLE
[5.8] Added example for custom tags in the docs

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -215,7 +215,6 @@ Here is a small example that adds the request response status as a tags which yo
      }
 
 <a name="available-watchers"></a>
-
 ## Available Watchers
 
 Telescope watchers gather application data when a request or console command is executed. You may customize the list of watchers that you would like to enable within your `config/telescope.php` configuration file:

--- a/telescope.md
+++ b/telescope.md
@@ -9,6 +9,8 @@
 - [Filtering](#filtering)
     - [Entries](#filtering-entries)
     - [Batches](#filtering-batches)
+- [Tagging](#tagging)
+    - [Adding custom tags](#tagging-adding)
 - [Available Watchers](#available-watchers)
     - [Cache Watcher](#cache-watcher)
     - [Command Watcher](#command-watcher)
@@ -45,7 +47,7 @@ You may use Composer to install Telescope into your Laravel project:
 After installing Telescope, publish its assets using the `telescope:install` Artisan command. After installing Telescope, you should also run the `migrate` command:
 
     php artisan telescope:install
-
+    
     php artisan migrate
 
 #### Updating Telescope
@@ -63,7 +65,7 @@ If you plan to only use Telescope to assist your local development, you may inst
 After running `telescope:install`, you should remove the `TelescopeServiceProvider` service provider registration from your `app` configuration file. Instead, manually register the service provider in the `register` method of your `AppServiceProvider`:
 
     use App\Providers\TelescopeServiceProvider;
-
+    
     /**
      * Register any application services.
      *
@@ -138,12 +140,12 @@ You may filter the data that is recorded by Telescope via the `filter` callback 
     public function register()
     {
         $this->hideSensitiveRequestDetails();
-
+    
         Telescope::filter(function (IncomingEntry $entry) {
             if ($this->app->isLocal()) {
                 return true;
             }
-
+    
             return $entry->isReportableException() ||
                 $entry->isFailedJob() ||
                 $entry->isScheduledTask() ||
@@ -157,7 +159,7 @@ You may filter the data that is recorded by Telescope via the `filter` callback 
 While the `filter` callback filters data for individual entries, you may use the `filterBatch` method to register a callback that filters all data for a given request or console command. If the callback returns `true`, all of the entries are recorded by Telescope:
 
     use Illuminate\Support\Collection;
-
+    
     /**
      * Register any application services.
      *
@@ -166,12 +168,12 @@ While the `filter` callback filters data for individual entries, you may use the
     public function register()
     {
         $this->hideSensitiveRequestDetails();
-
+    
         Telescope::filterBatch(function (Collection $entries) {
             if ($this->app->isLocal()) {
                 return true;
             }
-
+    
             return $entries->contains(function ($entry) {
                 return $entry->isReportableException() ||
                     $entry->isFailedJob() ||
@@ -181,7 +183,39 @@ While the `filter` callback filters data for individual entries, you may use the
         });
     }
 
+<a name="tagging"></a>
+
+## Tagging
+
+Telescope allows searching on specific tags to get a better detailed overview.
+
+<a name="tagging-adding"></a>
+
+### Adding custom tags
+
+You can add custom tags that will give you more insights via the `tags` callback that you can register in your `TelescopeServiceProvider`.
+
+Here is a small example that adds the request response status as a tags which you can search on.
+
+	/**
+	 * Register any application services.
+	 *
+	 * @return void
+	 */
+	public function register()
+	{
+	    $this->hideSensitiveRequestDetails();
+			
+			Telescope::tags(function (IncomingEntry $entry) {
+					if ($entry->type === 'request') {
+							return ['status: ' . $entry->content['response_status']];
+					}
+					
+					return [];
+			})
+	}
 <a name="available-watchers"></a>
+
 ## Available Watchers
 
 Telescope watchers gather application data when a request or console command is executed. You may customize the list of watchers that you would like to enable within your `config/telescope.php` configuration file:

--- a/telescope.md
+++ b/telescope.md
@@ -188,7 +188,7 @@ While the `filter` callback filters data for individual entries, you may use the
 
 Telescope allows searching on specific tags to get a better detailed overview.
 
-<a name="tagging-adding"></a>
+<a name="adding-custom-tags"></a>
 ### Adding custom tags
 
 You can add custom tags that will give you more insights via the `tags` callback that you can register in your `TelescopeServiceProvider`.

--- a/telescope.md
+++ b/telescope.md
@@ -10,7 +10,7 @@
     - [Entries](#filtering-entries)
     - [Batches](#filtering-batches)
 - [Tagging](#tagging)
-    - [Adding custom tags](#tagging-adding)
+    - [Adding custom tags](#adding-custom-tags)
 - [Available Watchers](#available-watchers)
     - [Cache Watcher](#cache-watcher)
     - [Command Watcher](#command-watcher)

--- a/telescope.md
+++ b/telescope.md
@@ -184,7 +184,6 @@ While the `filter` callback filters data for individual entries, you may use the
     }
 
 <a name="tagging"></a>
-
 ## Tagging
 
 Telescope allows searching on specific tags to get a better detailed overview.

--- a/telescope.md
+++ b/telescope.md
@@ -140,7 +140,7 @@ You may filter the data that is recorded by Telescope via the `filter` callback 
     public function register()
     {
         $this->hideSensitiveRequestDetails();
-   
+
         Telescope::filter(function (IncomingEntry $entry) {
             if ($this->app->isLocal()) {
                 return true;

--- a/telescope.md
+++ b/telescope.md
@@ -189,7 +189,6 @@ While the `filter` callback filters data for individual entries, you may use the
 Telescope allows searching on specific tags to get a better detailed overview.
 
 <a name="tagging-adding"></a>
-
 ### Adding custom tags
 
 You can add custom tags that will give you more insights via the `tags` callback that you can register in your `TelescopeServiceProvider`.

--- a/telescope.md
+++ b/telescope.md
@@ -196,7 +196,7 @@ Telescope allows searching on specific tags to get a better detailed overview.
 You can add custom tags that will give you more insights via the `tags` callback that you can register in your `TelescopeServiceProvider`.
 
 Here is a small example that adds the request response status as a tags which you can search on.
-
+    
     /**
      * Register any application services.
      *

--- a/telescope.md
+++ b/telescope.md
@@ -197,23 +197,24 @@ You can add custom tags that will give you more insights via the `tags` callback
 
 Here is a small example that adds the request response status as a tags which you can search on.
 
-	/**
-	 * Register any application services.
-	 *
-	 * @return void
-	 */
-	public function register()
-	{
-	    $this->hideSensitiveRequestDetails();
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->hideSensitiveRequestDetails();
 			
-			Telescope::tags(function (IncomingEntry $entry) {
-					if ($entry->type === 'request') {
-							return ['status: ' . $entry->content['response_status']];
-					}
-					
-					return [];
-			})
-	}
+        Telescope::tags(function (IncomingEntry $entry) {
+            if ($entry->type === 'request') {
+                return ['status: ' . $entry->content['response_status']];
+            }
+
+            return [];
+        });
+     }
+
 <a name="available-watchers"></a>
 
 ## Available Watchers

--- a/telescope.md
+++ b/telescope.md
@@ -47,7 +47,7 @@ You may use Composer to install Telescope into your Laravel project:
 After installing Telescope, publish its assets using the `telescope:install` Artisan command. After installing Telescope, you should also run the `migrate` command:
 
     php artisan telescope:install
-    
+
     php artisan migrate
 
 #### Updating Telescope
@@ -65,7 +65,7 @@ If you plan to only use Telescope to assist your local development, you may inst
 After running `telescope:install`, you should remove the `TelescopeServiceProvider` service provider registration from your `app` configuration file. Instead, manually register the service provider in the `register` method of your `AppServiceProvider`:
 
     use App\Providers\TelescopeServiceProvider;
-    
+
     /**
      * Register any application services.
      *
@@ -140,12 +140,12 @@ You may filter the data that is recorded by Telescope via the `filter` callback 
     public function register()
     {
         $this->hideSensitiveRequestDetails();
-    
+   
         Telescope::filter(function (IncomingEntry $entry) {
             if ($this->app->isLocal()) {
                 return true;
             }
-    
+
             return $entry->isReportableException() ||
                 $entry->isFailedJob() ||
                 $entry->isScheduledTask() ||
@@ -159,7 +159,7 @@ You may filter the data that is recorded by Telescope via the `filter` callback 
 While the `filter` callback filters data for individual entries, you may use the `filterBatch` method to register a callback that filters all data for a given request or console command. If the callback returns `true`, all of the entries are recorded by Telescope:
 
     use Illuminate\Support\Collection;
-    
+
     /**
      * Register any application services.
      *
@@ -168,12 +168,12 @@ While the `filter` callback filters data for individual entries, you may use the
     public function register()
     {
         $this->hideSensitiveRequestDetails();
-    
+
         Telescope::filterBatch(function (Collection $entries) {
             if ($this->app->isLocal()) {
                 return true;
             }
-    
+
             return $entries->contains(function ($entry) {
                 return $entry->isReportableException() ||
                     $entry->isFailedJob() ||


### PR DESCRIPTION
Because I couldn't find docs on how to edit add custom tags I reached out and got my answer from @themsaid.
I hope we can document this example for future references.