### PR TITLE
[5.8] Updated example PHPDoc block for MorphTo relations to avoid confusion

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -563,7 +563,7 @@ Next, let's examine the model definitions needed to build this relationship:
     class Image extends Model
     {
         /**
-         * Get all of the owning imageable models.
+         * Get the owning imageable model.
          */
         public function imageable()
         {
@@ -645,7 +645,7 @@ Next, let's examine the model definitions needed to build this relationship:
     class Comment extends Model
     {
         /**
-         * Get all of the owning commentable models.
+         * Get the owning commentable model.
          */
         public function commentable()
         {


### PR DESCRIPTION
Some of the examples of a `MorphTo` relation have a comment that would lead you to believe the relation resolves to a collection, where it resolves to a model instance.