### PR TITLE
[7.x] Note re-publishing markdown mail templates

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -16,6 +16,7 @@
 
 <div class="content-list" markdown="1">
 - [Unique Route Names](#unique-route-names)
+- [Markdown Mail Template Updates](#markdown-mail-template-updates)
 - [CORS Support](#cors-support)
 - [The `Blade::component` Method](#the-blade-component-method)
 - [Blade Components & "Blade X"](#blade-components-and-blade-x)
@@ -193,11 +194,16 @@ The Zend Diactoros library for generating PSR-7 responses has been deprecated. I
 
 In order to support multiple mailers, the default `mail` configuration file has changed in Laravel 7.x to include an array of `mailers`. However, in order to preserve backwards compatibility, the Laravel 6.x format of this configuration file is still supported. So, no changes are **required** when upgrading to Laravel 7.x; however, you may wish to [examine the new `mail` configuration file](https://github.com/laravel/laravel/blob/develop/config/mail.php) structure and update your file to reflect the changes.
 
+<a name="markdown-mail-template-updates"></a>
 #### Markdown Mail Template Updates
 
-**Likelihood Of Impact: Low**
+**Likelihood Of Impact: Medium**
 
 The default Markdown mail templates have been refreshed with a more professional and appealing design. In addition, the undocumented `promotion` Markdown mail component has been removed.
+
+Markdown mail templates not expect non-indented HTML. If you've previously published Laravel's default mail templates, you'll need to re-publish your mail templates:
+
+    php artisan vendor:publish --tag=laravel-mail --force
 
 ### Queue
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -201,7 +201,7 @@ In order to support multiple mailers, the default `mail` configuration file has 
 
 The default Markdown mail templates have been refreshed with a more professional and appealing design. In addition, the undocumented `promotion` Markdown mail component has been removed.
 
-Markdown mail templates not expect non-indented HTML. If you've previously published Laravel's default mail templates, you'll need to re-publish your mail templates:
+Because identitation has special meaning within Markdown, Markdown mail templates expect unindented HTML. If you've previously published Laravel's default mail templates, you'll need to re-publish your mail templates or manually unindent them:
 
     php artisan vendor:publish --tag=laravel-mail --force
 


### PR DESCRIPTION
Since it's now expected that all mail templates are un-indented, we should note that people need to republish their overwritten templates.