### PR TITLE
[Passport] 'load encryption keys in env file' example should escape slashes

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -186,8 +186,8 @@ If necessary, you may define the path where Passport's keys should be loaded fro
 
 Additionally, you may load the keys from environment variables:
 
-    PASSPORT_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n<private key here>\n-----END RSA PRIVATE KEY-----"
-    PASSPORT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n<public key here>\n-----END PUBLIC KEY-----\n"
+    PASSPORT_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\\n<private key here>\\n-----END RSA PRIVATE KEY-----"
+    PASSPORT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\\n<public key here>\\n-----END PUBLIC KEY-----\\n"
 
 <a name="configuration"></a>
 ## Configuration


### PR DESCRIPTION
I replaced every `\n` by `\\n` in the `load passport encryption keys in env file` example, as  phpdotenv V3 requires slashes to be escapes (https://github.com/vlucas/phpdotenv/blob/master/UPGRADING.md). If you copy and use the current example without escaped slashes, then a `fails with invalid escape sequence exception` error is thrown when the env file is read.