### PR TITLE
Replaced deprecated until() with takeUntil()

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1979,7 +1979,7 @@ You may also pass a simple value to the `takeUntil` method to get the items unti
 
     $collection = collect([1, 2, 3, 4]);
 
-    $subset = $collection->until(3);
+    $subset = $collection->takeUntil(3);
 
     $subset->all();
 


### PR DESCRIPTION
I just found that an instance of `until()` was not updated to `takeUntil()` in 
https://laravel.com/docs/7.x/collections#method-takeuntil

Possibly an oversight. Kindly merge this pull request to update.

<img width="683" alt="Screenshot 2020-04-26 at 22 23 13" src="https://user-images.githubusercontent.com/12666230/80320158-a0624000-880c-11ea-816b-196d37dc19cc.png">
