### PR TITLE
[5.8] Add seeding test data for test cases

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -3,6 +3,7 @@
 - [Introduction](#introduction)
 - [Generating Factories](#generating-factories)
 - [Resetting The Database After Each Test](#resetting-the-database-after-each-test)
+- [Seeding test data](#seeding-test-data)
 - [Writing Factories](#writing-factories)
     - [Factory States](#factory-states)
     - [Factory Callbacks](#factory-callbacks)
@@ -68,6 +69,37 @@ It is often useful to reset your database after each test so that data from a pr
         public function testBasicExample()
         {
             $response = $this->get('/');
+
+            // ...
+        }
+    }
+
+<a name="seeding-test-data"></a>
+## Seeding test data
+
+You may call the `seed` method to seed your database with test data for your test cases.
+
+    <?php
+
+    namespace Tests\Feature;
+
+    use Tests\TestCase;
+    use Illuminate\Foundation\Testing\RefreshDatabase;
+    use Illuminate\Foundation\Testing\WithoutMiddleware;
+    use OrderStatusesTableSeeder;
+
+    class ExampleTest extends TestCase
+    {
+        use RefreshDatabase;
+
+        /**
+         * Test creating a new order.
+         *
+         * @return void
+         */
+        public function testCreatingANewOrder()
+        {
+            $this->seed(OrderStatusesTableSeeder::class);
 
             // ...
         }


### PR DESCRIPTION
I found this super helpful in heaps of scenarios when I have to seed the status/type tables prior to running a test case. Some examples include order_statuses, item_statuses, product_types, book_genres... So maybe we should mention this in the docs.