### PR TITLE
[6.x] Add model replicate function.

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -18,6 +18,7 @@
 - [Deleting Models](#deleting-models)
     - [Soft Deleting](#soft-deleting)
     - [Querying Soft Deleted Models](#querying-soft-deleted-models)
+- [Replicating Models](#replicating-models)
 - [Query Scopes](#query-scopes)
     - [Global Scopes](#global-scopes)
     - [Local Scopes](#local-scopes)
@@ -706,6 +707,23 @@ Sometimes you may need to truly remove a model from your database. To permanentl
 
     // Force deleting all related models...
     $flight->history()->forceDelete();
+    
+<a name="replicating-models"></a>
+## Replicating Models
+
+You may create an unsaved copy of a model instance by using the `replicate` function. This is particularly helpful when you want to have a few model instances that share mostly the same attributes. 
+
+    $shippingAddress = App\Address::create([
+        'type' => 'shipping',
+        'line_1' => '123 Example Street',
+        'city' => 'Victorville',
+        'state' => 'CA',
+        'postcode' => '90001',
+    ]);
+
+    $billingAddress = $shippingAddress->replicate(['type' => 'billing']);
+    
+    $billingAddress->save();
 
 <a name="query-scopes"></a>
 ## Query Scopes

--- a/eloquent.md
+++ b/eloquent.md
@@ -721,7 +721,8 @@ You may create an unsaved copy of a model instance by using the `replicate` func
         'postcode' => '90001',
     ]);
 
-    $billingAddress = $shippingAddress->replicate(['type' => 'billing']);
+    $billingAddress = $shippingAddress->replicate()
+        ->fill(['type' => 'billing']);
     
     $billingAddress->save();
 


### PR DESCRIPTION
I found this especially useful when we need multiple model instance that share mostly the same attributes.

An additional example:

```php
$newborn = Newborn::create(
    'first_name' => 'John',
    'last_name' => 'Doe',
    'date_of_birth' => '2020-02-14',
    'hospital_id' => 1,
);

$twinBrother = tap(
    $newborn->replicate()->fill(['first_name' => 'Jack'])
)
->save();
```