### PR TITLE
[7.x] Update sanctum.md - Mention session driver for SPA

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -171,6 +171,10 @@ If you are having trouble authenticating with your application from an SPA that 
 
 You should ensure that your application's CORS configuration is returning the `Access-Control-Allow-Credentials` header with a value of `True` by setting the `supports_credentials` option within your application's `cors` configuration file to `true`.
 
+You will also need to update your application's `SESSION_DRIVER` variable to `cookie` within your .env file:
+
+    SESSION_DRIVER=cookie
+
 In addition, you should enable the `withCredentials` option on your global `axios` instance. Typically, this should be performed in your `resources/js/bootstrap.js` file:
 
     axios.defaults.withCredentials = true;


### PR DESCRIPTION
Following off these issues: 
https://github.com/laravel/sanctum/pull/47
https://github.com/laravel/sanctum/issues/43

The docs do not mention that the `SESSION_DRIVER` environmental variable should be set to `cookie`, which unless I'm misunderstanding something, is required for this to work. It defaults to `file` in the .env file of a new laravel app.