### PR TITLE
[5.8] update optional software

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -96,17 +96,29 @@ Homestead runs on any Windows, Mac, or Linux system, and includes the Nginx web 
 
 <div id="software-list" markdown="1">
 - Apache
+- Blackfire
+- Cassandra
+- Chronograf
+- CouchDB
 - Crystal & Lucky Framework
+- Docker
 - Dot Net Core
 - Elasticsearch
+- Gearman
 - Go
+- Grafana
+- InfluxDB
 - MariaDB
+- MinIO
 - MongoDB
 - Neo4j
 - Oh My Zsh
-- Ruby & Rails
+- Open Resty
+- PM2
+- Python
+- RabbitMQ
+- Solr
 - Webdriver & Laravel Dusk Utilities
-- Zend Z-Ray
 </div>
 
 <a name="installation-and-setup"></a>


### PR DESCRIPTION
I will need to add some docs about the new way to enable "features" in Homestead, but we'll get this updated for now.

based off this list: https://github.com/laravel/homestead/tree/master/scripts/features