### PR TITLE
[6.x] make middleware single word to plural

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -308,7 +308,7 @@ So far, we have only examined policy methods that return simple boolean values. 
                     : Response::deny('You do not own this post.');
     }
 
-When returning an authorization response from your policy, the `Gate::allows` method will still return a simple boolean value; however, you may use use the `Gate::inspect` method to get the full authorization response returned by the gate:
+When returning an authorization response from your policy, the `Gate::allows` method will still return a simple boolean value; however, you may use the `Gate::inspect` method to get the full authorization response returned by the gate:
 
     $response = Gate::inspect('update', $post);
 

--- a/authorization.md
+++ b/authorization.md
@@ -116,7 +116,7 @@ If you would like to attempt to authorize an action and automatically throw an `
 
     // The action is authorized...
 
-#### Supplying Additional Context 
+#### Supplying Additional Context
 
 The gate methods for authorizing abilities (`allows`, `denies`, `check`, `any`, `none`, `authorize`, `can`, `cannot`) and the authorization [Blade directives](#via-blade-templates) (`@can`, `@cannot`, `@canany`) can receive an array as the second argument. These array elements are passed as parameters to gate, and can be used for additional context when making authorization decisions:
 
@@ -142,7 +142,7 @@ So far, we have only examined gates that return simple boolean values. However, 
                     : Response::deny('You must be a super administrator.');
     });
 
-When returning an authorization response from your gate, the `Gate::allows` method will still return a simple boolean value; however, you may use use the `Gate::inspect` method to get the full authorization response returned by the gate:
+When returning an authorization response from your gate, the `Gate::allows` method will still return a simple boolean value; however, you may use the `Gate::inspect` method to get the full authorization response returned by the gate:
 
     $response = Gate::inspect('edit-settings', $post);
 
@@ -577,7 +577,7 @@ When authorizing actions using policies, you may pass an array as the second arg
      */
     public function update(User $user, Post $post, int $category)
     {
-        return $user->id === $post->user_id && 
+        return $user->id === $post->user_id &&
                $category > 3;
     }
 

--- a/providers.md
+++ b/providers.md
@@ -12,7 +12,7 @@
 
 Service providers are the central place of all Laravel application bootstrapping. Your own application, as well as all of Laravel's core services are bootstrapped via service providers.
 
-But, what do we mean by "bootstrapped"? In general, we mean **registering** things, including registering service container bindings, event listeners, middlewares, and even routes. Service providers are the central place to configure your application.
+But, what do we mean by "bootstrapped"? In general, we mean **registering** things, including registering service container bindings, event listeners, middleware, and even routes. Service providers are the central place to configure your application.
 
 If you open the `config/app.php` file included with Laravel, you will see a `providers` array. These are all of the service provider classes that will be loaded for your application. Note that many of these are "deferred" providers, meaning they will not be loaded on every request, but only when the services they provide are actually needed.
 

--- a/providers.md
+++ b/providers.md
@@ -12,7 +12,7 @@
 
 Service providers are the central place of all Laravel application bootstrapping. Your own application, as well as all of Laravel's core services are bootstrapped via service providers.
 
-But, what do we mean by "bootstrapped"? In general, we mean **registering** things, including registering service container bindings, event listeners, middleware, and even routes. Service providers are the central place to configure your application.
+But, what do we mean by "bootstrapped"? In general, we mean **registering** things, including registering service container bindings, event listeners, middlewares, and even routes. Service providers are the central place to configure your application.
 
 If you open the `config/app.php` file included with Laravel, you will see a `providers` array. These are all of the service provider classes that will be loaded for your application. Note that many of these are "deferred" providers, meaning they will not be loaded on every request, but only when the services they provide are actually needed.
 


### PR DESCRIPTION
Following fixes in this PR:
1. Make middleware singular to plural in `providers.md` file
2. Fix grammar mistakes in `authorization.md` file