### PR TITLE
Move auth controllers

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -50,8 +50,6 @@ Also, you should verify that your `users` (or equivalent) table contains a nulla
 <a name="authentication-quickstart"></a>
 ## Authentication Quickstart
 
-Laravel ships with several pre-built authentication controllers, which are located in the `App\Http\Controllers\Auth` namespace. The `RegisterController` handles new user registration, the `LoginController` handles authentication, the `ForgotPasswordController` handles e-mailing links for resetting passwords, and the `ResetPasswordController` contains the logic to reset passwords. Each of these controllers uses a trait to include their necessary methods. For many applications, you will not need to modify these controllers at all.
-
 <a name="included-routing"></a>
 ### Routing
 
@@ -62,6 +60,8 @@ Laravel's `laravel/ui` package provides a quick way to scaffold all of the route
     php artisan ui vue --auth
 
 This command should be used on fresh applications and will install a layout view, registration and login views, as well as routes for all authentication end-points. A `HomeController` will also be generated to handle post-login requests to your application's dashboard.
+
+Laravel ui generates several pre-built authentication controllers, which are located in the `App\Http\Controllers\Auth` namespace. The `RegisterController` handles new user registration, the `LoginController` handles authentication, the `ForgotPasswordController` handles e-mailing links for resetting passwords, and the `ResetPasswordController` contains the logic to reset passwords. Each of these controllers uses a trait to include their necessary methods. For many applications, you will not need to modify these controllers at all.
 
 > {tip} If your application doesn’t need registration, you may disable it by removing the newly created `RegisterController` and modifying your route declaration: `Auth::routes(['register' => false]);`.
 


### PR DESCRIPTION
As it currently reads, the docs imply that the auth controllers are installed by default, rather than by `laravel/ui`.