### PR TITLE
[6.x] Demonstrate simplest method to attach relation

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -227,7 +227,7 @@ You may also attach relationships to models in your factory definitions. For exa
         ];
     });
 
-If the relationship depends on the facotry that defines them you may use a callback that accepts the evaluated attribute array:
+If the relationship depends on the factory that defines it you may use a callback that accepts the evaluated attribute array:
 
     $factory->define(App\Post::class, function ($faker) {
         return [

--- a/database-testing.md
+++ b/database-testing.md
@@ -227,7 +227,7 @@ You may also attach relationships to models in your factory definitions. For exa
         ];
     });
 
-If the relationship depends on the factory that defines it you may use a callback that accepts the evaluated attribute array:
+If the relationship depends on the factory that defines it you may provide a callback which accepts the evaluated attribute array:
 
     $factory->define(App\Post::class, function ($faker) {
         return [

--- a/database-testing.md
+++ b/database-testing.md
@@ -208,7 +208,7 @@ In this example, we'll attach a relation to some created models. When using the 
                ->each(function ($user) {
                     $user->posts()->save(factory(App\Post::class)->make());
                 });
-                
+
 You may use the `createMany` method to create multiple related models:
 
     $user->posts()->createMany(
@@ -217,27 +217,23 @@ You may use the `createMany` method to create multiple related models:
 
 #### Relations & Attribute Closures
 
-You may also attach relationships to models using Closure attributes in your factory definitions. For example, if you would like to create a new `User` instance when creating a `Post`, you may do the following:
+You may also attach relationships to models in your factory definitions. For example, if you would like to create a new `User` instance when creating a `Post`, you may do the following:
 
     $factory->define(App\Post::class, function ($faker) {
         return [
             'title' => $faker->title,
             'content' => $faker->paragraph,
-            'user_id' => function () {
-                return factory(App\User::class)->create()->id;
-            },
+            'user_id' => factory(App\User::class),
         ];
     });
 
-These Closures also receive the evaluated attribute array of the factory that defines them:
+If the relationship depends on the facotry that defines them you may use a callback that accepts the evaluated attribute array:
 
     $factory->define(App\Post::class, function ($faker) {
         return [
             'title' => $faker->title,
             'content' => $faker->paragraph,
-            'user_id' => function () {
-                return factory(App\User::class)->create()->id;
-            },
+            'user_id' => factory(App\User::class),
             'user_type' => function (array $post) {
                 return App\User::find($post['user_id'])->type;
             },


### PR DESCRIPTION
I notice a lot of examples where developers are using complex setups in order to build associations in their model factories - either using `factory(Model::class)->create()->id`, or doing it in a callback to make it happen lazily.

I think the docs should demonstrate that the easiest solution is simply to associate `factory(Model::class)` and let Laravel do the rest of the work, while still showing how closures can be used for more complex configurations.