### PR TITLE
[5.8] document aliases to update the default CLI version of PHP

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -583,6 +583,14 @@ In addition, you may use any of the supported PHP versions via the CLI:
     php7.2 artisan list
     php7.3 artisan list
 
+You may also update the default CLI version:
+
+    php56
+    php70
+    php71
+    php72
+    php73
+
 <a name="web-servers"></a>
 ### Web Servers
 

--- a/homestead.md
+++ b/homestead.md
@@ -583,7 +583,7 @@ In addition, you may use any of the supported PHP versions via the CLI:
     php7.2 artisan list
     php7.3 artisan list
 
-You may also update the default CLI version:
+You may also update the default CLI version by issuing the following commands from within your Homestead virtual machine:
 
     php56
     php70


### PR DESCRIPTION
By default, the CLI version of PHP is 7.3 (currently).

Some users may only or mostly use a lower version of PHP, so rather than writing `php7.1 artisan` all the time, they can run `php71` and then only type `php artisan` to use version 7.1