### PR TITLE
[6.x] Starting 6.8(?) only feature tests extend laravels TestCase

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -29,7 +29,7 @@ Laravel provides a variety of helpful tools to make it easier to test your datab
 
 You can also use the `assertDatabaseMissing` helper to assert that data does not exist in the database.
 
-The `assertDatabaseHas` method and other helpers like it are for convenience. You are free to use any of PHPUnit's built-in assertion methods to supplement your tests.
+The `assertDatabaseHas` method and other helpers like it are for convenience. You are free to use any of PHPUnit's built-in assertion methods to supplement your feature tests.
 
 <a name="generating-factories"></a>
 ## Generating Factories
@@ -144,7 +144,7 @@ You may also define callbacks for [factory states](#factory-states):
 <a name="creating-models"></a>
 ### Creating Models
 
-Once you have defined your factories, you may use the global `factory` function in your tests or seed files to generate model instances. So, let's take a look at a few examples of creating models. First, we'll use the `make` method to create models but not save them to the database:
+Once you have defined your factories, you may use the global `factory` function in your feature tests or seed files to generate model instances. So, let's take a look at a few examples of creating models. First, we'll use the `make` method to create models but not save them to the database:
 
     public function testDatabase()
     {
@@ -243,7 +243,7 @@ If the relationship depends on the factory that defines it you may provide a cal
 <a name="using-seeds"></a>
 ## Using Seeds
 
-If you would like to use [database seeders](/docs/{{version}}/seeding) to populate your database during a test, you may use the `seed` method. By default, the `seed` method will return the `DatabaseSeeder`, which should execute all of your other seeders. Alternatively, you pass a specific seeder class name to the `seed` method:
+If you would like to use [database seeders](/docs/{{version}}/seeding) to populate your database during a feature test, you may use the `seed` method. By default, the `seed` method will return the `DatabaseSeeder`, which should execute all of your other seeders. Alternatively, you pass a specific seeder class name to the `seed` method:
 
     <?php
 
@@ -278,7 +278,7 @@ If you would like to use [database seeders](/docs/{{version}}/seeding) to popula
 <a name="available-assertions"></a>
 ## Available Assertions
 
-Laravel provides several database assertions for your [PHPUnit](https://phpunit.de/) tests:
+Laravel provides several database assertions for your [PHPUnit](https://phpunit.de/) feature tests:
 
 Method  | Description
 ------------- | -------------

--- a/http-tests.md
+++ b/http-tests.md
@@ -13,7 +13,7 @@
 <a name="introduction"></a>
 ## Introduction
 
-Laravel provides a very fluent API for making HTTP requests to your application and examining the output. For example, take a look at the test defined below:
+Laravel provides a very fluent API for making HTTP requests to your application and examining the output. For example, take a look at the feature test defined below:
 
     <?php
 
@@ -267,7 +267,7 @@ In addition to creating images, you may create files of any other type using the
 <a name="response-assertions"></a>
 ### Response Assertions
 
-Laravel provides a variety of custom assertion methods for your [PHPUnit](https://phpunit.de/) tests. These assertions may be accessed on the response that is returned from the `json`, `get`, `post`, `put`, and `delete` test methods:
+Laravel provides a variety of custom assertion methods for your [PHPUnit](https://phpunit.de/) feature tests. These assertions may be accessed on the response that is returned from the `json`, `get`, `post`, `put`, and `delete` test methods:
 
 <style>
     .collection-method-list > p {
@@ -648,7 +648,7 @@ Assert that the response view is missing a piece of bound data:
 <a name="authentication-assertions"></a>
 ### Authentication Assertions
 
-Laravel also provides a variety of authentication related assertions for your [PHPUnit](https://phpunit.de/) tests:
+Laravel also provides a variety of authentication related assertions for your [PHPUnit](https://phpunit.de/) feature tests:
 
 Method  | Description
 ------------- | -------------

--- a/testing.md
+++ b/testing.md
@@ -54,4 +54,6 @@ Once the test has been generated, you may define test methods as you normally wo
         }
     }
 
+> {note} Starting from version 6.8.x, new unit tests created with Artisan extend the TestCase class from PHPUnit. Due to this change, the Laravel framework is no longer booted in order to shorten the runtime of the tests. If you want to use functions from Laravel, these tests are better suited for the feature tests.
+
 > {note} If you define your own `setUp` / `tearDown` methods within a test class, be sure to call the respective `parent::setUp()` / `parent::tearDown()` methods on the parent class.

--- a/testing.md
+++ b/testing.md
@@ -54,6 +54,4 @@ Once the test has been generated, you may define test methods as you normally wo
         }
     }
 
-> {note} Starting from version 6.8.x, new unit tests created with Artisan extend the TestCase class from PHPUnit. Due to this change, the Laravel framework is no longer booted in order to shorten the runtime of the tests. If you want to use functions from Laravel, these tests are better suited for the feature tests.
-
 > {note} If you define your own `setUp` / `tearDown` methods within a test class, be sure to call the respective `parent::setUp()` / `parent::tearDown()` methods on the parent class.


### PR DESCRIPTION
Starting Version 6.8(?) unit tests extend PHPUnit TestCases, resulting in more performance, but also don't boot laravel and its features like factories or assertions added by laravel.