### PR TITLE
[5.8] Changing the version of the laravel telescope

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -41,7 +41,7 @@ Laravel Telescope is an elegant debug assistant for the Laravel framework. Teles
 
 You may use Composer to install Telescope into your Laravel project:
 
-    composer require laravel/telescope
+    composer require laravel/telescope "2.1.7"
 
 After installing Telescope, publish its assets using the `telescope:install` Artisan command. After installing Telescope, you should also run the `migrate` command:
 


### PR DESCRIPTION
Version 2.1.7 is the last that supports laravel 5.8 as release 3.0.0 removed support for laravel 5.8.