### PR TITLE
[7.x] Use proper link to Slack app

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -757,7 +757,7 @@ Before you can send notifications via Slack, you must install the notification c
 
     composer require laravel/slack-notification-channel
 
-You will also need to configure an ["Incoming Webhook"](https://api.slack.com/incoming-webhooks) integration for your Slack team. This integration will provide you with a URL you may use when [routing Slack notifications](#routing-slack-notifications).
+You will also need to configure an ["Incoming Webhook"](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks) integration for your Slack team. This integration will provide you with a URL you may use when [routing Slack notifications](#routing-slack-notifications).
 
 <a name="formatting-slack-notifications"></a>
 ### Formatting Slack Notifications


### PR DESCRIPTION
Apparently the current docs are referring to the newer way of setting up a custom app, rather than using the existing Slack one. The former doesn't supports customizing `from`.