### PR TITLE
[6.x] Note about locale name format

### DIFF
--- a/localization.md
+++ b/localization.md
@@ -30,7 +30,7 @@ All language files return an array of keyed strings. For example:
         'welcome' => 'Welcome to our application'
     ];
 
-> {note} For languages that differ by territory, it is recommended to name them following the ISO 15897 standard (POSIX locales). For example for British English, prefer naming it "en_GB" rather than "en-gb".
+> {note} For languages that differ by territory, you should name the language directories according to the ISO 15897. For example, "en_GB" should be used for British English rather than "en-gb".
 
 <a name="configuring-the-locale"></a>
 ### Configuring The Locale

--- a/localization.md
+++ b/localization.md
@@ -30,6 +30,8 @@ All language files return an array of keyed strings. For example:
         'welcome' => 'Welcome to our application'
     ];
 
+> {note} For languages that differ by territory, it is recommended to name them following the ISO 15897 standard (POSIX locales). For example for British English, prefer naming it "en_GB" rather than "en-gb".
+
 <a name="configuring-the-locale"></a>
 ### Configuring The Locale
 


### PR DESCRIPTION
Some parts of Laravel expect locale names to be formatted according to ISO 15897 (eg: https://github.com/laravel/framework/blob/e04a7ffba8b80b934506783a7d0a161dd52eb2ef/src/Illuminate/Translation/MessageSelector.php#L110). The doc does not mention this, so developers may think they're free to name their locales however they want. I personally got burnt by this and called my locales "en-gb / zh-cn" instead of "en_GB / zh_CN", and realised only later that `trans_choice()` did not properly handle plurals because of this.

English is not my first language so the wording may need improvements. Please native English speakers don't hesitate to correct.