### PR TITLE
Update eloquent.md

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -767,7 +767,7 @@ Writing a global scope is simple. Define a class that implements the `Illuminate
 
 #### Applying Global Scopes
 
-To assign a global scope to a model, you should override a given model's `booted` method and use the `addGlobalScope` method:
+To assign a global scope to a model, you should override a given model's `boot` method and use the `addGlobalScope` method:
 
     <?php
 
@@ -779,12 +779,14 @@ To assign a global scope to a model, you should override a given model's `booted
     class User extends Model
     {
         /**
-         * The "booted" method of the model.
+         * The "boot" method of the model.
          *
          * @return void
          */
-        protected static function booted()
+        protected static function boot()
         {
+            parent::boot();
+
             static::addGlobalScope(new AgeScope);
         }
     }
@@ -807,12 +809,14 @@ Eloquent also allows you to define global scopes using Closures, which is partic
     class User extends Model
     {
         /**
-         * The "booted" method of the model.
+         * The "boot" method of the model.
          *
          * @return void
          */
-        protected static function booted()
+        protected static function boot()
         {
+            parent::boot();
+
             static::addGlobalScope('age', function (Builder $builder) {
                 $builder->where('age', '>', 200);
             });
@@ -970,7 +974,7 @@ After defining and mapping your Eloquent events, you may use [event listeners](h
 <a name="events-using-closures"></a>
 ### Using Closures
 
-Instead of using custom event classes, you may register Closures that execute when various model events are fired. Typically, you should register these Closures in the `booted` method of your model:
+Instead of using custom event classes, you may register Closures that execute when various model events are fired. Typically, you should register these Closures in the `boot` method of your model:
 
     <?php
 
@@ -982,12 +986,14 @@ Instead of using custom event classes, you may register Closures that execute wh
     class User extends Model
     {
         /**
-         * The "booted" method of the model.
+         * The "boot" method of the model.
          *
          * @return void
          */
-        protected static function booted()
+        protected static function boot()
         {
+            parent::boot();
+
             static::created(function ($user) {
                 //
             });


### PR DESCRIPTION
As far as I can tell, there's never been a `booted()` method on `Illuminate\Database\Eloquent\Model`. `Illuminate/Foundation/Application::booted()` exists though, so maybe that's the source of this documentation error.

There are lots of code samples out there that list my changes as the correct way to add global scopes. I've also tested and have it working this way in my own code. Since there's no `booted()` method, I assume registering event listeners should be done similarly, so I've updated that here as well.