### PR TITLE
[6.x] Add support policies for databases

### DIFF
--- a/database.md
+++ b/database.md
@@ -14,10 +14,10 @@
 Laravel makes interacting with databases extremely simple across a variety of database backends using either raw SQL, the [fluent query builder](/docs/{{version}}/queries), and the [Eloquent ORM](/docs/{{version}}/eloquent). Currently, Laravel supports four databases:
 
 <div class="content-list" markdown="1">
-- MySQL
-- PostgreSQL
-- SQLite
-- SQL Server
+- MySQL 5.6+ ([Version Policy](https://en.wikipedia.org/wiki/MySQL#Release_history))
+- PostgreSQL 9.4+ ([Version Policy](https://www.postgresql.org/support/versioning/))
+- SQLite 3.0+
+- SQL Server 2017+ ([Version Policy](https://support.microsoft.com/en-us/lifecycle/search))
 </div>
 
 <a name="configuration"></a>

--- a/database.md
+++ b/database.md
@@ -16,7 +16,7 @@ Laravel makes interacting with databases extremely simple across a variety of da
 <div class="content-list" markdown="1">
 - MySQL 5.6+ ([Version Policy](https://en.wikipedia.org/wiki/MySQL#Release_history))
 - PostgreSQL 9.4+ ([Version Policy](https://www.postgresql.org/support/versioning/))
-- SQLite 3.0+
+- SQLite 3.8.8+
 - SQL Server 2017+ ([Version Policy](https://support.microsoft.com/en-us/lifecycle/search))
 </div>
 

--- a/releases.md
+++ b/releases.md
@@ -14,7 +14,7 @@ When referencing the Laravel framework or its components from your application o
 <a name="support-policy"></a>
 ## Support Policy
 
-For LTS releases, such as Laravel 6.0, bug fixes are provided for 2 years and security fixes are provided for 3 years. These releases provide the longest window of support and maintenance. For general releases, bug fixes are provided for 6 months and security fixes are provided for 1 year. For all additional libraries, including Lumen, only the latest release receives bug fixes.
+For LTS releases, such as Laravel 6.0, bug fixes are provided for 2 years and security fixes are provided for 3 years. These releases provide the longest window of support and maintenance. For general releases, bug fixes are provided for 6 months and security fixes are provided for 1 year. For all additional libraries, including Lumen, only the latest release receives bug fixes. Databases are supported for stable versions only and [can be reviewed here](/docs/{{version}}/database#introduction).
 
 | Version | Release | Bug Fixes Until | Security Fixes Until |
 | --- | --- | --- | --- |

--- a/releases.md
+++ b/releases.md
@@ -14,7 +14,7 @@ When referencing the Laravel framework or its components from your application o
 <a name="support-policy"></a>
 ## Support Policy
 
-For LTS releases, such as Laravel 6.0, bug fixes are provided for 2 years and security fixes are provided for 3 years. These releases provide the longest window of support and maintenance. For general releases, bug fixes are provided for 6 months and security fixes are provided for 1 year. For all additional libraries, including Lumen, only the latest release receives bug fixes. Databases are supported for stable versions only and [can be reviewed here](/docs/{{version}}/database#introduction).
+For LTS releases, such as Laravel 6.0, bug fixes are provided for 2 years and security fixes are provided for 3 years. These releases provide the longest window of support and maintenance. For general releases, bug fixes are provided for 6 months and security fixes are provided for 1 year. For all additional libraries, including Lumen, only the latest release receives bug fixes. In addition, please review the database versions [supported by Laravel](/docs/{{version}}/database#introduction).
 
 | Version | Release | Bug Fixes Until | Security Fixes Until |
 | --- | --- | --- | --- |


### PR DESCRIPTION
This adds version policies for the different database types and the minimum versions we support. I couldn't find a support policy for SQLite so I added the latest version (which was released in 2004). 

Also linked to the versions from the main support policy docs.