### PR TITLE
[6.x] Remove docs for serializeUsing

### DIFF
--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -178,39 +178,3 @@ You may customize the serialization format of individual Eloquent date attribute
         'birthday' => 'date:Y-m-d',
         'joined_at' => 'datetime:Y-m-d H:00',
     ];
-
-#### Global Customization Via Carbon
-
-Laravel extends the [Carbon](https://github.com/briannesbitt/Carbon) date library in order to provide convenient customization of Carbon's JSON serialization format. To customize how all Carbon dates throughout your application are serialized, use the `Carbon::serializeUsing` method. The `serializeUsing` method accepts a Closure which returns a string representation of the date for JSON serialization:
-
-    <?php
-
-    namespace App\Providers;
-
-    use Illuminate\Support\Carbon;
-    use Illuminate\Support\ServiceProvider;
-
-    class AppServiceProvider extends ServiceProvider
-    {
-        /**
-         * Register any application services.
-         *
-         * @return void
-         */
-        public function register()
-        {
-            //
-        }
-
-        /**
-         * Bootstrap any application services.
-         *
-         * @return void
-         */
-        public function boot()
-        {
-            Carbon::serializeUsing(function ($carbon) {
-                return $carbon->format('U');
-            });
-        }
-    }


### PR DESCRIPTION
Since this method is now deprecated by Carbon, we shouldn't recommend it anymore.

More background on this can be found here: https://github.com/briannesbitt/Carbon/issues/1870