### PR TITLE
[6.x] Make note of twitter for stateless auth

### DIFF
--- a/socialite.md
+++ b/socialite.md
@@ -118,6 +118,8 @@ The `stateless` method may be used to disable session state verification. This i
 
     return Socialite::driver('google')->stateless()->user();
 
+> {note} Stateless Authentication is not available for the Twitter driver, which uses OAuth 1.0 for authentication.
+
 <a name="retrieving-user-details"></a>
 ## Retrieving User Details
 

--- a/socialite.md
+++ b/socialite.md
@@ -118,7 +118,7 @@ The `stateless` method may be used to disable session state verification. This i
 
     return Socialite::driver('google')->stateless()->user();
 
-> {note} Stateless Authentication is not available for the Twitter driver, which uses OAuth 1.0 for authentication.
+> {note} Stateless authentication is not available for the Twitter driver, which uses OAuth 1.0 for authentication.
 
 <a name="retrieving-user-details"></a>
 ## Retrieving User Details


### PR DESCRIPTION
https://developer.twitter.com/en/docs/basics/authentication/overview/oauth

The Twitter driver currently makes use of OAuth 1.0 because it needs to authenticate on behalf of the user and not as the app. Therefor stateless authentication isn't available.

See https://github.com/laravel/socialite/issues/415