### PR TITLE
[5.8] Document the valet trust command

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -301,4 +301,5 @@ Command  | Description
 `valet restart` | Restart the Valet daemon.
 `valet start` | Start the Valet daemon.
 `valet stop` | Stop the Valet daemon.
+`valet trust` | Add sudoers files for Brew and Valet to make Valet commands run without passwords.
 `valet uninstall` | Uninstall the Valet daemon.


### PR DESCRIPTION
This command allows to add sudoers files for Brew and Valet to make valet commands run without passwords