### PR TITLE
[6.x] Upgrade chrome driver for travis ci

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1456,6 +1456,7 @@ To run your Dusk tests on [Travis CI](https://travis-ci.org), use the following 
       - cp .env.testing .env
       - travis_retry composer install --no-interaction --prefer-dist --no-suggest
       - php artisan key:generate
+      - php artisan dusk:chrome-driver
 
     before_script:
       - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &


### PR DESCRIPTION
This PR adds chrome driver update command during travis ci installation.

Without this command travis ci fails:
<img width="888" alt="Снимок экрана 2019-11-16 в 12 09 22" src="https://user-images.githubusercontent.com/15196379/68992313-fd26fb00-0869-11ea-91c5-3eb3aacc0544.png">