### PR TITLE
[5.8] Include parent model in withDefault method example

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1344,7 +1344,7 @@ To populate the default model with attributes, you may pass an array or Closure 
      */
     public function user()
     {
-        return $this->belongsTo('App\User')->withDefault(function ($user) {
+        return $this->belongsTo('App\User')->withDefault(function ($user, $post) {
             $user->name = 'Guest Author';
         });
     }


### PR DESCRIPTION
I needed the data from the parent model when creating a default model, but `$this` gives the wrong context inside the closure.

After some time I realized the callback provides the parent model as the second argument.

Perhaps documentation of the second argument is useful for other developers.

This PR should be seen as an proposal and not the actual feature documentation, as I'm not sure how the documentation should be structured.