### PR TITLE
[6.x] Directly clone release branch if we only want to use it

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -148,13 +148,11 @@ If this command fails, make sure your Vagrant installation is up to date.
 
 You may install Homestead by cloning the repository onto your host machine. Consider cloning the repository into a `Homestead` folder within your "home" directory, as the Homestead box will serve as the host to all of your Laravel projects:
 
-    git clone https://github.com/laravel/homestead.git ~/Homestead
+    git clone https://github.com/laravel/homestead.git -b release ~/Homestead
 
 You should check out a tagged version of Homestead since the `master` branch may not always be stable. You can find the latest stable version on the [GitHub Release Page](https://github.com/laravel/homestead/releases). Alternatively, you may checkout the `release` branch which always contains the latest stable release:
 
     cd ~/Homestead
-
-    git checkout release
 
 Once you have cloned the Homestead repository, run the `bash init.sh` command from the Homestead directory to create the `Homestead.yaml` configuration file. The `Homestead.yaml` file will be placed in the Homestead directory:
 


### PR DESCRIPTION
This saves us the extra step of checking out the branch later