### PR TITLE
[6.x] assertSessionHasErrors clarification

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -556,16 +556,16 @@ Assert that the session has a given list of values:
 <a name="assert-session-has-errors"></a>
 #### assertSessionHasErrors
 
-Assert that the session contains an error for the given `$fields`. If `$fields` is an associative array, assert that the session contains a specific error message (value) for each field (key):
+Assert that the session contains an error for the given `$keys`. If `$keys` is an associative array, assert that the session contains a specific error message (value) for each field (key):
 
-    $response->assertSessionHasErrors(array $fields, $format = null, $errorBag = 'default');
+    $response->assertSessionHasErrors(array $keys, $format = null, $errorBag = 'default');
 
 <a name="assert-session-has-errors-in"></a>
 #### assertSessionHasErrorsIn
 
-Assert that the session contains an error for the given `$fields`, within a specific error bag. If `$fields` is an associative array, assert that the session contains a specific error message (value) for each field (key), within a specific error bag:
+Assert that the session contains an error for the given `$keys`, within a specific error bag. If `$keys` is an associative array, assert that the session contains a specific error message (value) for each field (key), within the error bag:
 
-    $response->assertSessionHasErrorsIn($errorBag, $fields = [], $format = null);
+    $response->assertSessionHasErrorsIn($errorBag, $keys = [], $format = null);
 
 <a name="assert-session-has-no-errors"></a>
 #### assertSessionHasNoErrors

--- a/http-tests.md
+++ b/http-tests.md
@@ -556,16 +556,16 @@ Assert that the session has a given list of values:
 <a name="assert-session-has-errors"></a>
 #### assertSessionHasErrors
 
-Assert that the session contains an error for the given field:
+Assert that the session contains an error for the given `$fields`. If `$fields` is an associative array, assert that the session contains a specific error message (value) for each field (key):
 
-    $response->assertSessionHasErrors(array $keys, $format = null, $errorBag = 'default');
+    $response->assertSessionHasErrors(array $fields, $format = null, $errorBag = 'default');
 
 <a name="assert-session-has-errors-in"></a>
 #### assertSessionHasErrorsIn
 
-Assert that the session has the given errors:
+Assert that the session contains an error for the given `$fields`, within a specific error bag. If `$fields` is an associative array, assert that the session contains a specific error message (value) for each field (key), within a specific error bag:
 
-    $response->assertSessionHasErrorsIn($errorBag, $keys = [], $format = null);
+    $response->assertSessionHasErrorsIn($errorBag, $fields = [], $format = null);
 
 <a name="assert-session-has-no-errors"></a>
 #### assertSessionHasNoErrors


### PR DESCRIPTION
Update to #5564, reverting to `$keys` for consistency with source code. Kept other edits to `assertSessionHasErrors` and `assertSessionHasErrorsIn`.