### PR TITLE
Add a note about the Route Name Prefixes key

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -298,6 +298,8 @@ The `name` method may be used to prefix each route name in the group with a give
         })->name('users');
     });
 
+When using the array as a first parameter to the `Route::group` method, the key must be `as` and not `name`.
+
 <a name="route-model-binding"></a>
 ## Route Model Binding
 


### PR DESCRIPTION
When using the  `Route::group` with an array as  the first parameter, the key for name prefixes is not `name` but `as` and it is not mentioned in the documentation.

I let you change the formulation because English is not my native language.