### PR TITLE
[5.8] Add mention of Carbon 2.* being required alongside Carbon 1.*

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -26,6 +26,7 @@
 - [Model Names Ending With Irregular Plurals](#model-names-ending-with-irregular-plurals)
 - [Custom Pivot Models With Incrementing IDs](#custom-pivot-models-with-incrementing-ids)
 - [Pheanstalk 4.0](#pheanstalk-4)
+- [Carbon 2.0](#carbon-2.0)
 </div>
 
 <a name="upgrade-5.8.0"></a>
@@ -630,6 +631,19 @@ The Nexmo and Slack Notification channels have been extracted into first-party p
 
     composer require laravel/nexmo-notification-channel
     composer require laravel/slack-notification-channel
+
+<a name="#carbon-2.0"></a>
+### Carbon 2.0
+
+**Likelihood Of Impact: Medium**
+
+Laravel now require Carbon minimum version "1.26.3" OR "2.0", which mean it will try to upgrade to Carbon 2.0 if no compatibility issues with any other packages are detected.
+
+You can find all breaking changes in [the migration guide to Carbon 2.0](https://carbon.nesbot.com/docs/#api-carbon-2).
+
+If needed, you can lock Carbon version to 1.26.3 by running :
+
+    composer require nesbot/carbon:^1.26.3 
 
 <a name="miscellaneous"></a>
 ### Miscellaneous


### PR DESCRIPTION
Hi there !

I noticed after experiencing it myself and seeing some posts on Reddit that there is no mention Carbon 2.0 being added to 5.8.

The requirement in composer.json became `"nesbot/carbon": "^1.26.3 || ^2.0"` so Carbon 2.0 will be installed if no conflicts are found.
Composer can't find conflict inside the user code and things can broke with Carbon 2 ([see upgrade guide](https://carbon.nesbot.com/docs/#api-carbon-2))

I think it should be worth mentioning it in the Laravel upgrade guide to 5.8.

I took the liberty to label it as "medium" impact because almost every project will have no conflict and Carbon will be upgraded.

I did not upped this to "hard" impact because the list of breaking changes is not that big and not every people will face these problems.

What do you guys think ?

ps : I'm not an English native speaker, so if you see any typo or clumsy sentences let me now, I'll happily rephrase.
I've no problem moving it inside the page if it should no be on the menu or upper... let me now ! :)