### PR TITLE
Representing truthy with 1 and falsey with 0

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -928,7 +928,7 @@ You may use "dot" notation to execute a query against a nested relationship. For
     use Illuminate\Database\Eloquent\Builder;
 
     $posts = App\Post::whereDoesntHave('comments.author', function (Builder $query) {
-        $query->where('banned', 1);
+        $query->where('banned', 0);
     })->get();
 
 <a name="querying-polymorphic-relationships"></a>


### PR DESCRIPTION
Considering "banned" as truthy, and "not banned" as falsy.  We could represent them with 1 and 0 respectively. In case of documentation which is "not banned", we can replace it with 0.