### PR TITLE
[6.x] Add Str::ucfirst to docs

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -104,6 +104,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [Str::startsWith](#method-starts-with)
 [Str::studly](#method-studly-case)
 [Str::title](#method-title-case)
+[Str::ucfirst](#method-str-ucfirst)
 [Str::uuid](#method-str-uuid)
 [Str::words](#method-str-words)
 [trans](#method-trans)
@@ -974,6 +975,18 @@ The `Str::is` method determines if a given string matches a given pattern. Aster
     $matches = Str::is('baz*', 'foobar');
 
     // false
+
+<a name="method-str-ucfirst"></a>
+#### `Str::ucfirst()` {#collection-method}
+
+The `Str::ucfirst` method returns the given string with the first character capitalized.
+As with the other `Str` methods, but unlike PHP's built-in `ucfirst` method, it supports multibyte characters.
+
+    use Illuminate\Support\Str;
+
+    $converted = Str::ucfirst('foo bar');
+
+    // Foo bar
 
 <a name="method-str-is-uuid"></a>
 #### `Str::isUuid()` {#collection-method}

--- a/helpers.md
+++ b/helpers.md
@@ -979,12 +979,11 @@ The `Str::is` method determines if a given string matches a given pattern. Aster
 <a name="method-str-ucfirst"></a>
 #### `Str::ucfirst()` {#collection-method}
 
-The `Str::ucfirst` method returns the given string with the first character capitalized.
-As with the other `Str` methods, but unlike PHP's built-in `ucfirst` method, it supports multibyte characters.
+The `Str::ucfirst` method returns the given string with the first character capitalized:
 
     use Illuminate\Support\Str;
 
-    $converted = Str::ucfirst('foo bar');
+    $string = Str::ucfirst('foo bar');
 
     // Foo bar
 


### PR DESCRIPTION
This is a quite useful method since PHP doesn't come with a mb_ucfirst method, so it would be nice if it was included in the docs to make it easier to find.