### PR TITLE
[7.x] Update return type on json response

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -34,7 +34,7 @@ To make requests, you may use the `get`, `post`, `put`, `patch`, and `delete` me
 The `get` method returns an instance of `Illuminate\Http\Client\Response`, which provides a variety of methods that may be used to inspect the response:
 
     $response->body() : string;
-    $response->json(); // Mixed type. Get the JSON decoded body of the response as an array or scalar value.
+    $response->json() : array|mixed;
     $response->status() : int;
     $response->ok() : bool;
     $response->successful() : bool;

--- a/http-client.md
+++ b/http-client.md
@@ -34,7 +34,7 @@ To make requests, you may use the `get`, `post`, `put`, `patch`, and `delete` me
 The `get` method returns an instance of `Illuminate\Http\Client\Response`, which provides a variety of methods that may be used to inspect the response:
 
     $response->body() : string;
-    $response->json() : array;
+    $response->json(); // Mixed type. Get the JSON decoded body of the response as an array or scalar value.
     $response->status() : int;
     $response->ok() : bool;
     $response->successful() : bool;


### PR DESCRIPTION
In https://github.com/laravel/framework/pull/33163 the phpdoc was updated to reflect that `$response->json()` can return arrays or scalar types. This pull request reflects that change in the client documentation as well.