### PR TITLE
Removed type-hinting for explicit model binding

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -342,7 +342,7 @@ To register an explicit binding, use the router's `model` method to specify the 
 
 Next, define a route that contains a `{user}` parameter:
 
-    Route::get('profile/{user}', function (App\User $user) {
+    Route::get('profile/{user}', function ($user) {
         //
     });
 


### PR DESCRIPTION
type-hinting not required for variable names in explicit model binding