### PR TITLE
Fix scaffolding package install command for 6.x

### DIFF
--- a/frontend.md
+++ b/frontend.md
@@ -14,7 +14,7 @@ While Laravel does not dictate which JavaScript or CSS pre-processors you use, i
 
 The Bootstrap and Vue scaffolding provided by Laravel is located in the `laravel/ui` Composer package, which may be installed using Composer:
 
-    composer require laravel/ui --dev
+    composer require laravel/ui:1.*
 
 Once the `laravel/ui` package has been installed, you may install the frontend scaffolding using the `ui` Artisan command:
 

--- a/frontend.md
+++ b/frontend.md
@@ -14,7 +14,7 @@ While Laravel does not dictate which JavaScript or CSS pre-processors you use, i
 
 The Bootstrap and Vue scaffolding provided by Laravel is located in the `laravel/ui` Composer package, which may be installed using Composer:
 
-    composer require laravel/ui:1.*
+    composer require laravel/ui:^1.0 --dev
 
 Once the `laravel/ui` package has been installed, you may install the frontend scaffolding using the `ui` Artisan command:
 


### PR DESCRIPTION
Current laravel/ui 2.0 requires laravel 7.0, laravel/ui#69.