### PR TITLE
Fix syntax error in Github Actions configuration

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1557,7 +1557,7 @@ If you are using [Github Actions](https://github.com/features/actions) to run yo
           - name: Create Database
             run: |
               sudo systemctl start mysql
-              mysql --user="root" --password="root" -e "CREATE DATABASE my-database character set UTF8mb4 collate utf8mb4_bin;"
+              mysql --user="root" --password="root" -e "CREATE DATABASE 'my-database' character set UTF8mb4 collate utf8mb4_bin;"
           - name: Install Composer Dependencies
             run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
           - name: Generate Application Key


### PR DESCRIPTION
## Description
This PR simply fixes a syntax error for the step of creating a MySQL database.  The use of hyphens in the database name cannot be done without the use of single quotes around the database name.

Even though this is just an example Github Action configuration, then it would be nice for users to simply copy-paste this and not wasting time debugging the database step.

An alternative could be to change the example database name to `mydatabase` without a hyphen.

## Without this PR
Running this example configuration on Github Actions without changing the database name would cause a somewhat confusing error like this:

``` bash
ERROR 1064 (42000) at line 1: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-database character set UTF8mb4 collate utf8mb4_bin' at line 1
```

## With this PR
No error occurs when creating the database.