### PR TITLE
[6.x] Add crossJoin docs

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -28,6 +28,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 
 [Arr::add](#method-array-add)
 [Arr::collapse](#method-array-collapse)
+[Arr::crossJoin](#method-array-crossjoin)
 [Arr::divide](#method-array-divide)
 [Arr::dot](#method-array-dot)
 [Arr::except](#method-array-except)
@@ -226,6 +227,39 @@ The `Arr::collapse` method collapses an array of arrays into a single array:
 
     // [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
+<a name="method-array-crossjoin"></a>
+#### `Arr::crossJoin()` {#collection-method}
+
+The `Arr::crossJoin` method cross joins the given arrays, returning a Cartesian product with all possible permutations:
+
+    use Illuminate\Support\Arr;
+
+    $matrix = Arr::crossJoin([1, 2], ['a', 'b']);
+
+    /*
+        [
+            [1, 'a'],
+            [1, 'b'],
+            [2, 'a'],
+            [2, 'b'],
+        ]
+    */
+
+    $matrix = Arr::crossJoin([1, 2], ['a', 'b'], ['I', 'II']);
+
+    /*
+        [
+            [1, 'a', 'I'],
+            [1, 'a', 'II'],
+            [1, 'b', 'I'],
+            [1, 'b', 'II'],
+            [2, 'a', 'I'],
+            [2, 'a', 'II'],
+            [2, 'b', 'I'],
+            [2, 'b', 'II'],
+        ]
+    */
+
 <a name="method-array-divide"></a>
 #### `Arr::divide()` {#collection-method}
 
@@ -349,7 +383,7 @@ The `Arr::has` method checks whether a given item or items exists in an array us
     $contains = Arr::has($array, ['product.price', 'product.discount']);
 
     // false
- 
+
 <a name="method-array-isassoc"></a>
 #### `Arr::isAssoc()` {#collection-method}
 
@@ -941,9 +975,9 @@ You may also pass an array of values to determine if the given string ends with 
     $result = Str::endsWith('This is my name', ['name', 'foo']);
 
     // true
-    
+
     $result = Str::endsWith('This is my name', ['this', 'foo']);
-    
+
     // false
 
 <a name="method-str-finish"></a>
@@ -1214,7 +1248,7 @@ The `Str::words` method limits the number of words in a string:
     use Illuminate\Support\Str;
 
     return Str::words('Perfectly balanced, as all things should be.', 3, ' >>>');
-    
+
     // Perfectly balanced, as >>>
 
 <a name="method-trans"></a>


### PR DESCRIPTION
This PR adds the missing docs for the useful `Arr::crossJoin`.