### PR TITLE
[6.x] consistent wording for scheduling docs

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -111,7 +111,7 @@ Method  | Description
 `->everyFifteenMinutes();`  |  Run the task every fifteen minutes
 `->everyThirtyMinutes();`  |  Run the task every thirty minutes
 `->hourly();`  |  Run the task every hour
-`->hourlyAt(17);`  |  Run the task every hour at 17 mins past the hour
+`->hourlyAt(17);`  |  Run the task every hour at 17 minutes past the hour
 `->daily();`  |  Run the task every day at midnight
 `->dailyAt('13:00');`  |  Run the task every day at 13:00
 `->twiceDaily(1, 13);`  |  Run the task daily at 1:00 & 13:00


### PR DESCRIPTION
all the other examples use the full 'minutes' instead of 'mins'.

updating for consistency