### PR TITLE
[6.x] add a note on new 'confirm' middleware

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -222,6 +222,8 @@ To accomplish this, Laravel provides a `password.confirm` middleware. Attaching 
 
 After the user has successfully confirmed their password, the user redirected to the route they originally tried to access. By default, after confirming their password, the user will not have to confirm their password again for three hours. You are free to customize the length of time before the user must re-confirm their password using the `auth.password_timeout` configuration option.
 
+> {note} The `password.confirm` middleware can only be applied to `GET` routes.
+
 <a name="login-throttling"></a>
 ### Login Throttling
 


### PR DESCRIPTION
since we are redirecting, we can only send the user on to a `GET` route.

I would like to explore the ability to confirm `POST` routes, but with the current code, it is not possible.