### PR TITLE
[6.x] add Slack on demand notification example

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -153,6 +153,7 @@ Sometimes you may need to send a notification to someone who is not stored as a 
 
     Notification::route('mail', 'taylor@example.com')
                 ->route('nexmo', '5555555555')
+                ->route('slack', 'https://hooks.slack.com/services/...')
                 ->notify(new InvoicePaid($invoice));
 
 <a name="mail-notifications"></a>


### PR DESCRIPTION
since Slack messages tend to be directed at a workspace/channel, and not a specific user, adding a line to show how to send on-demand Slack notifications