### PR TITLE
[7.x] Warn about possible cookie problems

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -87,6 +87,8 @@ The `cookie` method on response instances allows you to easily attach cookies to
     return response($content)
                     ->header('Content-Type', $type)
                     ->cookie('name', 'value', $minutes);
+                    
+The cookie should be set before any headers are being sent. For example, cookies set after using the `dump()` function won't persist because a header is sent at that moment.
 
 The `cookie` method also accepts a few more arguments which are used less frequently. Generally, these arguments have the same purpose and meaning as the arguments that would be given to PHP's native [setcookie](https://secure.php.net/manual/en/function.setcookie.php) method:
 


### PR DESCRIPTION
Follow up for https://github.com/laravel/framework/issues/33215

TL;DR: Using dump sets headers, which might silent fail for setting cookies. (as they can't be set when headers are already sent)

This PR hopes to make possible cookie problems more clear and prevent people getting stuck:
https://laracasts.com/discuss/channels/laravel/cookie-setting-doesnt-work-if-i-use-dump-function
https://stackoverflow.com/questions/45207485/how-to-set-and-get-cookie-in-laravel

Feel free to request other wording or other tweaks, happy to adjust.