### PR TITLE
[5.8] Add note about collation in Cashier

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -79,6 +79,8 @@ If you would like to prevent Cashier's migrations from running entirely, you may
 
     Cashier::ignoreMigrations();
 
+> {note} It's noted by Stripe that any column used for storing Stripe identifiers should be case-sensitive so make sure your column collation for the `stripe_id` column is set to, for example, `utf8_bin` in MySQL. More info can be found [here](https://stripe.com/docs/upgrades#what-changes-does-stripe-consider-to-be-backwards-compatible).
+
 <a name="configuration"></a>
 ## Configuration
 


### PR DESCRIPTION
Instead of setting this through the migration it's best that we add a note in the docs. This because collation can't be set universal for every DB type.

See https://github.com/laravel/cashier/issues/747