### PR TITLE
[6.x] Add assertNoContent

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -277,6 +277,7 @@ Laravel provides a variety of custom assertion methods for your [PHPUnit](https:
 [assertJsonStructure](#assert-json-structure)
 [assertJsonValidationErrors](#assert-json-validation-errors)
 [assertLocation](#assert-location)
+[assertNoContent](#assert-no-content)
 [assertNotFound](#assert-not-found)
 [assertOk](#assert-ok)
 [assertPlainCookie](#assert-plain-cookie)
@@ -435,6 +436,13 @@ Assert that the response has the given JSON validation errors:
 Assert that the response has the given URI value in the `Location` header:
 
     $response->assertLocation($uri);
+
+<a name="assert-no-content"></a>
+#### assertNoContent
+
+Assert that the response has the given status code and no content.
+
+    $response->assertNoContent($status);
 
 <a name="assert-not-found"></a>
 #### assertNotFound

--- a/http-tests.md
+++ b/http-tests.md
@@ -442,7 +442,7 @@ Assert that the response has the given URI value in the `Location` header:
 
 Assert that the response has the given status code and no content.
 
-    $response->assertNoContent($status);
+    $response->assertNoContent($status = 204);
 
 <a name="assert-not-found"></a>
 #### assertNotFound


### PR DESCRIPTION
Adds the new `assertNoContent` (https://github.com/laravel/framework/pull/30125) method in 6.1.0.