### PR TITLE
[5.8] Fix eager loading type hints

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1158,17 +1158,13 @@ If you would like to remove an item from the `$with` property for a single query
 
 Sometimes you may wish to eager load a relationship, but also specify additional query conditions for the eager loading query. Here's an example:
 
-    use Illuminate\Database\Eloquent\Builder;
-
-    $users = App\User::with(['posts' => function (Builder $query) {
+    $users = App\User::with(['posts' => function ($query) {
         $query->where('title', 'like', '%first%');
     }])->get();
 
 In this example, Eloquent will only eager load posts where the post's `title` column contains the word `first`. You may call other [query builder](/docs/{{version}}/queries) methods to further customize the eager loading operation:
 
-    use Illuminate\Database\Eloquent\Builder;
-
-    $users = App\User::with(['posts' => function (Builder $query) {
+    $users = App\User::with(['posts' => function ($query) {
         $query->orderBy('created_at', 'desc');
     }])->get();
 
@@ -1187,9 +1183,7 @@ Sometimes you may need to eager load a relationship after the parent model has a
 
 If you need to set additional query constraints on the eager loading query, you may pass an array keyed by the relationships you wish to load. The array values should be `Closure` instances which receive the query instance:
 
-    use Illuminate\Database\Eloquent\Builder;
-
-    $books->load(['author' => function (Builder $query) {
+    $books->load(['author' => function ($query) {
         $query->orderBy('published_date', 'asc');
     }]);
 


### PR DESCRIPTION
#5294 added incorrect type hints for eager loading queries. Unlike with `whereHas()` or `withCount()`, `with()` and `load()` closures receive relationship instances (e.g. `HasMany`).

I think it's better not the type hint these examples. Especially for a new user, it would confusing if the code from the documentation doesn't work because they are using a different relationship type. 

I would keep the type hint for the [`MorphTo` example](https://github.com/laravel/docs/pull/5294/files#diff-8ee0e91f55a653895f3d8dc328c2cfc4R1103).

Reported in https://github.com/laravel/framework/issues/29352.