### PR TITLE
[7.x] Clarify Paddle plan parameter

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -143,7 +143,7 @@ Paddle lacks an extensive CRUD API to perform state changes. Therefore, most int
 
     $user = User::find(1);
 
-    $payLink = $user->newSubscription('default', 'premium')
+    $payLink = $user->newSubscription('default', $premium = 34567)
         ->returnTo(route('home'))
         ->create();
 
@@ -349,7 +349,7 @@ After the user has finished their checkout, a `subscription_created` webhook wil
 
 If you would like to specify additional customer or subscription details, you may do so by passing them as a key / value array to the `create` method:
 
-    $payLink = $user->newSubscription('default', 'monthly')
+    $payLink = $user->newSubscription('default', $monthly = 12345)
         ->returnTo(route('home'))
         ->create([
             'vat_number' => $vatNumber,
@@ -361,7 +361,7 @@ To learn more about the additional fields supported by Paddle, check out Paddle'
 
 If you would like to apply a coupon when creating the subscription, you may use the `withCoupon` method:
 
-    $payLink = $user->newSubscription('default', 'monthly')
+    $payLink = $user->newSubscription('default', $monthly = 12345)
         ->returnTo(route('home'))
         ->withCoupon('code')
         ->create();
@@ -370,7 +370,7 @@ If you would like to apply a coupon when creating the subscription, you may use 
 
 You can also pass an array of metadata using the `withMetadata` method:
 
-    $payLink = $user->newSubscription('default', 'monthly')
+    $payLink = $user->newSubscription('default', $monthly = 12345)
         ->returnTo(route('home'))
         ->withMetadata(['key' => 'value'])
         ->create();
@@ -404,15 +404,15 @@ If you would like to determine if a user is still within their trial period, you
         //
     }
 
-The `subscribedToPlan` method may be used to determine if the user is subscribed to a given plan based on a given Paddle plan ID. In this example, we will determine if the user's `default` subscription is actively subscribed to the `monthly` plan:
+The `subscribedToPlan` method may be used to determine if the user is subscribed to a given plan based on a given Paddle plan ID. In this example, we will determine if the user's `default` subscription is actively subscribed to the monthly plan:
 
-    if ($user->subscribedToPlan('monthly', 'default')) {
+    if ($user->subscribedToPlan($monthly = 12345, 'default')) {
         //
     }
 
-By passing an array to the `subscribedToPlan` method, you may determine if the user's `default` subscription is actively subscribed to the `monthly` or the `yearly` plan:
+By passing an array to the `subscribedToPlan` method, you may determine if the user's `default` subscription is actively subscribed to the monthly or the yearly plan:
 
-    if ($user->subscribedToPlan(['monthly', 'yearly'], 'default')) {
+    if ($user->subscribedToPlan([$monthly = 12345, $yearly = 54321], 'default')) {
         //
     }
 
@@ -529,7 +529,7 @@ After a user has subscribed to your application, they may occasionally want to c
 
     $user = App\User::find(1);
 
-    $user->subscription('default')->swap('provider-plan-id');
+    $user->subscription('default')->swap($premium = 34567);
 
 If the user is on trial, the trial period will be maintained. Also, if a "quantity" exists for the subscription, that quantity will also be maintained.
 
@@ -537,19 +537,19 @@ If you would like to swap plans and cancel any trial period the user is currentl
 
     $user->subscription('default')
             ->skipTrial()
-            ->swap('provider-plan-id');
+            ->swap($premium = 34567);
 
 If you would like to swap plans and immediately invoice the user instead of waiting for their next billing cycle, you may use the `swapAndInvoice` method:
 
     $user = App\User::find(1);
 
-    $user->subscription('default')->swapAndInvoice('provider-plan-id');
+    $user->subscription('default')->swapAndInvoice($premium = 34567);
 
 #### Prorations
 
 By default, Paddle prorates charges when swapping between plans. The `noProrate` method may be used to update the subscription's without prorating the charges:
 
-    $user->subscription('default')->noProrate()->swap('provider-plan-id');
+    $user->subscription('default')->noProrate()->swap($premium = 34567);
 
 <a name="subscription-quantity"></a>
 ### Subscription Quantity
@@ -628,7 +628,7 @@ If you would like to offer trial periods to your customers while still collectin
 
     $user = User::find(1);
 
-    $payLink = $user->newSubscription('default', 'monthly')
+    $payLink = $user->newSubscription('default', $monthly = 12345)
                 ->returnTo(route('home'))
                 ->trialDays(10)
                 ->create();
@@ -675,7 +675,7 @@ Once you are ready to create an actual subscription for the user, you may use th
 
     $user = User::find(1);
 
-    $payLink = $user->newSubscription('default', 'monthly')
+    $payLink = $user->newSubscription('default', $monthly = 12345)
         ->returnTo(route('home'))
         ->create();
 


### PR DESCRIPTION
I realised from this issue: https://github.com/laravel/cashier-paddle/issues/7 that the current plan parameters aren't correct. You'll always need to pass in the integer identifier of the product. I tried to make this clear by adding temp variables to still explain the plan types.