### PR TITLE
Fixed wrong info in frontend page

### DIFF
--- a/frontend.md
+++ b/frontend.md
@@ -14,7 +14,7 @@ While Laravel does not dictate which JavaScript or CSS pre-processors you use, i
 
 The Bootstrap and Vue scaffolding provided by Laravel is located in the `laravel/ui` Composer package, which may be installed using Composer:
 
-    composer require laravel/ui --dev
+    composer require laravel/ui
 
 Once the `laravel/ui` package has been installed, you may install the frontend scaffolding using the `ui` Artisan command:
 


### PR DESCRIPTION
Since Laravel 7 and Laravel UI 2, the Auth routes are defined in the latter. So the package should always be installed, not only in dev environments.

This change (https://github.com/laravel/framework/commit/aebd93d5f67de55473f3f0ff5056abbfc5972102) should be mentioned in the upgrade guide.