### PR TITLE
[6.x] Fixes grammar for Lazy Collection note

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -2660,7 +2660,7 @@ Almost all methods available on the `Collection` class are also available on the
 
 </div>
 
-> {note} Methods that mutate the collection (such as `shift`, `pop`, `prepend` etc.) are are _not_ available on the `LazyCollection` class.
+> {note} Methods that mutate the collection (such as `shift`, `pop`, `prepend` etc.) are _not_ available on the `LazyCollection` class.
 
 <a name="lazy-collection-methods"></a>
 ### Lazy Collection Methods


### PR DESCRIPTION
Noticed a very tiny mistake in the grammar for the docs where it says "are are" for the following note:

> Methods that mutate the collection (such as `shift`, `pop`, `prepend` etc.) are are not available on the `LazyCollection` class.