### PR TITLE
[7.x] Added status code to assertForbidden in HTTP Tests documentation

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -420,7 +420,7 @@ Assert that the response contains an exact match of the given JSON data:
 <a name="assert-forbidden"></a>
 #### assertForbidden
 
-Assert that the response has a forbidden status code:
+Assert that the response has a forbidden (403) status code:
 
     $response->assertForbidden();
 


### PR DESCRIPTION
I found myself searching for the string `403` on the HTTP Tests page to find if there is an assertion for such status code. But could not find one, when I searched for `401`, I could. That let me to assume there wasn't one. Started digging through code and found `assertForbidden`. 

I think it would be useful to add, makes searching the documentation easier.