### PR TITLE
Update the composer package reference. Reference Laravel/Framework #31017

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -121,7 +121,7 @@ The `method` method will return the HTTP verb for the request. You may use the `
 The [PSR-7 standard](https://www.php-fig.org/psr/psr-7/) specifies interfaces for HTTP messages, including requests and responses. If you would like to obtain an instance of a PSR-7 request instead of a Laravel request, you will first need to install a few libraries. Laravel uses the *Symfony HTTP Message Bridge* component to convert typical Laravel requests and responses into PSR-7 compatible implementations:
 
     composer require symfony/psr-http-message-bridge
-    composer require zendframework/zend-diactoros
+    composer require nyholm/psr7
 
 Once you have installed these libraries, you may obtain a PSR-7 request by type-hinting the request interface on your route Closure or controller method:
 


### PR DESCRIPTION
Diactoros has been archived by Zend and support has been removed by Symfony's PSR Bridge.