### PR TITLE
Formatting

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -50,7 +50,7 @@ Gates are Closures that determine if a user is authorized to perform a given act
         });
 
         Gate::define('update-post', function ($user, $post) {
-            return $user->id == $post->user_id;
+            return $user->id === $post->user_id;
         });
     }
 

--- a/collections.md
+++ b/collections.md
@@ -453,7 +453,7 @@ The `diffAssoc` method compares the collection against another collection or a p
         'color' => 'yellow',
         'type' => 'fruit',
         'remain' => 3,
-        'used' => 6
+        'used' => 6,
     ]);
 
     $diff->all();

--- a/contracts.md
+++ b/contracts.md
@@ -68,7 +68,7 @@ First, let's review some code that is tightly coupled to a cache implementation.
          */
         public function find($id)
         {
-            if ($this->cache->has($id))    {
+            if ($this->cache->has($id)) {
                 //
             }
         }

--- a/contributions.md
+++ b/contributions.md
@@ -82,7 +82,7 @@ Below is an example of a valid Laravel documentation block. Note that the `@para
      * @param  \Closure|string|null  $concrete
      * @param  bool  $shared
      * @return void
-     *     
+     *
      * @throws \Exception
      */
     public function bind($abstract, $concrete = null, $shared = false)

--- a/database-testing.md
+++ b/database-testing.md
@@ -23,7 +23,7 @@ Laravel provides a variety of helpful tools to make it easier to test your datab
         // Make call to application...
 
         $this->assertDatabaseHas('users', [
-            'email' => 'sally@example.com'
+            'email' => 'sally@example.com',
         ]);
     }
 
@@ -225,7 +225,7 @@ You may also attach relationships to models using Closure attributes in your fac
             'content' => $faker->paragraph,
             'user_id' => function () {
                 return factory(App\User::class)->create()->id;
-            }
+            },
         ];
     });
 
@@ -240,7 +240,7 @@ These Closures also receive the evaluated attribute array of the factory that de
             },
             'user_type' => function (array $post) {
                 return App\User::find($post['user_id'])->type;
-            }
+            },
         ];
     });
 

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -842,7 +842,7 @@ As demonstrated in the example above, you are free to add additional constraints
             ->orWhere('votes', '>=', 100)
             ->get();
 
-    // select * from posts 
+    // select * from posts
     // where user_id = ? and active = 1 or votes >= 100
 
 In most situations, you likely intend to use [constraint groups](/docs/{{version}}/queries#parameter-grouping) to logically group the conditional checks between parentheses:
@@ -856,7 +856,7 @@ In most situations, you likely intend to use [constraint groups](/docs/{{version
             })
             ->get();
 
-    // select * from posts 
+    // select * from posts
     // where user_id = ? and (active = 1 or votes >= 100)
 
 <a name="relationship-methods-vs-dynamic-properties"></a>
@@ -936,8 +936,8 @@ To query the existence of `MorphTo` relationships, you may use the `whereHasMorp
 
     // Retrieve comments associated to posts or videos with a title like foo%...
     $comments = App\Comment::whereHasMorph(
-        'commentable', 
-        ['App\Post', 'App\Video'], 
+        'commentable',
+        ['App\Post', 'App\Video'],
         function (Builder $query) {
             $query->where('title', 'like', 'foo%');
         }
@@ -945,29 +945,29 @@ To query the existence of `MorphTo` relationships, you may use the `whereHasMorp
 
     // Retrieve comments associated to posts with a title not like foo%...
     $comments = App\Comment::whereDoesntHaveMorph(
-        'commentable', 
-        'App\Post', 
+        'commentable',
+        'App\Post',
         function (Builder $query) {
             $query->where('title', 'like', 'foo%');
         }
-    )->get();    
-    
+    )->get();
+
 You may use the `$type` parameter to add different constraints depending on the related model:
 
     use Illuminate\Database\Eloquent\Builder;
 
     $comments = App\Comment::whereHasMorph(
-        'commentable', 
-        ['App\Post', 'App\Video'], 
+        'commentable',
+        ['App\Post', 'App\Video'],
         function (Builder $query, $type) {
             $query->where('title', 'like', 'foo%');
-    
+
             if ($type === 'App\Post') {
                 $query->orWhere('content', 'like', 'foo%');
             }
         }
     )->get();
-    
+
 Instead of passing an array of possible polymorphic models, you may provide `*` as a wildcard and let Laravel retrieve all the possible polymorphic types from the database. Laravel will execute an additional query in order to perform this operation:
 
     use Illuminate\Database\Eloquent\Builder;
@@ -1006,7 +1006,7 @@ You may also alias the relationship count result, allowing multiple counts on th
         'comments',
         'comments as pending_comments_count' => function (Builder $query) {
             $query->where('approved', false);
-        }
+        },
     ])->get();
 
     echo $posts[0]->comments_count;
@@ -1148,7 +1148,7 @@ Sometimes you might want to always load some relationships when retrieving a mod
             return $this->belongsTo('App\Author');
         }
     }
-   
+
 If you would like to remove an item from the `$with` property for a single query, you may use the `without` method:
 
     $books = App\Book::without('author')->get();
@@ -1195,7 +1195,7 @@ To load a relationship only when it has not already been loaded, use the `loadMi
 
         return [
             'name' => $book->name,
-            'author' => $book->author->name
+            'author' => $book->author->name,
         ];
     }
 
@@ -1380,7 +1380,7 @@ For convenience, `attach` and `detach` also accept arrays of IDs as input:
 
     $user->roles()->attach([
         1 => ['expires' => $expires],
-        2 => ['expires' => $expires]
+        2 => ['expires' => $expires],
     ]);
 
 #### Syncing Associations

--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -135,7 +135,7 @@ Occasionally, when casting models to an array or JSON, you may wish to add attri
          */
         public function getIsAdminAttribute()
         {
-            return $this->attributes['admin'] == 'yes';
+            return $this->attributes['admin'] === 'yes';
         }
     }
 

--- a/encryption.md
+++ b/encryption.md
@@ -43,7 +43,7 @@ You may encrypt a value using the `encrypt` helper. All encrypted values are enc
             $user = User::findOrFail($id);
 
             $user->fill([
-                'secret' => encrypt($request->secret)
+                'secret' => encrypt($request->secret),
             ])->save();
         }
     }

--- a/homestead.md
+++ b/homestead.md
@@ -608,7 +608,7 @@ Homestead includes the Postfix mail transfer agent, which is listening on port `
 <a name="debugging-web-requests"></a>
 ### Debugging Web Requests With Xdebug
 
-Homestead includes support for step debugging using [Xdebug](https://xdebug.org). For example, you can load a web page from a browser, and PHP will connect to your IDE to allow inspection and modification of the running code. 
+Homestead includes support for step debugging using [Xdebug](https://xdebug.org). For example, you can load a web page from a browser, and PHP will connect to your IDE to allow inspection and modification of the running code.
 
 By default Xdebug is already running and ready to accept connections. If you need to enable Xdebug on the CLI run the `sudo phpenmod xdebug` command within your Vagrant box. Next, follow your IDE's instructions to enable debugging. Finally, configure your browser to trigger Xdebug with an extension or [bookmarklet](https://www.jetbrains.com/phpstorm/marklets/).
 

--- a/queues.md
+++ b/queues.md
@@ -350,7 +350,7 @@ You may chain the `onConnection` and `onQueue` methods to specify the connection
     ProcessPodcast::dispatch($podcast)
                   ->onConnection('sqs')
                   ->onQueue('processing');
-                  
+
 Alternatively, you may specify the `connection` as a property on the job class:
 
     <?php


### PR DESCRIPTION
- Add missing trailing commas to arrays
- Use `===` where appropriate
- Trim trailing whitespace