### PR TITLE
[6.x] Add "Default Site" / fallback section to Valet docs

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -9,7 +9,7 @@
     - [The "Link" Command](#the-link-command)
     - [Securing Sites With TLS](#securing-sites)
 - [Sharing Sites](#sharing-sites)
-- [Setting a Default Site](#serving-a-default-site)
+- [Serving A Default Site](#serving-a-default-site)
 - [Site Specific Environment Variables](#site-specific-environment-variables)
 - [Custom Valet Drivers](#custom-valet-drivers)
     - [Local Drivers](#local-drivers)
@@ -201,18 +201,11 @@ Some applications using other frameworks may depend on server environment variab
     ];
 
 <a name="serving-a-default-site"></a>
-## Serving a Default Site
+## Serving A Default Site
 
-In some situations you may wish to configure your machine to serve a "default" site instead of a 404 if you visit a URL for a project that Valet is unable to find according to your parked or linked projects.
+Sometimes, you may wish to configure Valet to serve a "default" site instead of a `404` when visiting an unknown `test` domain. To accomplish this, you may add a `default` option to your `~/.config/valet/config.json` configuration file containing the path to the site that should function as your default site:
 
-This can also be helpful for some less flexible simulator apps or IDEs which only allow specifying 127.0.0.1 (and not a domain URL) for testing or simulation.
-
-To do this, manually edit your `~/.config/valet/config.json` file and add an item to the config array, pointing `default` at the path of the project to be served. For example:
-
-    "default": "/Users/YOUR_USERNAME/Sites/foo",
-    
-... and make sure the specified path contains files that can be served as a website.
-
+    "default": "/Users/Sally/Sites/foo",
 
 <a name="custom-valet-drivers"></a>
 ## Custom Valet Drivers

--- a/valet.md
+++ b/valet.md
@@ -9,6 +9,7 @@
     - [The "Link" Command](#the-link-command)
     - [Securing Sites With TLS](#securing-sites)
 - [Sharing Sites](#sharing-sites)
+- [Setting a Default Site](#serving-a-default-site)
 - [Site Specific Environment Variables](#site-specific-environment-variables)
 - [Custom Valet Drivers](#custom-valet-drivers)
     - [Local Drivers](#local-drivers)
@@ -198,6 +199,20 @@ Some applications using other frameworks may depend on server environment variab
             'key' => 'value',
         ],
     ];
+
+<a name="serving-a-default-site"></a>
+## Serving a Default Site
+
+In some situations you may wish to configure your machine to serve a "default" site instead of a 404 if you visit a URL for a project that Valet is unable to find according to your parked or linked projects.
+
+This can also be helpful for some less flexible simulator apps or IDEs which only allow specifying 127.0.0.1 (and not a domain URL) for testing or simulation.
+
+To do this, manually edit your `~/.config/valet/config.json` file and add an item to the config array, pointing `default` at the path of the project to be served. For example:
+
+    "default": "/Users/YOUR_USERNAME/Sites/foo",
+    
+... and make sure the specified path contains files that can be served as a website.
+
 
 <a name="custom-valet-drivers"></a>
 ## Custom Valet Drivers


### PR DESCRIPTION
The Default Site is used as a fallback for Emulators and IDEs which can only handle an IP address instead of a domain name that Valet would serve.