### PR TITLE
Remove extra text

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -63,8 +63,6 @@ If you plan to only use Telescope to assist your local development, you may inst
 
 After running `telescope:install`, you should remove the `TelescopeServiceProvider` service provider registration from your `app` configuration file. Instead, manually register the service provider in the `register` method of your `AppServiceProvider`:
 
-    use App\Providers\TelescopeServiceProvider;
-
     /**
      * Register any application services.
      *


### PR DESCRIPTION
Have not needed to include the TelescopeServiceProvider because AppServiceProvider is in the `App\Providers`