### PR TITLE
Consistency: API token length 80 characters

### DIFF
--- a/api-authentication.md
+++ b/api-authentication.md
@@ -54,7 +54,7 @@ Once the `api_token` column has been added to your `users` table, you are ready 
             'name' => $data['name'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
-            'api_token' => Str::random(60),
+            'api_token' => Str::random(80),
         ]);
     }
 
@@ -92,7 +92,7 @@ For example, a controller method that initializes / refreshes the token for a gi
          */
         public function update(Request $request)
         {
-            $token = Str::random(60);
+            $token = Str::random(80);
 
             $request->user()->forceFill([
                 'api_token' => hash('sha256', $token),


### PR DESCRIPTION
```php
Str::random(80)
```

 because of

```php
$table->string('api_token', 80)->after('password')
```