### PR TITLE
[5.8] Fix example. Remove last ',' in temporaryUrl

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -214,7 +214,7 @@ If you need to specify additional [S3 request parameters](https://docs.aws.amazo
     $url = Storage::temporaryUrl(
         'file.jpg',
         now()->addMinutes(5),
-        ['ResponseContentType' => 'application/octet-stream'],
+        ['ResponseContentType' => 'application/octet-stream']
     );
 
 #### Local URL Host Customization


### PR DESCRIPTION
The second example of the temporaryUrl is not working because there is an extra ',' at the end of the last argument.