### PR TITLE
Remove dev flag for Laravel UI 2

### DIFF
--- a/frontend.md
+++ b/frontend.md
@@ -95,7 +95,7 @@ If you are interested in learning more about writing Vue components, you should 
 
 If you prefer to use React to build your JavaScript application, Laravel makes it a cinch to swap the Vue scaffolding with React scaffolding:
 
-    composer require laravel/ui --dev
+    composer require laravel/ui
 
     // Generate basic scaffolding...
     php artisan ui react

--- a/passwords.md
+++ b/passwords.md
@@ -32,7 +32,7 @@ Next, a table must be created to store the password reset tokens. The migration 
 
 Laravel includes `Auth\ForgotPasswordController` and `Auth\ResetPasswordController` classes that contains the logic necessary to e-mail password reset links and reset user passwords. All of the routes needed to perform password resets may be generated using the `laravel/ui` Composer package:
 
-    composer require laravel/ui --dev
+    composer require laravel/ui
 
     php artisan ui vue --auth
 
@@ -41,7 +41,7 @@ Laravel includes `Auth\ForgotPasswordController` and `Auth\ResetPasswordControll
 
 To generate all of the necessary view for resetting passwords, you may use the `laravel/ui` Composer package:
 
-    composer require laravel/ui --dev
+    composer require laravel/ui
 
     php artisan ui vue --auth
 

--- a/verification.md
+++ b/verification.md
@@ -62,7 +62,7 @@ Laravel includes the `Auth\VerificationController` class that contains the neces
 
 To generate all of the necessary view for email verification, you may use the `laravel/ui` Composer package:
 
-    composer require laravel/ui --dev
+    composer require laravel/ui
 
     php artisan ui vue --auth
 


### PR DESCRIPTION
Since Laravel 7 and Laravel UI 2, all authentication scaffolding has been moved to the laravel/ui repository. So the package should always be installed, not only in dev environments.