### PR TITLE
[6.x] Improve note for onOneServer

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -231,7 +231,7 @@ If needed, you may specify how many minutes must pass before the "without overla
 <a name="running-tasks-on-one-server"></a>
 ### Running Tasks On One Server
 
-> {note} To utilize this feature, your application must be using the `memcached` or `redis` cache driver as your application's default cache driver. In addition, all servers must be communicating with the same central cache server.
+> {note} To utilize this feature, your application must be using the `memcached` or `redis` cache driver as your application's default cache driver. In addition, all servers must be communicating with the same central cache server as well as must have the exact same real path to the PHP executable.
 
 If your application is running on multiple servers, you may limit a scheduled job to only execute on a single server. For instance, assume you have a scheduled task that generates a new report every Friday night. If the task scheduler is running on three worker servers, the scheduled task will run on all three servers and generate the report three times. Not good!
 


### PR DESCRIPTION
The "command" used for generating the SHA1 to ensure a task is run on one server in a group, if an artisan command, will include the full path to the PHP executable. If there is a difference in the install location here, even if using a centralized memcached or redis server, the task will be run twice as a different SHA1 hash will be generated.

Note applies to all versions since 5.6. This note seems to have not changed text at all.