### PR TITLE
[6.0] Add warning of possible blade error when updating

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -219,8 +219,6 @@ All `str_` and `array_` helpers have been moved to the new `laravel/helpers` Com
 <a name="trans-and-trans-choice"></a>
 #### The `Lang::trans` & `Lang::transChoice` Methods
 
-> {note} You should run `php artisan view:clear` to avoid Blade errors related to the removal of `Lang::transChoice`, `Lang::trans` and `Lang::getFromJson`.
-
 **Likelihood Of Impact: Medium**
 
 The `Lang::trans` and `Lang::transChoice` methods of the translator have been renamed to `Lang::get` and `Lang::choice`.
@@ -233,6 +231,8 @@ In addition, if you are manually implementing the `Illuminate\Contracts\Translat
 **Likelihood Of Impact: Medium**
 
 The `Lang::get` and `Lang::getFromJson` methods have been consolidated. Calls to the `Lang::getFromJson` method should be updated to call `Lang::get`.
+
+> {note} You should run `php artisan view:clear` to avoid Blade errors related to the removal of `Lang::transChoice`, `Lang::trans` and `Lang::getFromJson`.
 
 ### Mail
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -232,7 +232,7 @@ In addition, if you are manually implementing the `Illuminate\Contracts\Translat
 
 The `Lang::get` and `Lang::getFromJson` methods have been consolidated. Calls to the `Lang::getFromJson` method should be updated to call `Lang::get`.
 
-> {note} You should run `php artisan view:clear` to avoid Blade errors related to the removal of `Lang::transChoice`, `Lang::trans` and `Lang::getFromJson`.
+> {note} You should run the `php artisan view:clear` Artisan command to avoid Blade errors related to the removal of `Lang::transChoice`, `Lang::trans`, and `Lang::getFromJson`.
 
 ### Mail
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -219,6 +219,8 @@ All `str_` and `array_` helpers have been moved to the new `laravel/helpers` Com
 <a name="trans-and-trans-choice"></a>
 #### The `Lang::trans` & `Lang::transChoice` Methods
 
+> {note} You should run `php artisan view:clear` to avoid Blade errors related to the removal of `Lang::transChoice`, `Lang::trans` and `Lang::getFromJson`.
+
 **Likelihood Of Impact: Medium**
 
 The `Lang::trans` and `Lang::transChoice` methods of the translator have been renamed to `Lang::get` and `Lang::choice`.


### PR DESCRIPTION
When i updated my application i was facing with some blade errors relationated to changes in `Lang` methods, because my view cache was using these methods.

This PR it for warn about clean view cache before uses application.