### PR TITLE
[6.x] Add optional() call on a nullable User type

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -365,7 +365,7 @@ By default, all gates and policies automatically return `false` if the incoming 
          */
         public function update(?User $user, Post $post)
         {
-            return $user->id === $post->user_id;
+            return optional($user)->id === $post->user_id;
         }
     }
 


### PR DESCRIPTION
The type is `?User`, so calling `->id` on null will result in an exception.