### PR TITLE
[7.x] Update upgrade.md - remove null in session config

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -77,10 +77,6 @@ First, the `report`, `render`, `shouldReport`, and `renderForConsole` methods of
     public function render($request, Throwable $exception);
     public function renderForConsole($output, Throwable $exception);
 
-Next, please update your `session` configuration file's `secure` option to have a fallback value of `null`:
-
-    'secure' => env('SESSION_SECURE_COOKIE', null),
-
 ### Authentication
 
 <a name="authentication-scaffolding"></a>


### PR DESCRIPTION
The upgrade docs from version 6 to 7 mention this:

> Next, please update your `session` configuration file's `secure` option to have a fallback value of `null`:
> 
>     'secure' => env('SESSION_SECURE_COOKIE', null),

However when viewing the version 7 session.php field, the null is not there. Is the documentation incorrect?