### PR TITLE
[5.8] Update the major version of pusher-php-server

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -59,7 +59,7 @@ Before broadcasting any events, you will first need to register the `App\Provide
 
 If you are broadcasting your events over [Pusher Channels](https://pusher.com/channels), you should install the Pusher Channels PHP SDK using the Composer package manager:
 
-    composer require pusher/pusher-php-server "~3.0"
+    composer require pusher/pusher-php-server "~4.0"
 
 Next, you should configure your Channels credentials in the `config/broadcasting.php` configuration file. An example Channels configuration is already included in this file, allowing you to quickly specify your Channels key, secret, and application ID. The `config/broadcasting.php` file's `pusher` configuration also allows you to specify additional `options` that are supported by Channels, such as the cluster:
 


### PR DESCRIPTION
A new major version has been released: https://github.com/pusher/pusher-http-php/pull/222.