### PR TITLE
Update authorization.md to correct phpdoc output

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -299,7 +299,7 @@ So far, we have only examined policy methods that return simple boolean values. 
      *
      * @param  \App\User  $user
      * @param  \App\Post  $post
-     * @return Response   $response
+     * @return \Illuminate\Auth\Access\Response
      */
     public function update(User $user, Post $post)
     {

--- a/authorization.md
+++ b/authorization.md
@@ -299,7 +299,7 @@ So far, we have only examined policy methods that return simple boolean values. 
      *
      * @param  \App\User  $user
      * @param  \App\Post  $post
-     * @return bool
+     * @return Response   $response
      */
     public function update(User $user, Post $post)
     {


### PR DESCRIPTION
The code sample under `Policy Responses` mistakenly had a phpdoc block stating that it returns a `bool`, when the code shows it returning a `Response`