### PR TITLE
[7.x] Added Stripe webhooks path

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -824,7 +824,7 @@ Stripe can notify your application of a variety of events via webhooks. By defau
 
 By default, this controller will automatically handle cancelling subscriptions that have too many failed charges (as defined by your Stripe settings), customer updates, customer deletions, subscription updates, and payment method changes; however, as we'll soon discover, you can extend this controller to handle any webhook event you like.
 
-To ensure your application can handle Stripe webhooks, be sure to configure the webhook URL in the Stripe control panel. The full list of all webhooks you should configure in the Stripe control panel are:
+To ensure your application can handle Stripe webhooks, be sure to configure the webhook URL in the Stripe control panel. By default, Cashier's webhook controller listens to the `/webhook/stripe` URL path. The full list of all webhooks you should configure in the Stripe control panel are:
 
 - `customer.subscription.updated`
 - `customer.subscription.deleted`


### PR DESCRIPTION
At the moment it is not said where Stripe's webhooks should be directed to be picked up by the default Cashier webhook controller.