### PR TITLE
[7.x] Add reference to MailSpons

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -677,9 +677,9 @@ Another solution provided by Laravel is to set a universal recipient of all emai
         'name' => 'Example'
     ],
 
-#### Mailtrap
+#### Mailtrap or MailSpons
 
-Finally, you may use a service like [Mailtrap](https://mailtrap.io) and the `smtp` driver to send your email messages to a "dummy" mailbox where you may view them in a true email client. This approach has the benefit of allowing you to actually inspect the final emails in Mailtrap's message viewer.
+Finally, you may use services like [Mailtrap](https://mailtrap.io) or [MailSpons](https://mailspons.com) and the `smtp` driver to send your email messages to a "dummy" mailbox where you may view them in a true email client. This approach has the benefit of allowing you to actually inspect the final emails in web-based message viewer.
 
 <a name="events"></a>
 ## Events


### PR DESCRIPTION
Disclaimer: I am the creator of MailSpons and I sincerely apologize if this is not the proper way to propose this change.

I am proposing to mention [MailSpons](https://mailspons.com/) in the Laravel docs as an alternative to Mailtrap. I've made a "MailSpons vs Mailtrap" page for quick comparison at: https://mailspons.com/vs-mailtrap.io

Kind regards,
Dave Bakker