### PR TITLE
[5.8] Mentioning mass assignment protection is disabled when using a factory

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -173,6 +173,8 @@ If you would like to override some of the default values of your models, you may
         'name' => 'Abigail',
     ]);
 
+> {tip} [Mass assignment protection](/docs/{{version}}/eloquent#mass-assignment) is automatically disabled when using a factory.
+
 <a name="persisting-models"></a>
 ### Persisting Models
 


### PR DESCRIPTION
I think it's worth mentioning as in [seeding](https://github.com/laravel/docs/blob/5.8/seeding.md#L23).
I had a problem with this and had to read the source code to find out what was causing it.