### PR TITLE
[6.x] Checking for scopes

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -912,7 +912,7 @@ The `scopes` middleware may be assigned to a route to verify that the incoming r
 
     Route::get('/orders', function () {
         // Access token has both "check-status" and "place-orders" scopes...
-    })->middleware('scopes:check-status,place-orders');
+    })->middleware(['auth:api', 'scopes:check-status,place-orders']);
 
 #### Check For Any Scopes
 
@@ -920,7 +920,7 @@ The `scope` middleware may be assigned to a route to verify that the incoming re
 
     Route::get('/orders', function () {
         // Access token has either "check-status" or "place-orders" scope...
-    })->middleware('scope:check-status,place-orders');
+    })->middleware(['auth:api', 'scope:check-status,place-orders']);
 
 #### Checking Scopes On A Token Instance
 


### PR DESCRIPTION
I found that you can't check for scopes without also checking for the 'auth:api' middleware, which is logical, but I still wasted hours before figuring it out =")

Another solution is to wrap all your routes that check for scopes in an 'auth:api' group middleware .. someone probably should write an example about that