### PR TITLE
[6.x] Explain the job isolation difference between queue:work and queue:listen

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -585,9 +585,9 @@ Laravel includes a queue worker that will process new jobs as they are pushed on
 
 > {tip} To keep the `queue:work` process running permanently in the background, you should use a process monitor such as [Supervisor](#supervisor-configuration) to ensure that the queue worker does not stop running.
 
-Remember, queue workers are long-lived processes and store the booted application state in memory. As a result, they will not notice changes in your code base after they have been started. So, during your deployment process, be sure to [restart your queue workers](#queue-workers-and-deployment).
+Remember, queue workers are long-lived processes and store the booted application state in memory. As a result, they will not notice changes in your code base after they have been started. So, during your deployment process, be sure to [restart your queue workers](#queue-workers-and-deployment). Another caveat is that long-lived processes also allow certain changes made by a job to be propagated to subsequent ones, e.g. non-idempotent mutations to static variables, which effectively lowers the degree of job isolation.
 
-Alternatively, you may run the `queue:listen` command. When using the `queue:listen` command, you don't have to manually restart the worker after your code is changed; however, this command is not as efficient as `queue:work`:
+Alternatively, you may run the `queue:listen` command. When using the `queue:listen` command, you don't have to manually restart the worker when you want to reload your updated code or reset the application state; however, this command is not as efficient as `queue:work`:
 
     php artisan queue:listen
 

--- a/queues.md
+++ b/queues.md
@@ -585,7 +585,7 @@ Laravel includes a queue worker that will process new jobs as they are pushed on
 
 > {tip} To keep the `queue:work` process running permanently in the background, you should use a process monitor such as [Supervisor](#supervisor-configuration) to ensure that the queue worker does not stop running.
 
-Remember, queue workers are long-lived processes and store the booted application state in memory. As a result, they will not notice changes in your code base after they have been started. So, during your deployment process, be sure to [restart your queue workers](#queue-workers-and-deployment). Another caveat is that long-lived processes also allow certain changes made by a job to be propagated to subsequent ones, e.g. non-idempotent mutations to static variables, which effectively lowers the degree of job isolation.
+Remember, queue workers are long-lived processes and store the booted application state in memory. As a result, they will not notice changes in your code base after they have been started. So, during your deployment process, be sure to [restart your queue workers](#queue-workers-and-deployment). In addition, remember that any static state created or modified by your application will not be automatically reset between jobs.
 
 Alternatively, you may run the `queue:listen` command. When using the `queue:listen` command, you don't have to manually restart the worker when you want to reload your updated code or reset the application state; however, this command is not as efficient as `queue:work`:
 


### PR DESCRIPTION
I was suggested to explain the difference between `queue:work` and `queue:listen` a bit more in laravel/framework#31120.

When `queue:work` is used, since workers are 'long-lived processes', it actually lowers the degree of job isolation and some changes made by a job can affect subsequent ones, e.g. non-idempotent mutations to static variables. This is not by design (I think) but a limitation of PHP.

In such a scenario, users can use `queue:listen` instead at the expense of performance.