### PR TITLE
Add APP_URL to Github Action example

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1542,7 +1542,7 @@ To run your Dusk tests on [Travis CI](https://travis-ci.org), use the following 
 <a name="running-tests-on-github-actions"></a>
 ### GitHub Actions
 
-If you are using [Github Actions](https://github.com/features/actions) to run your Dusk tests, you may use this configuration file as a starting point. Like TravisCI, we will use the `php artisan serve` command to launch PHP's built-in web server. Note that the application will be served on `http://127.0.0.1:8000` and simply using the default `APP_URL=http://localhost` will not work:
+If you are using [Github Actions](https://github.com/features/actions) to run your Dusk tests, you may use this configuration file as a starting point. Like TravisCI, we will use the `php artisan serve` command to launch PHP's built-in web server:
 
     name: CI
     on: [push]

--- a/dusk.md
+++ b/dusk.md
@@ -1542,7 +1542,7 @@ To run your Dusk tests on [Travis CI](https://travis-ci.org), use the following 
 <a name="running-tests-on-github-actions"></a>
 ### GitHub Actions
 
-If you are using [Github Actions](https://github.com/features/actions) to run your Dusk tests, you may use this configuration file as a starting point. Like TravisCI, we will use the `php artisan serve` command to launch PHP's built-in web server:
+If you are using [Github Actions](https://github.com/features/actions) to run your Dusk tests, you may use this configuration file as a starting point. Like TravisCI, we will use the `php artisan serve` command to launch PHP's built-in web server. Note that the application will be served on `http://127.0.0.1:8000` and simply using the default `APP_URL=http://localhost` will not work:
 
     name: CI
     on: [push]
@@ -1570,3 +1570,4 @@ If you are using [Github Actions](https://github.com/features/actions) to run yo
             run: php artisan serve &
           - name: Run Dusk Tests
             run: php artisan dusk
+              APP_URL: "http://127.0.0.1:8000"


### PR DESCRIPTION
## Description
This PR adds a default `APP_URL=http://127.0.0.1:8000` environment to the Github Action configuration example for running dusk + a short description that Github will not serve the application on `http://localhost` which is the default `APP_URL` for a clean Laravel installation

## Why
If one creates a completely fresh Laravel installation then `APP_URL=http://localhost` which works for many use cases. If one simply copies this Github Actions configuration example provide here, one would expect that it works out of the box, but this is not the case since Github Actions does not respond on `http://localhost` (I have no source confirming this except testing).

## With this PR
With this PR, people will be able to simply copy paste this example and start using Dusk tests on Github actions without any further configuration.

Setting a value for `APP_URL` will override the value provided in any environment files, but this is not an issue since the provided configuration will only respond on the provided address.