### PR TITLE
[6.0] Removed explicit deprecation of Predis

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -19,7 +19,7 @@ Alternatively, you can install the `predis/predis` package via Composer:
 
     composer require predis/predis
 
-> {note} Maintenance of Predis has been abandoned by the original author of the package and will be removed from Laravel in the 7.0 release.
+> {note} Maintenance of Predis has been abandoned by the original author of the package and will be removed from Laravel in future versions.
 
 <a name="configuration"></a>
 ### Configuration

--- a/redis.md
+++ b/redis.md
@@ -19,7 +19,7 @@ Alternatively, you can install the `predis/predis` package via Composer:
 
     composer require predis/predis
 
-> {note} Maintenance of Predis has been abandoned by the original author of the package and will be removed from Laravel in future versions.
+> {note} Predis has been abandoned by the package's original author and may be removed from Laravel in a future release.
 
 <a name="configuration"></a>
 ### Configuration


### PR DESCRIPTION
[Deprecation](https://github.com/laravel/framework/pull/29803) has been modified to remove the explicit version where it will be unsupported.