### PR TITLE
[7.x] Add all ExceptionHandler methods to upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -68,12 +68,14 @@ Finally, examine any other third-party packages consumed by your application and
 
 Laravel 7 utilizes the 5.x series of the Symfony components. Some minor changes to your application are required to accommodate this upgrade.
 
-First, the `report` and `render` methods of your application's `App\Exceptions\Handler` class should accept instances of the `Throwable` interface instead of `Exception` instances:
+First, the `report` and `render` methods (as well as `shouldReport` and `renderForConsole` if you are overriding those) of your application's `App\Exceptions\Handler` class should accept instances of the `Throwable` interface instead of `Exception` instances:
 
     use Throwable;
 
     public function report(Throwable $exception);
+    public function shouldReport(Throwable $exception);
     public function render($request, Throwable $exception);
+    public function renderForConsole($output, Throwable $exception);
 
 Next, please update your `session` configuration file's `secure` option to have a fallback value of `null`:
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -68,7 +68,7 @@ Finally, examine any other third-party packages consumed by your application and
 
 Laravel 7 utilizes the 5.x series of the Symfony components. Some minor changes to your application are required to accommodate this upgrade.
 
-First, the `report` and `render` methods (as well as `shouldReport` and `renderForConsole` if you are overriding those) of your application's `App\Exceptions\Handler` class should accept instances of the `Throwable` interface instead of `Exception` instances:
+First, the `report`, `render`, `shouldReport`, and `renderForConsole` methods of your application's `App\Exceptions\Handler` class should accept instances of the `Throwable` interface instead of `Exception` instances:
 
     use Throwable;
 


### PR DESCRIPTION
I am aware that the `shouldReport` and `renderForConsole` methods are not documented, but some projects are overriding them (or implementing the exception handler for other reasons) and it would be useful to know that these methods also accept `Throwable` instead of `Exception` now.