### PR TITLE
Added composer global installation path for Linux

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -44,9 +44,12 @@ First, download the Laravel installer using Composer:
 Make sure to place Composer's system-wide vendor bin directory in your `$PATH` so the laravel executable can be located by your system. This directory exists in different locations based on your operating system; however, some common locations include:
 
 <div class="content-list" markdown="1">
-- macOS and GNU / Linux Distributions: `$HOME/.composer/vendor/bin`
+- macOS: `$HOME/.composer/vendor/bin`
 - Windows: `%USERPROFILE%\AppData\Roaming\Composer\vendor\bin`
+- GNU / Linux Distributions: `$HOME/.config/composer/vendor/bin` or `$HOME/.composer/vendor/bin`
 </div>
+
+You could also find the composer's global installation path by running `composer global about` and looking up from the first line.
 
 Once installed, the `laravel new` command will create a fresh Laravel installation in the directory you specify. For instance, `laravel new blog` will create a directory named `blog` containing a fresh Laravel installation with all of Laravel's dependencies already installed:
 


### PR DESCRIPTION
> If your system uses freedesktop.org standards, then it will first check
XDG_CONFIG_HOME or default to `/home/\<user\>/.config/composer`

From [composer source code](https://github.com/composer/composer/blob/master/src/Composer/Command/GlobalCommand.php#L47-L48)

The doc is misleading developers on Linux leading to questions like [this](https://stackoverflow.com/a/40470979) and [this](https://laracasts.com/discuss/channels/laravel/i-add-homecomposervendorbin-to-my-ubuntu-path-but-it-then-removed-automatically) 