### PR TITLE
[7.x] Github Actions -> match the correct chrome-driver

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1542,7 +1542,7 @@ If you are using [Github Actions](https://github.com/features/actions) to run yo
           - name: Generate Application Key
             run: php artisan key:generate
           - name: Upgrade Chrome Driver
-            run: php artisan dusk:chrome-driver
+            run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
           - name: Start Chrome Driver
             run: ./vendor/laravel/dusk/bin/chromedriver-linux &
           - name: Run Laravel Server


### PR DESCRIPTION
Every time Chrome releases a new version, a version mismatch exists for a couple of days. This causes Laravel Dusk to fail with the message: 

`Facebook\WebDriver\Exception\SessionNotCreatedException: session not created: This version of ChromeDriver only supports Chrome version 81`

This problem exists until GitHub actions auto-updates their ubuntu-latest image. (about once a week). During that time the following version mismatch exists:

`php artisan dusk:chrome-driver` -> install the latest chrome-driver version (currently 81)
`/opt/google/chrome/chrome --version` -> Github's ubuntu-latests version is at 80.xx

This can be easily solved by installing the chrome-driver based on the chrome version of the current machine. 

This fix has been tested and is working for my use case.