### PR TITLE
[7.x] Mention new assertions assertNotSent and assertNothingSent

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -265,3 +265,24 @@ The `assertSent` method accepts a callback which will be given an `Illuminate\Ht
                $request['name'] == 'Taylor' &&
                $request['role'] == 'Developer';
     });
+    
+Besides that you can also expect that a specific request was not sent by using `assertNotSent`:
+
+    Http::fake();
+    
+    Http::post('http://test.com/users', [
+        'name' => 'Taylor',
+        'role' => 'Developer',
+    ]); 
+       
+    Http::assertNotSent(function (Request $request) {
+        return $request->url() === 'http://test.com/posts';
+    });
+    
+And if you want to make sure no request was sent at all, you can make use of `assertNothingSent`:
+
+    Http::fake();
+    
+    Http::assertNothingSent();
+    
+

--- a/http-client.md
+++ b/http-client.md
@@ -266,7 +266,7 @@ The `assertSent` method accepts a callback which will be given an `Illuminate\Ht
                $request['role'] == 'Developer';
     });
     
-Besides that you can also expect that a specific request was not sent by using `assertNotSent`:
+If needed, you may assert that a specific request was not sent using the `assertNotSent` method:
 
     Http::fake();
     
@@ -279,10 +279,8 @@ Besides that you can also expect that a specific request was not sent by using `
         return $request->url() === 'http://test.com/posts';
     });
     
-And if you want to make sure no request was sent at all, you can make use of `assertNothingSent`:
+Or, if you would like to assert that no requests were sent, you may use the `assertNothingSent` method:
 
     Http::fake();
     
     Http::assertNothingSent();
-    
-


### PR DESCRIPTION
This PR mentions the new assertions for the HTTP Client `assertNotSent` and `assertNothingSent`.

Framework Pull Request: https://github.com/laravel/framework/pull/32197