### PR TITLE
[7.x] Fix example in queues.md

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -300,9 +300,9 @@ Once you have written your job class, you may dispatch it using the `dispatch` m
 
 If you would like to conditionally dispatch a job, you may use the `dispatchIf` and `dispatchUnless` methods:
 
-    ProcessPodcast::dispatchIf($accountActive = true, $podcast);
+    ProcessPodcast::dispatchIf($accountActive === true, $podcast);
 
-    ProcessPodcast::dispatchUnless($accountSuspended = false, $podcast);
+    ProcessPodcast::dispatchUnless($accountSuspended === false, $podcast);
 
 <a name="delayed-dispatching"></a>
 ### Delayed Dispatching


### PR DESCRIPTION
I assume the examples are meant to have comparison rather than assignment operators, otherwise there's not much point in using conditional dispatch.