### PR TITLE
[6.x] Fix order of output for `whereIn`

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -2374,8 +2374,6 @@ The `whereIn` method filters the collection by a given key / value contained wit
 
 The `whereIn` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`whereInStrict`](#method-whereinstrict) method to filter using "strict" comparisons.
 
-> {tip} The order of returned elements will match their order in the original Collection, not the order of values passed in.
-
 <a name="method-whereinstrict"></a>
 #### `whereInStrict()` {#collection-method}
 

--- a/collections.md
+++ b/collections.md
@@ -2367,12 +2367,14 @@ The `whereIn` method filters the collection by a given key / value contained wit
 
     /*
         [
-            ['product' => 'Bookcase', 'price' => 150],
             ['product' => 'Desk', 'price' => 200],
+            ['product' => 'Bookcase', 'price' => 150],
         ]
     */
 
 The `whereIn` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`whereInStrict`](#method-whereinstrict) method to filter using "strict" comparisons.
+
+> {tip} The order of returned elements will match their order in the original Collection, not the order of values passed in.
 
 <a name="method-whereinstrict"></a>
 #### `whereInStrict()` {#collection-method}


### PR DESCRIPTION
since `whereIn` is using `filter` underneath the hood, the elements order is not manipulated at all, but rather maintains the same order as the original Collection.