### PR TITLE
[6.x] Add `QueueFake->assertPushedWithChain()` property-matching example

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -305,6 +305,8 @@ As an alternative to mocking, you may use the `Queue` facade's `fake` method to 
     namespace Tests\Feature;
 
     use App\Jobs\ShipOrder;
+    use App\Jobs\AnotherJob;
+    use App\Jobs\FinalJob;
     use Illuminate\Foundation\Testing\RefreshDatabase;
     use Illuminate\Foundation\Testing\WithoutMiddleware;
     use Illuminate\Support\Facades\Queue;
@@ -334,10 +336,20 @@ As an alternative to mocking, you may use the `Queue` facade's `fake` method to 
             // Assert a job was not pushed...
             Queue::assertNotPushed(AnotherJob::class);
 
-            // Assert a job was pushed with a specific chain...
+            // Assert a job was pushed with a given chain of jobs, matching by class...
             Queue::assertPushedWithChain(ShipOrder::class, [
                 AnotherJob::class,
                 FinalJob::class
+            ]);
+            
+            // Setup for matching jobs by class and properties
+            $expectedAnotherJob = new AnotherJob("foo");
+            $expectedFinalJob = new FinalJob("bar");
+            
+            // Assert a job was pushed with a given chain of jobs, matching by both class and properties...
+            Queue::assertPushedWithChain(ShipOrder::class, [
+                $expectedAnotherJob,
+                $expectedFinalJob
             ]);
         }
     }


### PR DESCRIPTION
This is #5721 sent to the right branch and simplified.

Long story short there aren't examples for passing an array of jobs rather than job classes to `assertPushedWithChain()`, which provides tighter assurances that may be necessary to attain the desired level of confidence from the test.

Couple observations that don't necessarily warrant a response. I am a newcomer to Laravel, but these things seemed weird:

It is strange to me that the tests in this mocking section of the docs are namespaced as feature tests.
 
To my fallible understanding, it seems to me that breaking Jobs out into traits in the particular way it was done -- one of which (`InteractsWithQueue`) is the actual holder of the property that implements the Job contract -- has polluted the domain concept of a job and created a fertile breeding ground for confusion. The class file that is produced when you generate a job isn't even a Job. It *has* a Job. I've found working with the Laravel queue ecosystem very frustrating and am hoping that this provides a minor experiential improvement to the next person. 