### PR TITLE
[6.x] Add note about subdirectories

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -29,6 +29,8 @@ However, if you are not using Homestead, you will need to make sure your server 
 - XML PHP Extension
 </div>
 
+> {note} Installing Laravel in a subdirectory is not supported.
+
 <a name="installing-laravel"></a>
 ### Installing Laravel
 


### PR DESCRIPTION
Installing Laravel in a subdirectory isn't supported but we still often get issues for it. Adding a note to the docs might be a good idea to let people know.