### PR TITLE
[7.x] Add fileinfo to system requirements.

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -22,6 +22,7 @@ However, if you are not using Homestead, you will need to make sure your server 
 - PHP >= 7.2.5
 - BCMath PHP Extension
 - Ctype PHP Extension
+- Fileinfo PHP extension
 - JSON PHP Extension
 - Mbstring PHP Extension
 - OpenSSL PHP Extension


### PR DESCRIPTION
See following error on fresh PHP installation:

Crafting application...
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.        

  Problem 1
    - Installation request for league/flysystem 1.0.64 -> satisfiable by league/flysystem[1.0.64].
    - league/flysystem 1.0.64 requires ext-fileinfo * -> the requested PHP extension fileinfo is missing from your system.
  Problem 2
    - league/flysystem 1.0.64 requires ext-fileinfo * -> the requested PHP extension fileinfo is missing from your system.
    - laravel/framework v7.0.1 requires league/flysystem ^1.0.8 -> satisfiable by league/flysystem[1.0.64].
    - Installation request for laravel/framework v7.0.1 -> satisfiable by laravel/framework[v7.0.1].

  To enable extensions, verify that they are enabled in your .ini files:
    - C:\php\php.ini
  You can also run `php --ini` inside terminal to see which files are used by PHP in CLI mode.