### PR TITLE
updates required php version to 7.2.5

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -19,7 +19,7 @@ The Laravel framework has a few system requirements. All of these requirements a
 However, if you are not using Homestead, you will need to make sure your server meets the following requirements:
 
 <div class="content-list" markdown="1">
-- PHP >= 7.2.0
+- PHP >= 7.2.5
 - BCMath PHP Extension
 - Ctype PHP Extension
 - JSON PHP Extension


### PR DESCRIPTION
This PR updates the required PHP version.

The version should most likely be 7.2.5: According to https://github.com/symfony/service-contracts/blob/master/composer.json it's the minimum required version for symfony contracts.

