### PR TITLE
[6.x] Create a database for Github Action

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1474,6 +1474,8 @@ If you are using [Github Actions](https://github.com/features/actions) to run yo
           - uses: actions/checkout@v1
           - name: Prepare The Environment
             run: cp .env.example .env
+          - name: Create Database
+            run: mysql --user="root" --password="root" -e "CREATE DATABASE my-database character set UTF8mb4 collate utf8mb4_bin;"
           - name: Install Composer Dependencies
             run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
           - name: Generate Application Key


### PR DESCRIPTION
to run a Dusk test the user will most likely need a database, so include it in the default suggestion for the Github Action.