### PR TITLE
[6.x] Add section for action() helper in upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -341,7 +341,7 @@ The `action` helper and `URL::action` method are also affected by this change:
     // Laravel 5.8: http://example.com/profile/1
     echo action('ProfileController@show', ['profile' => 1]);
 
-    // Laravel 6.0: http://example.com/profile?id=1
+    // Laravel 6.0: http://example.com/profile?profile=1
     echo action('ProfileController@show', ['profile' => 1]);   
 
 ### Validation

--- a/upgrade.md
+++ b/upgrade.md
@@ -334,6 +334,16 @@ In previous releases of Laravel, passing associative array parameters to the `ro
     // Laravel 6.0: http://example.com/profile?status=active
     echo route('profile', ['status' => 'active']);    
 
+The `action` helper and `URL::action` method are also affected by this change:
+
+    Route::get('/profile/{id}', 'ProfileController@show');
+
+    // Laravel 5.8: http://example.com/profile/1
+    echo action('ProfileController@show', ['profile' => 1]);
+
+    // Laravel 6.0: http://example.com/profile?id=1
+    echo action('ProfileController@show', ['profile' => 1]);   
+
 ### Validation
 
 #### FormRequest `validationData` Method


### PR DESCRIPTION
I noticed the `action()` helper is also affected if there is no matching key within the route path.

This PR makes that more clear in the upgrade guide.

I sent in #5548 this morning which was incorrect, I fixed that in this PR.