### PR TITLE
Update eloquent docs on event firing

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -863,7 +863,7 @@ Eloquent models fire several events, allowing you to hook into the following poi
 
 The `retrieved` event will fire when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will fire. If a model already existed in the database and the `save` method is called, the `updating` / `updated` events will fire. However, in both cases, the `saving` / `saved` events will fire.
 
-> {note} When issuing a mass update, or a mass delete, via Eloquent, the `saved`, `updated`, `deleting`, `deleted` model events will not be fired for the affected models. This is because the models are never actually retrieved when issuing a mass update or delete.
+> {note} When issuing a mass update or via Eloquent, the `saved`, `updated`, `deleting`, and `deleted` model events will not be fired for the affected models. This is because the models are never actually retrieved when issuing a mass update or delete.
 
 To get started, define a `$dispatchesEvents` property on your Eloquent model that maps various points of the Eloquent model's lifecycle to your own [event classes](/docs/{{version}}/events):
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -863,7 +863,7 @@ Eloquent models fire several events, allowing you to hook into the following poi
 
 The `retrieved` event will fire when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will fire. If a model already existed in the database and the `save` method is called, the `updating` / `updated` events will fire. However, in both cases, the `saving` / `saved` events will fire.
 
-> {note} When issuing a mass update via Eloquent, the `saved` and `updated` model events will not be fired for the updated models. This is because the models are never actually retrieved when issuing a mass update.
+> {note} When issuing a mass update, or a mass delete, via Eloquent, the `saved`, `updated`, `deleting`, `deleted` model events will not be fired for the affected models. This is because the models are never actually retrieved when issuing a mass update or delete.
 
 To get started, define a `$dispatchesEvents` property on your Eloquent model that maps various points of the Eloquent model's lifecycle to your own [event classes](/docs/{{version}}/events):
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -863,7 +863,7 @@ Eloquent models fire several events, allowing you to hook into the following poi
 
 The `retrieved` event will fire when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will fire. If a model already existed in the database and the `save` method is called, the `updating` / `updated` events will fire. However, in both cases, the `saving` / `saved` events will fire.
 
-> {note} When issuing a mass update or via Eloquent, the `saved`, `updated`, `deleting`, and `deleted` model events will not be fired for the affected models. This is because the models are never actually retrieved when issuing a mass update or delete.
+> {note} When issuing a mass update or delete via Eloquent, the `saved`, `updated`, `deleting`, and `deleted` model events will not be fired for the affected models. This is because the models are never actually retrieved when issuing a mass update or delete.
 
 To get started, define a `$dispatchesEvents` property on your Eloquent model that maps various points of the Eloquent model's lifecycle to your own [event classes](/docs/{{version}}/events):
 


### PR DESCRIPTION
The doc should be more clear that NO events will be fired on mass update and mass deletion.

If you try to do `User::whereKey($id)->forceDelete()` the observer will be ignored. This doc update expands the warning in order to let the developer knows that.

I've targeted the 6.x branch but I think this affect any Laravel version that has Eloquent observer in it