### PR TITLE
[6.x] Use `whereColumn` in `whereExists` subquery in favor of `whereRaw`

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -480,7 +480,7 @@ The `whereExists` method allows you to write `where exists` SQL clauses. The `wh
                ->whereExists(function ($query) {
                    $query->select(DB::raw(1))
                          ->from('orders')
-                         ->whereRaw('orders.user_id = users.id');
+                         ->whereColumn('orders.user_id', 'users.id');
                })
                ->get();
 


### PR DESCRIPTION
Would like to avoid `whereRaw` if possible. `whereColumn` works just as well in this case, and is safer to use in general.