### PR TITLE
Horizon upgrade command

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -104,7 +104,7 @@ When upgrading to a new major version of Horizon, it's important that you carefu
 
 In addition, you should re-publish Horizon's assets:
 
-    php artisan horizon:assets
+    php artisan vendor:publish --tag=horizon-assets --force
 
 <a name="running-horizon"></a>
 ## Running Horizon


### PR DESCRIPTION
Fixed command needed for re-publising horizon asstes. [Source](https://github.com/laravel/horizon/issues/525#issuecomment-467952910)

Fixes the following error after upgrading from version 1 to version 3.

> Unable to locate Mix file: /app.css. (View: /vendor/laravel/horizon/resources/views/layout.blade.php)