### PR TITLE
[6.x] Correct front-end and front end spelling

### DIFF
--- a/api-authentication.md
+++ b/api-authentication.md
@@ -71,7 +71,7 @@ In the examples above, API tokens are stored in your database as plain-text. If 
 
 #### Generating Hashed Tokens
 
-When using hashed API tokens, you should not generate your API tokens during user registration. Instead, you will need to implement your own API token management page within your application. This page should allow users to initialize and refresh their API token. When a user makes a request to initialize or refresh their token, you should store a hashed copy of the token in the database, and return the plain-text copy of token to the view / frontend client for one-time display.
+When using hashed API tokens, you should not generate your API tokens during user registration. Instead, you will need to implement your own API token management page within your application. This page should allow users to initialize and refresh their API token. When a user makes a request to initialize or refresh their token, you should store a hashed copy of the token in the database, and return the plain-text copy of token to the view / front-end client for one-time display.
 
 For example, a controller method that initializes / refreshes the token for a given user and returns the plain-text token as a JSON response might look like the following:
 

--- a/documentation.md
+++ b/documentation.md
@@ -29,10 +29,10 @@
     - [Validation](/docs/{{version}}/validation)
     - [Error Handling](/docs/{{version}}/errors)
     - [Logging](/docs/{{version}}/logging)
-- ## Frontend
+- ## Front End
     - [Blade Templates](/docs/{{version}}/blade)
     - [Localization](/docs/{{version}}/localization)
-    - [Frontend Scaffolding](/docs/{{version}}/frontend)
+    - [Front-end Scaffolding](/docs/{{version}}/front-end)
     - [Compiling Assets](/docs/{{version}}/mix)
 - ## Security
     - [Authentication](/docs/{{version}}/authentication)

--- a/dusk.md
+++ b/dusk.md
@@ -326,7 +326,7 @@ When your test requires migrations, like the authentication example above, you s
 <a name="dusk-selectors"></a>
 ### Dusk Selectors
 
-Choosing good CSS selectors for interacting with elements is one of the hardest parts of writing Dusk tests. Over time, frontend changes can cause CSS selectors like the following to break your tests:
+Choosing good CSS selectors for interacting with elements is one of the hardest parts of writing Dusk tests. Over time, front-end changes can cause CSS selectors like the following to break your tests:
 
     // HTML...
 

--- a/front-end.md
+++ b/front-end.md
@@ -10,13 +10,13 @@
 <a name="introduction"></a>
 ## Introduction
 
-While Laravel does not dictate which JavaScript or CSS pre-processors you use, it does provide a basic starting point using [Bootstrap](https://getbootstrap.com/), [React](https://reactjs.org/), and / or [Vue](https://vuejs.org/) that will be helpful for many applications. By default, Laravel uses [NPM](https://www.npmjs.org) to install both of these frontend packages.
+While Laravel does not dictate which JavaScript or CSS pre-processors you use, it does provide a basic starting point using [Bootstrap](https://getbootstrap.com/), [React](https://reactjs.org/), and / or [Vue](https://vuejs.org/) that will be helpful for many applications. By default, Laravel uses [NPM](https://www.npmjs.org) to install both of these front-end packages.
 
 The Bootstrap and Vue scaffolding provided by Laravel is located in the `laravel/ui` Composer package, which may be installed using Composer:
 
     composer require laravel/ui --dev
 
-Once the `laravel/ui` package has been installed, you may install the frontend scaffolding using the `ui` Artisan command:
+Once the `laravel/ui` package has been installed, you may install the front-end scaffolding using the `ui` Artisan command:
 
     // Generate basic scaffolding...
     php artisan ui bootstrap
@@ -39,9 +39,9 @@ Laravel does not require you to use a specific JavaScript framework or library t
 <a name="writing-css"></a>
 ## Writing CSS
 
-After installing the `laravel/ui` Composer package and [generating the frontend scaffolding](#introduction), Laravel's `package.json` file will include the `bootstrap` package to help you get started prototyping your application's frontend using Bootstrap. However, feel free to add or remove packages from the `package.json` file as needed for your own application. You are not required to use the Bootstrap framework to build your Laravel application - it is provided as a good starting point for those who choose to use it.
+After installing the `laravel/ui` Composer package and [generating the front-end scaffolding](#introduction), Laravel's `package.json` file will include the `bootstrap` package to help you get started prototyping your application's front end using Bootstrap. However, feel free to add or remove packages from the `package.json` file as needed for your own application. You are not required to use the Bootstrap framework to build your Laravel application - it is provided as a good starting point for those who choose to use it.
 
-Before compiling your CSS, install your project's frontend dependencies using the [Node package manager (NPM)](https://www.npmjs.org):
+Before compiling your CSS, install your project's front-end dependencies using the [Node package manager (NPM)](https://www.npmjs.org):
 
     npm install
 
@@ -49,7 +49,7 @@ Once the dependencies have been installed using `npm install`, you can compile y
 
     npm run dev
 
-The `webpack.mix.js` file included with Laravel's frontend scaffolding will compile the `resources/sass/app.scss` SASS file. This `app.scss` file imports a file of SASS variables and loads Bootstrap, which provides a good starting point for most applications. Feel free to customize the `app.scss` file however you wish or even use an entirely different pre-processor by [configuring Laravel Mix](/docs/{{version}}/mix).
+The `webpack.mix.js` file included with Laravel's front-end scaffolding will compile the `resources/sass/app.scss` SASS file. This `app.scss` file imports a file of SASS variables and loads Bootstrap, which provides a good starting point for most applications. Feel free to customize the `app.scss` file however you wish or even use an entirely different pre-processor by [configuring Laravel Mix](/docs/{{version}}/mix).
 
 <a name="writing-javascript"></a>
 ## Writing JavaScript
@@ -71,7 +71,7 @@ By default, the Laravel `webpack.mix.js` file compiles your SASS and the `resour
 <a name="writing-vue-components"></a>
 ### Writing Vue Components
 
-When using the `laravel/ui` package to scaffold your frontend, an `ExampleComponent.vue` Vue component will be placed in the `resources/js/components` directory. The `ExampleComponent.vue` file is an example of a [single file Vue component](https://vuejs.org/guide/single-file-components) which defines its JavaScript and HTML template in the same file. Single file components provide a very convenient approach to building JavaScript driven applications. The example component is registered in your `app.js` file:
+When using the `laravel/ui` package to scaffold your front end, an `ExampleComponent.vue` Vue component will be placed in the `resources/js/components` directory. The `ExampleComponent.vue` file is an example of a [single file Vue component](https://vuejs.org/guide/single-file-components) which defines its JavaScript and HTML template in the same file. Single file components provide a very convenient approach to building JavaScript driven applications. The example component is registered in your `app.js` file:
 
     Vue.component(
         'example-component',
@@ -110,7 +110,7 @@ Presets are "macroable", which allows you to add additional methods to the `UiCo
     use Laravel\Ui\UiCommand;
 
     UiCommand::macro('nextjs', function (UiCommand $command) {
-        // Scaffold your frontend...
+        // Scaffold your front end...
     });
 
 Then, you may call the new preset via the `ui` command:

--- a/passport.md
+++ b/passport.md
@@ -3,7 +3,7 @@
 - [Introduction](#introduction)
 - [Upgrading Passport](#upgrading)
 - [Installation](#installation)
-    - [Frontend Quickstart](#frontend-quickstart)
+    - [Front-end Quickstart](#front-end-quickstart)
     - [Deploying Passport](#deploying-passport)
 - [Configuration](#configuration)
     - [Token Lifetimes](#token-lifetimes)
@@ -131,12 +131,12 @@ If you are not going to use Passport's default migrations, you should call the `
 
 By default, Passport uses an integer column to store the `user_id`. If your application uses a different column type to identify users (for example: UUIDs), you should modify the default Passport migrations after publishing them.
 
-<a name="frontend-quickstart"></a>
-### Frontend Quickstart
+<a name="front-end-quickstart"></a>
+### Front-end Quickstart
 
-> {note} In order to use the Passport Vue components, you must be using the [Vue](https://vuejs.org) JavaScript framework. These components also use the Bootstrap CSS framework. However, even if you are not using these tools, the components serve as a valuable reference for your own frontend implementation.
+> {note} In order to use the Passport Vue components, you must be using the [Vue](https://vuejs.org) JavaScript framework. These components also use the Bootstrap CSS framework. However, even if you are not using these tools, the components serve as a valuable reference for your own front-end implementation.
 
-Passport ships with a JSON API that you may use to allow your users to create clients and personal access tokens. However, it can be time consuming to code a frontend to interact with these APIs. So, Passport also includes pre-built [Vue](https://vuejs.org) components you may use as an example implementation or starting point for your own implementation.
+Passport ships with a JSON API that you may use to allow your users to create clients and personal access tokens. However, it can be time consuming to code a front end to interact with these APIs. So, Passport also includes pre-built [Vue](https://vuejs.org) components you may use as an example implementation or starting point for your own implementation.
 
 To publish the Passport Vue components, use the `vendor:publish` Artisan command:
 
@@ -290,11 +290,11 @@ If you would like to whitelist multiple redirect URLs for your client, you may s
 
 Since your users will not be able to utilize the `client` command, Passport provides a JSON API that you may use to create clients. This saves you the trouble of having to manually code controllers for creating, updating, and deleting clients.
 
-However, you will need to pair Passport's JSON API with your own frontend to provide a dashboard for your users to manage their clients. Below, we'll review all of the API endpoints for managing clients. For convenience, we'll use [Axios](https://github.com/axios/axios) to demonstrate making HTTP requests to the endpoints.
+However, you will need to pair Passport's JSON API with your own front end to provide a dashboard for your users to manage their clients. Below, we'll review all of the API endpoints for managing clients. For convenience, we'll use [Axios](https://github.com/axios/axios) to demonstrate making HTTP requests to the endpoints.
 
 The JSON API is guarded by the `web` and `auth` middleware; therefore, it may only be called from your own application. It is not able to be called from an external source.
 
-> {tip} If you don't want to implement the entire client management frontend yourself, you can use the [frontend quickstart](#frontend-quickstart) to have a fully functional frontend in a matter of minutes.
+> {tip} If you don't want to implement the entire client management front end yourself, you can use the [front-end quickstart](#front-end-quickstart) to have a fully functional front end in a matter of minutes.
 
 #### `GET /oauth/clients`
 
@@ -689,11 +689,11 @@ Once you have created a personal access client, you may issue tokens for a given
 
 #### JSON API
 
-Passport also includes a JSON API for managing personal access tokens. You may pair this with your own frontend to offer your users a dashboard for managing personal access tokens. Below, we'll review all of the API endpoints for managing personal access tokens. For convenience, we'll use [Axios](https://github.com/mzabriskie/axios) to demonstrate making HTTP requests to the endpoints.
+Passport also includes a JSON API for managing personal access tokens. You may pair this with your own front end to offer your users a dashboard for managing personal access tokens. Below, we'll review all of the API endpoints for managing personal access tokens. For convenience, we'll use [Axios](https://github.com/mzabriskie/axios) to demonstrate making HTTP requests to the endpoints.
 
 The JSON API is guarded by the `web` and `auth` middleware; therefore, it may only be called from your own application. It is not able to be called from an external source.
 
-> {tip} If you don't want to implement the personal access token frontend yourself, you can use the [frontend quickstart](#frontend-quickstart) to have a fully functional frontend in a matter of minutes.
+> {tip} If you don't want to implement the personal access token front end yourself, you can use the [front-end quickstart](#front-end-quickstart) to have a fully functional front end in a matter of minutes.
 
 #### `GET /oauth/scopes`
 

--- a/releases.md
+++ b/releases.md
@@ -27,7 +27,7 @@ For LTS releases, such as Laravel 6, bug fixes are provided for 2 years and secu
 <a name="laravel-6"></a>
 ## Laravel 6
 
-Laravel 6 (LTS) continues the improvements made in Laravel 5.8 by introducing semantic versioning, compatibility with [Laravel Vapor](https://vapor.laravel.com), improved authorization responses, job middleware, lazy collections, sub-query improvements, the extraction of frontend scaffolding to the `laravel/ui` Composer package, and a variety of other bug fixes and usability improvements.
+Laravel 6 (LTS) continues the improvements made in Laravel 5.8 by introducing semantic versioning, compatibility with [Laravel Vapor](https://vapor.laravel.com), improved authorization responses, job middleware, lazy collections, sub-query improvements, the extraction of front-end scaffolding to the `laravel/ui` Composer package, and a variety of other bug fixes and usability improvements.
 
 ### Semantic Versioning
 
@@ -73,7 +73,7 @@ The authorization policy's response and message may be easily retrieved using th
         echo $response->message();
     }
 
-In addition, these custom messages will automatically be returned to your frontend when using helper methods such as `$this->authorize` or `Gate::authorize` from your routes or controllers.
+In addition, these custom messages will automatically be returned to your front end when using helper methods such as `$this->authorize` or `Gate::authorize` from your routes or controllers.
 
 ### Job Middleware
 
@@ -213,9 +213,9 @@ In addition, we can use new subquery features added to the query builder's `orde
 
 ### Laravel UI
 
-The frontend scaffolding typically provided with previous releases of Laravel has been extracted into a `laravel/ui` Composer package. This allows the first-party UI scaffolding to be developed and versioned separately from the primary framework. As a result of this change, no Bootstrap or Vue code is present in default framework scaffolding, and the `make:auth` command has been extracted from the framework as well.
+The front-end scaffolding typically provided with previous releases of Laravel has been extracted into a `laravel/ui` Composer package. This allows the first-party UI scaffolding to be developed and versioned separately from the primary framework. As a result of this change, no Bootstrap or Vue code is present in default framework scaffolding, and the `make:auth` command has been extracted from the framework as well.
 
-In order to restore the traditional Vue / Bootstrap scaffolding present in previous releases of Laravel, you may install the `laravel/ui` package and use the `ui` Artisan command to install the frontend scaffolding:
+In order to restore the traditional Vue / Bootstrap scaffolding present in previous releases of Laravel, you may install the `laravel/ui` package and use the `ui` Artisan command to install the front-end scaffolding:
 
     composer require laravel/ui --dev
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -199,7 +199,7 @@ Laravel 6.0 has received [performance optimizations](https://github.com/laravel/
 
 **Likelihood Of Impact: Medium**
 
-To prevent possible CSRF attacks, the `email/resend` route registered by the router when using Laravel's built-in email verification has been updated from a `GET` route to a `POST` route. Therefore, you will need to update your frontend to send the proper request type to this route. For example, if you are using the built-in email verification template scaffolding:
+To prevent possible CSRF attacks, the `email/resend` route registered by the router when using Laravel's built-in email verification has been updated from a `GET` route to a `POST` route. Therefore, you will need to update your front end to send the proper request type to this route. For example, if you are using the built-in email verification template scaffolding:
 
     {{ __('Before proceeding, please check your email for a verification link.') }}
     {{ __('If you did not receive the email') }},


### PR DESCRIPTION
Note that the file `frontend.md` has been renamed to `front-end.md`, which might result in unexpected behavior when switching between versions on the docs page. However, this change is needed to fully reflect the correct spelling.