### PR TITLE
[5.8] Added a note to pass class name as an argument to authorize function

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -355,7 +355,7 @@ In addition to helpful methods provided to the `User` model, Laravel provides a 
 
 #### Actions That Don't Require Models
 
-As previously discussed, some actions like `create` may not require a model instance. In these situations, you may pass a class name to the `authorize` method. The class name will be used to determine which policy to use when authorizing the action:
+As previously discussed, some actions like `create` may not require a model instance. In these situations, you need to pass a class name to the `authorize` method. The class name will be used to determine which policy to use when authorizing the action:
 
     /**
      * Create a new blog post.
@@ -370,6 +370,8 @@ As previously discussed, some actions like `create` may not require a model inst
 
         // The current user can create blog posts...
     }
+
+If no class is given as an argument, authorize will resolve itself to use `UserPolicy` as the `User` model gets added as the sole argument.
 
 #### Authorizing Resource Controllers
 

--- a/authorization.md
+++ b/authorization.md
@@ -355,7 +355,7 @@ In addition to helpful methods provided to the `User` model, Laravel provides a 
 
 #### Actions That Don't Require Models
 
-As previously discussed, some actions like `create` may not require a model instance. In these situations, you need to pass a class name to the `authorize` method. The class name will be used to determine which policy to use when authorizing the action:
+As previously discussed, some actions like `create` may not require a model instance. In these situations, you should pass a class name to the `authorize` method. The class name will be used to determine which policy to use when authorizing the action:
 
     /**
      * Create a new blog post.

--- a/authorization.md
+++ b/authorization.md
@@ -371,8 +371,6 @@ As previously discussed, some actions like `create` may not require a model inst
         // The current user can create blog posts...
     }
 
-If no class is given as an argument, authorize will resolve itself to use `UserPolicy` as the `User` model gets added as the sole argument.
-
 #### Authorizing Resource Controllers
 
 If you are utilizing [resource controllers](/docs/{{version}}/controllers#resource-controllers), you may make use of the `authorizeResource` method in the controller's constructor. This method will attach the appropriate `can` middleware definitions to the resource controller's methods.


### PR DESCRIPTION
Added a note that class should be given as an argument to authorize function if no Model is given. I ended up debugging this issue for hours only to discover that when arguments are null, the resolvePolicy() will end up resolving to UserPolicy, as the User model is inserted into the arguments.