### PR TITLE
[6.x] Document `app.mix_url` customizations

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -317,6 +317,15 @@ Because versioned files are usually unnecessary in development, you may instruct
         mix.version();
     }
 
+If you deploy mix builds to a custom location, you can use add a `mix_url` value to `config/app.php`:
+
+    'mix_url' => env('MIX_ASSET_URL', null)
+
+The `mix()` helper will prefix the configured URL to generate URLs:
+
+    https://cdn.example.com/js/app.js?id=1964becbdd96414518cd
+    https://cdn.example.com/css/app.css?id=cbb9e3ccbb701ad9981f
+
 <a name="browsersync-reloading"></a>
 ## Browsersync Reloading
 

--- a/mix.md
+++ b/mix.md
@@ -317,7 +317,7 @@ Because versioned files are usually unnecessary in development, you may instruct
         mix.version();
     }
 
-If you deploy mix builds to a custom location, you can use add a `mix_url` value to `config/app.php`:
+If you deploy mix builds to a custom location, you can add `mix_url` to `config/app.php`:
 
     'mix_url' => env('MIX_ASSET_URL', null)
 


### PR DESCRIPTION
Documents `app.mix_url` implemented in laravel/framework#28952.

I took a stab at the wording, figuring you'd shuffle/rearrange to your liking 😄 . I only documented it in 6.x, but happy to contribute it back to 5.8 as well once you're happy with the wording.

I also noticed this configuration option isn't included with `config/app.php` out of the box. Is that something you'd like a PR for?