### PR TITLE
[Mail] text isn't necessary for markdown emails

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -183,6 +183,8 @@ If you would like to define a plain-text version of your email, you may use the 
                     ->text('emails.orders.shipped_plain');
     }
 
+This is __not necessary__ with markdown emails, as markdown will render plain-text emails for you.
+
 <a name="view-data"></a>
 ### View Data
 


### PR DESCRIPTION
It seems that markdown actually generates the text emails for you, I spent a good bit of time trying to figure out why something like the following wasn't working: https://gist.github.com/zack6849/7dcd8183b71868cf55d0c2b417399a63

Turns out passing a text view will just pass it through markdown again and give you html even for the plaintext view, oops.