### PR TITLE
[6.x] Add anchor tag to introduction.

### DIFF
--- a/console-tests.md
+++ b/console-tests.md
@@ -3,6 +3,7 @@
 - [Introduction](#introduction)
 - [Expecting Input / Output](#expecting-input-and-output)
 
+<a name="introduction"></a>
 ## Introduction
 
 In addition to simplifying HTTP testing, Laravel provides a simple API for testing console applications that ask for user input.


### PR DESCRIPTION
There's no number sign next to the **Introduction** heading (and the whitespace is incorrect):

<img width="476" alt="Screen Shot 2019-11-27 at 1 58 06 PM" src="https://user-images.githubusercontent.com/751204/69751913-0d6a9000-111e-11ea-8659-cfcd8c5eb768.png">

I'm not sure if this fixes the issue, but the anchor tag for the introduction heading is present in every other file.