### PR TITLE
[5.7] Note about whereDate method change

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -271,6 +271,19 @@ In addition, the `cursor` method was added to the contract:
 
 If you are implementing this interface, you should add this method to your implementation.
 
+#### The `whereDate` Method
+
+**Likelihood Of Impact: Low**
+
+The query builder's `whereDate` method now converts `DateTime` instances to `Y-m-d` format:
+
+    // previous behaviour - SELECT * FROM `table` WHERE `created_at` > '2018-08-01 13:00:00'
+    $query->whereDate('created_at', '>', Carbon::parse('2018-08-01 13:00:00'));
+    
+    // current behaviour - SELECT * FROM `table` WHERE `created_at` > '2018-08-01'
+    $query->whereDate('created_at', '>', Carbon::parse('2018-08-01 13:00:00'));
+     
+
 #### Migration Command Output
 
 **Likelihood Of Impact: Very Low**


### PR DESCRIPTION
new whereDate method can break code for users who used DateTime instances already

See https://github.com/laravel/framework/commit/d4cb93bb9e2bf0b9ee030341c988145ecf0b0526