### PR TITLE
[6.x] Job Middleware example, added missing return statement as per docblocks

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -222,16 +222,16 @@ Instead of rate limiting in the handle method, we could define a job middleware 
          */
         public function handle($job, $next)
         {
-            Redis::throttle('key')
+            return Redis::throttle('key')
                     ->block(0)->allow(1)->every(5)
                     ->then(function () use ($job, $next) {
                         // Lock obtained...
 
-                        $next($job);
+                        return $next($job);
                     }, function () use ($job) {
                         // Could not obtain lock...
 
-                        $job->release(5);
+                        return $job->release(5);
                     });
         }
     }

--- a/releases.md
+++ b/releases.md
@@ -118,16 +118,16 @@ In Laravel 6, this logic may be extracted into a job middleware, allowing you to
          */
         public function handle($job, $next)
         {
-            Redis::throttle('key')
+            return Redis::throttle('key')
                     ->block(0)->allow(1)->every(5)
                     ->then(function () use ($job, $next) {
                         // Lock obtained...
 
-                        $next($job);
+                        return $next($job);
                     }, function () use ($job) {
                         // Could not obtain lock...
 
-                        $job->release(5);
+                        return $job->release(5);
                     });
         }
     }


### PR DESCRIPTION
Job Middleware example, added missing return statement as perdocblocks. It's mentioned the return type as `@mixed` but missed to return from example.

