### PR TITLE
Fix undefined variable in validateForPassportPasswordGrant

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -508,7 +508,7 @@ When authenticating using the password grant, Passport will use the `password` a
         */
         public function validateForPassportPasswordGrant($password)
         {
-            return Hash::check($password, $user->password);
+            return Hash::check($password, $this->password);
         }
     }
 


### PR DESCRIPTION
Replace undefined variable `$user` with `$this` (which is intended by purpose) in body of method `validateForPassportPasswordGrant`.