### PR TITLE
Update path to Laravel binary for *nix systems

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -44,7 +44,7 @@ First, download the Laravel installer using Composer:
 Make sure to place Composer's system-wide vendor bin directory in your `$PATH` so the laravel executable can be located by your system. This directory exists in different locations based on your operating system; however, some common locations include:
 
 <div class="content-list" markdown="1">
-- macOS and GNU / Linux Distributions: `$HOME/.config/composer/vendor/bin`
+- macOS and GNU / Linux Distributions: `$HOME/.composer/vendor/bin`
 - Windows: `%USERPROFILE%\AppData\Roaming\Composer\vendor\bin`
 </div>
 


### PR DESCRIPTION
As per composer's documentation [0], the default path for COMPOSER_HOME changed from "$HOME/.config/composer/" to "$HOME/.composer/".
[0] https://getcomposer.org/doc/03-cli.md