### PR TITLE
Fix example

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -578,7 +578,7 @@ When authorizing actions using policies, you may pass an array as the second arg
     public function update(User $user, Post $post, int $category)
     {
         return $user->id === $post->user_id && 
-               $category->group > 3;
+               $category > 3;
     }
 
 When attempting to determine if the authenticated user can update a given post, we can invoke this policy method like so:


### PR DESCRIPTION
(an integer is passed and expected, so can't treat it as an object)