### PR TITLE
[6.0] Setting phpredis as default client

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -64,7 +64,7 @@ You may also set the `host` option to a UNIX socket path. If you do this, the `p
 
 #### Redis
 
-Before using a Redis cache with Laravel, you will need to either install the `predis/predis` package (~1.0) via Composer or install the PhpRedis PHP extension via PECL.
+Before using a Redis cache with Laravel, you will need to either install the PhpRedis PHP extension via PECL or install the `predis/predis` package (~1.0) via Composer .
 
 For more information on configuring Redis, consult its [Laravel documentation page](/docs/{{version}}/redis#configuration).
 

--- a/redis.md
+++ b/redis.md
@@ -13,11 +13,13 @@
 
 [Redis](https://redis.io) is an open source, advanced key-value store. It is often referred to as a data structure server since keys can contain [strings](https://redis.io/topics/data-types#strings), [hashes](https://redis.io/topics/data-types#hashes), [lists](https://redis.io/topics/data-types#lists), [sets](https://redis.io/topics/data-types#sets), and [sorted sets](https://redis.io/topics/data-types#sorted-sets).
 
-Before using Redis with Laravel, you will need to install the `predis/predis` package via Composer:
+Before using Redis with Laravel, we encorage you to install and use the [PhpRedis](https://github.com/phpredis/phpredis) PHP extension via PECL. The extension is more complex to install but may yield better performance for applications that make heavy use of Redis.
+
+*Deprecated note: Maintenance of Predis has been abandoned by the original package and will be removed from Laravel in 7.0.*
+Alternatively, you can install the `predis/predis` package via Composer:
 
     composer require predis/predis
 
-Alternatively, you may install the [PhpRedis](https://github.com/phpredis/phpredis) PHP extension via PECL. The extension is more complex to install but may yield better performance for applications that make heavy use of Redis.
 
 <a name="configuration"></a>
 ### Configuration
@@ -26,7 +28,7 @@ The Redis configuration for your application is located in the `config/database.
 
     'redis' => [
 
-        'client' => 'predis',
+        'client' => env('REDIS_CLIENT', 'phpredis'),
 
         'default' => [
             'host' => env('REDIS_HOST', '127.0.0.1'),
@@ -52,7 +54,7 @@ If your application is utilizing a cluster of Redis servers, you should define t
 
     'redis' => [
 
-        'client' => 'predis',
+        'client' => env('REDIS_CLIENT', 'phpredis'),
 
         'clusters' => [
             'default' => [
@@ -71,10 +73,10 @@ By default, clusters will perform client-side sharding across your nodes, allowi
 
     'redis' => [
 
-        'client' => 'predis',
+        'client' => env('REDIS_CLIENT', 'phpredis'),
 
         'options' => [
-            'cluster' => 'redis',
+            'cluster' => env('REDIS_CLUSTER', 'redis'),
         ],
 
         'clusters' => [
@@ -86,6 +88,7 @@ By default, clusters will perform client-side sharding across your nodes, allowi
 <a name="predis"></a>
 ### Predis
 
+*Deprecated note: Maintenance of Predis has been abandoned by the original package and will be removed from Laravel in 7.0*
 In addition to the default `host`, `port`, `database`, and `password` server configuration options, Predis supports additional [connection parameters](https://github.com/nrk/predis/wiki/Connection-Parameters) that may be defined for each of your Redis servers. To utilize these additional configuration options, add them to your Redis server configuration in the `config/database.php` configuration file:
 
     'default' => [
@@ -96,14 +99,16 @@ In addition to the default `host`, `port`, `database`, and `password` server con
         'read_write_timeout' => 60,
     ],
 
+To utilize the Predis extension, you should change the `REDIS_CLIENT` env from `phpredis` to `predis`.
+
 <a name="phpredis"></a>
 ### PhpRedis
 
-To utilize the PhpRedis extension, you should change the `client` option of your Redis configuration to `phpredis`. This option is found in your `config/database.php` configuration file:
+The PhpRedis extension is configured as default at `REDIS_CLIENT` env and in your `config/database.php`:
 
     'redis' => [
 
-        'client' => 'phpredis',
+        'client' => env('REDIS_CLIENT', 'phpredis'),
 
         // Rest of Redis configuration...
     ],


### PR DESCRIPTION
In order to follow https://github.com/laravel/framework/pull/29688 and https://github.com/laravel/laravel/pull/5085 I changed the default configs about redis and predis to encorage the usage of `phpredis` instead of `predis`.

I created a *deprecation note* at `redis.md` but I don't know in sure how this handled. If this is not at right way please let me know so I can fix the issues.