### PR TITLE
Update Homestead included software

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -80,7 +80,6 @@ Homestead runs on any Windows, Mac, or Linux system, and includes Nginx, PHP, My
 - Xdebug
 - XHProf / Tideways / XHGui
 - wp-cli
-- Minio
 </div>
 
 <a name="optional-software"></a>


### PR DESCRIPTION
MinIO is not included in the base box of Homestead, it's an optional feature.