### PR TITLE
Wrong TTL unit variable naming

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -143,7 +143,7 @@ The `increment` and `decrement` methods may be used to adjust the value of integ
 
 Sometimes you may wish to retrieve an item from the cache, but also store a default value if the requested item doesn't exist. For example, you may wish to retrieve all users from the cache or, if they don't exist, retrieve them from the database and add them to the cache. You may do this using the `Cache::remember` method:
 
-    $value = Cache::remember('users', $seconds, function () {
+    $value = Cache::remember('users', $minutes, function () {
         return DB::table('users')->get();
     });
 


### PR DESCRIPTION
second parameter of the Cache::remember method receives minutes, not seconds.