### PR TITLE
[5.8] Clarify that running in the backgound does not work for all cases

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -251,6 +251,8 @@ By default, multiple commands scheduled at the same time will execute sequential
              ->daily()
              ->runInBackground();
 
+> {note} Background tasks can only be used for commands (and `exec`) and have no effect on other types of scheduling.
+
 <a name="maintenance-mode"></a>
 ### Maintenance Mode
 


### PR DESCRIPTION
Although one can apply `->runInBackground()` always, it's only used for commands and exec but not for other types of scheduling (.e.g `->call()`).