### PR TITLE
[6.x] Typo in Redis introduction section

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -13,7 +13,7 @@
 
 [Redis](https://redis.io) is an open source, advanced key-value store. It is often referred to as a data structure server since keys can contain [strings](https://redis.io/topics/data-types#strings), [hashes](https://redis.io/topics/data-types#hashes), [lists](https://redis.io/topics/data-types#lists), [sets](https://redis.io/topics/data-types#sets), and [sorted sets](https://redis.io/topics/data-types#sorted-sets).
 
-Before using Redis with Laravel, we encorage you to install and use the [PhpRedis](https://github.com/phpredis/phpredis) PHP extension via PECL. The extension is more complex to install but may yield better performance for applications that make heavy use of Redis.
+Before using Redis with Laravel, we encourage you to install and use the [PhpRedis](https://github.com/phpredis/phpredis) PHP extension via PECL. The extension is more complex to install but may yield better performance for applications that make heavy use of Redis.
 
 Alternatively, you can install the `predis/predis` package via Composer:
 


### PR DESCRIPTION
Encourage is spelled wrong here.

> Before using Redis with Laravel, we **encorage** you to install and use the PhpRedis PHP extension via PECL.