### PR TITLE
Fix grammar

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -460,7 +460,7 @@ This `/oauth/token` route will return a JSON response containing `access_token`,
 <a name="code-grant-pkce"></a>
 ## Authorization Code Grant with PKCE
 
-The Authorization Code grant with "Proof Key for Code Exchange" (PKCE) is a secure way to authenticate single page applications or native applications to access your API. This grant should be used when you can't guarantee that the client secret will be stored confidentiality or in order to mitigate the threat of having the authorization code intercepted by an attacker. A combination of a "code verifier" and a "code challenge" replaces the client secret when exchanging the authorization code for an access token.
+The Authorization Code grant with "Proof Key for Code Exchange" (PKCE) is a secure way to authenticate single page applications or native applications to access your API. This grant should be used when you can't guarantee that the client secret will be stored confidentially or in order to mitigate the threat of having the authorization code intercepted by an attacker. A combination of a "code verifier" and a "code challenge" replaces the client secret when exchanging the authorization code for an access token.
 
 <a name="creating-a-auth-pkce-grant-client"></a>
 ### Creating The Client


### PR DESCRIPTION
Change the noun, `confidentiality`, to the adverb `confidentially` so the sentence is grammatically correct.