### PR TITLE
[5.8] Update mail.md

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -636,6 +636,9 @@ To accomplish this, the `Mail` facade offers a `locale` method to set the desire
     Mail::to($request->user())->locale('es')->send(
         new OrderShipped($order)
     );
+    
+> {tip} The `locale` method will translate the text of the blade file and the text generated in the mailable's build() method. It does not translate the text generated in the constructor.
+
 
 ### User Preferred Locales
 


### PR DESCRIPTION
Mention that user should put translatable text in the build method and not the in the constructor to prevent issues.