### PR TITLE
[7.x] Add note about whereIntegerInRaw, whereIntegerNotInRaw

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -406,6 +406,8 @@ The `whereNotIn` method verifies that the given column's value is **not** contai
                         ->whereNotIn('id', [1, 2, 3])
                         ->get();
 
+> {note} If you are binding a large integer dataset, the `whereIntegerInRaw` or  `whereIntegerNotInRaw` method may be used to greatly reduce your memory usage.
+
 **whereNull / whereNotNull / orWhereNull / orWhereNotNull**
 
 The `whereNull` method verifies that the value of the given column is `NULL`:

--- a/queries.md
+++ b/queries.md
@@ -406,7 +406,7 @@ The `whereNotIn` method verifies that the given column's value is **not** contai
                         ->whereNotIn('id', [1, 2, 3])
                         ->get();
 
-> {note} If you are binding a large integer dataset, the `whereIntegerInRaw` or  `whereIntegerNotInRaw` method may be used to greatly reduce your memory usage.
+> {note} If you are adding a huge array of integer bindings to your query, the `whereIntegerInRaw` or `whereIntegerNotInRaw` methods may be used to greatly reduce your memory usage.
 
 **whereNull / whereNotNull / orWhereNull / orWhereNotNull**
 


### PR DESCRIPTION
PR adds note under the `whereIn` section about undocumented `whereIntegerInRaw` and `whereIntegerNotInRaw` methods.

Ref: https://github.com/laravel/framework/pull/26434