### PR TITLE
Update repo link

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -34,7 +34,7 @@ The Laravel source code is managed on GitHub, and there are repositories for eac
 - [Laravel Scout](https://github.com/laravel/scout)
 - [Laravel Socialite](https://github.com/laravel/socialite)
 - [Laravel Telescope](https://github.com/laravel/telescope)
-- [Laravel Website](https://github.com/laravel/laravel.com)
+- [Laravel Website](https://github.com/laravel/laravel.com-next)
 </div>
 
 <a name="core-development-discussion"></a>


### PR DESCRIPTION
The new repo link is 
https://github.com/laravel/laravel.com-next