### PR TITLE
Fixes Dusk Github action

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1569,5 +1569,6 @@ If you are using [Github Actions](https://github.com/features/actions) to run yo
           - name: Run Laravel Server
             run: php artisan serve &
           - name: Run Dusk Tests
-            run: php artisan dusk
+            env:
               APP_URL: "http://127.0.0.1:8000"
+            run: php artisan dusk


### PR DESCRIPTION
Fixes Error the error caused by the current Github Action for Dusk

```
Run php artisan dusk APP_URL:"http://127.0.0.1:8000"
Warning: TTY mode requires /dev/tty to be read/writable.
Cannot open file "APP/URL:http://127.0.0.1:8000.php".
```