### PR TITLE
[5.8] Added  a line for a simple binding example

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -71,6 +71,7 @@ If your service provider registers many simple bindings, you may wish to use the
     use Illuminate\Support\ServiceProvider;
     use App\Services\PingdomDowntimeNotifier;
     use App\Services\DigitalOceanServerProvider;
+    use App\Services\ServerToolsProvider;
 
     class AppServiceProvider extends ServiceProvider
     {
@@ -90,6 +91,7 @@ If your service provider registers many simple bindings, you may wish to use the
          */
         public $singletons = [
             DowntimeNotifier::class => PingdomDowntimeNotifier::class,
+            ServerToolsProvider::class => ServerToolsProvider::class
         ];
     }
 

--- a/providers.md
+++ b/providers.md
@@ -68,10 +68,10 @@ If your service provider registers many simple bindings, you may wish to use the
 
     use App\Contracts\ServerProvider;
     use App\Contracts\DowntimeNotifier;
+    use App\Services\ServerToolsProvider;
     use Illuminate\Support\ServiceProvider;
     use App\Services\PingdomDowntimeNotifier;
     use App\Services\DigitalOceanServerProvider;
-    use App\Services\ServerToolsProvider;
 
     class AppServiceProvider extends ServiceProvider
     {
@@ -91,7 +91,7 @@ If your service provider registers many simple bindings, you may wish to use the
          */
         public $singletons = [
             DowntimeNotifier::class => PingdomDowntimeNotifier::class,
-            ServerToolsProvider::class => ServerToolsProvider::class
+            ServerToolsProvider::class => ServerToolsProvider::class,
         ];
     }
 


### PR DESCRIPTION
Because it's not clear at first glance in you should add the same named class in the properties, meaning, that using no key in the array would register the Class as a number (given by the array).