### PR TITLE
[7.x] Reference the variable name passed to the custom pagination view

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -171,6 +171,8 @@ By default, the views rendered to display the pagination links are compatible wi
 
     // Passing data to the view...
     {{ $paginator->links('view.name', ['foo' => 'bar']) }}
+    
+We pass a `$paginator` variable to the custom view.
 
 However, the easiest way to customize the pagination views is by exporting them to your `resources/views/vendor` directory using the `vendor:publish` command:
 


### PR DESCRIPTION
Related to #6101, there is no mention about the name of the variable passed to a custom pagination view.

This is my attempt.