### PR TITLE
Add parentheses to modelKeys

### DIFF
--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -99,7 +99,7 @@ The `loadMissing` method eager loads the given relationships for all models in t
 
     $users->loadMissing('comments.author');
 
-#### `modelKeys`
+#### `modelKeys()`
 
 The `modelKeys` method returns the primary keys for all models in the collection:
 


### PR DESCRIPTION
Add parentheses to modelKeys for consistency with other zero argument methods found in documentation such as collection.md

Also assists with rendering (currently renders differently to the other methods listed)