### PR TITLE
[6.x] Warn about unintended query duplication when using * in view composers

### DIFF
--- a/views.md
+++ b/views.md
@@ -206,6 +206,8 @@ The `composer` method also accepts the `*` character as a wildcard, allowing you
     View::composer('*', function ($view) {
         //
     });
+    
+> {note} Using the `*` will also trigger the composer when loading views via @include; keep an eye to the performance
 
 #### View Creators
 


### PR DESCRIPTION
Devs new to view composers, sometimes assume `*` only triggers composers for views rendered via the view() function in the controller.
Since @include also triggers `*` view composers, data might be re-rendered much more than the dev meant to - often only a problem when the projects exists for a while and grows.

This PR adds some context to avoid this error.