### PR TITLE
[7.x] Document `skipUntil` and `skipWhile` collection methods

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1714,7 +1714,7 @@ The `skip` method returns a new collection, without the first given amount of it
 <a name="method-skipuntil"></a>
 #### `skipUntil()` {#collection-method}
 
-The `skipUntil` method skips items until the given callback returns `true`, and returns the remaining items in the collection:
+The `skipUntil` method skips items until the given callback returns `true` and then returns the remaining items in the collection:
 
     $collection = collect([1, 2, 3, 4]);
 
@@ -1741,7 +1741,7 @@ You may also pass a simple value to the `skipUntil` method to skip all items unt
 <a name="method-skipwhile"></a>
 #### `skipWhile()` {#collection-method}
 
-The `skipWhile` method skips items while the given callback returns `true`, and returns the remaining items in the collection:
+The `skipWhile` method skips items while the given callback returns `true` and then returns the remaining items in the collection:
 
     $collection = collect([1, 2, 3, 4]);
 

--- a/collections.md
+++ b/collections.md
@@ -152,6 +152,8 @@ For the remainder of this documentation, we'll discuss each method available on 
 [shift](#method-shift)
 [shuffle](#method-shuffle)
 [skip](#method-skip)
+[skipUntil](#method-skipuntil)
+[skipWhile](#method-skipwhile)
 [slice](#method-slice)
 [some](#method-some)
 [sort](#method-sort)
@@ -1709,6 +1711,50 @@ The `skip` method returns a new collection, without the first given amount of it
 
     // [5, 6, 7, 8, 9, 10]
 
+<a name="method-skipuntil"></a>
+#### `skipUntil()` {#collection-method}
+
+The `skipUntil` method skips items until the given callback returns `true`, and returns the remaining items in the collection:
+
+    $collection = collect([1, 2, 3, 4]);
+
+    $subset = $collection->skipUntil(function ($item) {
+        return $item >= 3;
+    });
+
+    $subset->all();
+
+    // [3, 4]
+
+You may also pass a simple value to the `skipUntil` method to skip all items until the given value is found:
+
+    $collection = collect([1, 2, 3, 4]);
+
+    $subset = $collection->skipUntil(3);
+
+    $subset->all();
+
+    // [3, 4]
+
+> {note} If the given value is not found or the callback never returns `true`, the `skipUntil` method will return an empty collection.
+
+<a name="method-skipwhile"></a>
+#### `skipWhile()` {#collection-method}
+
+The `skipWhile` method skips items while the given callback returns `true`, and returns the remaining items in the collection:
+
+    $collection = collect([1, 2, 3, 4]);
+
+    $subset = $collection->skipWhile(function ($item) {
+        return $item <= 3;
+    });
+
+    $subset->all();
+
+    // [4]
+
+> {note} If the callback never returns `true`, the `skipWhile` method will return an empty collection.
+
 <a name="method-slice"></a>
 #### `slice()` {#collection-method}
 
@@ -2598,7 +2644,7 @@ The `zip` method merges together the values of the given array with the values o
 <a name="higher-order-messages"></a>
 ## Higher Order Messages
 
-Collections also provide support for "higher order messages", which are short-cuts for performing common actions on collections. The collection methods that provide higher order messages are: [`average`](#method-average), [`avg`](#method-avg), [`contains`](#method-contains), [`each`](#method-each), [`every`](#method-every), [`filter`](#method-filter), [`first`](#method-first), [`flatMap`](#method-flatmap), [`groupBy`](#method-groupby), [`keyBy`](#method-keyby), [`map`](#method-map), [`max`](#method-max), [`min`](#method-min), [`partition`](#method-partition), [`reject`](#method-reject), [`some`](#method-some), [`sortBy`](#method-sortby), [`sortByDesc`](#method-sortbydesc), [`sum`](#method-sum) [`takeUntil`](#method-takeuntil), [`takeWhile`](#method-takewhile) and [`unique`](#method-unique).
+Collections also provide support for "higher order messages", which are short-cuts for performing common actions on collections. The collection methods that provide higher order messages are: [`average`](#method-average), [`avg`](#method-avg), [`contains`](#method-contains), [`each`](#method-each), [`every`](#method-every), [`filter`](#method-filter), [`first`](#method-first), [`flatMap`](#method-flatmap), [`groupBy`](#method-groupby), [`keyBy`](#method-keyby), [`map`](#method-map), [`max`](#method-max), [`min`](#method-min), [`partition`](#method-partition), [`reject`](#method-reject), [`skipUntil`](#method-skipuntil), [`skipWhile`](#method-skipwhile), [`some`](#method-some), [`sortBy`](#method-sortby), [`sortByDesc`](#method-sortbydesc), [`sum`](#method-sum), [`takeUntil`](#method-takeuntil), [`takeWhile`](#method-takewhile) and [`unique`](#method-unique).
 
 Each higher order message can be accessed as a dynamic property on a collection instance. For instance, let's use the `each` higher order message to call a method on each object within a collection:
 


### PR DESCRIPTION
For laravel/framework#32672