### PR TITLE
Edit a Typo in Redis Default Client Section

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -117,7 +117,7 @@ If you plan to utilize [Laravel Vapor](https://vapor.laravel.com), you should up
 
 **Likelihood Of Impact: Medium**
 
-The default Redis client has changed from `predis` to `phpredis`. In order to keep using `predis`, ensure the `redis.client` configuration option is set to `predis` in your `config/database.php` configuration file.
+The default Redis client has changed from `predis` to `phpredis`. In order to keep using `predis`, ensure the `redis.client` configuration option is set to `phpredis` in your `config/database.php` configuration file.
 
 ### Database
 


### PR DESCRIPTION
I had found a typo in the (redis default client) section and corrected it.