### PR TITLE
Add note about issues with block_for=0

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -93,6 +93,8 @@ Adjusting this value based on your queue load can be more efficient than continu
         'retry_after' => 90,
         'block_for' => 5,
     ],
+    
+> {note} Using a value of `0` for `block_for` will cause the queue workers to block indefinitely until the next job gets released. This will also prevent signals like `SIGTERM` sent to the queue workers from being handled until the next job has been fetched and processed.
 
 #### Other Driver Prerequisites
 


### PR DESCRIPTION
This is something I've been debugging for quite some time to be honest. I have no idea why `block_for` has been set to `0` in my application configuration, but it will block queue workers while being mid-loop, preventing any signals from being handled.

https://github.com/laravel/framework/blob/e11246c25faefecf5540b696b6942310e625a21c/src/Illuminate/Queue/Worker.php#L96-L139

_Explanation: `block_for => 0` will block the queue worker in `$this->getNextJob()`, preventing `$this->stopIfNecessary()` to be executed on a regular basis._

The issue with this is that the queue workers will only restart after the next job has been fetched and processed. Especially on queues with only few throughput (or very irregular throughput), this can be an issue when updating application code. This is because the first job after the application update will still be executed by the old process, leading to a few potential problems:
- The leftover queue worker doesn't have the application code for the new job to be processed.
- The leftover queue worker has old application code for the job to be processed, i.e. performs not desired actions (think about a bugfix not taking effect).

Apparently, sending any signal except for `SIGKILL` to the processes will not work. But `SIGKILL` isn't really an option as it requires `sudo` and is simply dirty. Also is it hard to determine from outside the process whether `SIGKILL` is really necessary or if the worker is just processing an extensive job.