### PR TITLE
Fix a typo in the 7.x config retrieval example.

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -112,7 +112,7 @@ You may easily access your configuration values using the global `config` helper
     $value = config('app.timezone');
 
     // Retrieve a default value if the configuration value does not exist...
-    $value = config('app.timezone', Asia/Seoul');
+    $value = config('app.timezone', 'Asia/Seoul');
 
 To set configuration values at runtime, pass an array to the `config` helper:
 


### PR DESCRIPTION
Introduced in #6056

This is what it looked like before:

<img width="796" alt="image" src="https://user-images.githubusercontent.com/357072/82266446-56620b00-992f-11ea-97c2-ef6e84760eb3.png">
