### PR TITLE
[6.x] Clarify what 'active_url' actually does

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -620,10 +620,7 @@ The field under validation must be _yes_, _on_, _1_, or _true_. This is useful f
 <a name="rule-active-url"></a>
 #### active_url
 
-The field under validation must have a valid A or AAAA record according to the `dns_get_record` PHP function.
-
-> {note} The hostname of the provided URL is extracted using the `parse_url` PHP function, before being passed to `dns_get_record`. 
-
+The field under validation must have a valid A or AAAA record according to the `dns_get_record` PHP function. The hostname of the provided URL is extracted using the `parse_url` PHP function before being passed to `dns_get_record`.
 
 <a name="rule-after"></a>
 #### after:_date_

--- a/validation.md
+++ b/validation.md
@@ -622,6 +622,9 @@ The field under validation must be _yes_, _on_, _1_, or _true_. This is useful f
 
 The field under validation must have a valid A or AAAA record according to the `dns_get_record` PHP function.
 
+> {note} The hostname of the provided URL is extracted using the `parse_url` PHP function, before being passed to `dns_get_record`. 
+
+
 <a name="rule-after"></a>
 #### after:_date_
 


### PR DESCRIPTION
The 'active_url' validation rule in the docs is a little bit misleading.  

From the docs:
> The field under validation must have a valid A or AAAA record
> according to the `dns_get_record` PHP function.

To me, this sounds like the field being validated is passed straight to `dns_get_record`, when in fact the field is first passed to `parse_url` to extract the hostname portion of the URL.

From the source code:
```php
public  function  validateActiveUrl($attribute, $value)
{
	if (! is_string($value)) {
		return  false;
	}
	if ($url  =  parse_url($value,  PHP_URL_HOST)) {
		try {
			return  count(dns_get_record($url,  DNS_A  |  DNS_AAAA))  >  0;
		} catch  (Exception  $e) {
			return  false;
		}
	}
	return  false;
}
```

This leads to unexpected behaviour: Note the difference between the **count(dns_get_record())** and **Valid** columns.

![unexpected behaviour](https://i.ibb.co/7tF27J1/Screenshot-2019-11-12-at-13-44-17.png)

(Table generated [here](https://repl.it/@samnockels/Laravel-Active-URL-test))

I think a note in the docs that the hostname portion of the URL is extracted before validation would clear things up.