### PR TITLE
[7.x] Blade components - Added some words between the two colons for readability.

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -490,7 +490,7 @@ If the component class is nested deeper within the `App\View\Components` directo
 <a name="passing-data-to-components"></a>
 ### Passing Data To Components
 
-You may pass data to Blade components using HTML attributes. Hard-coded, primitive values may be passed to the component using simple HTML attributes. PHP expressions and variables should be passed to the component via attributes that are prefixed with `:`:
+You may pass data to Blade components using HTML attributes. Hard-coded, primitive values may be passed to the component using simple HTML attributes. PHP expressions and variables should be passed to the component via attributes that are prefixed with `:` like so:
 
     <x-alert type="error" :message="$message"/>
 


### PR DESCRIPTION
Added a few words between the colons so the reader won't get confused as to whether it is supposed to be a single or double colon. 