### PR TITLE
Add note about moved Assert class

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -21,6 +21,8 @@
 - [Markdown Mail Template Updates](#markdown-mail-template-updates)
 - [The `Blade::component` Method](#the-blade-component-method)
 - [The `assertSee` Assertion](#assert-see)
+- [The `TestResponse` class](#test-response)
+- [The `Assert` class](#assert-class)
 - [The `different` Validation Rule](#the-different-rule)
 - [Unique Route Names](#unique-route-names)
 </div>
@@ -267,12 +269,19 @@ The `array` session driver data is now persistent for the current request. Previ
 
 The `assertSee` and `assertDontSee` assertions on the `TestResponse` class will now automatically escape values. If you are manually escaping any values passed to these assertions you should no longer do so. If you need to assert unescaped values, you may pass `false` as the second argument to the method.
 
-<a name="assert-see"></a>
+<a name="test-response"></a>
 #### The `TestResponse` Class
 
 **Likelihood Of Impact: Low**
 
 The `Illuminate\Foundation\Testing\TestResponse` class has been renamed to `Illuminate\Testing\TestResponse`. If you're extending this class, make sure to update the namespace.
+
+<a name="assert-class"></a>
+#### The `Assert` Class
+
+**Likelihood Of Impact: Low**
+
+The `Illuminate\Foundation\Testing\Assert` class has been renamed to `Illuminate\Testing\Assert`. If you're using this class, make sure to update the namespace.
 
 ### Validation
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -21,8 +21,6 @@
 - [Markdown Mail Template Updates](#markdown-mail-template-updates)
 - [The `Blade::component` Method](#the-blade-component-method)
 - [The `assertSee` Assertion](#assert-see)
-- [The `TestResponse` class](#test-response)
-- [The `Assert` class](#assert-class)
 - [The `different` Validation Rule](#the-different-rule)
 - [Unique Route Names](#unique-route-names)
 </div>


### PR DESCRIPTION
Add a section to the upgrade guide to explain that the `Assert` class has moved to a new namespace.

Also adds a TOC link for `TestResponse`, and fixes the duplicate `assert-see` named anchor.
