### PR TITLE
[7.x] Sanctum - added note that API and frontend have to share the same TLD

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -143,7 +143,7 @@ Sanctum exists to offer a simple way to authenticate single page applications (S
 
 For this feature, Sanctum does not use tokens of any kind. Instead, Sanctum uses Laravel's built-in cookie based session authentication services. This provides the benefits of CSRF protection, session authentication, as well as protects against leakage of the authentication credentials via XSS. Sanctum will only attempt to authenticate using cookies when the incoming request originates from your own SPA frontend.
 
-Please note, in order to use this type of built-in SPA authentication, your SPA and API have to share the same TLD.
+> {note} In order to authenticate, your SPA and API must share the same top-level domain. However, they may be placed on different subdomains.
 
 <a name="spa-configuration"></a>
 ### Configuration

--- a/sanctum.md
+++ b/sanctum.md
@@ -143,6 +143,8 @@ Sanctum exists to offer a simple way to authenticate single page applications (S
 
 For this feature, Sanctum does not use tokens of any kind. Instead, Sanctum uses Laravel's built-in cookie based session authentication services. This provides the benefits of CSRF protection, session authentication, as well as protects against leakage of the authentication credentials via XSS. Sanctum will only attempt to authenticate using cookies when the incoming request originates from your own SPA frontend.
 
+Please note, in order to use this type of built-in SPA authentication, your SPA and API have to share the same TLD.
+
 <a name="spa-configuration"></a>
 ### Configuration
 


### PR DESCRIPTION
To me, it was not obvious right away that this was a requirement.

Having read GitHub issues over and over again and after chatting in Discord's Sanctum channel, it seems it was not quite clear amongst people there either.

Even though it makes complete sense that this is a requirement, I think noting it in the docs is important as I have spend days trying to educate myself on this issue on why it wasn't working, instead of learning how the foundation is working.

So I hope this helps people not make the same mistake as me 🤦🏼‍♂️