### PR TITLE
[6.x] Document testing anonymous notification with callback

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -276,7 +276,7 @@ You may use the `Notification` facade's `fake` method to prevent notifications f
                 new AnonymousNotifiable, OrderShipped::class
             );
             
-            // Assert that a notifcation sent via the Notification::route() method was sent to the correct user...
+            // Assert Notification::route() method sent notification to the correct user...
             Notification::assertSentTo(
                 new AnonymousNotifiable,
                 OrderShipped::class,

--- a/mocking.md
+++ b/mocking.md
@@ -275,6 +275,15 @@ You may use the `Notification` facade's `fake` method to prevent notifications f
             Notification::assertSentTo(
                 new AnonymousNotifiable, OrderShipped::class
             );
+            
+            // Assert that a notifcation sent via the Notification::route() method was sent to the correct user...
+            Notification::assertSentTo(
+                new AnonymousNotifiable,
+                OrderShipped::class,
+                function ($notification, $channels, $notifiable) use ($user) {
+                    return $notifiable->routes['mail'] === $user->email;
+                }
+            );
         }
     }
 


### PR DESCRIPTION
This could be merged into the docs for 5.5 and upwards.

Whilst the docs show how anonymous notifications sent using `Notification::route` can be tested, they don't show that you can check where that notification has been sent to as implemented in https://github.com/laravel/framework/pull/21379