### PR TITLE
[7.x] Prevent Telescope auto-discovery in production

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -71,9 +71,20 @@ After running `telescope:install`, you should remove the `TelescopeServiceProvid
     public function register()
     {
         if ($this->app->isLocal()) {
+            $this->app->register(\Laravel\Telescope\TelescopeServiceProvider::class);
             $this->app->register(TelescopeServiceProvider::class);
         }
     }
+
+You should also prevent Telescope to be [auto-discovered](packages#package-discovery) in your `composer.json`:
+
+    "extra": {
+        "laravel": {
+            "dont-discover": [
+                "laravel/telescope"
+            ]
+        }
+    },
 
 <a name="migration-customization"></a>
 ### Migration Customization

--- a/telescope.md
+++ b/telescope.md
@@ -76,7 +76,7 @@ After running `telescope:install`, you should remove the `TelescopeServiceProvid
         }
     }
 
-You should also prevent Telescope to be [auto-discovered](packages#package-discovery) in your `composer.json`:
+You should also prevent the Telescope package from being [auto-discovered](/docs/{{version}}/packages#package-discovery) by adding the following to your `composer.json` file:
 
     "extra": {
         "laravel": {


### PR DESCRIPTION
I had a hard time finding why Telescope was running in production in my apps by following the doc. It turned out that it was because of package auto-discovery.

So here’s an amendment to make sure Telescope isn’t enabled at all outside of local environment.

From [@michaeldyrynda’s article](https://dyrynda.com.au/blog/using-laravel-telescope-in-specific-environments).