### PR TITLE
[5.8] Specify job chaining order

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -268,7 +268,7 @@ If you would like to dispatch a job immediately (synchronously), you may use the
 <a name="job-chaining"></a>
 ### Job Chaining
 
-Job chaining allows you to specify a list of queued jobs that should be run in sequence. If one job in the sequence fails, the rest of the jobs will not be run. To execute a queued job chain, you may use the `withChain` method on any of your dispatchable jobs:
+Job chaining allows you to specify a list of queued jobs that should be run in sequence after the job has been successful. If one job in the sequence fails, the rest of the jobs will not be run. To execute a queued job chain, you may use the `withChain` method on any of your dispatchable jobs:
 
     ProcessPodcast::withChain([
         new OptimizePodcast,

--- a/queues.md
+++ b/queues.md
@@ -268,7 +268,7 @@ If you would like to dispatch a job immediately (synchronously), you may use the
 <a name="job-chaining"></a>
 ### Job Chaining
 
-Job chaining allows you to specify a list of queued jobs that should be run in sequence after the job has been successful. If one job in the sequence fails, the rest of the jobs will not be run. To execute a queued job chain, you may use the `withChain` method on any of your dispatchable jobs:
+Job chaining allows you to specify a list of queued jobs that should be run in sequence after the primary job has executed successfully. If one job in the sequence fails, the rest of the jobs will not be run. To execute a queued job chain, you may use the `withChain` method on any of your dispatchable jobs:
 
     ProcessPodcast::withChain([
         new OptimizePodcast,


### PR DESCRIPTION
When I was reading the docs it wasn't clear to me in which order the chain of jobs would be run and if the this would run before or after the primary job. Hopefully, this little tweak will help others understand it better.