### PR TITLE
Update horizon.md for the right installation

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -25,7 +25,7 @@ All of your worker configuration is stored in a single, simple configuration fil
 <a name="installation"></a>
 ## Installation
 
-> {note} You should ensure that your queue driver is set to `redis` in your `queue` configuration file.
+> {note} You should ensure that your queue connection is set to `redis` in your `queue` configuration file.
 
 You may use Composer to install Horizon into your Laravel project:
 


### PR DESCRIPTION
In Laravel 5.8 queue driver became queue connection, however the docs still mention to change queue driver and not connection.