### PR TITLE
Fix incorrect term (“directory” -> “namespace”)

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -456,7 +456,7 @@ The `make:component` command will also create a view template for the component.
 
 #### Manually Registering Package Components
 
-When writing components for your own application, components are automatically discovered within the `App\View\Components` namespace and `resources/views/components` directory.
+When writing components for your own application, components are automatically discovered within the `app/View/Components` directory and `resources/views/components` directory.
 
 However, if you are building a package that utilizes Blade components, you will need to manually register your component class and its HTML tag alias. You should typically register your components in the `boot` method of your package's service provider:
 

--- a/blade.md
+++ b/blade.md
@@ -456,7 +456,7 @@ The `make:component` command will also create a view template for the component.
 
 #### Manually Registering Package Components
 
-When writing components for your own application, components are automatically discovered within the `App\View\Components` directory and `resources/views/components` directory.
+When writing components for your own application, components are automatically discovered within the `App\View\Components` namespace and `resources/views/components` directory.
 
 However, if you are building a package that utilizes Blade components, you will need to manually register your component class and its HTML tag alias. You should typically register your components in the `boot` method of your package's service provider:
 


### PR DESCRIPTION
Just spotted that while digging the `master` docs for new sweets and candies 👀 