### PR TITLE
[7.x] Document serialize date changes

### DIFF
--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -170,6 +170,21 @@ You may instruct a single model instance to append attributes using the `append`
 <a name="date-serialization"></a>
 ## Date Serialization
 
+#### Customizing The Default Date Format
+
+You may customize the default serialization format by overriding the `serializeDate` method:
+
+    /**
+     * Prepare a date for array / JSON serialization.
+     *
+     * @param  \DateTimeInterface  $date
+     * @return string
+     */
+    protected function serializeDate(DateTimeInterface $date)
+    {
+        return $date->format('Y-m-d');
+    }
+
 #### Customizing The Date Format Per Attribute
 
 You may customize the serialization format of individual Eloquent date attributes by specifying the date format in the [cast declaration](/docs/{{version}}/eloquent-mutators#attribute-casting):

--- a/upgrade.md
+++ b/upgrade.md
@@ -6,16 +6,14 @@
 ## High Impact Changes
 
 <div class="content-list" markdown="1">
-- ...
+- [Date Serialization](#date-serialization)
 </div>
 
 <a name="medium-impact-changes"></a>
 ## Medium Impact Changes
 
 <div class="content-list" markdown="1">
-
 - ...
-
 </div>
 
 <a name="upgrade-7.0"></a>
@@ -25,9 +23,45 @@
 
 > {note} We attempt to document every possible breaking change. Since some of these breaking changes are in obscure parts of the framework only a portion of these changes may actually affect your application.
 
-### WIP
+### Symfony 5 Required
 
-Upgrade notes will be placed here.
+**Likelihood Of Impact: Medium**
+
+Laravel 7 adds support for Symfony 5 which is now also the new minimum compatible version.
+
+### PHP 7.2.5 Required
+
+**Likelihood Of Impact: Low**
+
+The new minimum PHP version (which mimics Symfony 5.0) is now 7.2.5.
+
+<a name="updating-dependencies"></a>
+### Updating Dependencies
+
+Update your `laravel/framework` dependency to `^7.0` in your `composer.json` file.
+
+Next, examine any 3rd party packages consumed by your application and verify you are using the proper version for Laravel 7 support.
+
+### Eloquent
+
+<a name="date-serialization"></a>
+#### Date Serialization
+
+**Likelihood Of Impact: High**
+
+Laravel 7 comes with a new default for serializing dates when using the `toArray` or `toJson` method on Eloquent models. It makes use of the default Carbon `toJSON` behavior and will provide a datetime string with fractions and timezone info.
+
+The previous behavior would serialize a date, for example, to `2019-12-02 20:01:00`. The new behavior will serialize a date to something like `2019-12-02T20:01:00.283041Z`. This will provide more info if you're, for example, building API's.
+
+If you want to keep using the previous behavior you can override the `serializeDate` method on your model:
+
+    /**
+     * Prepare a date for array / JSON serialization.
+     */
+    protected function serializeDate(DateTimeInterface $date) : string
+    {
+        return $date->format('Y-m-d H:i:s');
+    }
 
 <a name="miscellaneous"></a>
 ### Miscellaneous

--- a/upgrade.md
+++ b/upgrade.md
@@ -57,8 +57,11 @@ If you want to keep using the previous behavior you can override the `serializeD
 
     /**
      * Prepare a date for array / JSON serialization.
+     *
+     * @param  \DateTimeInterface  $date
+     * @return string
      */
-    protected function serializeDate(DateTimeInterface $date) : string
+    protected function serializeDate(DateTimeInterface $date)
     {
         return $date->format('Y-m-d H:i:s');
     }


### PR DESCRIPTION
This adds the recent date serialization changes of https://github.com/laravel/framework/pull/30715 to the upgrade guide and also adds documentation for overriding the default serialization format.

I've also added the new minimum PHP and Symfony version requirements.