### PR TITLE
[6.x] Update the way of enable foreign keys in SQLite

### DIFF
--- a/database.md
+++ b/database.md
@@ -34,12 +34,9 @@ After creating a new SQLite database using a command such as `touch database/dat
     DB_CONNECTION=sqlite
     DB_DATABASE=/absolute/path/to/database.sqlite
 
-To enable foreign key constraints for SQLite connections, you should add the `foreign_key_constraints` option to your `config/database.php` configuration file:
+To enable foreign key constraints for SQLite connections, you should add the `DB_FOREIGN_KEYS` environment variable:
 
-    'sqlite' => [
-        // ...
-        'foreign_key_constraints' => true,
-    ],
+    DB_FOREIGN_KEYS=true
 
 #### Configuration Using URLs
 

--- a/database.md
+++ b/database.md
@@ -34,7 +34,7 @@ After creating a new SQLite database using a command such as `touch database/dat
     DB_CONNECTION=sqlite
     DB_DATABASE=/absolute/path/to/database.sqlite
 
-To enable foreign key constraints for SQLite connections, you should add the `DB_FOREIGN_KEYS` environment variable:
+To enable foreign key constraints for SQLite connections, you should set the `DB_FOREIGN_KEYS` environment variable to `true`:
 
     DB_FOREIGN_KEYS=true
 


### PR DESCRIPTION
If we check `config/database.php`, it actually uses `'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),`. So we should set `DB_FOREIGN_KEYS` in `.env` file, which is more portable. And you only need to edit one file to make SQLite work.