### PR TITLE
[7.x] Document that Component classes don't support default constructor parameters

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -494,7 +494,7 @@ You may pass data to Blade components using HTML attributes. Hard-coded, primiti
 
     <x-alert type="error" :message="$message"/>
 
-You should define the component's required data in its class constructor. All public properties on a component will automatically be made available to the component's view. It is not necessary to pass the data to the view from the component's `render` method:
+You should define the component's required data in its class constructor, all constructor parameters are required, and **default values are not permitted**. All public properties on a component will automatically be made available to the component's view. It is not necessary to pass the data to the view from the component's `render` method:
 
     <?php
 


### PR DESCRIPTION
See: laravel/framework#31980

Feel free to change the phrasing, i'm not really sure what the style guidelines are for the docs in regards to how to word things.