### PR TITLE
[6.x] Add partialMock shorthand method

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -38,7 +38,7 @@ In order to make this more convenient, you may use the `mock` method, which is p
         $mock->shouldReceive('process')->once();
     });
 
-You may use the `partialMock` method if you only need to mock several methods of an object and leaving the remainder to respond to calls normally. 
+You may use the `partialMock` method if you only need to mock several methods of an object and leaving the remainder frees to respond to calls normally. 
    
     use App\Service;
 

--- a/mocking.md
+++ b/mocking.md
@@ -38,6 +38,14 @@ In order to make this more convenient, you may use the `mock` method, which is p
         $mock->shouldReceive('process')->once();
     });
 
+You may use the `partialMock` method if you only need to mock several methods of an object and leaving the remainder to respond to calls normally. 
+   
+    use App\Service;
+
+    $this->partialMock(Service::class, function ($mock) {
+       $mock->shouldReceive('process')->once();
+    });
+
 Similarly, if you want to spy on an object, Laravel's base test case class offers a `spy` method as a convenient wrapper around the `Mockery::spy` method:
 
     use App\Service;

--- a/mocking.md
+++ b/mocking.md
@@ -38,8 +38,8 @@ In order to make this more convenient, you may use the `mock` method, which is p
         $mock->shouldReceive('process')->once();
     });
 
-You may use the `partialMock` method if you only need to mock several methods of an object and leaving the remainder frees to respond to calls normally. 
-   
+You may use the `partialMock` method when you only need to mock a few methods of an object. The methods that are not mocked will be executed normally when called:
+
     use App\Service;
 
     $this->partialMock(Service::class, function ($mock) {

--- a/mocking.md
+++ b/mocking.md
@@ -43,7 +43,7 @@ You may use the `partialMock` method if you only need to mock several methods of
     use App\Service;
 
     $this->partialMock(Service::class, function ($mock) {
-       $mock->shouldReceive('process')->once();
+        $mock->shouldReceive('process')->once();
     });
 
 Similarly, if you want to spy on an object, Laravel's base test case class offers a `spy` method as a convenient wrapper around the `Mockery::spy` method:


### PR DESCRIPTION
This merge request adds `partialMock` shorthand method.

Reference: https://github.com/laravel/framework/pull/30202