### PR TITLE
Adjust the Passport example to not require scrolling

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -394,7 +394,10 @@ If the user approves the authorization request, they will be redirected back to 
     Route::get('/callback', function (Request $request) {
         $state = $request->session()->pull('state');
 
-        throw_unless(strlen($state) > 0 && $state === $request->state, InvalidArgumentException::class);
+        throw_unless(
+            strlen($state) > 0 && $state === $request->state,
+            InvalidArgumentException::class
+        );
 
         $http = new GuzzleHttp\Client;
 


### PR DESCRIPTION
The line length of the code sample added in #5363 is a little too long and gets cut off in the docs.

![Screenshot from 2019-08-14 11-18-17](https://user-images.githubusercontent.com/9440455/63033244-4ccde300-be85-11e9-9a24-153945730c6c.png)
