### PR TITLE
[6.x] Fix documentation on pagination.md

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -196,7 +196,8 @@ Method  |  Description
 `$results->firstItem()`  |  Get the result number of the first item in the results.
 `$results->getOptions()`  |  Get the paginator options.
 `$results->getUrlRange($start, $end)`  |  Create a range of pagination URLs.
-`$results->hasMorePages()`  |  Determine if there are enough items to split into multiple pages.
+`$results->hasPages()`  |  Determine if there are enough items to split into multiple pages.
+`$results->hasMorePages()`  |  Determine if there is more items in the data store.
 `$results->items()`  |  Get the items for the current page.
 `$results->lastItem()`  |  Get the result number of the last item in the results.
 `$results->lastPage()`  |  Get the page number of the last available page. (Not available when using `simplePaginate`).


### PR DESCRIPTION
Fix issue on the pagination.md documentation.

If we follow the API documentation at [https://laravel.com/api/6.x/Illuminate/Contracts/Pagination/LengthAwarePaginator.html](url), the `hasMorePages()` method has the wrong documentation (it has the `hasPages()` one).
I fixed it, and added the documentation for the `hasPages()` method.