### PR TITLE
remove dead link to webhooks

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -7,7 +7,6 @@
     - [Billable Model](#billable-model)
     - [API Keys](#api-keys)
     - [Currency Configuration](#currency-configuration)
-    - [Webhooks](#webhooks)
 - [Customers](#customers)
     - [Creating Customers](#creating-customers)
 - [Payment Methods](#payment-methods)


### PR DESCRIPTION
Webhooks are no longer under config there is a dedicated section for them: https://laravel.com/docs/5.8/billing#handling-stripe-webhooks