### PR TITLE
Added tip to add api_token to fillable attributes

### DIFF
--- a/api-authentication.md
+++ b/api-authentication.md
@@ -58,6 +58,8 @@ Once the `api_token` column has been added to your `users` table, you are ready 
         ]);
     }
 
+> {tip} Add the `api_token` to the fillable attributes of the `User` model to avoid having `null` API tokens after registration.
+
 <a name="hashing-tokens"></a>
 ### Hashing Tokens
 


### PR DESCRIPTION
Users may spend some time to figure out why they're having null API tokens due to the Mass Assignment on the `create` method of the `RegisterController` so I think it's a good idea to mention this