### PR TITLE
[6.x] Update upgrade guide to include HandlesAuthorization trait change

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -79,6 +79,22 @@ The constructor signature of the `Illuminate\Auth\Access\Response` class has cha
 
 The `Illuminate\Contracts\Auth\Access\Gate` contract has received a new `inspect` method. If you are implementing this interface manually, you should add this method to your implementation.
 
+#### The `Illuminate\Auth\Access\HandlesAuthorization` Trait
+
+**Likelihood Of Impact: Low**
+
+The `Illuminate\Auth\Access\HandlesAuthorization` trait's method `deny()` has been updated to return `\Illuminate\Auth\Access\Response`. Previously it would throw an exception. 
+You may need to update your policy classes to add a `return` statement like:
+
+    public function update(User $user, Post $post)
+    {
+        if($user->role !== 'editor') {
+            return $this->deny("You must be an editor to edit a post.")
+        }
+        
+        return $user->id === $post->user_id;
+    }
+    
 ### Carbon
 
 <a name="carbon-support"></a>


### PR DESCRIPTION
Hi,

This PR adds instructions for a change in `Illuminate\Auth\Access\HandlesAuthorization` trait that was introduced in this pull request.
https://github.com/laravel/framework/pull/29117

#### Laravel 5.8 behaviour
The `deny()` method throws an exception and there is no need of `return` statement.
The return is useless here knowing that it will throw exception.
```php
    public function update(User $user, Post $post)
    {
        if($user->role !== 'editor') {
            // works without return
            $this->deny("You must be an editor to edit a post.")
        }
        
        return $user->id === $post->user_id;
    }
```
#### Laravel 6.0 behaviour
The `deny()` method no longer throws an exception, developer need to add a `return` statement in order to make the policy work.
Without the return statement, all of the `deny()` calls are being ignored.
```php
    public function update(User $user, Post $post)
    {
        if($user->role !== 'editor') {
           // need to add return
            return $this->deny("You must be an editor to edit a post.")
        }
        
        return $user->id === $post->user_id;
    }
```

Feel free to suggest edits.
