### PR TITLE
add the `horizon:status` Artisan command to the Horizon documentation`

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -119,6 +119,10 @@ You may pause the Horizon process and instruct it to continue processing jobs us
 
     php artisan horizon:continue
 
+You may check the current status of the Horizon process using the `horizon:status` Artisan command:
+
+    php artisan horizon:status
+
 You may gracefully terminate the master Horizon process on your machine using the `horizon:terminate` Artisan command. Any jobs that Horizon is currently processing will be completed and then Horizon will exit:
 
     php artisan horizon:terminate


### PR DESCRIPTION
Adds recent `horizon:status` to horizon documentation as per https://github.com/laravel/horizon/issues/468