### PR TITLE
Add findMany method to eloquent collections

### DIFF
--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -103,7 +103,8 @@ The `find` method finds a model that has a given primary key. If `$key` is a mod
     
 <a name="method-findMany"></a>
 #### `findMany($keys)`
-The `findMany` method returns all models that belong to a primary key passed in the `$keys` array:
+
+The `findMany` method returns all models with a primary key that is included in the `$keys` array:
 
     $users = User::all();
     

--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -54,6 +54,7 @@ In addition, the `Illuminate\Database\Eloquent\Collection` class provides a supe
 [diff](#method-diff)
 [except](#method-except)
 [find](#method-find)
+[findMany](#method-findMany)
 [fresh](#method-fresh)
 [intersect](#method-intersect)
 [load](#method-load)
@@ -99,7 +100,15 @@ The `find` method finds a model that has a given primary key. If `$key` is a mod
     $users = User::all();
 
     $user = $users->find(1);
+    
+<a name="method-findMany"></a>
+#### `findMany($keys)`
+The `findMany` method returns all models that belong to a primary key passed in the `$keys` array:
 
+    $users = User::all();
+    
+    $user = $users->findMany([1, 2, 3]);
+    
 <a name="method-fresh"></a>
 #### `fresh($with = [])`
 


### PR DESCRIPTION
I've been using the `findMany` method in some projects and I was wondering why it isn't in the documentation. Maybe this is intended, if not I think this is a useful addition. When this is intentional I'd love to know why you shouldn't use this method. I know that the `find` method can handle an array and uses the `findMany` method to do so.