### PR TITLE
Fix passport Client::skipsAuthorization() method example

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -380,7 +380,7 @@ Sometimes you may wish to skip the authorization prompt, such as when authorizin
          */
         public function skipsAuthorization()
         {
-            return $this->first_party;
+            return $this->firstParty();
         }
     }
 


### PR DESCRIPTION
Laravel\Passport\Client doesn't have a first_party attribute but a firstParty() method