### PR TITLE
Fix typo for attributes variable

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -112,7 +112,7 @@ _Blade component tags were contributed by [Spatie](https://spatie.be/), [Marcel 
 
 > {tip} Blade components have been overhauled to allow tag based rendering, attribute management, component classes, inline view components, and more. Since the overhaul of Blade components is so extensive, please consult the [full Blade component documentation](/docs/{{version}}/blade#components) to learn about this feature.
 
-In summary, a component may now have an associated class which specifies the data it accepts. All public properties and methods defined on the component class will automatically be made available to the component view. Any additional HTML attributes specified on the component may be managed using the automatically included `$attribute` variable, which is an attribute bag instance.
+In summary, a component may now have an associated class which specifies the data it accepts. All public properties and methods defined on the component class will automatically be made available to the component view. Any additional HTML attributes specified on the component may be managed using the automatically included `$attributes` variable, which is an attribute bag instance.
 
 In this example, we will assume that an `App\View\Components\Alert` component has been defined like so:
 


### PR DESCRIPTION
The doc should show attributes variable name as `$attributes`, not `$attribute`.