### PR TITLE
[6.x] Document closure as second parameter

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -5,7 +5,7 @@
 - [Writing Commands](#writing-commands)
     - [Generating Commands](#generating-commands)
     - [Command Structure](#command-structure)
-    - [Closure Commands](#closure-commands)
+    - [Commands](#closure-commands)
 - [Defining Input Expectations](#defining-input-expectations)
     - [Arguments](#arguments)
     - [Options](#options)
@@ -331,6 +331,12 @@ If you need to ask the user for a simple confirmation, you may use the `confirm`
 The `anticipate` method can be used to provide auto-completion for possible choices. The user can still choose any answer, regardless of the auto-completion hints:
 
     $name = $this->anticipate('What is your name?', ['Taylor', 'Dayle']);
+    
+Alternatively, you may pass a closure instead of an array as the second parameter. This closure will be called each time the user types a character into the input. It should accept a string parameter containing the user's input so far, and return an array of options for autocompletion. This is useful when you need to generate the autocompletion options dynamically based on the user's input, rather than upfront.
+
+    $name = $this->anticipate('What is your name?', function ($input) {
+        return $this->externalService->getFilteredNames($input)->toArray();
+    });
 
 #### Multiple Choice Questions
 


### PR DESCRIPTION
- Anticipate can now accept a closure as a second parameter instead of an array, as of 6.0