### PR TITLE
[7.x] Mention that reset password tables comes with laravel/ui package

### DIFF
--- a/passwords.md
+++ b/passwords.md
@@ -23,8 +23,10 @@ To get started, verify that your `App\User` model implements the `Illuminate\Con
 
 #### Generating The Reset Token Table Migration
 
-Next, a table must be created to store the password reset tokens. The migration for this table is included with Laravel out of the box, and resides in the `database/migrations` directory. So, all you need to do is run your database migrations:
+Next, a table must be created to store the password reset tokens. The migration for this table is included in `laravel/ui` package. So, all you need to do is install the package and run your database migrations:
 
+    composer require laravel/ui
+    
     php artisan migrate
 
 <a name="resetting-routing"></a>

--- a/passwords.md
+++ b/passwords.md
@@ -23,7 +23,7 @@ To get started, verify that your `App\User` model implements the `Illuminate\Con
 
 #### Generating The Reset Token Table Migration
 
-Next, a table must be created to store the password reset tokens. The migration for this table is included in `laravel/ui` package. So, all you need to do is install the package and run your database migrations:
+Next, a table must be created to store the password reset tokens. The migration for this table is included in the `laravel/ui` Composer package. After installing the `laravel/ui` package, you may use the `migrate` command to create the password reset token database table:
 
     composer require laravel/ui
     


### PR DESCRIPTION
The doc mentioned that reset password tables migration is included with Laravel out of the box, while in fact that isn't true anymore. 

The reset password migration file has been removed from Laravel codebase on 21 Dec, 2019 by @taylorotwell, this is the diff https://github.com/laravel/laravel/commit/13e43893ba2457c3e49898f0066a5ce8d7ea74f4#diff-1dc5ac688c033a49fe866c452e212a4c. The reason for deletion is to host the file in laravel/ui package instead.

This pull request try to help the reader who read the doc to see the clear picture of where the file is.