### PR TITLE
[6.x] Add link for header Creating Lazy Collections

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -7,6 +7,7 @@
 - [Higher Order Messages](#higher-order-messages)
 - [Lazy Collections](#lazy-collections)
     - [Introduction](#lazy-collection-introduction)
+    - [Creating Lazy Collections](#creating-lazy-collections)
     - [The Enumerable Contract](#the-enumerable-contract)
     - [Lazy Collection Methods](#lazy-collection-methods)
 


### PR DESCRIPTION
Add a link for the subheader "Creating Lazy Collections" under "Lazy Collections", in `collections.md`.