### PR TITLE
[7.x] Change utf8 references to utf8mb4

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -87,7 +87,7 @@ If you would like to prevent Cashier's migrations from running entirely, you may
 
     Cashier::ignoreMigrations();
 
-> {note} Stripe recommends that any column used for storing Stripe identifiers should be case-sensitive. Therefore, you should ensure the column collation for the `stripe_id` column is set to, for example, `utf8_bin` in MySQL. More info can be found [in the Stripe documentation](https://stripe.com/docs/upgrades#what-changes-does-stripe-consider-to-be-backwards-compatible).
+> {note} Stripe recommends that any column used for storing Stripe identifiers should be case-sensitive. Therefore, you should ensure the column collation for the `stripe_id` column is set to, for example, `utf8mb4_bin` in MySQL. More info can be found [in the Stripe documentation](https://stripe.com/docs/upgrades#what-changes-does-stripe-consider-to-be-backwards-compatible).
 
 <a name="configuration"></a>
 ## Configuration

--- a/billing.md
+++ b/billing.md
@@ -87,7 +87,7 @@ If you would like to prevent Cashier's migrations from running entirely, you may
 
     Cashier::ignoreMigrations();
 
-> {note} Stripe recommends that any column used for storing Stripe identifiers should be case-sensitive. Therefore, you should ensure the column collation for the `stripe_id` column is set to, for example, `utf8mb4_bin` in MySQL. More info can be found [in the Stripe documentation](https://stripe.com/docs/upgrades#what-changes-does-stripe-consider-to-be-backwards-compatible).
+> {note} Stripe recommends that any column used for storing Stripe identifiers should be case-sensitive. Therefore, you should ensure the column collation for the `stripe_id` column is set to, for example, `utf8_bin` in MySQL. More info can be found [in the Stripe documentation](https://stripe.com/docs/upgrades#what-changes-does-stripe-consider-to-be-backwards-compatible).
 
 <a name="configuration"></a>
 ## Configuration

--- a/migrations.md
+++ b/migrations.md
@@ -176,8 +176,8 @@ You may use the following commands on the schema builder to define the table's o
 Command  |  Description
 -------  |  -----------
 `$table->engine = 'InnoDB';`  |  Specify the table storage engine (MySQL).
-`$table->charset = 'utf8';`  |  Specify a default character set for the table (MySQL).
-`$table->collation = 'utf8_unicode_ci';`  |  Specify a default collation for the table (MySQL).
+`$table->charset = 'utf8mb4';`  |  Specify a default character set for the table (MySQL).
+`$table->collation = 'utf8mb4_unicode_ci';`  |  Specify a default collation for the table (MySQL).
 `$table->temporary();`  |  Create a temporary table (except SQL Server).
 
 <a name="renaming-and-dropping-tables"></a>
@@ -292,8 +292,8 @@ Modifier  |  Description
 --------  |  -----------
 `->after('column')`  |  Place the column "after" another column (MySQL)
 `->autoIncrement()`  |  Set INTEGER columns as auto-increment (primary key)
-`->charset('utf8')`  |  Specify a character set for the column (MySQL)
-`->collation('utf8_unicode_ci')`  |  Specify a collation for the column (MySQL/PostgreSQL/SQL Server)
+`->charset('utf8mb4')`  |  Specify a character set for the column (MySQL)
+`->collation('utf8mb4_unicode_ci')`  |  Specify a collation for the column (MySQL/PostgreSQL/SQL Server)
 `->comment('my comment')`  |  Add a comment to a column (MySQL/PostgreSQL)
 `->default($value)`  |  Specify a "default" value for the column
 `->first()`  |  Place the column "first" in the table (MySQL)


### PR DESCRIPTION
MySQL's utf8 encoding isn't actually utf8. It's a good idea to use utf8mb4 instead unless you specifically need MySQL's utf8 - e.g. for comparability with legacy applications or the like.

https://medium.com/@adamhooper/in-mysql-never-use-utf8-use-utf8mb4-11761243e434