### PR TITLE
[5.8] Improve whereHasMorph() examples

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -934,6 +934,7 @@ To query the existence of `MorphTo` relationships, you may use the `whereHasMorp
 
     use Illuminate\Database\Eloquent\Builder;
 
+    // Retrieve comments that are associated to posts or videos with a title like foo%...
     $comments = App\Comment::whereHasMorph(
         'commentable', 
         ['App\Post', 'App\Video'], 
@@ -942,9 +943,14 @@ To query the existence of `MorphTo` relationships, you may use the `whereHasMorp
         }
     )->get();
 
-    $comments = App\Comment::doesntHaveMorph(
+    // Retrieve comments that are associated to posts with a title not like foo%...
+    // The query does NOT retrieve comments that are associated to videos or other types.
+    $comments = App\Comment::whereDoesntHaveMorph(
         'commentable', 
-        ['App\Post', 'App\Video']
+        'App\Post', 
+        function (Builder $query) {
+            $query->where('title', 'like', 'foo%');
+        }
     )->get();    
     
 You may use the `$type` parameter to add different constraints depending on the related model:

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -934,7 +934,7 @@ To query the existence of `MorphTo` relationships, you may use the `whereHasMorp
 
     use Illuminate\Database\Eloquent\Builder;
 
-    // Retrieve comments that are associated to posts or videos with a title like foo%...
+    // Retrieve comments associated to posts or videos with a title like foo%...
     $comments = App\Comment::whereHasMorph(
         'commentable', 
         ['App\Post', 'App\Video'], 
@@ -943,8 +943,7 @@ To query the existence of `MorphTo` relationships, you may use the `whereHasMorp
         }
     )->get();
 
-    // Retrieve comments that are associated to posts with a title not like foo%...
-    // The query does NOT retrieve comments that are associated to videos or other types.
+    // Retrieve comments associated to posts with a title not like foo%...
     $comments = App\Comment::whereDoesntHaveMorph(
         'commentable', 
         'App\Post', 


### PR DESCRIPTION
I clarified the behavior of `doesntHaveMorph`/`whereDoesntHaveMorph` as it can be unexpected (https://github.com/laravel/framework/issues/29138).

There aren't that many use cases for `doesntHaveMorph()`, so I added an example for `whereDoesntHaveMorph()`.