### PR TITLE
[6.x] Nginx configuration fixed

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -45,6 +45,7 @@ If you are deploying your application to a server that is running Nginx, you may
         error_page 404 /index.php;
 
         location ~ \.php$ {
+            try_files $uri =404;
             fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;


### PR DESCRIPTION
When user try open non exist file with .php extension, laravel don't handle with 404 error page, only show simple "File not found." message.
If you accept it, I fix the previous docs versions.

How to reproduce it?


- download this zip file: [docs-example.zip](https://github.com/laravel/docs/files/4263020/docs-example.zip)

- unzip it
- run `docker-composer up -d`
- Test the `http://old.localhost:8080/test.php` and `http://new.localhost:8080/test.php`