### PR TITLE
[6.x] Fix wrong class name in API Resources

### DIFF
--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -660,7 +660,7 @@ As you have already read, resources may be returned directly from routes and con
         return new UserResource(User::find(1));
     });
 
-However, sometimes you may need to customize the outgoing HTTP response before it is sent to the client. There are two ways to accomplish this. First, you may chain the `response` method onto the resource. This method will return an `Illuminate\Http\Response` instance, allowing you full control of the response's headers:
+However, sometimes you may need to customize the outgoing HTTP response before it is sent to the client. There are two ways to accomplish this. First, you may chain the `response` method onto the resource. This method will return an `Illuminate\Http\JsonResponse` instance, allowing you full control of the response's headers:
 
     use App\Http\Resources\User as UserResource;
     use App\User;


### PR DESCRIPTION
Just noticed a small error while reading through the docs.