### PR TITLE
[6.x] Mention the URL::defaults method in routing.md and redirect

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -219,6 +219,8 @@ If you pass additional parameters in the array, those key / value pairs will aut
     $url = route('profile', ['id' => 1, 'photos' => 'yes']);
 
     // /user/1/profile?photos=yes
+    
+For some applications, you may wish to specify request-wide default values for certain URL parameters (locale, current user slug, ...). To that end, you may [use the `URL::defaults` method](/docs/{{version}}/urls#default-values).
 
 #### Inspecting The Current Route
 


### PR DESCRIPTION
Everytime I hear someone talking about routing in a multi-tenancy application, even a few weeks in the project, their minds are blown when they realise they missed the `Url::defaults` method. Last time was today on reddit.

I think part of the problem is people searching in routing.md instead of url.md, as it is usually where they are first introduced to url parameters and the `route` helper.

I don't want to duplicate content, so I copied the bare minimum from the urls#default-values section to introduce it, and just redirected to the other section.

Feel completely free to close this if you don't think it necessary.

Same for the exact wording, I'm not a native speaker and I know it.