### PR TITLE
Removed wrong example in queues/timeout

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -650,7 +650,7 @@ In your `config/queue.php` configuration file, each queue connection defines a `
 
 #### Worker Timeouts
 
-The `queue:work` Artisan command exposes a `--timeout` option. The `--timeout` option specifies how long the Laravel queue master process will wait before killing off a child queue worker that is processing a job. Sometimes a child queue process can become "frozen" for various reasons, such as an external HTTP call that is not responding. The `--timeout` option removes frozen processes that have exceeded that specified time limit:
+The `queue:work` Artisan command exposes a `--timeout` option. The `--timeout` option specifies how long the Laravel queue master process will wait before killing off a child queue worker that is processing a job. Sometimes a child queue process can become "frozen" for various reasons. The `--timeout` option removes frozen processes that have exceeded that specified time limit:
 
     php artisan queue:work --timeout=60
 


### PR DESCRIPTION
Based on laravel/framework#22301

See; https://github.com/laravel/framework/issues/22301#issuecomment-351452235