### PR TITLE
[5.8] Update composer vendor/bin location for Linux

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -45,8 +45,7 @@ First, download the Laravel installer using Composer:
 Make sure to place composer's system-wide vendor bin directory in your `$PATH` so the laravel executable can be located by your system. This directory exists in different locations based on your operating system; however, some common locations include:
 
 <div class="content-list" markdown="1">
-- macOS: `$HOME/.composer/vendor/bin`
-- GNU / Linux Distributions: `$HOME/.config/composer/vendor/bin`
+- macOS and GNU / Linux Distributions: `$HOME/.composer/vendor/bin`
 - Windows: `%USERPROFILE%\AppData\Roaming\Composer\vendor\bin`
 </div>
 


### PR DESCRIPTION
This is on my Ubuntu 19.04:

```
~  ls ~/.composer 
cache  composer.json  composer.lock  keys.dev.pub  keys.tags.pub  vendor
~  ls ~/.config/composer 
keys.dev.pub  keys.tags.pub
```