### PR TITLE
[5.8] Removing global scopes on relationship

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -724,6 +724,28 @@ If you would like to remove several or even all of the global scopes, you may us
         FirstScope::class, SecondScope::class
     ])->get();
 
+It is also possible to remove the global scope on a relationship:
+
+    <?php
+
+    namespace App;
+
+    use Illuminate\Database\Eloquent\Model;
+
+    class Post extends Model
+    {
+        /**
+         * Define a relationship between a post and its creator without any global scopes specified for users.
+         *
+         * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+         */
+       
+        public function creator()
+        {
+            return $this->belongsTo(User::class)->withoutGlobalScopes();
+        }
+    }    
+
 <a name="local-scopes"></a>
 ### Local Scopes
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -724,7 +724,7 @@ If you would like to remove several or even all of the global scopes, you may us
         FirstScope::class, SecondScope::class
     ])->get();
 
-It is also possible to remove the global scope on a relationship:
+It is also possible to remove a global scope from a relationship:
 
     <?php
 
@@ -735,11 +735,10 @@ It is also possible to remove the global scope on a relationship:
     class Post extends Model
     {
         /**
-         * Define a relationship between a post and its creator without any global scopes specified for users.
+         * Get the creator of the post.
          *
          * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
          */
-       
         public function creator()
         {
             return $this->belongsTo(User::class)->withoutGlobalScopes();


### PR DESCRIPTION
In the current 5.x branch are no information about the possibility to remove a global scope on relationships.

Since I am not a native speaker I am very pleased about any enhancements on the phrasing.