### PR TITLE
Removed a line about no current paradigm shifting release under development.

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -11,7 +11,7 @@ Laravel's versioning scheme maintains the following convention: `paradigm.major.
 
 When referencing the Laravel framework or its components from your application or package, you should always use a version constraint such as `5.8.*`, since major releases of Laravel do include breaking changes. However, we strive to always ensure you may update to a new major release in one day or less.
 
-Paradigm shifting releases are separated by many years and represent fundamental shifts in the framework's architecture and conventions. Currently, there is no paradigm shifting release under development.
+Paradigm shifting releases are separated by many years and represent fundamental shifts in the framework's architecture and conventions.
 
 <a name="support-policy"></a>
 ## Support Policy


### PR DESCRIPTION
In **Release Notes** section of the docs under "_Versioning Scheme_", the last line of the last paragraph says:
> Currently, there is no paradigm shifting release under development.

But we know that Laravel 6 is being released! so this is kind of wrong.