### PR TITLE
[5.8] Add new assert methods for Dusk

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -719,6 +719,7 @@ Dusk provides a variety of assertions that you may make against your application
 [assertVueIsNot](#assert-vue-is-not)
 [assertVueContains](#assert-vue-contains)
 [assertVueDoesNotContain](#assert-vue-does-not-contain)
+[assertAttribute](#assert-attribute)
 </div>
 
 <a name="assert-title"></a>
@@ -1116,6 +1117,35 @@ Assert that a given Vue component data property is an array and contains the giv
 Assert that a given Vue component data property is an array and does not contain the given value:
 
     $browser->assertVueDoesNotContain($property, $value, $componentSelector = null);
+
+<a name="assert-attribute"></a>
+#### assertAttribute
+
+Assert that the element matching the given selector has the given value in the provided attribute:
+
+    $browser->assertAttribute($selector, $attribute, $value);
+
+<a name="assert-aria-attribute"></a>
+#### assertArriaAttribute
+
+Assert that the element matching the given selector has the given value in the provided aria attribute:
+
+    $browser->assertAriaAttribute($selector, $attribute, $value);
+
+For example, with `<button aria-label="Add"></>` you can assert the `aria-label` attribute with
+
+    $browser->assertAriaAttribute('button', 'label', 'Add')
+
+<a name="assert-data-attribute"></a>
+#### assertDataAttribute
+
+Assert that the element matching the given selector has the given value in the provided data attribute:
+
+    $browser->assertDataAttribute($selector, $attribute, $value);
+
+For example, with `<tr id="row-1" data-content="attendees"></>` you can assert the `data-label` attribute with
+
+    $browser->assertDataAttribute('#row-1', 'content', 'attendees')
 
 <a name="pages"></a>
 ## Pages


### PR DESCRIPTION
Following a Dusk PR being merged (https://github.com/laravel/dusk/pull/751), this PR is about updating the documentation.

Laravel Dusk 5 is, AFAIK, used from Laravel 5.8 upwards. This PR is only about the 5.8 branch of the documentation. Once accepted I will create more PRs for version 6 and 7.