### PR TITLE
[7.x] Remove note about Markdown autolink feature not being supported

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -461,8 +461,6 @@ Markdown mailables use a combination of Blade components and Markdown syntax whi
 
 > {tip} Do not use excess indentation when writing Markdown emails. Markdown parsers will render indented content as code blocks.
 
-> {note} The "autolink" feature of Markdown is not currently supported. Please construct links using the long form link syntax provided by Markdown.
-
 #### Button Component
 
 The button component renders a centered button link. The component accepts two arguments, a `url` and an optional `color`. Supported colors are `primary`, `success`, and `error`. You may add as many button components to a message as you wish:


### PR DESCRIPTION
It seems that the "autolink" feature of Markdown is supported now.