### PR TITLE
[7.x]  Change variable name results to paginator for the Paginator API reference

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -208,21 +208,21 @@ Each paginator instance provides additional pagination information via the follo
 
 Method  |  Description
 -------  |  -----------
-`$results->count()`  |  Get the number of items for the current page.
-`$results->currentPage()`  |  Get the current page number.
-`$results->firstItem()`  |  Get the result number of the first item in the results.
-`$results->getOptions()`  |  Get the paginator options.
-`$results->getUrlRange($start, $end)`  |  Create a range of pagination URLs.
-`$results->hasPages()`  |  Determine if there are enough items to split into multiple pages.
-`$results->hasMorePages()`  |  Determine if there is more items in the data store.
-`$results->items()`  |  Get the items for the current page.
-`$results->lastItem()`  |  Get the result number of the last item in the results.
-`$results->lastPage()`  |  Get the page number of the last available page. (Not available when using `simplePaginate`).
-`$results->nextPageUrl()`  |  Get the URL for the next page.
-`$results->onFirstPage()`  |  Determine if the paginator is on the first page.
-`$results->perPage()`  |  The number of items to be shown per page.
-`$results->previousPageUrl()`  |  Get the URL for the previous page.
-`$results->total()`  |  Determine the total number of matching items in the data store. (Not available when using `simplePaginate`).
-`$results->url($page)`  |  Get the URL for a given page number.
-`$results->getPageName()`  |  Get the query string variable used to store the page.
-`$results->setPageName($name)`  |  Set the query string variable used to store the page.
+`$paginator->count()`  |  Get the number of items for the current page.
+`$paginator->currentPage()`  |  Get the current page number.
+`$paginator->firstItem()`  |  Get the result number of the first item in the results.
+`$paginator->getOptions()`  |  Get the paginator options.
+`$paginator->getUrlRange($start, $end)`  |  Create a range of pagination URLs.
+`$paginator->hasPages()`  |  Determine if there are enough items to split into multiple pages.
+`$paginator->hasMorePages()`  |  Determine if there is more items in the data store.
+`$paginator->items()`  |  Get the items for the current page.
+`$paginator->lastItem()`  |  Get the result number of the last item in the results.
+`$paginator->lastPage()`  |  Get the page number of the last available page. (Not available when using `simplePaginate`).
+`$paginator->nextPageUrl()`  |  Get the URL for the next page.
+`$paginator->onFirstPage()`  |  Determine if the paginator is on the first page.
+`$paginator->perPage()`  |  The number of items to be shown per page.
+`$paginator->previousPageUrl()`  |  Get the URL for the previous page.
+`$paginator->total()`  |  Determine the total number of matching items in the data store. (Not available when using `simplePaginate`).
+`$paginator->url($page)`  |  Get the URL for a given page number.
+`$paginator->getPageName()`  |  Get the query string variable used to store the page.
+`$paginator->setPageName($name)`  |  Set the query string variable used to store the page.


### PR DESCRIPTION
Hello!

Looking at the documentation for handling pagination with Laravel, there is no statement with the name of the variable passed with the paginator to a custom pagination view.

As the name of this variable is `paginator`, I think it makes more sense to use it for the API description. 

It's also used there:
> By default, the views rendered to display the pagination links are compatible with the Bootstrap CSS framework. However, if you are not using Bootstrap, you are free to define your own views to render these links. When calling the `links` method on a paginator instance, pass the view name as the first argument to the method:
    {{ $paginator->links('view.name') }}
    {{ $paginator->links('view.name') }}
    // Passing data to the view...

I think this should also be mentioned somewhere but I think that someone that speaks English decently (unlike me) should write that :smile:.