### PR TITLE
fix: correct webhook route in cashier docs

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -824,7 +824,7 @@ Stripe can notify your application of a variety of events via webhooks. By defau
 
 By default, this controller will automatically handle cancelling subscriptions that have too many failed charges (as defined by your Stripe settings), customer updates, customer deletions, subscription updates, and payment method changes; however, as we'll soon discover, you can extend this controller to handle any webhook event you like.
 
-To ensure your application can handle Stripe webhooks, be sure to configure the webhook URL in the Stripe control panel. By default, Cashier's webhook controller listens to the `/webhook/stripe` URL path. The full list of all webhooks you should configure in the Stripe control panel are:
+To ensure your application can handle Stripe webhooks, be sure to configure the webhook URL in the Stripe control panel. By default, Cashier's webhook controller listens to the `/stripe/webhook` URL path. The full list of all webhooks you should configure in the Stripe control panel are:
 
 - `customer.subscription.updated`
 - `customer.subscription.deleted`


### PR DESCRIPTION
It's in the wrong order, confused me :P

Prefix is `stripe` by default, set [here]( https://github.com/laravel/cashier/blob/11.x/src/CashierServiceProvider.php#L89-L95) and route defined [here](https://github.com/laravel/cashier/blob/11.x/routes/web.php#L6)