### PR TITLE
[7.x] Mutators are also now run on getOriginal

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -169,7 +169,7 @@ Laravel 7 removes the "factory types" feature. This feature has been undocumente
 
 **Likelihood Of Impact: Low**
 
-The `$model->getOriginal()` method will now respect any casts defined on the model. Previously, this method returned the uncast, raw attributes. If you would like to continue retrieving the raw, uncast values, you may use the `getRawOriginal` method instead.
+The `$model->getOriginal()` method will now respect any casts and mutators defined on the model. Previously, this method returned the uncast, raw attributes. If you would like to continue retrieving the raw, uncast values, you may use the `getRawOriginal` method instead.
 
 #### Route Binding
 


### PR DESCRIPTION
`transformModelValue` Runs mutators then casts. This caught me out during an upgrade. Albeit perhaps in quite a niche scenario.