### PR TITLE
[5.8] Update migrations.md

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -247,7 +247,6 @@ Command  |  Description
 `$table->point('position');`  |  POINT equivalent column.
 `$table->polygon('positions');`  |  POLYGON equivalent column.
 `$table->rememberToken();`  |  Adds a nullable `remember_token` VARCHAR(100) equivalent column.
-`$table->set('flavors', ['strawberry', 'vanilla']);`  |  SET equivalent column.
 `$table->smallIncrements('id');`  |  Auto-incrementing UNSIGNED SMALLINT (primary key) equivalent column.
 `$table->smallInteger('votes');`  |  SMALLINT equivalent column.
 `$table->softDeletes();`  |  Adds a nullable `deleted_at` TIMESTAMP equivalent column for soft deletes.


### PR DESCRIPTION
`set()` is not implemented anymore in 5.8.11, At least i can't find the definition at all in the class file.