### PR TITLE
Add note for HTTP test route calls

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -40,6 +40,7 @@ Laravel provides a very fluent API for making HTTP requests to your application 
 
 The `get` method makes a `GET` request into the application, while the `assertStatus` method asserts that the returned response should have the given HTTP status code. In addition to this simple assertion, Laravel also contains a variety of assertions for inspecting the response headers, content, JSON structure, and more.
 
+**Note:** You can only call a route once per test.
 <a name="customizing-request-headers"></a>
 ### Customizing Request Headers
 


### PR DESCRIPTION
Quote: "This is expected behavior. You can only call a route once per test."

Source: https://github.com/laravel/framework/issues/29673#issuecomment-523352043