### PR TITLE
[6.x] Document prorations during plan swap

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -478,11 +478,11 @@ If you would like to swap plans and immediately invoice the user instead of wait
 
 #### Prorations
 
-By default, Stripe applies proration. The `noProrate` method may be used to update the subscription's without prorating the charges:
+By default, Stripe prorates charges when swapping between plans. The `noProrate` method may be used to update the subscription's without prorating the charges:
 
     $user->subscription('default')->noProrate()->swap('provider-plan-id');
 
-For more information on subscription prorations, consult the [Stripe documentation](https://stripe.com/docs/billing/subscriptions/prorations).
+For more information on subscription proration, consult the [Stripe documentation](https://stripe.com/docs/billing/subscriptions/prorations).
 
 <a name="subscription-quantity"></a>
 ### Subscription Quantity

--- a/billing.md
+++ b/billing.md
@@ -476,6 +476,14 @@ If you would like to swap plans and immediately invoice the user instead of wait
 
     $user->subscription('default')->swapAndInvoice('provider-plan-id');
 
+#### Prorations
+
+By default, Stripe applies proration. The `noProrate` method may be used to update the subscription's without prorating the charges:
+
+    $user->subscription('default')->noProrate()->swap('provider-plan-id');
+
+For more information on subscription prorations, consult the [Stripe documentation](https://stripe.com/docs/billing/subscriptions/prorations).
+
 <a name="subscription-quantity"></a>
 ### Subscription Quantity
 
@@ -497,7 +505,7 @@ Alternatively, you may set a specific quantity using the `updateQuantity` method
 
     $user->subscription('default')->updateQuantity(10);
 
-The `noProrate` method may be used to update the subscription's quantity without pro-rating the charges:
+The `noProrate` method may be used to update the subscription's quantity without prorating the charges:
 
     $user->subscription('default')->noProrate()->updateQuantity(10);
 


### PR DESCRIPTION
This makes it clear that it can be used for all kind of plan changes, not just quantities. Some people on Discord mentioned this wasn't that clear atm.