### PR TITLE
Supervisor configuration details on horizon page

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -134,9 +134,17 @@ You may gracefully terminate the master Horizon process on your machine using th
 
 If you are deploying Horizon to a live server, you should configure a process monitor to monitor the `php artisan horizon` command and restart it if it quits unexpectedly. When deploying fresh code to your server, you will need to instruct the master Horizon process to terminate so it can be restarted by your process monitor and receive your code changes.
 
-#### Supervisor Configuration
+#### Installing Supervisor
 
-If you are using the Supervisor process monitor to manage your `horizon` process, the following configuration file should suffice:
+Supervisor is a process monitor for the Linux operating system, and will automatically restart your `horizon` process if it fails. To install Supervisor on Ubuntu, you may use the following command:
+
+    sudo apt-get install supervisor
+
+> {tip} If configuring Supervisor yourself sounds overwhelming, consider using [Laravel Forge](https://forge.laravel.com), which will automatically install and configure Supervisor for your Laravel projects.
+
+#### Configuring Supervisor
+
+Supervisor configuration files are typically stored in the `/etc/supervisor/conf.d` directory. Within this directory, you may create any number of configuration files that instruct supervisor how your processes should be monitored. For example, let's create a `laravel-worker.conf` file that starts and monitors a `horizon` process:
 
     [program:horizon]
     process_name=%(program_name)s
@@ -146,6 +154,18 @@ If you are using the Supervisor process monitor to manage your `horizon` process
     user=forge
     redirect_stderr=true
     stdout_logfile=/home/forge/app.com/horizon.log
+
+#### Starting Supervisor
+
+Once the configuration file has been created, you may update the Supervisor configuration and start the processes using the following commands:
+
+    sudo supervisorctl reread
+
+    sudo supervisorctl update
+
+    sudo supervisorctl start laravel-worker:*
+
+For more information on Supervisor, consult the [Supervisor documentation](http://supervisord.org/index.html).
 
 > {tip} If you are uncomfortable managing your own servers, consider using [Laravel Forge](https://forge.laravel.com). Forge provisions PHP 7+ servers with everything you need to run modern, robust Laravel applications with Horizon.
 

--- a/horizon.md
+++ b/horizon.md
@@ -144,7 +144,7 @@ Supervisor is a process monitor for the Linux operating system, and will automat
 
 #### Configuring Supervisor
 
-Supervisor configuration files are typically stored in the `/etc/supervisor/conf.d` directory. Within this directory, you may create any number of configuration files that instruct supervisor how your processes should be monitored. For example, let's create a `laravel-worker.conf` file that starts and monitors a `horizon` process:
+Supervisor configuration files are typically stored in the `/etc/supervisor/conf.d` directory. Within this directory, you may create any number of configuration files that instruct supervisor how your processes should be monitored. For example, let's create a `horizon.conf` file that starts and monitors a `horizon` process:
 
     [program:horizon]
     process_name=%(program_name)s
@@ -163,7 +163,7 @@ Once the configuration file has been created, you may update the Supervisor conf
 
     sudo supervisorctl update
 
-    sudo supervisorctl start laravel-worker:*
+    sudo supervisorctl start horizon
 
 For more information on Supervisor, consult the [Supervisor documentation](http://supervisord.org/index.html).
 


### PR DESCRIPTION
There is a small guide about how to install & configure supervisor on Queue documentation page.
It would be nice if we can add the same guide on Horizon Page.

That's what i have done. :)