### PR TITLE
[7.x] Document withoutMiddleware and global middleware

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -159,6 +159,8 @@ When assigning middleware to a group of routes, you may occasionally need to pre
             //
         })->withoutMiddleware([CheckAge::class]);
     });
+    
+> {note} Note that `withoutMiddleware` does not applies to globally defined middlewares.
 
 <a name="middleware-groups"></a>
 ### Middleware Groups


### PR DESCRIPTION
Add a note that `withoutMiddleware` does not applies to globally defined middleware.