### PR TITLE
[6.x] Clarify app url setting for Dusk CI

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1372,6 +1372,10 @@ Once the component has been defined, we can easily select a date within the date
 <a name="continuous-integration"></a>
 ## Continuous Integration
 
+Before adding a CI file, make sure that in your `.env.testing` file, you adjust the value of `APP_URL` to:
+
+    APP_URL=http://127.0.0.1:8000
+
 <a name="running-tests-on-circle-ci"></a>
 ### CircleCI
 
@@ -1468,11 +1472,6 @@ To run your Dusk tests on [Travis CI](https://travis-ci.org), use the following 
     script:
       - php artisan dusk
 
-
-In your `.env.testing` file, adjust the value of `APP_URL`:
-
-    APP_URL=http://127.0.0.1:8000
-
 <a name="running-tests-on-github-actions"></a>
 ### GitHub Actions
 
@@ -1502,8 +1501,3 @@ If you are using [Github Actions](https://github.com/features/actions) to run yo
             run: php artisan serve > /dev/null 2>&1 &
           - name: Run Dusk Tests
             run: php artisan dusk
-
-
-In your `.env.testing` file, adjust the value of `APP_URL`:
-
-    APP_URL=http://127.0.0.1:8000

--- a/dusk.md
+++ b/dusk.md
@@ -1384,6 +1384,8 @@ If you are using CircleCI to run your Dusk tests, you may use this configuration
                 - run: sudo apt-get install -y libsqlite3-dev
                 - run: cp .env.testing .env
                 - run: composer install -n --ignore-platform-reqs
+                - run: php artisan key:generate
+                - run: php artisan dusk:chrome-driver
                 - run: npm install
                 - run: npm run production
                 - run: vendor/bin/phpunit
@@ -1416,6 +1418,7 @@ To run Dusk tests on [Codeship](https://codeship.com), add the following command
     mkdir -p ./bootstrap/cache
     composer install --no-interaction --prefer-dist
     php artisan key:generate
+    php artisan dusk:chrome-driver
     nohup bash -c "php artisan serve 2>&1 &" && sleep 5
     php artisan dusk
 
@@ -1464,6 +1467,11 @@ To run your Dusk tests on [Travis CI](https://travis-ci.org), use the following 
 
     script:
       - php artisan dusk
+
+
+In your `.env.testing` file, adjust the value of `APP_URL`:
+
+    APP_URL=http://127.0.0.1:8000
 
 <a name="running-tests-on-github-actions"></a>
 ### GitHub Actions

--- a/dusk.md
+++ b/dusk.md
@@ -1372,9 +1372,7 @@ Once the component has been defined, we can easily select a date within the date
 <a name="continuous-integration"></a>
 ## Continuous Integration
 
-Before adding a CI file, make sure that in your `.env.testing` file, you adjust the value of `APP_URL` to:
-
-    APP_URL=http://127.0.0.1:8000
+> {note} Before adding a continous integration configuration file, ensure that your `.env.testing` file contains an `APP_URL` entry with a value of `http://127.0.0.1:8000`.
 
 <a name="running-tests-on-circle-ci"></a>
 ### CircleCI


### PR DESCRIPTION
Every CI env needs to have the proper APP_URL set for `artisan serve`. Also added the `dusk:chrome-driver` to every CI env.