### PR TITLE
Added 'directory' property to Supervisor config

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -758,7 +758,8 @@ Supervisor configuration files are typically stored in the `/etc/supervisor/conf
 
     [program:laravel-worker]
     process_name=%(program_name)s_%(process_num)02d
-    command=php /home/forge/app.com/artisan queue:work sqs --sleep=3 --tries=3
+    directory=/home/forge/app.com
+    command=php artisan queue:work sqs --sleep=3 --tries=3
     autostart=true
     autorestart=true
     user=forge


### PR DESCRIPTION
The runtime of the Supervisor and PHP can be set with the 'directory' property. No need to specify the Artisan path in the 'command' property.

http://supervisord.org/configuration.html?highlight=directory#program-x-section-example