### PR TITLE
[5.8] Typo in Telescope Tag function name.

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -198,7 +198,7 @@ Telescope allows you to search entries by "tag". Often, tags are Eloquent model 
     {
         $this->hideSensitiveRequestDetails();
 
-        Telescope::tags(function (IncomingEntry $entry) {
+        Telescope::tag(function (IncomingEntry $entry) {
             if ($entry->type === 'request') {
                 return ['status:'.$entry->content['response_status']];
             }


### PR DESCRIPTION
Fix the typo in function name . tags  -> tag.