### PR TITLE
[5.8] Add `items()` method for pagination

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -197,6 +197,7 @@ Method  |  Description
 `$results->getOptions()`  |  Get the paginator options.
 `$results->getUrlRange($start, $end)`  |  Create a range of pagination URLs.
 `$results->hasMorePages()`  |  Determine if there are enough items to split into multiple pages.
+`$results->items()`  |  Get the items found for the current page.
 `$results->lastItem()`  |  Get the result number of the last item in the results.
 `$results->lastPage()`  |  Get the page number of the last available page. (Not available when using `simplePaginate`).
 `$results->nextPageUrl()`  |  Get the URL for the next page.


### PR DESCRIPTION
Currently there is no information about this in the documentation and also navigating the code of `Paginator` it uses `$this->items`, so I thought it would be helpful to add this method in the docs to let users know how to retrieve the paginated data.