### PR TITLE
Add tip to customise mail notification theme

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -410,6 +410,8 @@ After exporting the components, the `resources/views/vendor/mail/html/themes` di
 
 > {tip} If you would like to build an entirely new theme for the Markdown components, write a new CSS file within the `html/themes` directory and change the `theme` option of your `mail` configuration file.
 
+> {tip} If you have multiple themes you can choose which one to use for each Mail Notification by using the `theme()` method on the `MailMessage` object.
+
 <a name="database-notifications"></a>
 ## Database Notifications
 


### PR DESCRIPTION
This PR is to update the docs following the release of the feature to be able to choose which theme to use for a single Mail Notification (commit #29132 on laravel/framework)