### PR TITLE
Align object operators

### DIFF
--- a/api-authentication.md
+++ b/api-authentication.md
@@ -24,10 +24,11 @@ By default, Laravel ships with a simple solution to API authentication via a ran
 Before using the `token` driver, you will need to [create a migration](/docs/{{version}}/migrations) which adds an `api_token` column to your `users` table:
 
     Schema::table('users', function ($table) {
-        $table->string('api_token', 80)->after('password')
-                            ->unique()
-                            ->nullable()
-                            ->default(null);
+        $table->string('api_token', 80)
+              ->after('password')
+              ->unique()
+              ->nullable()
+              ->default(null);
     });
 
 Once the migration has been created, run the `migrate` Artisan command.

--- a/billing.md
+++ b/billing.md
@@ -504,8 +504,8 @@ By default, the billing cycle anchor is the date the subscription was created, o
     $anchor = Carbon::parse('first day of next month');
 
     $user->newSubscription('main', 'premium')
-                ->anchorBillingCycleOn($anchor->startOfDay())
-                ->create($paymentMethod);
+         ->anchorBillingCycleOn($anchor->startOfDay())
+         ->create($paymentMethod);
 
 For more information on managing subscription billing cycles, consult the [Stripe billing cycle documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle)
 
@@ -548,8 +548,8 @@ If you would like to offer trial periods to your customers while still collectin
     $user = User::find(1);
 
     $user->newSubscription('main', 'monthly')
-                ->trialDays(10)
-                ->create($paymentMethod);
+         ->trialDays(10)
+         ->create($paymentMethod);
 
 This method will set the trial period ending date on the subscription record within the database, as well as instruct Stripe to not begin billing the customer until after this date. When using the `trialDays` method, Cashier will overwrite any default trial period configured for the plan in Stripe.
 
@@ -560,8 +560,8 @@ The `trialUntil` method allows you to provide a `DateTime` instance to specify w
     use Carbon\Carbon;
 
     $user->newSubscription('main', 'monthly')
-                ->trialUntil(Carbon::now()->addDays(10))
-                ->create($paymentMethod);
+         ->trialUntil(Carbon::now()->addDays(10))
+         ->create($paymentMethod);
 
 You may determine if the user is within their trial period using either the `onTrial` method of the user instance, or the `onTrial` method of the subscription instance. The two examples below are identical:
 
@@ -782,7 +782,7 @@ First, you could redirect your customer to the dedicated payment confirmation pa
 
     try {
         $subscription = $user->newSubscription('default', $planId)
-                                ->create($paymentMethod);
+                             ->create($paymentMethod);
     } catch (IncompletePayment $exception) {
         return redirect()->route(
             'cashier.payment',

--- a/container.md
+++ b/container.md
@@ -107,8 +107,8 @@ You may also bind an existing object instance into the container using the `inst
 Sometimes you may have a class that receives some injected classes, but also needs an injected primitive value such as an integer. You may easily use contextual binding to inject any value your class may need:
 
     $this->app->when('App\Http\Controllers\UserController')
-              ->needs('$variableName')
-              ->give($value);
+         ->needs('$variableName')
+         ->give($value);
 
 <a name="binding-interfaces-to-implementations"></a>
 ### Binding Interfaces To Implementations

--- a/database-testing.md
+++ b/database-testing.md
@@ -204,11 +204,11 @@ You may override attributes on the model by passing an array to the `create` met
 In this example, we'll attach a relation to some created models. When using the `create` method to create multiple models, an Eloquent [collection instance](/docs/{{version}}/eloquent-collections) is returned, allowing you to use any of the convenient functions provided by the collection, such as `each`:
 
     $users = factory(App\User::class, 3)
-               ->create()
-               ->each(function ($user) {
-                    $user->posts()->save(factory(App\Post::class)->make());
-                });
-                
+        ->create()
+        ->each(function ($user) {
+            $user->posts()->save(factory(App\Post::class)->make());
+        });
+
 You may use the `createMany` method to create multiple related models:
 
     $user->posts()->createMany(

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -314,8 +314,8 @@ As noted earlier, attributes from the intermediate table may be accessed on mode
 For example, if your application contains users that may subscribe to podcasts, you probably have a many-to-many relationship between users and podcasts. If this is the case, you may wish to rename your intermediate table accessor to `subscription` instead of `pivot`. This can be done using the `as` method when defining the relationship:
 
     return $this->belongsToMany('App\Podcast')
-                    ->as('subscription')
-                    ->withTimestamps();
+                ->as('subscription')
+                ->withTimestamps();
 
 Once this is done, you may access the intermediate table data using the customized name:
 
@@ -384,11 +384,11 @@ You can combine `using` and `withPivot` in order to retrieve columns from the in
         public function users()
         {
             return $this->belongsToMany('App\User')
-                            ->using('App\RoleUser')
-                            ->withPivot([
-                                'created_by',
-                                'updated_by'
-                            ]);
+                        ->using('App\RoleUser')
+                        ->withPivot([
+                          'created_by',
+                          'updated_by',
+                      ]);
         }
     }
 
@@ -838,9 +838,9 @@ You are able to use any of the [query builder](/docs/{{version}}/queries) method
 As demonstrated in the example above, you are free to add additional constraints to relationships when querying them. However, use caution when chaining `orWhere` clauses onto a relationship, as the `orWhere` clauses will be logically grouped at the same level as the relationship constraint:
 
     $user->posts()
-            ->where('active', 1)
-            ->orWhere('votes', '>=', 100)
-            ->get();
+         ->where('active', 1)
+         ->orWhere('votes', '>=', 100)
+         ->get();
 
     // select * from posts 
     // where user_id = ? and active = 1 or votes >= 100
@@ -850,11 +850,11 @@ In most situations, you likely intend to use [constraint groups](/docs/{{version
     use Illuminate\Database\Eloquent\Builder;
 
     $user->posts()
-            ->where(function (Builder $query) {
-                return $query->where('active', 1)
-                             ->orWhere('votes', '>=', 100);
-            })
-            ->get();
+         ->where(function (Builder $query) {
+             return $query->where('active', 1)
+                          ->orWhere('votes', '>=', 100);
+         })
+         ->get();
 
     // select * from posts 
     // where user_id = ? and (active = 1 or votes >= 100)

--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -644,9 +644,9 @@ Sometimes you may wish to only include certain meta data with a resource respons
 You may also add top-level data when constructing resource instances in your route or controller. The `additional` method, which is available on all resources, accepts an array of data that should be added to the resource response:
 
     return (new UserCollection(User::all()->load('roles')))
-                    ->additional(['meta' => [
-                        'key' => 'value',
-                    ]]);
+        ->additional(['meta' => [
+            'key' => 'value',
+        ]]);
 
 <a name="resource-responses"></a>
 ## Resource Responses
@@ -667,8 +667,8 @@ However, sometimes you may need to customize the outgoing HTTP response before i
 
     Route::get('/user', function () {
         return (new UserResource(User::find(1)))
-                    ->response()
-                    ->header('X-Value', 'True');
+            ->response()
+            ->header('X-Value', 'True');
     });
 
 Alternatively, you may define a `withResponse` method within the resource itself. This method will be called when the resource is returned as the outer-most resource in a response:

--- a/eloquent.md
+++ b/eloquent.md
@@ -240,9 +240,9 @@ Once you have created a model and [its associated database table](/docs/{{versio
 The Eloquent `all` method will return all of the results in the model's table. Since each Eloquent model serves as a [query builder](/docs/{{version}}/queries), you may also add constraints to queries, and then use the `get` method to retrieve the results:
 
     $flights = App\Flight::where('active', 1)
-                   ->orderBy('name', 'desc')
-                   ->take(10)
-                   ->get();
+                         ->orderBy('name', 'desc')
+                         ->take(10)
+                         ->get();
 
 > {tip} Since Eloquent models are query builders, you should review all of the methods available on the [query builder](/docs/{{version}}/queries). You may use any of these methods in your Eloquent queries.
 
@@ -335,10 +335,10 @@ In addition, the query builder's `orderBy` function supports subqueries. We may 
 
     return Destination::orderByDesc(
         Flight::select('arrived_at')
-            ->whereColumn('destination_id', 'destinations.id')
-            ->orderBy('arrived_at', 'desc')
-            ->latest()
-            ->limit(1)
+              ->whereColumn('destination_id', 'destinations.id')
+              ->orderBy('arrived_at', 'desc')
+              ->latest()
+              ->limit(1)
     )->get();
 
 <a name="retrieving-single-models"></a>
@@ -610,8 +610,8 @@ To determine if a given model instance has been soft deleted, use the `trashed` 
 As noted above, soft deleted models will automatically be excluded from query results. However, you may force soft deleted models to appear in a result set using the `withTrashed` method on the query:
 
     $flights = App\Flight::withTrashed()
-                    ->where('account_id', 1)
-                    ->get();
+                         ->where('account_id', 1)
+                         ->get();
 
 The `withTrashed` method may also be used on a [relationship](/docs/{{version}}/eloquent-relationships) query:
 
@@ -622,8 +622,8 @@ The `withTrashed` method may also be used on a [relationship](/docs/{{version}}/
 The `onlyTrashed` method will retrieve **only** soft deleted models:
 
     $flights = App\Flight::onlyTrashed()
-                    ->where('airline_id', 1)
-                    ->get();
+                         ->where('airline_id', 1)
+                         ->get();
 
 #### Restoring Soft Deleted Models
 
@@ -634,8 +634,8 @@ Sometimes you may wish to "un-delete" a soft deleted model. To restore a soft de
 You may also use the `restore` method in a query to quickly restore multiple models. Again, like other "mass" operations, this will not fire any model events for the models that are restored:
 
     App\Flight::withTrashed()
-            ->where('airline_id', 1)
-            ->restore();
+              ->where('airline_id', 1)
+              ->restore();
 
 Like the `withTrashed` method, the `restore` method may also be used on [relationships](/docs/{{version}}/eloquent-relationships):
 

--- a/http-tests.md
+++ b/http-tests.md
@@ -60,11 +60,10 @@ You may use the `withHeaders` method to customize the request's headers before i
                 'X-Header' => 'Value',
             ])->json('POST', '/user', ['name' => 'Sally']);
 
-            $response
-                ->assertStatus(201)
-                ->assertJson([
-                    'created' => true,
-                ]);
+            $response->assertStatus(201)
+                     ->assertJson([
+                         'created' => true,
+                    ]);
         }
     }
 
@@ -156,11 +155,10 @@ Laravel also provides several helpers for testing JSON APIs and their responses.
         {
             $response = $this->json('POST', '/user', ['name' => 'Sally']);
 
-            $response
-                ->assertStatus(201)
-                ->assertJson([
-                    'created' => true,
-                ]);
+            $response->assertStatus(201)
+                     ->assertJson([
+                         'created' => true,
+                    ]);
         }
     }
 
@@ -184,11 +182,10 @@ If you would like to verify that the given array is an **exact** match for the J
         {
             $response = $this->json('POST', '/user', ['name' => 'Sally']);
 
-            $response
-                ->assertStatus(201)
-                ->assertExactJson([
-                    'created' => true,
-                ]);
+            $response->assertStatus(201)
+                     ->assertExactJson([
+                         'created' => true,
+                     ]);
         }
     }
 

--- a/mail.md
+++ b/mail.md
@@ -590,8 +590,8 @@ If you wish to delay the delivery of a queued email message, you may use the `la
 Since all mailable classes generated using the `make:mail` command make use of the `Illuminate\Bus\Queueable` trait, you may call the `onQueue` and `onConnection` methods on any mailable class instance, allowing you to specify the connection and queue name for the message:
 
     $message = (new OrderShipped($order))
-                    ->onConnection('sqs')
-                    ->onQueue('emails');
+        ->onConnection('sqs')
+        ->onQueue('emails');
 
     Mail::to($request->user())
         ->cc($moreUsers)

--- a/mocking.md
+++ b/mocking.md
@@ -405,9 +405,9 @@ We can mock the call to the `Cache` facade by using the `shouldReceive` method, 
         public function testGetIndex()
         {
             Cache::shouldReceive('get')
-                        ->once()
-                        ->with('key')
-                        ->andReturn('value');
+                 ->once()
+                 ->with('key')
+                 ->andReturn('value');
 
             $response = $this->get('/users');
 

--- a/queries.md
+++ b/queries.md
@@ -144,8 +144,8 @@ The query builder also provides a variety of aggregate methods such as `count`, 
 You may combine these methods with other clauses:
 
     $price = DB::table('orders')
-                    ->where('finalized', 1)
-                    ->avg('price');
+               ->where('finalized', 1)
+               ->avg('price');
 
 #### Determining If Records Exist
 
@@ -180,10 +180,10 @@ If you already have a query builder instance and you wish to add a column to its
 Sometimes you may need to use a raw expression in a query. To create a raw expression, you may use the `DB::raw` method:
 
     $users = DB::table('users')
-                         ->select(DB::raw('count(*) as user_count, status'))
-                         ->where('status', '<>', 1)
-                         ->groupBy('status')
-                         ->get();
+               ->select(DB::raw('count(*) as user_count, status'))
+               ->where('status', '<>', 1)
+               ->groupBy('status')
+               ->get();
 
 > {note} Raw statements will be injected into the query as strings, so you should be extremely careful to not create SQL injection vulnerabilities.
 
@@ -197,34 +197,34 @@ Instead of using `DB::raw`, you may also use the following methods to insert a r
 The `selectRaw` method can be used in place of `select(DB::raw(...))`. This method accepts an optional array of bindings as its second argument:
 
     $orders = DB::table('orders')
-                    ->selectRaw('price * ? as price_with_tax', [1.0825])
-                    ->get();
+                ->selectRaw('price * ? as price_with_tax', [1.0825])
+                ->get();
 
 #### `whereRaw / orWhereRaw`
 
 The `whereRaw` and `orWhereRaw` methods can be used to inject a raw `where` clause into your query. These methods accept an optional array of bindings as their second argument:
 
     $orders = DB::table('orders')
-                    ->whereRaw('price > IF(state = "TX", ?, 100)', [200])
-                    ->get();
+                ->whereRaw('price > IF(state = "TX", ?, 100)', [200])
+                ->get();
 
 #### `havingRaw / orHavingRaw`
 
 The `havingRaw` and `orHavingRaw` methods may be used to set a raw string as the value of the `having` clause. These methods accept an optional array of bindings as their second argument:
 
     $orders = DB::table('orders')
-                    ->select('department', DB::raw('SUM(price) as total_sales'))
-                    ->groupBy('department')
-                    ->havingRaw('SUM(price) > ?', [2500])
-                    ->get();
+                ->select('department', DB::raw('SUM(price) as total_sales'))
+                ->groupBy('department')
+                ->havingRaw('SUM(price) > ?', [2500])
+                ->get();
 
 #### `orderByRaw`
 
 The `orderByRaw` method may be used to set a raw string as the value of the `order by` clause:
 
     $orders = DB::table('orders')
-                    ->orderByRaw('updated_at - created_at DESC')
-                    ->get();
+                ->orderByRaw('updated_at - created_at DESC')
+                ->get();
 
 <a name="joins"></a>
 ## Joins
@@ -234,63 +234,63 @@ The `orderByRaw` method may be used to set a raw string as the value of the `ord
 The query builder may also be used to write join statements. To perform a basic "inner join", you may use the `join` method on a query builder instance. The first argument passed to the `join` method is the name of the table you need to join to, while the remaining arguments specify the column constraints for the join. You can even join to multiple tables in a single query:
 
     $users = DB::table('users')
-                ->join('contacts', 'users.id', '=', 'contacts.user_id')
-                ->join('orders', 'users.id', '=', 'orders.user_id')
-                ->select('users.*', 'contacts.phone', 'orders.price')
-                ->get();
+               ->join('contacts', 'users.id', '=', 'contacts.user_id')
+               ->join('orders', 'users.id', '=', 'orders.user_id')
+               ->select('users.*', 'contacts.phone', 'orders.price')
+               ->get();
 
 #### Left Join / Right Join Clause
 
 If you would like to perform a "left join" or "right join" instead of an "inner join", use the `leftJoin` or `rightJoin` methods. These methods have the same signature as the `join` method:
 
     $users = DB::table('users')
-                ->leftJoin('posts', 'users.id', '=', 'posts.user_id')
-                ->get();
+               ->leftJoin('posts', 'users.id', '=', 'posts.user_id')
+               ->get();
 
     $users = DB::table('users')
-                ->rightJoin('posts', 'users.id', '=', 'posts.user_id')
-                ->get();
+               ->rightJoin('posts', 'users.id', '=', 'posts.user_id')
+               ->get();
 
 #### Cross Join Clause
 
 To perform a "cross join" use the `crossJoin` method with the name of the table you wish to cross join to. Cross joins generate a cartesian product between the first table and the joined table:
 
     $users = DB::table('sizes')
-                ->crossJoin('colours')
-                ->get();
+               ->crossJoin('colours')
+               ->get();
 
 #### Advanced Join Clauses
 
 You may also specify more advanced join clauses. To get started, pass a `Closure` as the second argument into the `join` method. The `Closure` will receive a `JoinClause` object which allows you to specify constraints on the `join` clause:
 
     DB::table('users')
-            ->join('contacts', function ($join) {
-                $join->on('users.id', '=', 'contacts.user_id')->orOn(...);
-            })
-            ->get();
+        ->join('contacts', function ($join) {
+            $join->on('users.id', '=', 'contacts.user_id')->orOn(...);
+        })
+        ->get();
 
 If you would like to use a "where" style clause on your joins, you may use the `where` and `orWhere` methods on a join. Instead of comparing two columns, these methods will compare the column against a value:
 
     DB::table('users')
-            ->join('contacts', function ($join) {
-                $join->on('users.id', '=', 'contacts.user_id')
-                     ->where('contacts.user_id', '>', 5);
-            })
-            ->get();
+        ->join('contacts', function ($join) {
+            $join->on('users.id', '=', 'contacts.user_id')
+                 ->where('contacts.user_id', '>', 5);
+        })
+        ->get();
 
 #### Sub-Query Joins
 
 You may use the `joinSub`, `leftJoinSub`, and `rightJoinSub` methods to join a query to a sub-query. Each of these methods receive three arguments: the sub-query, its table alias, and a Closure that defines the related columns:
 
     $latestPosts = DB::table('posts')
-                       ->select('user_id', DB::raw('MAX(created_at) as last_post_created_at'))
-                       ->where('is_published', true)
-                       ->groupBy('user_id');
+                     ->select('user_id', DB::raw('MAX(created_at) as last_post_created_at'))
+                     ->where('is_published', true)
+                     ->groupBy('user_id');
 
     $users = DB::table('users')
-            ->joinSub($latestPosts, 'latest_posts', function ($join) {
-                $join->on('users.id', '=', 'latest_posts.user_id');
-            })->get();
+               ->joinSub($latestPosts, 'latest_posts', function ($join) {
+                   $join->on('users.id', '=', 'latest_posts.user_id');
+               })->get();
 
 <a name="unions"></a>
 ## Unions
@@ -298,12 +298,12 @@ You may use the `joinSub`, `leftJoinSub`, and `rightJoinSub` methods to join a q
 The query builder also provides a quick way to "union" two queries together. For example, you may create an initial query and use the `union` method to union it with a second query:
 
     $first = DB::table('users')
-                ->whereNull('first_name');
+               ->whereNull('first_name');
 
     $users = DB::table('users')
-                ->whereNull('last_name')
-                ->union($first)
-                ->get();
+               ->whereNull('last_name')
+               ->union($first)
+               ->get();
 
 > {tip} The `unionAll` method is also available and has the same method signature as `union`.
 
@@ -325,16 +325,16 @@ For convenience, if you want to verify that a column is equal to a given value, 
 You may use a variety of other operators when writing a `where` clause:
 
     $users = DB::table('users')
-                    ->where('votes', '>=', 100)
-                    ->get();
+               ->where('votes', '>=', 100)
+               ->get();
 
     $users = DB::table('users')
-                    ->where('votes', '<>', 100)
-                    ->get();
+               ->where('votes', '<>', 100)
+               ->get();
 
     $users = DB::table('users')
-                    ->where('name', 'like', 'T%')
-                    ->get();
+               ->where('name', 'like', 'T%')
+               ->get();
 
 You may also pass an array of conditions to the `where` function:
 
@@ -348,9 +348,9 @@ You may also pass an array of conditions to the `where` function:
 You may chain where constraints together as well as add `or` clauses to the query. The `orWhere` method accepts the same arguments as the `where` method:
 
     $users = DB::table('users')
-                        ->where('votes', '>', 100)
-                        ->orWhere('name', 'John')
-                        ->get();
+               ->where('votes', '>', 100)
+               ->orWhere('name', 'John')
+               ->get();
 
 #### Additional Where Clauses
 
@@ -359,110 +359,111 @@ You may chain where constraints together as well as add `or` clauses to the quer
 The `whereBetween` method verifies that a column's value is between two values:
 
     $users = DB::table('users')
-                        ->whereBetween('votes', [1, 100])->get();
+               ->whereBetween('votes', [1, 100])
+               ->get();
 
 **whereNotBetween / orWhereNotBetween**
 
 The `whereNotBetween` method verifies that a column's value lies outside of two values:
 
     $users = DB::table('users')
-                        ->whereNotBetween('votes', [1, 100])
-                        ->get();
+               ->whereNotBetween('votes', [1, 100])
+               ->get();
 
 **whereIn / whereNotIn / orWhereIn / orWhereNotIn**
 
 The `whereIn` method verifies that a given column's value is contained within the given array:
 
     $users = DB::table('users')
-                        ->whereIn('id', [1, 2, 3])
-                        ->get();
+               ->whereIn('id', [1, 2, 3])
+               ->get();
 
 The `whereNotIn` method verifies that the given column's value is **not** contained in the given array:
 
     $users = DB::table('users')
-                        ->whereNotIn('id', [1, 2, 3])
-                        ->get();
+               ->whereNotIn('id', [1, 2, 3])
+               ->get();
 
 **whereNull / whereNotNull / orWhereNull / orWhereNotNull**
 
 The `whereNull` method verifies that the value of the given column is `NULL`:
 
     $users = DB::table('users')
-                        ->whereNull('updated_at')
-                        ->get();
+               ->whereNull('updated_at')
+               ->get();
 
 The `whereNotNull` method verifies that the column's value is not `NULL`:
 
     $users = DB::table('users')
-                        ->whereNotNull('updated_at')
-                        ->get();
+               ->whereNotNull('updated_at')
+               ->get();
 
 **whereDate / whereMonth / whereDay / whereYear / whereTime**
 
 The `whereDate` method may be used to compare a column's value against a date:
 
     $users = DB::table('users')
-                    ->whereDate('created_at', '2016-12-31')
-                    ->get();
+               ->whereDate('created_at', '2016-12-31')
+               ->get();
 
 The `whereMonth` method may be used to compare a column's value against a specific month of a year:
 
     $users = DB::table('users')
-                    ->whereMonth('created_at', '12')
-                    ->get();
+               ->whereMonth('created_at', '12')
+               ->get();
 
 The `whereDay` method may be used to compare a column's value against a specific day of a month:
 
     $users = DB::table('users')
-                    ->whereDay('created_at', '31')
-                    ->get();
+               ->whereDay('created_at', '31')
+               ->get();
 
 The `whereYear` method may be used to compare a column's value against a specific year:
 
     $users = DB::table('users')
-                    ->whereYear('created_at', '2016')
-                    ->get();
+               ->whereYear('created_at', '2016')
+               ->get();
 
 The `whereTime` method may be used to compare a column's value against a specific time:
 
     $users = DB::table('users')
-                    ->whereTime('created_at', '=', '11:20:45')
-                    ->get();
+               ->whereTime('created_at', '=', '11:20:45')
+               ->get();
 
 **whereColumn / orWhereColumn**
 
 The `whereColumn` method may be used to verify that two columns are equal:
 
     $users = DB::table('users')
-                    ->whereColumn('first_name', 'last_name')
-                    ->get();
+               ->whereColumn('first_name', 'last_name')
+               ->get();
 
 You may also pass a comparison operator to the method:
 
     $users = DB::table('users')
-                    ->whereColumn('updated_at', '>', 'created_at')
-                    ->get();
+               ->whereColumn('updated_at', '>', 'created_at')
+               ->get();
 
 The `whereColumn` method can also be passed an array of multiple conditions. These conditions will be joined using the `and` operator:
 
     $users = DB::table('users')
-                    ->whereColumn([
-                        ['first_name', '=', 'last_name'],
-                        ['updated_at', '>', 'created_at']
-                    ])->get();
+               ->whereColumn([
+                   ['first_name', '=', 'last_name'],
+                   ['updated_at', '>', 'created_at'],
+               ])->get();
 
 <a name="parameter-grouping"></a>
 ### Parameter Grouping
 
 Sometimes you may need to create more advanced where clauses such as "where exists" clauses or nested parameter groupings. The Laravel query builder can handle these as well. To get started, let's look at an example of grouping constraints within parenthesis:
 
-    DB::table('users')
-                ->where('name', '=', 'John')
-                ->where(function ($query) {
-                    $query->where('votes', '>', 100)
-                          ->orWhere('title', '=', 'Admin');
-                })
-                ->get();
+    $users = DB::table('users')
+               ->where('name', '=', 'John')
+               ->where(function ($query) {
+                   $query->where('votes', '>', 100)
+                         ->orWhere('title', '=', 'Admin');
+               })
+               ->get();
 
 As you can see, passing a `Closure` into the `where` method instructs the query builder to begin a constraint group. The `Closure` will receive a query builder instance which you can use to set the constraints that should be contained within the parenthesis group. The example above will produce the following SQL:
 
@@ -475,13 +476,13 @@ As you can see, passing a `Closure` into the `where` method instructs the query 
 
 The `whereExists` method allows you to write `where exists` SQL clauses. The `whereExists` method accepts a `Closure` argument, which will receive a query builder instance allowing you to define the query that should be placed inside of the "exists" clause:
 
-    DB::table('users')
-                ->whereExists(function ($query) {
-                    $query->select(DB::raw(1))
-                          ->from('orders')
-                          ->whereRaw('orders.user_id = users.id');
-                })
-                ->get();
+    $users = DB::table('users')
+               ->whereExists(function ($query) {
+                   $query->select(DB::raw(1))
+                         ->from('orders')
+                         ->whereRaw('orders.user_id = users.id');
+               })
+               ->get();
 
 The query above will produce the following SQL:
 
@@ -496,34 +497,34 @@ The query above will produce the following SQL:
 Laravel also supports querying JSON column types on databases that provide support for JSON column types. Currently, this includes MySQL 5.7, PostgreSQL, SQL Server 2016, and SQLite 3.9.0 (with the [JSON1 extension](https://www.sqlite.org/json1.html)). To query a JSON column, use the `->` operator:
 
     $users = DB::table('users')
-                    ->where('options->language', 'en')
-                    ->get();
+               ->where('options->language', 'en')
+               ->get();
 
     $users = DB::table('users')
-                    ->where('preferences->dining->meal', 'salad')
-                    ->get();
+               ->where('preferences->dining->meal', 'salad')
+               ->get();
 
 You may use `whereJsonContains` to query JSON arrays (not supported on SQLite):
 
     $users = DB::table('users')
-                    ->whereJsonContains('options->languages', 'en')
-                    ->get();
+               ->whereJsonContains('options->languages', 'en')
+               ->get();
 
 MySQL and PostgreSQL support `whereJsonContains` with multiple values:
 
     $users = DB::table('users')
-                    ->whereJsonContains('options->languages', ['en', 'de'])
-                    ->get();
+               ->whereJsonContains('options->languages', ['en', 'de'])
+               ->get();
 
 You may use `whereJsonLength` to query JSON arrays by their length:
 
     $users = DB::table('users')
-                    ->whereJsonLength('options->languages', 0)
-                    ->get();
+               ->whereJsonLength('options->languages', 0)
+               ->get();
 
     $users = DB::table('users')
-                    ->whereJsonLength('options->languages', '>', 1)
-                    ->get();
+               ->whereJsonLength('options->languages', '>', 1)
+               ->get();
 
 <a name="ordering-grouping-limit-and-offset"></a>
 ## Ordering, Grouping, Limit, & Offset
@@ -533,16 +534,16 @@ You may use `whereJsonLength` to query JSON arrays by their length:
 The `orderBy` method allows you to sort the result of the query by a given column. The first argument to the `orderBy` method should be the column you wish to sort by, while the second argument controls the direction of the sort and may be either `asc` or `desc`:
 
     $users = DB::table('users')
-                    ->orderBy('name', 'desc')
-                    ->get();
+               ->orderBy('name', 'desc')
+               ->get();
 
 #### latest / oldest
 
 The `latest` and `oldest` methods allow you to easily order results by date. By default, result will be ordered by the `created_at` column. Or, you may pass the column name that you wish to sort by:
 
     $user = DB::table('users')
-                    ->latest()
-                    ->first();
+              ->latest()
+              ->first();
 
 #### inRandomOrder
 
@@ -557,16 +558,16 @@ The `inRandomOrder` method may be used to sort the query results randomly. For e
 The `groupBy` and `having` methods may be used to group the query results. The `having` method's signature is similar to that of the `where` method:
 
     $users = DB::table('users')
-                    ->groupBy('account_id')
-                    ->having('account_id', '>', 100)
-                    ->get();
+               ->groupBy('account_id')
+               ->having('account_id', '>', 100)
+               ->get();
 
 You may pass multiple arguments to the `groupBy` method to group by multiple columns:
 
     $users = DB::table('users')
-                    ->groupBy('first_name', 'status')
-                    ->having('account_id', '>', 100)
-                    ->get();
+               ->groupBy('first_name', 'status')
+               ->having('account_id', '>', 100)
+               ->get();
 
 For more advanced `having` statements, see the [`havingRaw`](#raw-methods) method.
 
@@ -579,9 +580,9 @@ To limit the number of results returned from the query, or to skip a given numbe
 Alternatively, you may use the `limit` and `offset` methods:
 
     $users = DB::table('users')
-                    ->offset(10)
-                    ->limit(5)
-                    ->get();
+               ->offset(10)
+               ->limit(5)
+               ->get();
 
 <a name="conditional-clauses"></a>
 ## Conditional Clauses
@@ -591,10 +592,10 @@ Sometimes you may want clauses to apply to a query only when something else is t
     $role = $request->input('role');
 
     $users = DB::table('users')
-                    ->when($role, function ($query, $role) {
-                        return $query->where('role_id', $role);
-                    })
-                    ->get();
+               ->when($role, function ($query, $role) {
+                   return $query->where('role_id', $role);
+               })
+               ->get();
 
 The `when` method only executes the given Closure when the first parameter is `true`. If the first parameter is `false`, the Closure will not be executed.
 
@@ -603,12 +604,12 @@ You may pass another Closure as the third parameter to the `when` method. This C
     $sortBy = null;
 
     $users = DB::table('users')
-                    ->when($sortBy, function ($query, $sortBy) {
-                        return $query->orderBy($sortBy);
-                    }, function ($query) {
-                        return $query->orderBy('name');
-                    })
-                    ->get();
+               ->when($sortBy, function ($query, $sortBy) {
+                   return $query->orderBy($sortBy);
+               }, function ($query) {
+                   return $query->orderBy('name');
+               })
+               ->get();
 
 <a name="inserts"></a>
 ## Inserts
@@ -648,9 +649,9 @@ If the table has an auto-incrementing id, use the `insertGetId` method to insert
 
 In addition to inserting records into the database, the query builder can also update existing records using the `update` method. The `update` method, like the `insert` method, accepts an array of column and value pairs containing the columns to be updated. You may constrain the `update` query using `where` clauses:
 
-    DB::table('users')
-                ->where('id', 1)
-                ->update(['votes' => 1]);
+    $affected = DB::table('users')
+                  ->where('id', 1)
+                  ->update(['votes' => 1]);
 
 #### Update Or Insert
 
@@ -669,9 +670,9 @@ The `updateOrInsert` method will first attempt to locate a matching database rec
 
 When updating a JSON column, you should use `->` syntax to access the appropriate key in the JSON object. This operation is supported on MySQL 5.7+ and PostgreSQL 9.5+:
 
-    DB::table('users')
-                ->where('id', 1)
-                ->update(['options->enabled' => true]);
+    $affected = DB::table('users')
+                  ->where('id', 1)
+                  ->update(['options->enabled' => true]);
 
 <a name="increment-and-decrement"></a>
 ### Increment & Decrement

--- a/queues.md
+++ b/queues.md
@@ -221,20 +221,20 @@ Instead of rate limiting in the handle method, we could define a job middleware 
         public function handle($job, $next)
         {
             Redis::throttle('key')
-                    ->block(0)->allow(1)->every(5)
-                    ->then(function () use ($job, $next) {
-                        // Lock obtained...
+                 ->block(0)->allow(1)->every(5)
+                 ->then(function () use ($job, $next) {
+                     // Lock obtained...
 
-                        $next($job);
-                    }, function () use ($job) {
-                        // Could not obtain lock...
+                     $next($job);
+                 }, function () use ($job) {
+                     // Could not obtain lock...
 
-                        $job->release(5);
-                    });
+                     $job->release(5);
+                 });
         }
     }
 
-As you can see, like [route middleware](/docs/{{version}}/middleware), job middleware receive the job being processed and a callback that should be invoked to continue processing the job. 
+As you can see, like [route middleware](/docs/{{version}}/middleware), job middleware receive the job being processed and a callback that should be invoked to continue processing the job.
 
 After creating job middleware, they may be attached to a job by returning them from the job's `middleware` method. This method does not exist on jobs scaffolded by the `make:job` Artisan command, so you will need to add it to your own job class definition:
 
@@ -305,7 +305,7 @@ If you would like to delay the execution of a queued job, you may use the `delay
             // Create podcast...
 
             ProcessPodcast::dispatch($podcast)
-                    ->delay(now()->addMinutes(10));
+                          ->delay(now()->addMinutes(10));
         }
     }
 

--- a/releases.md
+++ b/releases.md
@@ -115,16 +115,16 @@ In Laravel 6.0, this logic may be extracted into a job middleware, allowing you 
         public function handle($job, $next)
         {
             Redis::throttle('key')
-                    ->block(0)->allow(1)->every(5)
-                    ->then(function () use ($job, $next) {
-                        // Lock obtained...
+                  ->block(0)->allow(1)->every(5)
+                  ->then(function () use ($job, $next) {
+                      // Lock obtained...
 
-                        $next($job);
-                    }, function () use ($job) {
-                        // Could not obtain lock...
+                      $next($job);
+                  }, function () use ($job) {
+                      // Could not obtain lock...
 
-                        $job->release(5);
-                    });
+                      $job->release(5);
+                  });
         }
     }
 
@@ -202,9 +202,9 @@ In addition, we can use new subquery features added to the query builder's `orde
 
     return Destination::orderByDesc(
         Flight::select('arrived_at')
-            ->whereColumn('destination_id', 'destinations.id')
-            ->orderBy('arrived_at', 'desc')
-            ->limit(1)
+              ->whereColumn('destination_id', 'destinations.id')
+              ->orderBy('arrived_at', 'desc')
+              ->limit(1)
     )->get();
 
 ### Laravel UI 

--- a/responses.md
+++ b/responses.md
@@ -43,7 +43,7 @@ Returning a full `Response` instance allows you to customize the response's HTTP
 
     Route::get('home', function () {
         return response('Hello World', 200)
-                      ->header('Content-Type', 'text/plain');
+            ->header('Content-Type', 'text/plain');
     });
 
 <a name="attaching-headers-to-responses"></a>
@@ -52,18 +52,18 @@ Returning a full `Response` instance allows you to customize the response's HTTP
 Keep in mind that most response methods are chainable, allowing for the fluent construction of response instances. For example, you may use the `header` method to add a series of headers to the response before sending it back to the user:
 
     return response($content)
-                ->header('Content-Type', $type)
-                ->header('X-Header-One', 'Header Value')
-                ->header('X-Header-Two', 'Header Value');
+        ->header('Content-Type', $type)
+        ->header('X-Header-One', 'Header Value')
+        ->header('X-Header-Two', 'Header Value');
 
 Or, you may use the `withHeaders` method to specify an array of headers to be added to the response:
 
     return response($content)
-                ->withHeaders([
-                    'Content-Type' => $type,
-                    'X-Header-One' => 'Header Value',
-                    'X-Header-Two' => 'Header Value',
-                ]);
+        ->withHeaders([
+            'Content-Type' => $type,
+            'X-Header-One' => 'Header Value',
+            'X-Header-Two' => 'Header Value',
+        ]);
 
 ##### Cache Control Middleware
 
@@ -85,8 +85,8 @@ Laravel includes a `cache.headers` middleware, which may be used to quickly set 
 The `cookie` method on response instances allows you to easily attach cookies to the response. For example, you may use the `cookie` method to generate a cookie and fluently attach it to the response instance like so:
 
     return response($content)
-                    ->header('Content-Type', $type)
-                    ->cookie('name', 'value', $minutes);
+        ->header('Content-Type', $type)
+        ->cookie('name', 'value', $minutes);
 
 The `cookie` method also accepts a few more arguments which are used less frequently. Generally, these arguments have the same purpose and meaning as the arguments that would be given to PHP's native [setcookie](https://secure.php.net/manual/en/function.setcookie.php) method:
 
@@ -212,8 +212,8 @@ The `response` helper may be used to generate other types of response instances.
 If you need control over the response's status and headers but also need to return a [view](/docs/{{version}}/views) as the response's content, you should use the `view` method:
 
     return response()
-                ->view('hello', $data, 200)
-                ->header('Content-Type', $type);
+        ->view('hello', $data, 200)
+        ->header('Content-Type', $type);
 
 Of course, if you do not need to pass a custom HTTP status code or custom headers, you should use the global `view` helper function.
 
@@ -230,8 +230,8 @@ The `json` method will automatically set the `Content-Type` header to `applicati
 If you would like to create a JSONP response, you may use the `json` method in combination with the `withCallback` method:
 
     return response()
-                ->json(['name' => 'Abigail', 'state' => 'CA'])
-                ->withCallback($request->input('callback'));
+        ->json(['name' => 'Abigail', 'state' => 'CA'])
+        ->withCallback($request->input('callback'));
 
 <a name="file-downloads"></a>
 ### File Downloads
@@ -252,8 +252,8 @@ Sometimes you may wish to turn the string response of a given operation into a d
 
     return response()->streamDownload(function () {
         echo GitHub::api('repo')
-                    ->contents()
-                    ->readme('laravel', 'laravel')['contents'];
+                   ->contents()
+                   ->readme('laravel', 'laravel')['contents'];
     }, 'laravel-readme.md');
 
 <a name="file-responses"></a>

--- a/scheduling.md
+++ b/scheduling.md
@@ -132,10 +132,10 @@ These methods may be combined with additional constraints to create even more fi
 
     // Run hourly from 8 AM to 5 PM on weekdays...
     $schedule->command('foo')
-              ->weekdays()
-              ->hourly()
-              ->timezone('America/Chicago')
-              ->between('8:00', '17:00');
+             ->weekdays()
+             ->hourly()
+             ->timezone('America/Chicago')
+             ->between('8:00', '17:00');
 
 Below is a list of the additional schedule constraints:
 
@@ -159,14 +159,14 @@ Method  | Description
 The `between` method may be used to limit the execution of a task based on the time of day:
 
     $schedule->command('reminders:send')
-                        ->hourly()
-                        ->between('7:00', '22:00');
+             ->hourly()
+             ->between('7:00', '22:00');
 
 Similarly, the `unlessBetween` method can be used to exclude the execution of a task for a period of time:
 
     $schedule->command('reminders:send')
-                        ->hourly()
-                        ->unlessBetween('23:00', '4:00');
+             ->hourly()
+             ->unlessBetween('23:00', '4:00');
 
 #### Truth Test Constraints
 
@@ -189,8 +189,8 @@ When using chained `when` methods, the scheduled command will only execute if al
 The `environments` method may be used to execute tasks only on the given environments:
 
     $schedule->command('emails:send')
-                ->daily()
-                ->environments(['staging', 'production']);
+             ->daily()
+             ->environments(['staging', 'production']);
 
 <a name="timezones"></a>
 ### Timezones
@@ -238,9 +238,9 @@ If your application is running on multiple servers, you may limit a scheduled jo
 To indicate that the task should run on only one server, use the `onOneServer` method when defining the scheduled task. The first server to obtain the task will secure an atomic lock on the job to prevent other servers from running the same task at the same time:
 
     $schedule->command('report:generate')
-                    ->fridays()
-                    ->at('17:00')
-                    ->onOneServer();
+             ->fridays()
+             ->at('17:00')
+             ->onOneServer();
 
 <a name="background-tasks"></a>
 ### Background Tasks

--- a/validation.md
+++ b/validation.md
@@ -362,8 +362,8 @@ If you do not want to use the `validate` method on the request, you may create a
 
             if ($validator->fails()) {
                 return redirect('post/create')
-                            ->withErrors($validator)
-                            ->withInput();
+                    ->withErrors($validator)
+                    ->withInput();
             }
 
             // Store the blog post...
@@ -390,7 +390,7 @@ If you would like to create a validator instance manually but still take advanta
 If you have multiple forms on a single page, you may wish to name the `MessageBag` of errors, allowing you to retrieve the error messages for a specific form. Pass a name as the second argument to `withErrors`:
 
     return redirect('register')
-                ->withErrors($validator, 'login');
+        ->withErrors($validator, 'login');
 
 You may then access the named `MessageBag` instance from the `$errors` variable:
 


### PR DESCRIPTION
The alignment of object operators looked to differ between files. This PR aims to bring consistency throughout the docs by choosing an alignment and sticking with it. Where appropriate, trailing commas have been added to arrays. Also, any code missing a variable assignment has been added.