### PR TITLE
[7.X] Use foreignId() instead of unsignedInteger()

### DIFF
--- a/session.md
+++ b/session.md
@@ -45,7 +45,7 @@ When using the `database` session driver, you will need to create a table to con
 
     Schema::create('sessions', function ($table) {
         $table->string('id')->unique();
-        $table->unsignedInteger('user_id')->nullable();
+        $table->foreignId('user_id')->nullable();
         $table->string('ip_address', 45)->nullable();
         $table->text('user_agent')->nullable();
         $table->text('payload');


### PR DESCRIPTION
I know this change is unnecessary but I think using the alias is more appropriate as it makes it easier to read.