### PR TITLE
Session Fixation source link changed to an official security source

### DIFF
--- a/session.md
+++ b/session.md
@@ -192,7 +192,7 @@ The `forget` method will remove a piece of data from the session. If you would l
 <a name="regenerating-the-session-id"></a>
 ### Regenerating The Session ID
 
-Regenerating the session ID is often done in order to prevent malicious users from exploiting a [session fixation](https://en.wikipedia.org/wiki/Session_fixation) attack on your application.
+Regenerating the session ID is often done in order to prevent malicious users from exploiting a [session fixation](https://owasp.org/www-community/attacks/Session_fixation) attack on your application.
 
 Laravel automatically regenerates the session ID during authentication if you are using the built-in `LoginController`; however, if you need to manually regenerate the session ID, you may use the `regenerate` method.
 


### PR DESCRIPTION
I notice the source link in the reference for the Session Fixation attack could be replaced for an official web application source [OWASP].