### PR TITLE
[6.x] Installation - Add missing PHP extensions

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -28,6 +28,8 @@ However, if you are not using Homestead, you will need to make sure your server 
 - PDO PHP Extension
 - Tokenizer PHP Extension
 - XML PHP Extension
+- DOM PHP Extension
+- XMLWriter PHP Extension
 </div>
 
 <a name="installing-laravel"></a>

--- a/installation.md
+++ b/installation.md
@@ -28,6 +28,7 @@ However, if you are not using Homestead, you will need to make sure your server 
 - PDO PHP Extension
 - Tokenizer PHP Extension
 - XML PHP Extension
+- Sessions PHP Extension
 - DOM PHP Extension
 - XMLWriter PHP Extension
 </div>


### PR DESCRIPTION
Adds 3 PHP extensions to the installation docs which may be required to get a running example project working.

---

I have tried following the [Laravel Installation docs](https://laravel.com/docs/master/installation) with Alpine Linux.

`composer create-project --prefer-dist laravel/laravel blog` fails to install due to missing extensions for PHPUnit, `DOM` and `XMLWriter`. These two are required while the others listed in [PHPUnit requirements](https://phpunit.readthedocs.io/en/8.4/installation.html#requirements) should already be available. 

`XDebug` appears to be optional, or at least the default Laravel install via Composer succeeds without it.

After a successful installation, `php artisan serve` fails to load the `public/index.php` due to an error about sessions. Installing the `Sessions` PHP extension resolves this.