### PR TITLE
[7.x] added reference to document for previous `@component` syntax

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -744,6 +744,8 @@ You may specify which attributes should be considered data variables using the `
         {{ $message }}
     </div>
 
+> {note} The previous `@component` syntax for Blade components has not and will not be removed. For more information, please consult the [Laravel 6.x Componens & Slots documentation](https://laravel.com/docs/6.x/blade#components-and-slots) 
+
 <a name="including-subviews"></a>
 ## Including Subviews
 


### PR DESCRIPTION
Hello,

Please consider to accept this PR to add reference to old `@component` syntax.

Currently, note for old syntax appears only in Laravel 7 release note https://laravel.com/docs/7.x/releases#laravel-7

As this syntax won't be removed so it is good idea to put reference to old documentation [Laravel 7 Blade Templates / Components](https://laravel.com/docs/7.x/blade#components) document too.


Thank you,