### PR TITLE
[6.x] Fix Passport environment keys example

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -186,13 +186,9 @@ If necessary, you may define the path where Passport's keys should be loaded fro
 
 Additionally, you may publish Passport's configuration file using `php artisan vendor:publish --tag=passport-config`, which will then provide the option to load the encryption keys from your environment variables:
 
-    PASSPORT_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
-    <private key here>
-    -----END RSA PRIVATE KEY-----"
+    PASSPORT_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n<private key here>\n-----END RSA PRIVATE KEY-----"
 
-    PASSPORT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
-    <public key here>
-    -----END PUBLIC KEY-----"
+    PASSPORT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n<public key here>\n-----END PUBLIC KEY-----
 
 <a name="configuration"></a>
 ## Configuration


### PR DESCRIPTION
Hello,

As shown in the [original Pull Request example](https://github.com/laravel/passport/pull/683), environment keys for Passport need to be placed in one line.