### PR TITLE
[6.x] Clarify trial days in Cashier

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -606,7 +606,7 @@ If the user cancels a subscription and then resumes that subscription before the
 <a name="subscription-trials"></a>
 ## Subscription Trials
 
-> {note} Since Cashier sets the trial end on the subscription itself and does not derive it from a Stripe plan, it's recommended to not rely on the trial days in your Stripe plans and always set them to a value of zero days.
+> {note} Cashier will manage trial dates for subscriptions and does not derive them from the Stripe plan. Therefore, you should configure your plan in Stripe to have a trial period of zero days so that Cashier can manage the trials instead.
 
 <a name="with-payment-method-up-front"></a>
 ### With Payment Method Up Front

--- a/billing.md
+++ b/billing.md
@@ -606,6 +606,8 @@ If the user cancels a subscription and then resumes that subscription before the
 <a name="subscription-trials"></a>
 ## Subscription Trials
 
+> {note} Since Cashier sets the trial end on the subscription itself and does not derive it from a Stripe plan, it's recommended to not rely on the trial days in your Stripe plans and always set them to a value of zero days.
+
 <a name="with-payment-method-up-front"></a>
 ### With Payment Method Up Front
 

--- a/billing.md
+++ b/billing.md
@@ -606,7 +606,7 @@ If the user cancels a subscription and then resumes that subscription before the
 <a name="subscription-trials"></a>
 ## Subscription Trials
 
-> {note} Cashier will manage trial dates for subscriptions and does not derive them from the Stripe plan. Therefore, you should configure your plan in Stripe to have a trial period of zero days so that Cashier can manage the trials instead.
+> {note} Cashier manages trial dates for subscriptions and does not derive them from the Stripe plan. Therefore, you should configure your plan in Stripe to have a trial period of zero days so that Cashier can manage the trials instead.
 
 <a name="with-payment-method-up-front"></a>
 ### With Payment Method Up Front


### PR DESCRIPTION
I've noticed regularly that people don't seem to understand that Stripe Plan trial days aren't used in Cashier and that trialing is always set on the subscriptions directly. I think it's important that we clarify this concept properly in the docs.