### PR TITLE
[6.x] Document how to use a custom Passport Client model

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -384,7 +384,7 @@ If you would like to customize the authorization approval screen, you may publis
 
     php artisan vendor:publish --tag=passport-views
 
-Sometimes you may wish to skip the authorization prompt, such as when authorizing a first-party client. You may accomplish this by defining a `skipsAuthorization` method on the client model. If `skipsAuthorization` returns `true` the client will be approved and the user will be redirected back to the `redirect_uri` immediately:
+Sometimes you may wish to skip the authorization prompt, such as when authorizing a first-party client. You may accomplish this by extending the `Client` model and defining a `skipsAuthorization` method. If `skipsAuthorization` returns `true` the client will be approved and the user will be redirected back to the `redirect_uri` immediately:
 
     <?php
 
@@ -403,6 +403,24 @@ Sometimes you may wish to skip the authorization prompt, such as when authorizin
         {
             return $this->firstParty();
         }
+    }
+
+You then need to tell Passport to use your extended model in the `AuthServiceProvider`:
+
+    use App\Models\Passport\Client;
+
+    /**
+     * Register any authentication / authorization services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->registerPolicies();
+
+        Passport::routes();
+
+        Passport::useClientModel(Client::class);
     }
 
 #### Converting Authorization Codes To Access Tokens

--- a/passport.md
+++ b/passport.md
@@ -405,9 +405,10 @@ Sometimes you may wish to skip the authorization prompt, such as when authorizin
         }
     }
 
-You then need to tell Passport to use your extended model in the `AuthServiceProvider`:
+You then need to tell Passport to use your extended model. You may do this in the `boot` method of your `AuthServiceProvider`:
 
     use App\Models\Passport\Client;
+    use Laravel\Passport\Passport;
 
     /**
      * Register any authentication / authorization services.


### PR DESCRIPTION
Added in Passport 7.0 is the ability to extend the Passport Client model to add a skipsAuthorization method. However, no documentation was included on how to tell Passport to use the extended model.