### PR TITLE
[7.x] Swift Mailer Bindings Removed

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -208,6 +208,17 @@ Because indentation has special meaning within Markdown, Markdown mail templates
 
     php artisan vendor:publish --tag=laravel-mail --force
 
+#### Swift Mailer Bindings Removed
+
+**Likelihood Of Impact: Low**
+
+Laravel 7.x doesn't provide `swift.mailer` and `swift.transport` bindings.
+
+You can still get them through `mailer`, but please note that Laravel 8.x or 9.x will likely not use Swift Mailer anymore:
+
+    $swiftMailer = app('mailer')->getSwiftMailer();
+    $swiftTransport = $swiftMailer->getTransport();
+
 ### Queue
 
 #### Deprecated `--daemon` Flag Removed

--- a/upgrade.md
+++ b/upgrade.md
@@ -208,15 +208,14 @@ Because indentation has special meaning within Markdown, Markdown mail templates
 
     php artisan vendor:publish --tag=laravel-mail --force
 
-#### Swift Mailer Bindings Removed
+#### Swift Mailer Bindings
 
 **Likelihood Of Impact: Low**
 
-Laravel 7.x doesn't provide `swift.mailer` and `swift.transport` bindings.
-
-You can still get them through `mailer`, but please note that Laravel 8.x or 9.x will likely not use Swift Mailer anymore:
+Laravel 7.x doesn't provide `swift.mailer` and `swift.transport` container bindings. You may now access these objects through the `mailer` binding:
 
     $swiftMailer = app('mailer')->getSwiftMailer();
+
     $swiftTransport = $swiftMailer->getTransport();
 
 ### Queue


### PR DESCRIPTION
Updating docs according to [this merged PR #32165](https://github.com/laravel/framework/pull/32165), and our initial conversation [in another PR #32145](https://github.com/laravel/framework/pull/32145#issuecomment-605655948).