### PR TITLE
Update migrations.md

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -46,7 +46,7 @@ If you would like to specify a custom output path for the generated migration, y
 <a name="migration-structure"></a>
 ## Migration Structure
 
-A migration class contains two methods: `up` and `down`. The `up` method is used to add new tables, columns, or indexes to your database, while the `down` method should reverse the operations performed by the `up` method.
+A migration class contains two methods: `up` and `down`. The `up` method is used to perform some action on the database, such as adding a new table, dropping a column, or adding indexes to your database, while the `down` method should reverse the operations performed by the `up` method.
 
 Within both of these methods you may use the Laravel schema builder to expressively create and modify tables. To learn about all of the methods available on the `Schema` builder, [check out its documentation](#creating-tables). For example, this migration example creates a `flights` table:
 


### PR DESCRIPTION
I know this is minor, but this confused one of my junior devs when I told him to create a migration that drops a table. He put the dropTable in the down method instead of up because the docs said up was for adding to the database and he assumed down would be for removing it. 