### PR TITLE
[5.8] Note to update morphable_type columns when using Morph Map

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -799,6 +799,8 @@ By default, Laravel will use the fully qualified class name to store the type of
 
 You may register the `morphMap` in the `boot` function of your `AppServiceProvider` or create a separate service provider if you wish.
 
+> {note} Adding a "morph map" to an existing application will require you to migrate every `{morphable}_type` column in your database to the new "morph map" name `posts` instead of the fully qualified class name `App\Post`. If you don't, any morph-based relationship query in your application will skip over database rows that are still using the fully qualified class name `App\Post` instead of your new "morph map" name `posts`.
+
 <a name="querying-relations"></a>
 ## Querying Relations
 

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -799,7 +799,7 @@ By default, Laravel will use the fully qualified class name to store the type of
 
 You may register the `morphMap` in the `boot` function of your `AppServiceProvider` or create a separate service provider if you wish.
 
-> {note} Adding a "morph map" to an existing application will require you to migrate every `{morphable}_type` column in your database to the new "morph map" name `posts` instead of the fully qualified class name `App\Post`. If you don't, any morph-based relationship query in your application will skip over database rows that are still using the fully qualified class name `App\Post` instead of your new "morph map" name `posts`.
+> {note} When adding a "morph map" to your application, every morph `*_type` column in your database still using the fully qualified name such as `App\Post` or `App\Comment` will need to be replaced with its respective "morph map" name `posts` or `comments`. When querying, Eloquent will only use your "morph map" names like `posts` and will skip over database rows still using the fully qualified name like `App\Post`.
 
 <a name="querying-relations"></a>
 ## Querying Relations


### PR DESCRIPTION
A common issue I see when implementing a "morph map" is that Laravel stops querying for the fully qualified name `App\Post` and only uses the morph map name `posts`. This has been the cause of some frustration as it makes various data in the database seem to "disappear" when querying for it.

I documented the requirement to swap the database's `{morphable}_type` columns with the "morph map" name instead of the fully qualified name when implementing a "morph map" on an existing application.

