### PR TITLE
Update validation.md

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -693,7 +693,7 @@ The field under validation must be equal to the given date. The dates will be pa
 <a name="rule-date-format"></a>
 #### date_format:_format_
 
-The field under validation must match the given _format_. You should use **either** `date` or `date_format` when validating a field, not both.
+The field under validation must match the given _format_. You should use **either** `date` or `date_format` when validating a field, not both. The formats allowed are the ones for [DateTime](https://www.php.net/manual/es/class.datetime.php) class.
 
 <a name="rule-different"></a>
 #### different:_field_

--- a/validation.md
+++ b/validation.md
@@ -693,7 +693,7 @@ The field under validation must be equal to the given date. The dates will be pa
 <a name="rule-date-format"></a>
 #### date_format:_format_
 
-The field under validation must match the given _format_. You should use **either** `date` or `date_format` when validating a field, not both. The formats allowed are the ones for [DateTime](https://www.php.net/manual/es/class.datetime.php) class.
+The field under validation must match the given _format_. You should use **either** `date` or `date_format` when validating a field, not both. This validation rule supports all formats supported by PHP's [DateTime](https://www.php.net/manual/es/class.datetime.php) class.
 
 <a name="rule-different"></a>
 #### different:_field_


### PR DESCRIPTION
There are some formats failing (for example 'c') that **date** uses and DateTime does not, so **date_format** will fail.
It is necessary to add a clarification to the developer that only DateTime class' formats are allowed.