### PR TITLE
Add missing "static" declaration in custom resolution logic example

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -331,7 +331,7 @@ If a matching model instance is not found in the database, a 404 HTTP response w
 
 If you wish to use your own resolution logic, you may use the `Route::bind` method. The `Closure` you pass to the `bind` method will receive the value of the URI segment and should return the instance of the class that should be injected into the route:
 
-    public function boot()
+    public static function boot()
     {
         parent::boot();
 


### PR DESCRIPTION
Personally, I quite often copy the example you provide in the docs - this one was missing the `static` declaration. 