### PR TITLE
[6.x] Clarify extending models with Passport

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -229,7 +229,7 @@ By default, Passport issues long-lived access tokens that expire after one year.
 <a name="overriding-default-models"></a>
 ### Overriding Default Models
 
-You are free to **extend** the models used internally by Passport:
+You are free to extend the models used internally by Passport:
 
     use App\Models\Passport\Client as PassportClient;
 

--- a/passport.md
+++ b/passport.md
@@ -229,7 +229,16 @@ By default, Passport issues long-lived access tokens that expire after one year.
 <a name="overriding-default-models"></a>
 ### Overriding Default Models
 
-You are free to extend the models used internally by Passport. Then, you may instruct Passport to use your custom models via the `Passport` class:
+You are free to **extend** the models used internally by Passport:
+
+    use App\Models\Passport\Client as PassportClient;
+
+    class Client extends PassportClient
+    {
+        // ...
+    }
+
+Then, you may instruct Passport to use your custom models via the `Passport` class:
 
     use App\Models\Passport\AuthCode;
     use App\Models\Passport\Client;


### PR DESCRIPTION
I've seen several issues with people trying to override the default models without first extending the original ones so I hope these changes make it more clear.