### PR TITLE
[7.x] Updated Fluent matchAll Anchor

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -154,7 +154,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [lower](#method-fluent-str-lower)
 [ltrim](#method-fluent-str-ltrim)
 [match](#method-fluent-str-match)
-[matchAll](#method-fluent-str-matchAll)
+[matchAll](#method-fluent-str-match-all)
 [plural](#method-fluent-str-plural)
 [prepend](#method-fluent-str-prepend)
 [replace](#method-fluent-str-replace)


### PR DESCRIPTION
The link in the documentation pointed to matchAll when it should have been match-all - corrected this in line with other anchor tags.