### PR TITLE
[5.8] Update Cashier docs for v10

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -309,7 +309,9 @@ To determine if the user has cancelled their subscription and is no longer withi
 <a name="incomplete-and-past-due-status"></a>
 #### Incomplete and Past Due Status
 
-If a subscription requires a secondary payment action after creating a subscription the subscription becomes "incomplete". The same thing happens when swapping a plan but then the subscription becomes "past_due". When your subscription is in either of these states it will not be active until the customer has confirmed their payment. Checking if a subscription has an incomplete payment can be done with the following method on the user or subscription:
+If a subscription requires a secondary payment action after creation the subscription will be marked as `incomplete`. Subscription statuses are stored in the `status` column of Cashier's `subscriptions` database table.
+
+Similarly, if a secondary payment action is required when swapping plans the subscription will be marked as `past_due`. When your subscription is in either of these states it will not be active until the customer has confirmed their payment. Checking if a subscription has an incomplete payment can be done using the `hasIncompletePayment` method on the Billable model or a subscription instance:
 
     if ($user->hasIncompletePayment()) {
         //
@@ -319,13 +321,13 @@ If a subscription requires a secondary payment action after creating a subscript
         //
     }
 
-When your subscription has an incomplete payment you'll need to redirect your user to the payment page so the user can confirm the payment. You can use the `latestPayment` on the `Subscription` model for this:
+When a subscription has an incomplete payment, you should direct the user to Cashier's payment confirmation page, passing the `latestPayment` identifier. You may use the `latestPayment` method available on subscription instance to retrieve this identifier:
 
     <a href="{{ route('cashier.payment', $subscription->latestPayment()->id) }}">
         Please confirm your payment.
     </a>
 
-> {note} When your subscription is in an `incomplete` state it cannot be changed until payment was confirmed. This means that the `swap` and `updateQuantity` methods will throw an exception if you attempt to use them in this state.
+> {note} When a subscription is in an `incomplete` state it cannot be changed until the payment is confirmed. Therefore, the `swap` and `updateQuantity` methods will throw an exception when the subscription is in an `incomplete` state.
 
 <a name="changing-plans"></a>
 ### Changing Plans
@@ -344,7 +346,7 @@ If you would like to swap plans and cancel any trial period the user is currentl
             ->skipTrial()
             ->swap('provider-plan-id');
 
-If you want to swap plans and also immediately invoice the user instead of waiting for the next billing cyle, you can use the `swapAndInvoice` method:
+If you would like to swap plans and immediately invoice the user instead of waiting for their next billing cycle, you may use the `swapAndInvoice` method:
 
     $user = App\User::find(1);
 

--- a/billing.md
+++ b/billing.md
@@ -404,7 +404,7 @@ If a subscription requires a secondary payment action after creation the subscri
 
 Similarly, if a secondary payment action is required when swapping plans the subscription will be marked as `past_due`. When your subscription is in either of these states it will not be active until the customer has confirmed their payment. Checking if a subscription has an incomplete payment can be done using the `hasIncompletePayment` method on the Billable model or a subscription instance:
 
-    if ($user->hasIncompletePayment()) {
+    if ($user->hasIncompletePayment('main')) {
         //
     }
 

--- a/billing.md
+++ b/billing.md
@@ -200,6 +200,8 @@ To add a new payment method, you can call the `addPaymentMethod` method on the b
 
     $user->addPaymentMethod($paymentMethod);
 
+You can retrieve the `$paymentMethod` token by following [this guide](#storing-payment-methods).
+
 <a name="deleting-payment-methods"></a>
 ### Deleting Payment Methods
 

--- a/billing.md
+++ b/billing.md
@@ -30,7 +30,6 @@
     - [With Payment Method Up Front](#with-payment-method-up-front)
     - [Without Payment Method Up Front](#without-payment-method-up-front)
 - [Handling Stripe Webhooks](#handling-stripe-webhooks)
-    - [Testing Webhooks Locally](#testing-webhooks-locally)
     - [Defining Webhook Event Handlers](#defining-webhook-event-handlers)
     - [Failed Subscriptions](#handling-failed-subscriptions)
     - [Verifying Webhook Signatures](#verifying-webhook-signatures)
@@ -606,6 +605,8 @@ Once you are ready to create an actual subscription for the user, you may use th
 <a name="handling-stripe-webhooks"></a>
 ## Handling Stripe Webhooks
 
+> {note} You can use [Laravel Valet](https://laravel.com/docs/5.8/valet)'s [`valet share`](https://laravel.com/docs/5.8/valet#sharing-sites) command to help test webhooks while developing locally.
+
 Stripe can notify your application of a variety of events via webhooks. By default, a route that points to Cashier's webhook controller is configured through the Cashier service provider. This controller will handle all incoming webhook requests.
 
 By default, this controller will automatically handle cancelling subscriptions that have too many failed charges (as defined by your Stripe settings), customer updates, customer deletions, subscription updates, and payment method changes; however, as we'll soon discover, you can extend this controller to handle any webhook event you like.
@@ -619,13 +620,6 @@ To ensure your application can handle Stripe webhooks, be sure to configure the 
 - `invoice.payment_action_required`
 
 > {note} Make sure you protect incoming requests with Cashier's included [webhook signature verification](/docs/{{version}}/billing#verifying-webhook-signatures) middleware.
-
-<a name="testing-webhooks-locally"></a>
-#### Testing Webhooks Locally
-
-You can use a service such as [UltraHook](http://www.ultrahook.com/) to forward webhooks to your local development environment. You can also use [ngrok](https://ngrok.com/) to expose your site to the wider web using a private URL for testing.
-
-> {note} if you're using [Laravel Valet](https://laravel.com/docs/5.8/valet), you can use `ngrok` by simply using the [`valet share`](https://laravel.com/docs/5.8/valet#sharing-sites) command from the root of your laravel project.
 
 #### Webhooks & CSRF Protection
 

--- a/billing.md
+++ b/billing.md
@@ -795,7 +795,7 @@ Incomplete payment exceptions may be thrown for the following methods: `charge`,
 
 #### Incomplete and Past Due State
 
-When a payment needs additional confirmation, the subscription will remain in an `incomplete` or `past_due` state as indicated by its `status` database column. Cashier will make automatically activate the customer's subscription via a webhook as soon as payment confirmation is complete.
+When a payment needs additional confirmation, the subscription will remain in an `incomplete` or `past_due` state as indicated by its `stripe_status` database column. Cashier will make automatically activate the customer's subscription via a webhook as soon as payment confirmation is complete.
 
 For more information on `incomplete` and `past_due` states, please refer to [our additional documentation](#incomplete-and-past-due-status).
 

--- a/billing.md
+++ b/billing.md
@@ -41,7 +41,7 @@
     - [Generating Invoice PDFs](#generating-invoice-pdfs)
 - [Strong Customer Authentication (SCA)](#strong-customer-authentication)
     - [Payments Requiring Additional Confirmation](#payments-requiring-additional-confirmation)
-    - [Off-session Payment Notification](#off-session-payment-notification)
+    - [Off-session Payment Notifications](#off-session-payment-notifications)
 
 <a name="introduction"></a>
 ## Introduction
@@ -708,7 +708,7 @@ When a payment needs additional confirmation, the subscription will remain in an
 
 For more information on `incomplete` and `past_due` states, please refer to [our additional documentation](#incomplete-and-past-due-status).
 
-<a name="off-session-payment-notification"></a>
+<a name="off-session-payment-notifications"></a>
 ### Off-Session Payment Notifications
 
 Since SCA regulations require customers to occasionally verify their payment details even while their subscription is active, Cashier can send a payment notification to the customer when off-session payment confirmation is required. For example, this may occur when a subscription is renewing. Cashier's payment notification can be enabled by setting the `CASHIER_PAYMENT_NOTIFICATION` environment variable to a notification class. By default, this notification is disabled. Of course, Cashier includes a notification class you may use for this purpose, but you are free to provide your own notification class if desired:

--- a/billing.md
+++ b/billing.md
@@ -95,7 +95,7 @@ Before using Cashier, we'll need to add the `Billable` trait to your model defin
 
 Cashier assumes your Billable model will be the default `App\User` class that ships with Laravel. If you wish to change this you can update this in your `.env` file:
 
-    CASHIER_MODEL="App\User"
+    CASHIER_MODEL=App\User
 
 <a name="api-keys"></a>
 ### API Keys

--- a/billing.md
+++ b/billing.md
@@ -53,7 +53,7 @@ Laravel Cashier provides an expressive, fluent interface to [Stripe's](https://s
 <a name="upgrading-cashier"></a>
 ## Upgrading Cashier
 
-When upgrading to a new major version of Cashier, it's important that you carefully review [the upgrade guide](https://github.com/laravel/cashier/blob/master/UPGRADE.md).
+When upgrading to a new version of Cashier, it's important that you carefully review [the upgrade guide](https://github.com/laravel/cashier/blob/master/UPGRADE.md).
 
 <a name="installation"></a>
 ## Installation
@@ -70,7 +70,7 @@ If you need to overwrite the migrations that ship with the Cashier package, you 
 
     php artisan vendor:publish --tag="cashier-migrations"
 
-After this you should add the following setting to the `boot` method of your `AppServiceProvider` in order to prevent the shipped migrations from running:
+After publishing you should add the following setting to the `boot` method of your `AppServiceProvider` in order to prevent the shipped migrations from running:
 
     use Laravel\Cashier\Cashier;
 
@@ -565,8 +565,6 @@ Next, define a route to your Cashier controller within your `routes/web.php` fil
 
 What if a customer's credit card expires? No worries - Cashier's Webhook controller will cancel the customer's subscription for you. Failed payments will be captured and handled by the controller. The controller will cancel the customer's subscription when Stripe determines the subscription has failed (normally after three failed payment attempts).
 
-// Todo: payment action required
-
 <a name="verifying-webhook-signatures"></a>
 ### Verifying Webhook Signatures
 
@@ -709,6 +707,6 @@ Since SCA regulations require customers to occasionally verify their payment det
 
     CASHIER_PAYMENT_NOTIFICATION=Laravel\Cashier\Notifications\ConfirmPayment
 
-This also gives you an easy way to swap out the notification class with a custom one if you want to configure more notification channels.
+This also gives you an easy way to swap out the notification class with a custom one if you want to configure more notification channels. [Make sure webhooks are set up](#handling-stripe-webhooks) for this and the `invoice.payment_action_required` webhook is configured in the Stripe dashboard.
 
 > {note} One limitation of this is that notifications will be sent out even when customers are on-session during a payment that requires an extra action. This is because there's no way to know for Stripe that the payment was done on- or off-session. But a customer will never be charged twice and will simply see a "Payment Successful" message if they visit the payment page again.

--- a/billing.md
+++ b/billing.md
@@ -11,7 +11,7 @@
 - [Customers](#customers)
     - [Creating Customers](#creating-customers)
 - [Payment Methods](#payment-methods)
-    - [Saving Payment Methods](#saving-payment-methods)
+    - [Storing Payment Methods](#storing-payment-methods)
     - [Retrieving Payment Methods](#retrieving-payment-methods)
     - [Check For A Payment Method](#check-for-a-payment-method)
     - [Updating The Default Payment Method](#updating-the-default-payment-method)
@@ -137,7 +137,7 @@ Once the customer has been created in Stripe, you may begin a subscription at a 
 <a name="payment-methods"></a>
 ## Payment Methods
 
-<a name="saving-payment-methods"></a>
+<a name="storing-payment-methods"></a>
 ### Storing Payment Methods
 
 In order to create subscriptions or perform "one off" charges with Stripe, you will need to store a payment method and retrieve its identifier from Stripe. The approach used to accomplish differs based on whether you plan to use the payment method for subscriptions or single charges, so we will examine both below.

--- a/billing.md
+++ b/billing.md
@@ -144,7 +144,7 @@ In order to create subscriptions or perform "one off" charges with Stripe, you w
 
 #### Payment Methods For Subscriptions
 
-When storing credit cards to a customer for future use, the Stripe Setup Intents API to must be used to securely gather the customer's payment method details. A "Setup Intent" indicates to Stripe the intention to charge a customer's payment method. Cashier's `Billable` trait includes the `createSetupIntent` to easily create a new Setup Intent. You should call this method from the route or controller that will render the form which gathers your customer's payment method details:
+When storing credit cards to a customer for future use, the Stripe Setup Intents API must be used to securely gather the customer's payment method details. A "Setup Intent" indicates to Stripe the intention to charge a customer's payment method. Cashier's `Billable` trait includes the `createSetupIntent` to easily create a new Setup Intent. You should call this method from the route or controller that will render the form which gathers your customer's payment method details:
 
     return view('update-payment-method', [
         'intent' => $user->createSetupIntent()

--- a/billing.md
+++ b/billing.md
@@ -154,7 +154,7 @@ After you've created the Setup Intent you'll need to pass its secret to the elem
     <!-- placeholder for Elements -->
     <div id="card-element"></div>
     <button id="card-button" data-secret="<?= $intent->client_secret ?>">
-      Save Card
+        Save Card
     </button>
 
 After that we'll need to set up the JS to retrieve the payment method id. First, make sure you put the official Stripe.js in the `head` of your site:
@@ -205,7 +205,7 @@ We'll first need to set up some HTML to perform the payment:
     <!-- placeholder for Elements -->
     <div id="card-element"></div>
     <button id="card-button">
-      Save Card
+        Make Payment
     </button>
 
 After that we'll need to set up the JS to retrieve the payment method id. First, make sure you put the official Stripe.js in the `head` of your site:
@@ -235,11 +235,11 @@ After that we'll need to use the [`stripe.createPaymentMethod`](https://stripe.c
         if (error) {
             // Display error.message in your UI.
         } else {
-            // The setup has succeeded. Display a success message.
+            // The setup has succeeded. Submit payment form or make an Ajax call here.
         }
     });
 
-Now that you have the `paymentMethod.id` you can pass it to the backend in whatever way you wish, being it an Ajax call, hidden field, whatever. Now you're ready to [create single charges](#simple-charge).
+Now that you have the `paymentMethod.id` you can pass it to the backend being it an Ajax call, hidden field, or whatever you wish. Now you're ready to [create single charges](#simple-charge).
 
 <a name="retrieving-payment-methods"></a>
 ### Retrieving Payment Methods

--- a/billing.md
+++ b/billing.md
@@ -806,6 +806,6 @@ Since SCA regulations require customers to occasionally verify their payment det
 
     CASHIER_PAYMENT_NOTIFICATION=Laravel\Cashier\Notifications\ConfirmPayment
 
-To ensure that off-session payment confirmation notifications are delivered, verify that [Stripe webhooks are configured](#handling-stripe-webhooks) for your application and the `invoice.payment_action_required` webhooks is enabled in your Stripe dashboard.
+To ensure that off-session payment confirmation notifications are delivered, verify that [Stripe webhooks are configured](#handling-stripe-webhooks) for your application and the `invoice.payment_action_required` webhook is enabled in your Stripe dashboard.
 
 > {note} Notifications will be sent even when customers are manually making a payment that requires additional confirmation. Unfortunately, there is no way for Stripe to know that the payment was done manually or "off-session". But, a customer will simply see a "Payment Successful" message if they visit the payment page after already confirming their payment. The customer will not be allowed to accidentally confirm the same payment twice and incur an accidental second charge.

--- a/billing.md
+++ b/billing.md
@@ -277,11 +277,11 @@ To sync your default payment method information with the customer's default paym
 <a name="adding-payment-methods"></a>
 ### Adding Payment Methods
 
-To add a new payment method, you can call the `addPaymentMethod` method on the billable user:
+To add a new payment method, you may call the `addPaymentMethod` method on the billable user, passing the payment method token / identifier:
 
     $user->addPaymentMethod($paymentMethod);
 
-You can retrieve the `$paymentMethod` token by following [this guide](#storing-payment-methods).
+> {tip} To learn how to retrieve payment method tokens please review the [payment method storage documentation](#storing-payment-methods).
 
 <a name="deleting-payment-methods"></a>
 ### Deleting Payment Methods

--- a/billing.md
+++ b/billing.md
@@ -318,7 +318,7 @@ The first argument passed to the `newSubscription` method should be the name of 
 
 The `create` method, which accepts [a Stripe payment method identifier](#storing-payment-methods) or Stripe `PaymentMethod` object, will begin the subscription as well as update your database with the customer ID and other relevant billing information.
 
-> {note} Passing a Payment Method string directly to the `create()` subscription method will also automatically save it to the user.
+> {note} Passing a payment method identifier directly to the `create()` subscription method will also automatically add it to the user's stored payment methods.
 
 #### Additional User Details
 

--- a/billing.md
+++ b/billing.md
@@ -70,7 +70,7 @@ If you need to overwrite the migrations that ship with the Cashier package, you 
 
     php artisan vendor:publish --tag="cashier-migrations"
 
-After publishing you should add the following setting to the `boot` method of your `AppServiceProvider` in order to prevent the shipped migrations from running:
+After publishing you should add the following setting to the `register` method of your `AppServiceProvider` in order to prevent the shipped migrations from running:
 
     use Laravel\Cashier\Cashier;
 

--- a/billing.md
+++ b/billing.md
@@ -30,6 +30,7 @@
     - [With Payment Method Up Front](#with-payment-method-up-front)
     - [Without Payment Method Up Front](#without-payment-method-up-front)
 - [Handling Stripe Webhooks](#handling-stripe-webhooks)
+    - [Testing Webhooks Locally](#testing-webhooks-locally)
     - [Defining Webhook Event Handlers](#defining-webhook-event-handlers)
     - [Failed Subscriptions](#handling-failed-subscriptions)
     - [Verifying Webhook Signatures](#verifying-webhook-signatures)
@@ -618,6 +619,13 @@ To ensure your application can handle Stripe webhooks, be sure to configure the 
 - `invoice.payment_action_required`
 
 > {note} Make sure you protect incoming requests with Cashier's included [webhook signature verification](/docs/{{version}}/billing#verifying-webhook-signatures) middleware.
+
+<a name="testing-webhooks-locally"></a>
+#### Testing Webhooks Locally
+
+You can use a service such as [UltraHook](http://www.ultrahook.com/) to forward webhooks to your local development environment. You can also use [ngrok](https://ngrok.com/) to expose your site to the wider web using a private URL for testing.
+
+> {note} if you're using [Laravel Valet](https://laravel.com/docs/5.8/valet), you can use `ngrok` by simply using the [`valet share`](https://laravel.com/docs/5.8/valet#sharing-sites) command from the root of your laravel project.
 
 #### Webhooks & CSRF Protection
 

--- a/billing.md
+++ b/billing.md
@@ -163,7 +163,7 @@ A detailed example can be examined [in the Stripe docs](https://stripe.com/docs/
 <a name="retrieving-payment-methods"></a>
 ### Retrieving Payment Methods
 
-The `paymentMethods` method on the billable model instance returns a collection of `Laravel\Cashier\PaymentMethod` instances:
+The `paymentMethods` method on the Billable model instance returns a collection of `Laravel\Cashier\PaymentMethod` instances:
 
     $paymentMethods = $user->paymentMethods();
 
@@ -172,9 +172,9 @@ To retrieve the default payment method, the `defaultPaymentMethod` method may be
     $paymentMethod = $user->defaultPaymentMethod();
 
 <a name="check-for-a-payment-method"></a>
-### Check For A Payment Method
+### Determining If A User Has A Payment Method
 
-You may check if a customer has a payment method attached to their account using the `hasPaymentMethod` method:
+To determine if a Billable model has a payment method attached to their account, use the `hasPaymentMethod` method:
 
     if ($user->hasPaymentMethod()) {
         //
@@ -191,7 +191,7 @@ To sync your default payment method information with the customer's default paym
 
     $user->updateDefaultPaymentMethodFromStripe();
 
-> {note} The default payment method on a customer can only be used for invoicing and creating new subscriptions. Because of a limitation by Stripe, it cannot be used for single charges.
+> {note} The default payment method on a customer can only be used for invoicing and creating new subscriptions. Due to limitations from Stripe, it may not be used for single charges.
 
 <a name="adding-payment-methods"></a>
 ### Adding Payment Methods
@@ -203,15 +203,15 @@ To add a new payment method, you can call the `addPaymentMethod` method on the b
 <a name="deleting-payment-methods"></a>
 ### Deleting Payment Methods
 
-To delete a payment method, you can call the `delete` method on the paymentMethod instance you wish to delete:
+To delete a payment method, you may call the `delete` method on the `Laravel\Cashier\PaymentMethod` instance you wish to delete:
 
     $paymentMethod->delete();
 
-The `deletePaymentMethods` method will delete all of the payment method information stored by your application:
+The `deletePaymentMethods` method will delete all of the payment method information for the Billable model:
 
     $user->deletePaymentMethods();
 
-> {note} If the user has an active subscription, you should consider preventing them from deleting the default payment method.
+> {note} If a user has an active subscription, you should prevent them from deleting their default payment method.
 
 <a name="subscriptions"></a>
 ## Subscriptions

--- a/billing.md
+++ b/billing.md
@@ -176,7 +176,7 @@ Next, the Stripe.js library may be used to attach a Stripe Element to the form a
 
 Next, the card can be verified and a secure "payment method identifier" can be retrieved from Stripe using [Stripe's `handleCardSetup` method](https://stripe.com/docs/stripe-js/reference#stripe-handle-card-setup):
 
-    const cardHolderName = document.getElementById('cardholder-name');
+    const cardHolderName = document.getElementById('card-holder-name');
     const cardButton = document.getElementById('card-button');
     const clientSecret = cardButton.dataset.secret;
 
@@ -196,7 +196,7 @@ Next, the card can be verified and a secure "payment method identifier" can be r
         }
     });
 
-After the card has been verified by Stripe, you may pass the resulting `setupIntent.paymentMethod` identifier to your Laravel application, where it can be attached to the customer. The payment method can either be [added as a new payment method](#adding-payment-methods) or [used to update the default payment method](#updating-the-default-payment-method). You can also immediately use the payment method identifier to [create a new subscription](#creating-subscriptions).
+After the card has been verified by Stripe, you may pass the resulting `setupIntent.payment_method` identifier to your Laravel application, where it can be attached to the customer. The payment method can either be [added as a new payment method](#adding-payment-methods) or [used to update the default payment method](#updating-the-default-payment-method). You can also immediately use the payment method identifier to [create a new subscription](#creating-subscriptions).
 
 > {tip} If you would like more information about Setup Intents and gathering customer payment details please [review this overview provided by Stripe](https://stripe.com/docs/payments/cards/saving-cards#saving-card-without-payment).
 

--- a/billing.md
+++ b/billing.md
@@ -227,7 +227,7 @@ To create a subscription, first retrieve an instance of your billable model, whi
 
 The first argument passed to the `newSubscription` method should be the name of the subscription. If your application only offers a single subscription, you might call this `main` or `primary`. The second argument is the specific plan the user is subscribing to. This value should correspond to the plan's identifier in Stripe.
 
-The `create` method, which accepts [a Stripe payment method identifier](#saving-payment-methods) or Stripe `PaymentMethod` object, will begin the subscription as well as update your database with the customer ID and other relevant billing information.
+The `create` method, which accepts [a Stripe payment method identifier](#storing-payment-methods) or Stripe `PaymentMethod` object, will begin the subscription as well as update your database with the customer ID and other relevant billing information.
 
 #### Additional User Details
 
@@ -588,7 +588,7 @@ To enable webhook verification, ensure that the `STRIPE_WEBHOOK_SECRET` environm
 
 > {note} The `charge` method accepts the amount you would like to charge in the **lowest denominator of the currency used by your application**.
 
-If you would like to make a "one off" charge against a subscribed customer's payment method, you may use the `charge` method on a billable model instance. You'll need to [provide a payment method identifier](#saving-payment-methods) as the second argument:
+If you would like to make a "one off" charge against a subscribed customer's payment method, you may use the `charge` method on a billable model instance. You'll need to [provide a payment method identifier](#storing-payment-methods) as the second argument:
 
     // Stripe Accepts Charges In Cents...
     $stripeCharge = $user->charge(100, $paymentMethod);

--- a/billing.md
+++ b/billing.md
@@ -13,7 +13,7 @@
 - [Payment Methods](#payment-methods)
     - [Storing Payment Methods](#storing-payment-methods)
     - [Retrieving Payment Methods](#retrieving-payment-methods)
-    - [Check For A Payment Method](#check-for-a-payment-method)
+    - [Determining If A User Has A Payment Method](#check-for-a-payment-method)
     - [Updating The Default Payment Method](#updating-the-default-payment-method)
     - [Adding Payment Methods](#adding-payment-methods)
     - [Deleting Payment Methods](#deleting-payment-methods)
@@ -40,7 +40,7 @@
 - [Invoices](#invoices)
     - [Generating Invoice PDFs](#generating-invoice-pdfs)
 - [Strong Customer Authentication (SCA)](#strong-customer-authentication)
-    - [Handling Extra Payment Actions](#handling-extra-payment-actions)
+    - [Payments Requiring Additional Confirmation](#payments-requiring-additional-confirmation)
     - [Off-session Payment Notification](#off-session-payment-notification)
 
 <a name="introduction"></a>
@@ -677,7 +677,7 @@ If your business is based in Europe you will need to abide by the Strong Custome
 
 > {note} Before getting started, review [Stripe's guide on PSD2 and SCA](https://stripe.com/en-be/guides/strong-customer-authentication) as well as their [documentation on the new SCA API's](https://stripe.com/docs/strong-customer-authentication).
 
-<a name="handling-extra-payment-actions"></a>
+<a name="payments-requiring-additional-confirmation"></a>
 ### Payments Requiring Additional Confirmation
 
 SCA regulations often require extra verification in order to confirm and process a payment. When this happens, Cashier will throw an `IncompletePayment` exception that informs you that this extra verification is needed. After catching this exception, you have two options on how to proceed.

--- a/billing.md
+++ b/billing.md
@@ -605,7 +605,7 @@ Once you are ready to create an actual subscription for the user, you may use th
 <a name="handling-stripe-webhooks"></a>
 ## Handling Stripe Webhooks
 
-> {note} You can use [Laravel Valet](https://laravel.com/docs/5.8/valet)'s [`valet share`](https://laravel.com/docs/5.8/valet#sharing-sites) command to help test webhooks while developing locally.
+> {tip} You may use [Laravel Valet's](/docs/{{version}}/valet) `valet share` command to help test webhooks during local development.
 
 Stripe can notify your application of a variety of events via webhooks. By default, a route that points to Cashier's webhook controller is configured through the Cashier service provider. This controller will handle all incoming webhook requests.
 

--- a/queues.md
+++ b/queues.md
@@ -495,11 +495,9 @@ Laravel includes a queue worker that will process new jobs as they are pushed on
 
 Remember, queue workers are long-lived processes and store the booted application state in memory. As a result, they will not notice changes in your code base after they have been started. So, during your deployment process, be sure to [restart your queue workers](#queue-workers-and-deployment).
 
-Alternatively, you may run the following command:
+Alternatively, you may run the `queue:listen` command. When using the `queue:listen` command, you don't have to manually restart the worker after your code is changed; however, this command is not as efficient as `queue:work`:
 
     php artisan queue:listen
-
-With the `queue:listen` command, you don't have to manually restart the worker after your code is changed. However, more server resources will be consumed.
 
 #### Specifying The Connection & Queue
 

--- a/queues.md
+++ b/queues.md
@@ -495,6 +495,12 @@ Laravel includes a queue worker that will process new jobs as they are pushed on
 
 Remember, queue workers are long-lived processes and store the booted application state in memory. As a result, they will not notice changes in your code base after they have been started. So, during your deployment process, be sure to [restart your queue workers](#queue-workers-and-deployment).
 
+Alternatively, you may run the following command:
+
+    php artisan queue:listen
+
+With the `queue:listen` command, you don't have to manually restart the worker after your code is changed. However, more server resources will be consumed.
+
 #### Specifying The Connection & Queue
 
 You may also specify which queue connection the worker should utilize. The connection name passed to the `work` command should correspond to one of the connections defined in your `config/queue.php` configuration file:


### PR DESCRIPTION
This updates Cashier's docs for the upcoming v10 release.

I've moved the customer and payment method docs before the subscription docs because they're now a little more important to be know up-front.

WIP until finished and the new release has been tagged.