### PR TITLE
[5.8] Update validation docs to reduce confusion on weakly checked integer validation

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -830,7 +830,7 @@ The field under validation must exist in _anotherfield_'s values.
 <a name="rule-integer"></a>
 #### integer
 
-The field under validation must be an integer.
+The field under validation must be like an integer, but will not check the type.
 
 <a name="rule-ip"></a>
 #### ip


### PR DESCRIPTION
specify that integer validation does not behave as expected and will not check type