### PR TITLE
Added ExpressionEngine as supported out of the box

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -42,7 +42,7 @@ Out of the box, Valet support includes, but is not limited to:
 - [Contao](https://contao.org/en/)
 - [Craft](https://craftcms.com)
 - [Drupal](https://www.drupal.org/)
-- [ExpressionEngine] (expressionengine.com/)
+- [ExpressionEngine] (https://www.expressionengine.com/)
 - [Jigsaw](https://jigsaw.tighten.co)
 - [Joomla](https://www.joomla.org/)
 - [Katana](https://github.com/themsaid/katana)

--- a/valet.md
+++ b/valet.md
@@ -42,6 +42,7 @@ Out of the box, Valet support includes, but is not limited to:
 - [Contao](https://contao.org/en/)
 - [Craft](https://craftcms.com)
 - [Drupal](https://www.drupal.org/)
+- [ExpressionEngine] (expressionengine.com/)
 - [Jigsaw](https://jigsaw.tighten.co)
 - [Joomla](https://www.joomla.org/)
 - [Katana](https://github.com/themsaid/katana)

--- a/valet.md
+++ b/valet.md
@@ -42,7 +42,7 @@ Out of the box, Valet support includes, but is not limited to:
 - [Contao](https://contao.org/en/)
 - [Craft](https://craftcms.com)
 - [Drupal](https://www.drupal.org/)
-- [ExpressionEngine] (https://www.expressionengine.com/)
+- [ExpressionEngine](https://www.expressionengine.com/)
 - [Jigsaw](https://jigsaw.tighten.co)
 - [Joomla](https://www.joomla.org/)
 - [Katana](https://github.com/themsaid/katana)


### PR DESCRIPTION
Valet can be used as is with ExpressionEngine default install. We can also provide custom drivers for common configurations if that is helpful. 