### PR TITLE
[7.x] Specifying a disk with storeAs

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -341,12 +341,12 @@ By default, this method will use your default disk. If you would like to specify
         'avatars/'.$request->user()->id, 's3'
     );
     
-If you are using the `storeAs` method, pass the disk name in a third argument of options array:
+If you are using the `storeAs` method, you may pass the disk name as the third argument to the method:
 
     $path = $request->file('avatar')->storeAs(
         'avatars',
         $request->user()->id,
-        ['disk' => 's3']
+        's3'
     );
 
 #### Other File Information

--- a/filesystem.md
+++ b/filesystem.md
@@ -340,6 +340,14 @@ By default, this method will use your default disk. If you would like to specify
     $path = $request->file('avatar')->store(
         'avatars/'.$request->user()->id, 's3'
     );
+    
+If you are using the `storeAs` method, pass the disk name in a third argument of options array:
+
+    $path = $request->file('avatar')->storeAs(
+        'avatars',
+        $request->user()->id,
+        ['disk' => 's3']
+    );
 
 #### Other File Information
 


### PR DESCRIPTION
Added a explanation about how to specify a disk to `storeAs` method.