### PR TITLE
[7.x] Added expectsConfirmation docs to console tests page

### DIFF
--- a/console-tests.md
+++ b/console-tests.md
@@ -40,5 +40,9 @@ You may test this command with the following test which utilizes the `expectsQue
              ->expectsOutput('Your name is Taylor Otwell and you program in PHP.')
              ->assertExitCode(0);
     }
+    
+When writing a command which expects a confirmation in the form of a yes or no answer, you may utilize the `expectsConfirmation` method:
 
-
+    $this->artisan('module:import')
+        ->expectsConfirmation('Do you really wish to run this command?', 'no')
+        ->assertExitCode(1);


### PR DESCRIPTION
Added documentation for the recent method `expectsConfirmation` which was added in Laravel 7.2 and can be used to test artisan commands that expect a confirmation such as yes or no.