### PR TITLE
Fix incorrect doc block in Blade Templates under casing

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -570,7 +570,6 @@ Component constructor arguments should be specified using `camelCase`, while `ke
      * Create the component instance.
      *
      * @param  string  $alertType
-     * @param  string  $message
      * @return void
      */
     public function __construct($alertType)


### PR DESCRIPTION
There was an unnecessary ` * @param  string  $message` entry in the docblock which is incorrect.