### PR TITLE
[5.8] Updating source mapping documentation

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -189,7 +189,7 @@ With this addition to your `webpack.mix.js` file, Mix will no longer match any `
 Though disabled by default, source maps may be activated by calling the `mix.sourceMaps()` method in your `webpack.mix.js` file. Though it comes with a compile/performance cost, this will provide extra debugging information to your browser's developer tools when using compiled assets.
 
     mix.js('resources/js/app.js', 'public/js')
-       .sourceMaps();
+       .sourceMaps(true, 'source-map');
 
 <a name="working-with-scripts"></a>
 ## Working With JavaScript

--- a/mix.md
+++ b/mix.md
@@ -189,7 +189,13 @@ With this addition to your `webpack.mix.js` file, Mix will no longer match any `
 Though disabled by default, source maps may be activated by calling the `mix.sourceMaps()` method in your `webpack.mix.js` file. Though it comes with a compile/performance cost, this will provide extra debugging information to your browser's developer tools when using compiled assets.
 
     mix.js('resources/js/app.js', 'public/js')
-       .sourceMaps(true, 'source-map');
+       .sourceMaps();
+
+Webpack offers a variety of [source mapping styles](https://webpack.js.org/configuration/devtool/#devtool). By default, the source mapping style is set to `eval-source-map`, which provides a fast rebuild time. If you want to change the style, you may do so as follows:
+
+    let productionToo = true;
+    mix.js('resources/js/app.js', 'public/js')
+       .sourceMaps(productionToo, 'source-map');
 
 <a name="working-with-scripts"></a>
 ## Working With JavaScript

--- a/mix.md
+++ b/mix.md
@@ -193,7 +193,7 @@ Though disabled by default, source maps may be activated by calling the `mix.sou
 
 Webpack offers a variety of [source mapping styles](https://webpack.js.org/configuration/devtool/#devtool). By default, the source mapping style is set to `eval-source-map`, which provides a fast rebuild time. If you want to change the style, you may do so as follows:
 
-    let productionToo = true;
+    let productionToo = false;
     mix.js('resources/js/app.js', 'public/js')
        .sourceMaps(productionToo, 'source-map');
 


### PR DESCRIPTION
Although this might not be effecting everyone, some environments simply don't offer support to `eval-source-map`. As stated here: https://github.com/JeffreyWay/laravel-mix/issues/1793

I believe that many people would benefit from knowing that there are more styles out there and that they can easily indicate the one they want.