### PR TITLE
[7.x] Add note about autolink in Markdown section

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -461,6 +461,8 @@ Markdown mailables use a combination of Blade components and Markdown syntax whi
 
 > {tip} Do not use excess indentation when writing Markdown emails. Markdown parsers will render indented content as code blocks.
 
+> {note} Please note that the `autolink` feature of Markdown is currently unsupported.
+
 #### Button Component
 
 The button component renders a centered button link. The component accepts two arguments, a `url` and an optional `color`. Supported colors are `primary`, `success`, and `error`. You may add as many button components to a message as you wish:

--- a/mail.md
+++ b/mail.md
@@ -461,7 +461,7 @@ Markdown mailables use a combination of Blade components and Markdown syntax whi
 
 > {tip} Do not use excess indentation when writing Markdown emails. Markdown parsers will render indented content as code blocks.
 
-> {note} Please note that the `autolink` feature of Markdown is currently unsupported.
+> {note} The "autolink" feature of Markdown is not currently supported. Please construct links using the long form link syntax provided by Markdown.
 
 #### Button Component
 


### PR DESCRIPTION
Note for https://github.com/laravel/framework/issues/31977