### PR TITLE
Homestead: Remove incorrect instructions for xDebug

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -609,12 +609,7 @@ Homestead includes the Postfix mail transfer agent, which is listening on port `
 
 Homestead includes support for step debugging using [Xdebug](https://xdebug.org). For example, you can load a web page from a browser, and PHP will connect to your IDE to allow inspection and modification of the running code.
 
-To enable debugging, run the following commands inside your Vagrant box:
-
-    sudo phpenmod xdebug
-
-    # Update this command to match your PHP version...
-    sudo systemctl restart php7.3-fpm
+By default Xdebug is already running and ready to accept connections. If you need to enable Xdebug on the CLI simply run `sudo phpenmod xdebug`.
 
 Next, follow your IDE's instructions to enable debugging. Finally, configure your browser to trigger Xdebug with an extension or [bookmarklet](https://www.jetbrains.com/phpstorm/marklets/).
 

--- a/homestead.md
+++ b/homestead.md
@@ -607,11 +607,9 @@ Homestead includes the Postfix mail transfer agent, which is listening on port `
 <a name="debugging-web-requests"></a>
 ### Debugging Web Requests With Xdebug
 
-Homestead includes support for step debugging using [Xdebug](https://xdebug.org). For example, you can load a web page from a browser, and PHP will connect to your IDE to allow inspection and modification of the running code.
+Homestead includes support for step debugging using [Xdebug](https://xdebug.org). For example, you can load a web page from a browser, and PHP will connect to your IDE to allow inspection and modification of the running code. 
 
-By default Xdebug is already running and ready to accept connections. If you need to enable Xdebug on the CLI simply run `sudo phpenmod xdebug`.
-
-Next, follow your IDE's instructions to enable debugging. Finally, configure your browser to trigger Xdebug with an extension or [bookmarklet](https://www.jetbrains.com/phpstorm/marklets/).
+By default Xdebug is already running and ready to accept connections. If you need to enable Xdebug on the CLI run the `sudo phpenmod xdebug` command within your Vagrant box. Next, follow your IDE's instructions to enable debugging. Finally, configure your browser to trigger Xdebug with an extension or [bookmarklet](https://www.jetbrains.com/phpstorm/marklets/).
 
 > {note} Xdebug causes PHP to run significantly slower. To disable Xdebug, run `sudo phpdismod xdebug` within your Vagrant box and restart the FPM service.
 


### PR DESCRIPTION
Xdebug ships enabled on FPM SAPIs and disabled on CLI.