### PR TITLE
Add "visibility to permissions" mapping

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -50,6 +50,23 @@ When using the `local` driver, all file operations are relative to the `root` di
 
     Storage::disk('local')->put('file.txt', 'Contents');
 
+The `public` [visibility](#file-visibility) translates to `0755` for directories and `0644` for files. You can override the mappings in the configuration file:
+
+    'someLocalDisk' => [
+        'driver'   => 'local',
+        'root'     => '/your/store',
+        'permissions' => [
+            'file' => [
+                'public'  => 0664,
+                'private' => 0600,
+            ],
+            'dir'  => [
+                'public'  => 0775,
+                'private' => 0700,
+            ],
+        ],
+    ],
+
 <a name="driver-prerequisites"></a>
 ### Driver Prerequisites
 


### PR DESCRIPTION
It was hard for me to find out how to specify permissions for nodes created via local driver. I propose adding this to docs as the expected syntax is far from obvious.