### PR TITLE
[6.x] Typo Fix

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1595,7 +1595,7 @@ The `replace` method behaves similarly to `merge`; however, in addition to overw
 <a name="method-replacerecursive"></a>
 #### `replaceRecursive()` {#collection-method}
 
-This method works like `replace`, but it will recurs into arrays and apply the same replacement process to the inner values:
+This method works like `replace`, but it will recur into arrays and apply the same replacement process to the inner values:
 
     $collection = collect(['Taylor', 'Abigail', ['James', 'Victoria', 'Finn']]);
 

--- a/collections.md
+++ b/collections.md
@@ -1595,7 +1595,7 @@ The `replace` method behaves similarly to `merge`; however, in addition to overw
 <a name="method-replacerecursive"></a>
 #### `replaceRecursive()` {#collection-method}
 
-This method works like `replace`, but it will recurse into arrays and apply the same replacement process to the inner values:
+This method works like `replace`, but it will recurs into arrays and apply the same replacement process to the inner values:
 
     $collection = collect(['Taylor', 'Abigail', ['James', 'Victoria', 'Finn']]);
 

--- a/queues.md
+++ b/queues.md
@@ -243,7 +243,7 @@ After creating job middleware, they may be attached to a job by returning them f
     use App\Jobs\Middleware\RateLimited;
 
     /**
-     * Get the middlewarwe the job should pass through.
+     * Get the middleware the job should pass through.
      *
      * @return array
      */


### PR DESCRIPTION
1. Changed the word `recurse` to `recurs` to be meaningful.
2. Corrected spelling mistake for `middlewarwe` to `middleware`.