### PR TITLE
[5.8] Remove duplicate vagrant destroy instructions

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -719,7 +719,11 @@ When using Homestead in a team setting, you may want to tweak Homestead to bette
 <a name="updating-homestead"></a>
 ## Updating Homestead
 
-Before you begin updating Homestead ensure you run `vagrant destroy` to remove your current virtual machine. Then, you should update the Vagrant box using the `vagrant box update` command:
+Before you begin updating Homestead ensure you have removed your current virtual machine by running the following command in your Homestead directory:
+
+    vagrant destroy
+
+Then, you should update the Vagrant box using the `vagrant box update` command:
 
     vagrant box update
 
@@ -735,9 +739,7 @@ If you have installed Homestead via your project's `composer.json` file, you sho
 
     composer update
 
-Finally, you will need to destroy and regenerate your Homestead box to utilize the latest Vagrant installation. To accomplish this, run the following commands in your Homestead directory:
-
-    vagrant destroy
+Finally, you will need to regenerate your Homestead box to utilize the latest Vagrant installation:
 
     vagrant up
 


### PR DESCRIPTION
At the beginning of the current upgrade instructions we ask the user to ensure they have removed their current virtual machine with an inline mention of `vagrant destroy`, but without mentioning it should be run in the Homestead directory.

As the final instruction we ask them again to destroy their vagrant box, this time mentioning that the command should be run the Homestead directory, and with the `vagrant destroy` command included in a code block. If they've already destroyed it as instructed at the beginning, this second attempt will result in an error.

This change simplifies the instructions by:
1. Instructing the user to be in the Homestead directory from the beginning.
2. Placeing the first `vagrant destroy` instruction in a code block for consistency with the remaining commands.
3. Removing the second unnecessary instruction to call `vagrant destroy`.