### PR TITLE
[6.x] Recommend copying .env.example file instead of renaming

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -85,7 +85,7 @@ After installing Laravel, you may need to configure some permissions. Directorie
 
 The next thing you should do after installing Laravel is set your application key to a random string. If you installed Laravel via Composer or the Laravel installer, this key has already been set for you by the `php artisan key:generate` command.
 
-Typically, this string should be 32 characters long. The key can be set in the `.env` environment file. If you have not renamed the `.env.example` file to `.env`, you should do that now. **If the application key is not set, your user sessions and other encrypted data will not be secure!**
+Typically, this string should be 32 characters long. The key can be set in the `.env` environment file. If you have not made a copy of the `.env.example` file named `.env`, you should do that now. **If the application key is not set, your user sessions and other encrypted data will not be secure!**
 
 #### Additional Configuration
 


### PR DESCRIPTION
One common mistake I see people make getting started with Laravel is how they rename .env.example to .env then don't have a copy of the file available in version control to get themselves started when they start the repo again.

The most common solution for this I've seen in repos is to just keep the .env.example file and make a copy of it instead. Seems like it wouldn't hurt to be worded that way in the docs.