### PR TITLE
[5.8] Document new feature to set theme for mail notifications

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -408,7 +408,17 @@ This command will publish the Markdown mail components to the `resources/views/v
 
 After exporting the components, the `resources/views/vendor/mail/html/themes` directory will contain a `default.css` file. You may customize the CSS in this file and your styles will automatically be in-lined within the HTML representations of your Markdown notifications.
 
-> {tip} If you would like to build an entirely new theme for the Markdown components, write a new CSS file within the `html/themes` directory and change the `theme` option of your `mail` configuration file.
+If you would instead like to build an entirely new theme for the Markdown components, just write a new CSS file within the `html/themes` directory and change the `theme` option in your `mail` configuration file.
+
+You can also have multiple themes and apply them individually to a Mail Notification. To do that write new themes within the `html/themes` directory and use the `theme()` method on the `MailMessage` object.
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+                    ->theme('invoices')
+                    ->subject('Invoice Paid')
+                    ->markdown('mail.invoice.paid', ['url' => $url]);
+    }
 
 <a name="database-notifications"></a>
 ## Database Notifications


### PR DESCRIPTION
This PR is to update the docs following the release of the feature to be able to choose which theme to use for a single Mail Notification (commit #29132 on laravel/framework)