### PR TITLE
Missing UploadController added in use statement in example

### DIFF
--- a/container.md
+++ b/container.md
@@ -141,8 +141,8 @@ This statement tells the container that it should inject the `RedisEventPusher` 
 Sometimes you may have two classes that utilize the same interface, but you wish to inject different implementations into each class. For example, two controllers may depend on different implementations of the `Illuminate\Contracts\Filesystem\Filesystem` [contract](/docs/{{version}}/contracts). Laravel provides a simple, fluent interface for defining this behavior:
 
     use App\Http\Controllers\PhotoController;
-    use App\Http\Controllers\VideoController;
     use App\Http\Controllers\UploadController;
+    use App\Http\Controllers\VideoController;
     use Illuminate\Contracts\Filesystem\Filesystem;
     use Illuminate\Support\Facades\Storage;
 

--- a/container.md
+++ b/container.md
@@ -142,6 +142,7 @@ Sometimes you may have two classes that utilize the same interface, but you wish
 
     use App\Http\Controllers\PhotoController;
     use App\Http\Controllers\VideoController;
+    use App\Http\Controllers\UploadController;
     use Illuminate\Contracts\Filesystem\Filesystem;
     use Illuminate\Support\Facades\Storage;
 


### PR DESCRIPTION
In the example of Contextual Binding, UploadController class was missing in the use parameter.