### PR TITLE
[6.x] Add information about multiple answer attribute for artisan choice()

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -356,6 +356,8 @@ If you need to give the user a predefined set of choices, you may use the `choic
 
     $name = $this->choice('What is your name?', ['Taylor', 'Dayle'], $defaultIndex);
 
+Additionally you can specify number of attempts for the question in case an invalid value was presented as attribute number 4 and whether multiple values are allowed as attribute 5.
+
 <a name="writing-output"></a>
 ### Writing Output
 


### PR DESCRIPTION
Currently there is no information about the fact that artisan command `choice()` method is capable of accepting multiple options. This PR adds information about attributes 4 & 5 (attempts and multiple) for the documentation in choice about choice method