### PR TITLE
[6.x] Remove misleading information about optional parameters

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -307,9 +307,9 @@ The `rackspace` storage driver has been removed. If you would like to continue u
 
 #### Route URL Generation & Extra Parameters
 
-In previous releases of Laravel, passing associative array parameters to the `route` helper or `URL::route` method would occasionally use these parameters as URI values when generating URLs for routes with optional parameters, even if the parameter value had no matching key within the route path. Beginning in Laravel 6.0, these values will be attached to the query string instead. For example, consider the following route:
+In previous releases of Laravel, passing associative array parameters to the `route` helper or `URL::route` method would occasionally use these parameters as URI values when generating URLs for routes, even if the parameter value had no matching key within the route path. Beginning in Laravel 6.0, these values will be attached to the query string instead. For example, consider the following route:
 
-    Route::get('/profile/{location?}', function ($location = null) {
+    Route::get('/profile/{location}', function ($location = null) {
         //
     })->name('profile');
 


### PR DESCRIPTION
In documentation there is misleading information that route generation change affects optional paramters. But in fact it affects all paramters and not only optional. 

I've tested this today when making upgrade from Laravel 5.8 to 6.0.3 and confirmed it affects also normal parameters so when having code like this:

```
    Route::get('/profile/{location}', function ($location = null) {
        //
    })->name('profile');
```

result is like below:

```
    // Laravel 5.8: http://example.com/profile/active
    echo route('profile', ['status' => 'active']);

    // Laravel 6.0: http://example.com/profile?status=active
    echo route('profile', ['status' => 'active']); 
```