### PR TITLE
[7.x] Mention that validation rule names are case-sensitive

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -108,7 +108,7 @@ To get a better understanding of the `validate` method, let's jump back into the
         // The blog post is valid...
     }
 
-As you can see, we pass the desired validation rules into the `validate` method. Again, if the validation fails, the proper response will automatically be generated. If the validation passes, our controller will continue executing normally.
+As you can see, we pass the desired validation rules into the `validate` method. Again, if the validation fails, the proper response will automatically be generated. If the validation passes, our controller will continue executing normally. Keep in mind rule names are case-sensitive.
 
 Alternatively, validation rules may be specified as arrays of rules instead of a single `|` delimited string:
 


### PR DESCRIPTION
This might be obvious to some, but I guess it doesn't hurt to mention it :slightly_smiling_face:

In the future, we could consider being more strict about validation names. This would likely be a breaking change though.