### PR TITLE
Remove the mention to same_site in upgrade guide.

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -75,11 +75,9 @@ First, the `report` and `render` methods of your application's `App\Exceptions\H
     public function report(Throwable $exception);
     public function render($request, Throwable $exception);
 
-Next, please update your `session` configuration file's `secure` option to have a fallback value of `null` and the `same_site` option to have a fallback value of `lax`:
+Next, please update your `session` configuration file's `secure` option to have a fallback value of `null`.
 
     'secure' => env('SESSION_SECURE_COOKIE', null),
-
-    'same_site' => 'lax',
 
 ### Authentication
 


### PR DESCRIPTION
Hi. 
This is more an issue than a suggestion.

For the Laravel 6 to 7 migration I've followed the migration guide, which ask to change the same_site value from `null` to `lax`.
This broke my app local development (a SPA served by webpack web server).

Actually I don't understand why this change has been made, as it's a breaking change, but is absolutely not needed for symfony 5 compatibility.

Each time we create a Symfony cookie we set sameSite with the value from the config, and null is a totally accepted value 🤷‍♂️.

We actually also have to change the phpdoc of `config/session.php` file for:

```
Supported: "lax", "strict", "none", null
```

Thanks.
