### PR TITLE
Added in full path for validator 

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/validation.md
+++ b/validation.md
@@ -333,9 +333,9 @@ If you do not want to use the `validate` method on the request, you may create a
 
     namespace App\Http\Controllers;
 
-    use Illuminate\Support\Facades\Validator;
     use Illuminate\Http\Request;
     use App\Http\Controllers\Controller;
+    use Illuminate\Support\Facades\Validator;
 
     class PostController extends Controller
     {

--- a/validation.md
+++ b/validation.md
@@ -333,7 +333,7 @@ If you do not want to use the `validate` method on the request, you may create a
 
     namespace App\Http\Controllers;
 
-    use Validator;
+    use Illuminate\Support\Facades\Validator;
     use Illuminate\Http\Request;
     use App\Http\Controllers\Controller;
 


### PR DESCRIPTION
Added in full path for validator import. The way it is now, if I use that code I get an error saying Validator class not found. It does say above that the Validator is a facade but you have to click there and realize that you need to add the Illuminate\Support\Facades\ in front of it to get it working. Idk if thats on purpose but I feel like it would be simpler if we had the right path.