### PR TITLE
[5.8] Horizon auth example - clarify that Gate can accept optional user

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -94,7 +94,8 @@ Horizon exposes a dashboard at `/horizon`. By default, you will only be able to 
             ]);
         });
     }
-Note: Remember that Laravel injects the *authenticated* user to the Gate automatically. If your app is providing Horizon security via another method (perhaps IP restrictions) then your Horizon users might not require login, and therefore you will need to change `function ($user)` above to `function ($user = null)` to not force Laravel authentication.
+
+> {note} Remember that Laravel injects the *authenticated* user to the Gate automatically. If your app is providing Horizon security via another method (perhaps IP restrictions) then your Horizon users might not require login, and therefore you will need to change `function ($user)` above to `function ($user = null)` to not force Laravel authentication.
 
 <a name="running-horizon"></a>
 ## Running Horizon

--- a/horizon.md
+++ b/horizon.md
@@ -94,6 +94,7 @@ Horizon exposes a dashboard at `/horizon`. By default, you will only be able to 
             ]);
         });
     }
+Note: Remember that Laravel injects the *authenticated* user to the Gate automatically. If your app is providing Horizon security via another method (perhaps IP restrictions) then your Horizon users might not require login, and therefore you will need to change `function ($user)` above to `function ($user = null)` to not force Laravel authentication.
 
 <a name="running-horizon"></a>
 ## Running Horizon


### PR DESCRIPTION
Docs [PR requested](https://github.com/laravel/horizon/issues/563#issuecomment-501694826) by @driesvints 

Explanation provided by @mfn:
> I had the same problem (Laravel 5.8, Horizon 3.2.2)
> 
> My issue was this default code in the published `HorizonServiceProvider`:
> 
> ```
>         Gate::define('viewHorizon', function ($user) {
>             return true;
>         });
> ```
> 
> In my case I've no auth middleware because it's done on the webserver already via IP-addresses matching VPN, etc.
> 
> So, no authenticated user present.
> 
> However: when defining the closure like this `function ($user) {… }` and there is _no_ authenticated user, this gate is entirely skipped because of this code https://github.com/laravel/framework/blob/9b7520a2ac0009d4c1ff2322e3ef673ef702e7e2/src/Illuminate/Auth/Access/Gate.php#L527-L528
> 
> The `canBeCalledWithUser` performs PHP reflection on the closure and if there's no auth user but `$user` is present, it will not execute the gate.
> 
> The solution: change the closure to have user optional: `function ($user = null) { … }`

