### PR TITLE
Update validator extend method

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1384,7 +1384,7 @@ The custom validator Closure receives four arguments: the name of the `$attribut
 
 You may also pass a class and method to the `extend` method instead of a Closure:
 
-    Validator::extend('foo', 'FooValidator@validate');
+    Validator::extend('foo', 'FooValidator@passes');
 
 #### Defining The Error Message
 


### PR DESCRIPTION
I'm getting the error message
`call_user_func_array() expects parameter 1 to be a valid callback, class 'App\Rules\MyRule' does not have a method 'validate'. `

So, I have fixed to   `Validator::extend('foo', 'FooValidator@passes');`. It is working for me.