### PR TITLE
Add note to Eager loading documentation

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1149,6 +1149,8 @@ For this operation, only two queries will be executed:
     select * from books
 
     select * from authors where id in (1, 2, 3, 4, 5, ...)
+    
+> {note} When using Eager Loading and non-integer primary keys, you should make sure that `protected $keyType` is set properly on the [model](/docs/7.x/eloquent#eloquent-model-conventions) to prevent all models from being retrieved.
 
 #### Eager Loading Multiple Relationships
 


### PR DESCRIPTION
Added a note to Eager Loading section to make user's aware that if you do not set the $keyType for a model, using non-integer keys, the default behavior will retrieve all models from the database.