### PR TITLE
[7.x] Remove type-hinting in explicit binding

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -378,7 +378,7 @@ To register an explicit binding, use the router's `model` method to specify the 
 
 Next, define a route that contains a `{user}` parameter:
 
-    Route::get('profile/{user}', function (App\User $user) {
+    Route::get('profile/{user}', function ($user) {
         //
     });
 


### PR DESCRIPTION
Type-hinting isn't needed anymore if model is bound explicitly in RouteServiceProvider