### PR TITLE
[5.3] Rename deprecated Pusher Channels `encrypted` to `forceTLS

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -62,7 +62,7 @@ Next, you should configure your Pusher credentials in the `config/broadcasting.p
 
     'options' => [
         'cluster' => 'eu',
-        'encrypted' => true
+        'useTLS' => true
     ],
 
 When using Pusher and [Laravel Echo](#installing-laravel-echo), you should specify `pusher` as your desired broadcaster when instantiating the Echo instance in your `resources/assets/js/bootstrap.js` file:
@@ -364,13 +364,13 @@ Once Echo is installed, you are ready to create a fresh Echo instance in your ap
         key: 'your-pusher-key'
     });
 
-When creating an Echo instance that uses the `pusher` connector, you may also specify a `cluster` as well as whether the connection should be encrypted:
+When creating an Echo instance that uses the `pusher` connector, you may also specify a `cluster` as well as whether the connection must be made over TLS (by default, when `forceTLS` is `false`, a non-TLS connection will be made if the page was loaded over HTTP, or as a fallback if a TLS connection fails):
 
     window.Echo = new Echo({
         broadcaster: 'pusher',
         key: 'your-pusher-key',
         cluster: 'eu',
-        encrypted: true
+        forceTLS: true
     });
 
 <a name="listening-for-events"></a>


### PR DESCRIPTION
It was renamed in https://github.com/pusher/pusher-js/commit/922ed101b9a546554d1a308f485b14e812ae56ac.

I also made the description of `forceTLS` semantics a bit clearer.