### PR TITLE
Add missing Engine::map argument to scout docs

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -376,7 +376,7 @@ If one of the built-in Scout search engines doesn't fit your needs, you may writ
     abstract public function search(Builder $builder);
     abstract public function paginate(Builder $builder, $perPage, $page);
     abstract public function mapIds($results);
-    abstract public function map($results, $model);
+    abstract public function map(Builder $builder, $results, $model);
     abstract public function getTotalCount($results);
     abstract public function flush($model);
 


### PR DESCRIPTION
The `Engine::map` method [takes a `Builder $builder` parameter](https://github.com/laravel/scout/blob/31ddbaa62791d0148bb79a0456e1c9a287c50e2c/src/Engines/Engine.php#L59) as the first argument.