### PR TITLE
[6.x] Move docs from readme

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -33,13 +33,25 @@ Every command also includes a "help" screen which displays and describes the com
 <a name="tinker"></a>
 ### Tinker (REPL)
 
-All Laravel applications include Tinker, a REPL powered by the [PsySH](https://github.com/bobthecow/psysh) package. Tinker allows you to interact with your entire Laravel application on the command line, including the Eloquent ORM, jobs, events, and more. To enter the Tinker environment, run the `tinker` Artisan command:
+Laravel Tinker is a powerful REPL for the Laravel framework, powered by the [PsySH](https://github.com/bobthecow/psysh) package.
+
+#### Installation
+
+All Laravel applications include Tinker by default. If you still need to install it in your Laravel app, simply run:
+
+    composer require laravel/tinker
+
+#### Usage
+
+Tinker allows you to interact with your entire Laravel application on the command line, including the Eloquent ORM, jobs, events, and more. To enter the Tinker environment, run the `tinker` Artisan command:
 
     php artisan tinker
 
 You can publish Tinker's configuration file using the `vendor:publish` command:
 
     php artisan vendor:publish --provider="Laravel\Tinker\TinkerServiceProvider"
+
+> {note} The `dispatch` helper function and `dispatch` method on the `Dispatchable` class depends on garbage collection to place the job on the queue. Therefore, when using tinker, you should use `Bus::dispatch` or `Queue::push` to dispatch jobs.
 
 #### Command Whitelist
 


### PR DESCRIPTION
This PR accompanies https://github.com/laravel/tinker/pull/86 to move the documentation to the docs repo so we have a single place where we can maintain it.