### PR TITLE
[6.x] Update example test method name to be consistent

### DIFF
--- a/console-tests.md
+++ b/console-tests.md
@@ -31,7 +31,7 @@ You may test this command with the following test which utilizes the `expectsQue
      *
      * @return void
      */
-    public function test_console_command()
+    public function testConsoleCommand()
     {
         $this->artisan('question')
              ->expectsQuestion('What is your name?', 'Taylor Otwell')


### PR DESCRIPTION
Update example test method name to be consistent with the rest of the example test methods.