### PR TITLE
Explain what happens with the XSRF-TOKEN

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -188,7 +188,7 @@ To authenticate your SPA, your SPA's login page should first make a request to t
         // Login...
     });
 
-This will set an `XSRF-TOKEN` cookie containing the CSRF token. This token should then be passed in an `X-XSRF-TOKEN` header in subsequent requests, which libraries like Axios or the Angular HttpClient will do automatically for you.
+During this request Laravel will set an `XSRF-TOKEN` cookie containing the current CSRF token. This token should then be passed in an `X-XSRF-TOKEN` header on subsequent requests, which libraries like Axios and the Angular HttpClient will do automatically for you.
 
 Once CSRF protection has been initialized, you should make a `POST` request to the typical Laravel `/login` route. This `/login` route may be provided by the `laravel/ui` [authentication scaffolding](/docs/{{version}}/authentication#introduction) package.
 

--- a/sanctum.md
+++ b/sanctum.md
@@ -188,6 +188,8 @@ To authenticate your SPA, your SPA's login page should first make a request to t
         // Login...
     });
 
+This will set an `XSRF-TOKEN` cookie containing the CSRF token. This token should then be passed in an `X-XSRF-TOKEN` header in subsequent requests, which libraries like Axios or the Angular HttpClient will do automatically for you.
+
 Once CSRF protection has been initialized, you should make a `POST` request to the typical Laravel `/login` route. This `/login` route may be provided by the `laravel/ui` [authentication scaffolding](/docs/{{version}}/authentication#introduction) package.
 
 If the login request is successful, you will be authenticated and subsequent requests to your API routes will automatically be authenticated via the session cookie that the Laravel backend issued to your client.


### PR DESCRIPTION
Explains that the example using Axios relies on the fact that Axios will automatically read the `XSRF-TOKEN` cookie and re-inject its content into the `X-XSRF-TOKEN` header, otherwise a users who want to test Sanctum by manually querying the api might not understand why they end up with a token mismatch exception.