### PR TITLE
[6.x] Updates collection whereInstanceOf method.

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -2370,13 +2370,20 @@ This method has the same signature as the [`whereIn`](#method-wherein) method; h
 
 The `whereInstanceOf` method filters the collection by a given class type:
 
+    use App\User;
+    use App\Post;
+
     $collection = collect([
         new User,
         new User,
         new Post,
     ]);
 
-    return $collection->whereInstanceOf(User::class);
+    $filtered = $collection->whereInstanceOf(User::class);
+
+    $filtered->all();
+
+    // [App\User, App\User]
 
 <a name="method-wherenotbetween"></a>
 #### `whereNotBetween()` {#collection-method}


### PR DESCRIPTION
Added missing filtered example results just like other `where` methods.