### PR TITLE
[6.x] Cannot use dot directories

### DIFF
--- a/views.md
+++ b/views.md
@@ -32,7 +32,7 @@ Views may also be nested within subdirectories of the `resources/views` director
 
     return view('admin.profile', $data);
 
-> {note} When using "Dot" notation to reference views, you cannot make use of directories containing dots in their name.
+> {note} View directory names should not contain the `.` character.
 
 #### Determining If A View Exists
 

--- a/views.md
+++ b/views.md
@@ -32,6 +32,8 @@ Views may also be nested within subdirectories of the `resources/views` director
 
     return view('admin.profile', $data);
 
+> {note} When using "Dot" notation to reference views, you cannot make use of directories containing dots in their name.
+
 #### Determining If A View Exists
 
 If you need to determine if a view exists, you may use the `View` facade. The `exists` method will return `true` if the view exists:


### PR DESCRIPTION
If `foo.bar` is a directory and `baz.blade.php` is a view inside that directory then you can't reference it as `view('foo.bar.baz')`.

See https://github.com/laravel/framework/issues/30709