### PR TITLE
[7.x] Update CI Github Action example

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1530,11 +1530,13 @@ If you are using [Github Actions](https://github.com/features/actions) to run yo
       dusk-php:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v1
+          - uses: actions/checkout@v2
           - name: Prepare The Environment
             run: cp .env.example .env
           - name: Create Database
-            run: mysql --user="root" --password="root" -e "CREATE DATABASE my-database character set UTF8mb4 collate utf8mb4_bin;"
+            run: |
+              sudo systemctl start mysql
+              mysql --user="root" --password="root" -e "CREATE DATABASE my-database character set UTF8mb4 collate utf8mb4_bin;"
           - name: Install Composer Dependencies
             run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
           - name: Generate Application Key


### PR DESCRIPTION
This PR changes the *Dusk -> Continuous Integration -> Github Action* example with the following:
- Add command to start MySQL service before a database is created (using the MySQL service). This was a breaking change introduced on [March 3rd, 2020](https://github.community/t5/GitHub-Actions/Github-Actions-Can-t-connect-to-mysql/m-p/50610#M7891) where Ubuntu virtual environments no longer starts the MySQL service automatically and the [solution](https://github.community/t5/GitHub-Actions/Github-Actions-Can-t-connect-to-mysql/m-p/50610#M7891) is simply to start the service manually.
- Bump the version `actions/checkout` to the latest `v2`