### PR TITLE
[6.x] Added build artifacts for CircleCI

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1396,6 +1396,10 @@ If you are using CircleCI to run your Dusk tests, you may use this configuration
                 - run:
                     name: Run Laravel Dusk Tests
                     command: php artisan dusk
+                    
+                - store_artifacts:
+                    path: tests/Browser/screenshots
+
 
 <a name="running-tests-on-codeship"></a>
 ### Codeship


### PR DESCRIPTION
Documented a very handy way on CircleCI to access Dusk screenshots when the tests fail. I keep it light though to avoid confusions. If people want to know more about this, they'll probably Google "store_artifacts".