### PR TITLE
[7.x] Clarify authorizeResource method usage

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -483,7 +483,7 @@ As previously discussed, some actions like `create` may not require a model inst
 
 If you are utilizing [resource controllers](/docs/{{version}}/controllers#resource-controllers), you may make use of the `authorizeResource` method in the controller's constructor. This method will attach the appropriate `can` middleware definitions to the resource controller's methods.
 
-The `authorizeResource` method accepts the model's class name as its first argument, and the name of the route / request parameter that will contain the model's ID as its second argument. You should ensure your [resource controller](/docs/{{version}}/controllers#resource-controllers) is created with the `--model` flag to have the required method signatures and type hints:
+The `authorizeResource` method accepts the model's class name as its first argument, and optionaly the name of the route / request parameter that will contain the model's ID as its second argument. If the second parameter is not provided, it will be guessed to be the model's name converted to snake case. You should ensure your [resource controller](/docs/{{version}}/controllers#resource-controllers) is created with the `--model` flag to have the required method signatures and type hints:
 
     <?php
 
@@ -497,7 +497,7 @@ The `authorizeResource` method accepts the model's class name as its first argum
     {
         public function __construct()
         {
-            $this->authorizeResource(Post::class, 'post');
+            $this->authorizeResource(Post::class);
         }
     }
 


### PR DESCRIPTION
authorizeResource doesn't require the second argument. So having it there in the documentation is confusing especially in a case where the snake_case  of the given Model name would be the same as 2nd argument. 

Potentially, if the point of having it there is to highlight that this snake_case guessing can be overridden, we should add another example where the Model name and the request parameter are not the same.