### PR TITLE
Fix Telescope image aspect ratio on mobile

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -33,7 +33,7 @@
 Laravel Telescope is an elegant debug assistant for the Laravel framework. Telescope provides insight into the requests coming into your application, exceptions, log entries, database queries, queued jobs, mail, notifications, cache operations, scheduled tasks, variable dumps and more. Telescope makes a wonderful companion to your local Laravel development environment.
 
 <p align="center">
-<img src="https://res.cloudinary.com/dtfbvvkyp/image/upload/v1539110860/Screen_Shot_2018-10-09_at_1.47.23_PM.png" width="600" height="347">
+<img src="https://res.cloudinary.com/dtfbvvkyp/image/upload/v1539110860/Screen_Shot_2018-10-09_at_1.47.23_PM.png" width="600">
 </p>
 
 <a name="installation"></a>


### PR DESCRIPTION
The height should be computed automatically based on the width, so that the image won't appear distorted when viewed on mobile.

PS: This fix is also relevant for the `master` branch, should I also submit it there?