### PR TITLE
[7.x] Remove --daemon deprecation message in upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -218,14 +218,6 @@ Laravel 7.x doesn't provide `swift.mailer` and `swift.transport` container bindi
 
     $swiftTransport = $swiftMailer->getTransport();
 
-### Queue
-
-#### Deprecated `--daemon` Flag Removed
-
-**Likelihood Of Impact: Low**
-
-The deprecated `--daemon` flag on the `queue:work` command has been removed. This flag is no longer necessary as the worker runs as a daemon by default.
-
 ### Resources
 
 #### The `Illuminate\Http\Resources\Json\Resource` Class


### PR DESCRIPTION
The flag was initially removed but then reverted back in https://github.com/laravel/framework/commit/24c18182a82ee24be62d2ac1c6793c237944cda8