### PR TITLE
[7.x] Specifying Custom Attributes In Validator section

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -529,15 +529,13 @@ In most cases, you will probably specify your custom messages in a language file
         ],
     ],
 
-#### Specifying Custom Attributes In Language Files
+#### Specifying Custom Attribute Values
 
 If you would like the `:attribute` portion of your validation message to be replaced with a custom attribute name, you may specify the custom name in the `attributes` array of your `resources/lang/xx/validation.php` language file:
 
     'attributes' => [
         'email' => 'email address',
     ],
-
-#### Specifying Custom Attributes In Validator
 
 You may also pass the custom attributes as the fourth argument to the `Validator::make` method:
 

--- a/validation.md
+++ b/validation.md
@@ -537,6 +537,16 @@ If you would like the `:attribute` portion of your validation message to be repl
         'email' => 'email address',
     ],
 
+#### Specifying Custom Attributes In Validator
+
+You may also pass the custom attributes as the fourth argument to the `Validator::make` method:
+
+    $customAttributes = [
+        'email' => 'email address',
+    ];
+
+    $validator = Validator::make($input, $rules, $messages, $customAttributes);
+
 #### Specifying Custom Values In Language Files
 
 Sometimes you may need the `:value` portion of your validation message to be replaced with a custom representation of the value. For example, consider the following rule that specifies that a credit card number is required if the `payment_type` has a value of `cc`:


### PR DESCRIPTION
Added a section about using the fourth argument in `Validator::make()` as an alternative of using language files.