### PR TITLE
Adds chrome version number to artisan command

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1479,7 +1479,7 @@ If you are using [Github Actions](https://github.com/features/actions) to run yo
           - name: Generate Application Key
             run: php artisan key:generate
           - name: Upgrade Chrome Driver
-            run: php artisan dusk:chrome-driver
+            run: php artisan dusk:chrome-driver 76
           - name: Start Chrome Driver
             run: ./vendor/laravel/dusk/bin/chromedriver-linux > /dev/null 2>&1 &
           - name: Run Laravel Server


### PR DESCRIPTION
Github Actions has specific software in virtual environments: https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions#ubuntu-1804-lts

Currently the version of Chrome used in Actions is 76. Now the version of chrome available is 77 you need to specify the version number.