### PR TITLE
[5.5] Fix code example for Route Name Prefixes

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -270,7 +270,7 @@ The `name` method may be used to prefix each route name in the group with a give
     Route::name('admin.')->group(function () {
         Route::get('users', function () {
             // Route assigned name "admin.users"...
-        });
+        })->name('users');
     });
 
 <a name="route-model-binding"></a>


### PR DESCRIPTION
The code example for the Route Name Prefixes section was missing a name assignment for the route. 

A similar docs issue has already been fixed for 5.6 (laravel/docs#4122). Future versions of the docs do not have this issue.