### PR TITLE
[7.x] Method order fixed

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -37,8 +37,8 @@ The `get` method returns an instance of `Illuminate\Http\Client\Response`, which
     $response->json() : array;
     $response->status() : int;
     $response->ok() : bool;
-    $response->failed() : bool;
     $response->successful() : bool;
+    $response->failed() : bool;
     $response->serverError() : bool;
     $response->clientError() : bool;
     $response->header($header) : string;


### PR DESCRIPTION
Now the order of displaying methods is as follows:
```
$response->ok() : bool;
$response->failed() : bool;
$response->successful() : bool;
$response->serverError() : bool;
$response->clientError() : bool;
```
It looks nice, but the failed method breaks the combination of methods `ok` and `successful`.

I think it would be better to make it like this:
```
$response->ok() : bool;
$response->successful() : bool;
$response->failed() : bool;
$response->serverError() : bool;
$response->clientError() : bool;
```
This code looks logically correct.