### PR TITLE
[7.x] Documenting the Queue Job retryAfter method

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -793,6 +793,19 @@ If you would like to configure the failed job retry delay on a per-job basis, yo
      */
     public $retryAfter = 3;
 
+If you require more complex logic for determining the retry delay, you may define a `retryAfter` method on your queued job class:
+
+    /**
+    * Calculate the number of seconds to wait before retrying the job.
+    *
+    * @return int
+    */
+    public function retryAfter()
+    {
+        // 1m, 2m, 4m, 8m, 16m etc
+        return 60 * pow(2, $this->attempts());
+    }
+
 <a name="cleaning-up-after-failed-jobs"></a>
 ### Cleaning Up After Failed Jobs
 

--- a/queues.md
+++ b/queues.md
@@ -802,7 +802,6 @@ If you require more complex logic for determining the retry delay, you may defin
     */
     public function retryAfter()
     {
-        // 1m, 2m, 4m, 8m, 16m etc
         return 60 * pow(2, $this->attempts());
     }
 


### PR DESCRIPTION
Adding documentation for the Queue retryAfter method that was (re)-added for 7.x as mentioned in https://github.com/laravel/framework/pull/32370 but is not mentioned in the docs