### PR TITLE
[6.x] Describe the correct JSON API helpers

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -141,7 +141,7 @@ You may also specify which guard should be used to authenticate the given user b
 <a name="testing-json-apis"></a>
 ## Testing JSON APIs
 
-Laravel also provides several helpers for testing JSON APIs and their responses. For example, the `json`, `get`, `post`, `put`, `patch`, `delete`, and `option` methods may be used to issue requests with various HTTP verbs. You may also easily pass data and headers to these methods. To get started, let's write a test to make a `POST` request to `/user` and assert that the expected data was returned:
+Laravel also provides several helpers for testing JSON APIs and their responses. For example, the `json`, `getJson`, `postJson`, `putJson`, `patchJson`, `deleteJson`, and `optionsJson` methods may be used to issue JSON requests with various HTTP verbs. You may also easily pass data and headers to these methods. To get started, let's write a test to make a `POST` request to `/user` and assert that the expected data was returned:
 
     <?php
 
@@ -154,7 +154,10 @@ Laravel also provides several helpers for testing JSON APIs and their responses.
          */
         public function testBasicExample()
         {
-            $response = $this->json('POST', '/user', ['name' => 'Sally']);
+            $response = $this->postJson('/user', ['name' => 'Sally']);
+            
+            // Which is a shorthand for:
+            // $response = $this->json('POST', '/user', ['name' => 'Sally']);
 
             $response
                 ->assertStatus(201)

--- a/http-tests.md
+++ b/http-tests.md
@@ -155,9 +155,6 @@ Laravel also provides several helpers for testing JSON APIs and their responses.
         public function testBasicExample()
         {
             $response = $this->postJson('/user', ['name' => 'Sally']);
-            
-            // Which is a shorthand for:
-            // $response = $this->json('POST', '/user', ['name' => 'Sally']);
 
             $response
                 ->assertStatus(201)


### PR DESCRIPTION
This pull request fixes the wrong naming of the JSON API helpers. Previously the documentation reported only the `json()` helper, and misleading told that `post()`, `get()`, etc will issue a JSON API request.