### PR TITLE
Note assertSee changes in Laravel 7.x

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -399,16 +399,16 @@ Assert that the response has a 201 status code:
 <a name="assert-dont-see"></a>
 #### assertDontSee
 
-Assert that the given string is not contained within the response:
+Assert that the given string is not contained within the response. This assertion will automatically escape the given string unless you pass a second argument of `false`:
 
-    $response->assertDontSee($value);
+    $response->assertDontSee($value, $escaped = true);
 
 <a name="assert-dont-see-text"></a>
 #### assertDontSeeText
 
-Assert that the given string is not contained within the response text:
+Assert that the given string is not contained within the response text. This assertion will automatically escape the given string unless you pass a second argument of `false`:
 
-    $response->assertDontSeeText($value);
+    $response->assertDontSeeText($value, $escaped = true);
 
 <a name="assert-exact-json"></a>
 #### assertExactJson
@@ -546,30 +546,30 @@ Assert that the response is a redirect to a given URI:
 <a name="assert-see"></a>
 #### assertSee
 
-Assert that the given string is contained within the response:
+Assert that the given string is contained within the response. This assertion will automatically escape the given string unless you pass a second argument of `false`:
 
-    $response->assertSee($value);
+    $response->assertSee($value, $escaped = true);
 
 <a name="assert-see-in-order"></a>
 #### assertSeeInOrder
 
-Assert that the given strings are contained in order within the response:
+Assert that the given strings are contained in order within the response. This assertion will automatically escape the given strings unless you pass a second argument of `false`:
 
-    $response->assertSeeInOrder(array $values);
+    $response->assertSeeInOrder(array $values, $escaped = true);
 
 <a name="assert-see-text"></a>
 #### assertSeeText
 
-Assert that the given string is contained within the response text:
+Assert that the given string is contained within the response text. This assertion will automatically escape the given string unless you pass a second argument of `false`:
 
-    $response->assertSeeText($value);
+    $response->assertSeeText($value, $escaped = true);
 
 <a name="assert-see-text-in-order"></a>
 #### assertSeeTextInOrder
 
-Assert that the given strings are contained in order within the response text:
+Assert that the given strings are contained in order within the response text. This assertion will automatically escape the given strings unless you pass a second argument of `false`:
 
-    $response->assertSeeTextInOrder(array $values);
+    $response->assertSeeTextInOrder(array $values, $escaped = true);
 
 <a name="assert-session-has"></a>
 #### assertSessionHas

--- a/upgrade.md
+++ b/upgrade.md
@@ -236,7 +236,7 @@ The `array` session driver data is now persistent for the current request. Previ
 
 **Likelihood Of Impact: Medium**
 
-The `assertSee` and `assertDontSee` assertions on the `TestResponse` class will now automatically escape values. If you are manually escaping any values passed to these assertions you should no longer do so. If you need to assert unescaped values, you may pass `false` as the second argument.
+The `assertSee` and `assertDontSee` assertions on the `TestResponse` class will now automatically escape values. If you are manually escaping any values passed to these assertions you should no longer do so. If you need to assert unescaped values, you may pass `false` as the second argument to the method.
 
 ### Validation
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -236,7 +236,7 @@ The `array` session driver data is now persistent for the current request. Previ
 
 **Likelihood Of Impact: Medium**
 
-The `assertSee` and `assertDontSee` assertions on the `TestResponse` class will now automatically escape values. If you are manually escaping any values passed to these assertions you should no longer do so.
+The `assertSee` and `assertDontSee` assertions on the `TestResponse` class will now automatically escape values. If you are manually escaping any values passed to these assertions you should no longer do so. If you need to assert unescaped values, you may pass `false` as the second argument.
 
 ### Validation
 


### PR DESCRIPTION
This notes the new `escaped` parameter for the `assertSee` and `assertDontSee` set of assertions in both the Upgrade Guide and HTTP Test sections.