### PR TITLE
[6.x] Clarification on assertSessionHasErrors

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -556,16 +556,16 @@ Assert that the session has a given list of values:
 <a name="assert-session-has-errors"></a>
 #### assertSessionHasErrors
 
-Assert that the session contains an error for the given field:
+Assert that the session contains an error for the given `$fields`. If `$fields` is an associative array, assert that the session contains a specific error message (value) for each field (key):
 
-    $response->assertSessionHasErrors(array $keys, $format = null, $errorBag = 'default');
+    $response->assertSessionHasErrors(array $fields, $format = null, $errorBag = 'default');
 
 <a name="assert-session-has-errors-in"></a>
 #### assertSessionHasErrorsIn
 
-Assert that the session has the given errors:
+Assert that the session contains an error for the given `$fields`, within a specific error bag. If `$fields` is an associative array, assert that the session contains a specific error message (value) for each field (key), within a specific error bag:
 
-    $response->assertSessionHasErrorsIn($errorBag, $keys = [], $format = null);
+    $response->assertSessionHasErrorsIn($errorBag, $fields = [], $format = null);
 
 <a name="assert-session-has-no-errors"></a>
 #### assertSessionHasNoErrors


### PR DESCRIPTION
Adding some clarification on `assertSessionHasErrors` and `assertSessionHasErrorsIn`. Most notably, that you can pass either a simple, indexed array of fields to check for (generally), or an associate array of fields and specific error messages. Very open to suggestions on wording, but thought this would be a worthwhile, helpful addition.