### PR TITLE
[7.x] Mention all updated methods with auto escaping

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -277,7 +277,7 @@ The `array` session driver data is now persistent for the current request. Previ
 
 **Likelihood Of Impact: Medium**
 
-The `assertSee` and `assertDontSee` assertions on the `TestResponse` class will now automatically escape values. If you are manually escaping any values passed to these assertions you should no longer do so. If you need to assert unescaped values, you may pass `false` as the second argument to the method.
+The `assertSee`, `assertDontSee`, `assertSeeText`, `assertDontSeeText`, `assertSeeInOrder` and `assertSeeTextInOrder` assertions on the `TestResponse` class will now automatically escape values. If you are manually escaping any values passed to these assertions you should no longer do so. If you need to assert unescaped values, you may pass `false` as the second argument to the method.
 
 <a name="test-response"></a>
 #### The `TestResponse` Class


### PR DESCRIPTION
Based on https://github.com/laravel/framework/pull/31196/files and https://github.com/laravel/framework/pull/31315/files more methods were updated that mentioned in upgrade guide.