### PR TITLE
[7.x] Tweak query time casting example

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -482,5 +482,5 @@ The `last_posted_at` attribute on the results of this query will be a raw string
         'last_posted_at' => Post::selectRaw('MAX(created_at)')
                 ->whereColumn('user_id', 'users.id')
     ])->withCasts([
-        'last_posted_at' => 'date'
+        'last_posted_at' => 'datetime'
     ])->get();


### PR DESCRIPTION
Super minor tweak:

This example currently uses the "date" cast, but since the "last_posted_at" includes the time (given that convention, it probably makes more sense to use "datetime" in this example.