### PR TITLE
[6.x] Fix syntax error in the '$request->missing()' example

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -239,7 +239,7 @@ If you would like to determine if a value is present on the request and is not e
 
 To determine if a given key is absent from the request, you may use the `missing` method:
 
-    if ($request->missing('name') {
+    if ($request->missing('name')) {
         //
     }
 


### PR DESCRIPTION
Hey there,

Just spotted this little syntax error in the `$request->missing()` method example.