### PR TITLE
[6.x] Update GitHub Actions example config for Dusk

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1496,7 +1496,7 @@ If you are using [Github Actions](https://github.com/features/actions) to run yo
         steps:
           - uses: actions/checkout@v1
           - name: Prepare The Environment
-            run: cp .env.example .env
+            run: cp .env.testing .env
           - name: Create Database
             run: mysql --user="root" --password="root" -e "CREATE DATABASE my-database character set UTF8mb4 collate utf8mb4_bin;"
           - name: Install Composer Dependencies


### PR DESCRIPTION
This PR updates GitHub Actions example by replacing `.env.example` with `.env.testing` since at the beginning of the Continuous Integration section, it says: we need to ensure that `.env.testing` file contains an `APP_URL` with a value of `http://127.0.0.1:8000` and also all other ci examples are using `.env.testing`.