### PR TITLE
[5.8] Add note about cleaning up pathnames

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -335,6 +335,8 @@ You may also use the `putFileAs` method on the `Storage` facade, which will perf
         'avatars', $request->file('avatar'), $request->user()->id
     );
 
+> {note} When specifying a file name or path, make sure to always normalize it before passing it through. Internally the `League\Flysystem\Util::normalizePath` method will be called to clean the path before storing so it could be that the file ends up in a different path than you specified.
+
 #### Specifying A Disk
 
 By default, this method will use your default disk. If you would like to specify another disk, pass the disk name as the second argument to the `store` method:

--- a/filesystem.md
+++ b/filesystem.md
@@ -335,7 +335,7 @@ You may also use the `putFileAs` method on the `Storage` facade, which will perf
         'avatars', $request->file('avatar'), $request->user()->id
     );
 
-> {note} When specifying a file name or path, make sure to always normalize it before passing it through. Internally the `League\Flysystem\Util::normalizePath` method will be called to clean the path before storing so it could be that the file ends up in a different path than you specified.
+> {note} Unprintable and invalid unicode characters will automatically be removed from file paths. Therefore, you may wish to sanitize your file paths before passing them to Laravel's file storage methods. File paths are normalized using the `League\Flysystem\Util::normalizePath` method.
 
 #### Specifying A Disk
 


### PR DESCRIPTION
When passing pathnames with invalid characters they'll be stripped by the `Util::normalizePath` method and the file might end up on a different pathname. This won't be returned because the `put` method of the Flysystem Filesystem class only returns booleans. 

See https://github.com/laravel/framework/issues/29538