### PR TITLE
Rename 'default permissions' to 'permissions'

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -50,9 +50,9 @@ When using the `local` driver, all file operations are relative to the `root` di
 
     Storage::disk('local')->put('file.txt', 'Contents');
 
-#### Default Permissions
+#### Permissions
 
-The `public` [visibility](#file-visibility) translates to `0755` for directories and `0644` for files. You can modify the default permissions mappings in your `filesystems` configuration file:
+The `public` [visibility](#file-visibility) translates to `0755` for directories and `0644` for files. You can modify the permissions mappings in your `filesystems` configuration file:
 
     'local' => [
         'driver' => 'local',


### PR DESCRIPTION
Sorry that I am bringing this up but I think the wording is a bit misleading. "Default Permissions" seem to imply that these values can be overriden on case-by-case basis, but AFAIK as soon as a Storage disk is created, the permissions are locked.

I'm not a native speaker so I might be wrong on all of this...