### PR TITLE
[7.x] Align upgrade note with change in `laravel/laravel` repo

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -77,9 +77,11 @@ First, the `report`, `render`, `shouldReport`, and `renderForConsole` methods of
     public function render($request, Throwable $exception);
     public function renderForConsole($output, Throwable $exception);
 
-Next, please update your `session` configuration file's `secure` option to have a fallback value of `null`:
+Next, please update your `session` configuration file's `secure` option to fallback to a value of `null`:
 
-    'secure' => env('SESSION_SECURE_COOKIE', null),
+    // 'secure' => env('SESSION_SECURE_COOKIE', false),
+
+    'secure' => env('SESSION_SECURE_COOKIE'),
 
 ### Authentication
 


### PR DESCRIPTION
Not that the upgrade note is wrong but it doesn't align with the change as seen in `laravel/laravel` via the [GitHub comparison tool](https://github.com/laravel/laravel/compare/6.x...master#files_bucket).

```diff
- 'secure' => env('SESSION_SECURE_COOKIE', false),
+ 'secure' => env('SESSION_SECURE_COOKIE'),
```