### PR TITLE
[6.0] Documenting new error bag @error directive parameter

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -496,6 +496,18 @@ The `@error` directive may be used to quickly check if [validation error message
         <div class="alert alert-danger">{{ $message }}</div>
     @enderror
 
+You may also optionally pass [the name of a specific error bag](/docs/{{version}}/validation#named-error-bags) as the second parameter of the `@error` directive to retrieve validation error messages on pages containing multiple forms:
+
+    <!-- /resources/views/auth.blade.php -->
+    
+    <label for="email">Email address</label>
+
+    <input id="email" type="email" class="@error('email', 'login') is-invalid @enderror">
+
+    @error('email', 'login')
+        <div class="alert alert-danger">{{ $message }}</div>
+    @enderror
+
 <a name="including-sub-views"></a>
 ## Including Sub-Views
 


### PR DESCRIPTION
Documentation for the changes made in laravel/framework#29750

Adding example of usage and a quick description of the new parameter, referencing the validation page's named error bags section.

I didn't feel it was necessary to clutter the example with actual multiple forms/inputs, so I left it to just one.