### PR TITLE
fix Defining Middleware section bug

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -45,8 +45,8 @@ This command will place a new `CheckAge` class within your `app/Http/Middleware`
          */
         public function handle($request, Closure $next)
         {
-            if ($request->age <= 200) {
-                return redirect('home');
+            if ($request->age <= 200 && Route::current()->getName() !== 'home') {
+                return redirect()->route('home');
             }
 
             return $next($request);


### PR DESCRIPTION
Here in current Laravel docs example check age middleware will redirect us too many times and it is not usable at all.
In addition it becomes complicated for user in order to test on their local.

So I added an additional && condition and check if it is already redirected to home page and is on the home page so send the next middleware action. 