### PR TITLE
[7.x] Adding a note on Authorizing Resource Controllers

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -483,6 +483,8 @@ As previously discussed, some actions like `create` may not require a model inst
 
 If you are utilizing [resource controllers](/docs/{{version}}/controllers#resource-controllers), you may make use of the `authorizeResource` method in the controller's constructor. This method will attach the appropriate `can` middleware definitions to the resource controller's methods.
 
+> {note} Make sure your [resource controller](/docs/{{version}}/controllers#resource-controllers) is created with the `--model` flag to have the required method signatures and type hints.
+
 The `authorizeResource` method accepts the model's class name as its first argument, and the name of the route / request parameter that will contain the model's ID as its second argument:
 
     <?php

--- a/authorization.md
+++ b/authorization.md
@@ -483,9 +483,7 @@ As previously discussed, some actions like `create` may not require a model inst
 
 If you are utilizing [resource controllers](/docs/{{version}}/controllers#resource-controllers), you may make use of the `authorizeResource` method in the controller's constructor. This method will attach the appropriate `can` middleware definitions to the resource controller's methods.
 
-> {note} Make sure your [resource controller](/docs/{{version}}/controllers#resource-controllers) is created with the `--model` flag to have the required method signatures and type hints.
-
-The `authorizeResource` method accepts the model's class name as its first argument, and the name of the route / request parameter that will contain the model's ID as its second argument:
+The `authorizeResource` method accepts the model's class name as its first argument, and the name of the route / request parameter that will contain the model's ID as its second argument. You should ensure your [resource controller](/docs/{{version}}/controllers#resource-controllers) is created with the `--model` flag to have the required method signatures and type hints:
 
     <?php
 


### PR DESCRIPTION
If a resource controller is created by calling 

    php artisan make:controller UserController --resource

it will not work with the described approach in the docs since the policy expects an injected model. If you do

    class UserController extends Controller
        {
            public function __construct()
        {
        $this->authorizeResource(User::class, 'user');
        }
    ...

it will fail to authorize and return a `403` for the methods.
Creating it with 

    php artisan make:controller UserController --resource --model=User

will work as it creates matching signatures / type hints