### PR TITLE
use $notifiable in example instead of $this->user

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -219,7 +219,7 @@ In addition, you may return a [mailable object](/docs/{{version}}/mail) from the
      */
     public function toMail($notifiable)
     {
-        return (new Mailable($this->invoice))->to($this->user->email);
+        return (new Mailable($this->invoice))->to($notifiable->email);
     }
 
 <a name="error-messages"></a>


### PR DESCRIPTION
I think the email is intended to be sent to the '$notifiable' instead of (presumably) passing a user in through the constructor