### PR TITLE
[5.4] Fix url to GitHub repository for Dusk modifier keys

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -348,7 +348,7 @@ You may even send a "hot key" to the primary CSS selector that contains your app
 
     $browser->keys('.app', ['{command}', 'j']);
 
-> {tip} All modifier keys are wrapped in `{}` characters, and match the constants defined in the `Facebook\WebDriver\WebDriverKeys` class, which can be [found on GitHub](https://github.com/facebook/php-webdriver/blob/community/lib/WebDriverKeys.php).
+> {tip} All modifier keys are wrapped in `{}` characters, and match the constants defined in the `Facebook\WebDriver\WebDriverKeys` class, which can be [found on GitHub](https://github.com/php-webdriver/php-webdriver/blob/master/lib/WebDriverKeys.php).
 
 <a name="using-the-mouse"></a>
 ### Using The Mouse


### PR DESCRIPTION
This is a cherry pick of https://github.com/laravel/docs/commit/5896fb9dfe03210854f9b8cdc595f94345d43093

It should also be applied to the 5.5, 5.6, 5.7 and 5.8 branches