### PR TITLE
[7.x] State how to upload to the public directory directly

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -313,7 +313,7 @@ In web applications, one of the most common use-cases for storing files is stori
 
 There are a few important things to note about this example. Note that we only specified a directory name, not a file name. By default, the `store` method will generate a unique ID to serve as the file name. The file's extension will be determined by examining the file's MIME type. The path to the file will be returned by the `store` method so you can store the path, including the generated file name, in your database.
 
-We prepend `public/` in the `store` method so that the file gets uploaded in the `public` directory (`storage/app/public`). If you upload the file to the `public` directory then it makes your life easier when it comes to access the file later. Without adding this, the file would be uploaded in the `storage/app/avatars` directory.
+We prepend `public/` in the `store` method so that the file gets uploaded in the `public` directory (`storage/app/public`). If you upload the file to the `public` directory then you can access the file from the `public/storage` symlink. Without adding this, the file would be uploaded in the `storage/app/avatars` directory.
 
 You may also call the `putFile` method on the `Storage` facade to perform the same file manipulation as the example above:
 

--- a/filesystem.md
+++ b/filesystem.md
@@ -313,7 +313,7 @@ In web applications, one of the most common use-cases for storing files is stori
 
 There are a few important things to note about this example. Note that we only specified a directory name, not a file name. By default, the `store` method will generate a unique ID to serve as the file name. The file's extension will be determined by examining the file's MIME type. The path to the file will be returned by the `store` method so you can store the path, including the generated file name, in your database.
 
-We prepend `public/` in the `store` method so that the file gets uploaded in the `public` directory (`storage/app/public`). If you upload the file to the `public` directory then you can access the file from the `public/storage` symlink. Without adding this, the file would be uploaded in the `storage/app/avatars` directory.
+We prepend `public/` in the `store` method so that the file gets uploaded in the `public` directory (`storage/app/public/avatars`). If you upload the file to the `public` directory then you can access the file from the `public/storage` symlink. Without adding this, the file would be uploaded in the `storage/app/avatars` directory.
 
 You may also call the `putFile` method on the `Storage` facade to perform the same file manipulation as the example above:
 

--- a/filesystem.md
+++ b/filesystem.md
@@ -305,7 +305,7 @@ In web applications, one of the most common use-cases for storing files is stori
          */
         public function update(Request $request)
         {
-            $path = $request->file('avatar')->store('avatars');
+            $path = $request->file('avatar')->store('public/avatars');
 
             return $path;
         }
@@ -313,9 +313,11 @@ In web applications, one of the most common use-cases for storing files is stori
 
 There are a few important things to note about this example. Note that we only specified a directory name, not a file name. By default, the `store` method will generate a unique ID to serve as the file name. The file's extension will be determined by examining the file's MIME type. The path to the file will be returned by the `store` method so you can store the path, including the generated file name, in your database.
 
+We prepend `public/` in the `store` method so that the file gets uploaded in the `public` directory (`storage/app/public`). If you upload the file to the `public` directory then it makes your life easier when it comes to access the file later. Without adding this, the file would be uploaded in the `storage/app/avatars` directory.
+
 You may also call the `putFile` method on the `Storage` facade to perform the same file manipulation as the example above:
 
-    $path = Storage::putFile('avatars', $request->file('avatar'));
+    $path = Storage::putFile('avatars', $request->file('public/avatar'));
 
 #### Specifying A File Name
 


### PR DESCRIPTION
I've always had trouble understanding the `File upload` documentation and these changes make things less ambiguous when it comes to `avatar` and `avatars`. Also by adding the `public/` this makes it far more useful in the real world because you want to upload the files in the `storage/app/public` directory so you can access it from the `public/storage` directory symlink.

It now explicitly states if you don't want to upload to the `public` directory but in my view, this should be a secondary item.