### PR TITLE
[6.x] Documents how to ignore a resource at the unique rule

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1095,7 +1095,7 @@ You may also use the string syntax to ignore a given ID:
 
     'email' => 'unique:users,email,' . $user->id
 
-If you need to ignore by a column different than `id`, you may specify the name of the column name at the expression:
+If you need to ignore by a column different than `id`, you may specify the name of the column at the expression:
 
     'email' => 'unique:users,email,' . $user->id . ',user_id'
 

--- a/validation.md
+++ b/validation.md
@@ -1095,7 +1095,7 @@ You may also use the string syntax to ignore a given ID:
 
     'email' => 'unique:users,email,' . $user->id
 
-If you need to use another column to ignore, just pass the column name as the last argument to expression:
+If you need to ignore by a column different than `id`, you may specify the name of the column name at the expression:
 
     'email' => 'unique:users,email,' . $user->id . ',user_id'
 

--- a/validation.md
+++ b/validation.md
@@ -1089,7 +1089,15 @@ If your table uses a primary key column name other than `id`, you may specify th
 
 By default, the `unique` rule will check the uniqueness of the column matching the name of the attribute being validated. However, you may pass a different column name as the second argument to the `unique` method:
 
-    Rule::unique('users', 'email_address')->ignore($user->id),
+    Rule::unique('users', 'email_address')->ignore($user->id)
+
+You may also use the string syntax to ignore a given ID:
+
+    'email' => 'unique:users,email,' . $user->id
+
+If you need to use another column to ignore, just pass the column name as the last argument to expression:
+
+    'email' => 'unique:users,email,' . $user->id . ',user_id'
 
 **Adding Additional Where Clauses:**
 


### PR DESCRIPTION
I had some troubles to understand at the docs how to ignore a column with the unique clause. Actually, in the docs the only way to do this is by using the **Rule** facade.

This PR creates an example of how to ignore some id by using the simple string syntax. Also, it documents how to use the argument *(idColumn)* at unique rule.