### PR TITLE
[5.8] assertJsonValidationErrors Message Value

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -423,9 +423,9 @@ Assert that the response has a given JSON structure:
 <a name="assert-json-validation-errors"></a>
 #### assertJsonValidationErrors
 
-Assert that the response has the given JSON validation errors for the given keys:
+Assert that the response has the given JSON validation errors:
 
-    $response->assertJsonValidationErrors($keys);
+    $response->assertJsonValidationErrors(array $data);
 
 <a name="assert-location"></a>
 #### assertLocation


### PR DESCRIPTION
Updates documentation on `assertJsonValidationErrors` to reflect that it can handle more than validation keys with the recent message value assertion addition.

laravel/framework/pull/28787

