### PR TITLE
[7.x] Clarify cast set value

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -303,7 +303,7 @@ As an example, we will define a custom cast class that casts multiple model valu
         public function set($model, $key, $value, $attributes)
         {
             if (! $value instanceof Address) {
-                throw InvalidArgumentException('Value is not an Address instance.');
+                throw InvalidArgumentException('The given value is not an Address instance.');
             }
 
             return [

--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -270,6 +270,7 @@ As an example, we will define a custom cast class that casts multiple model valu
 
     use App\Address;
     use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+    use InvalidArgumentException;
 
     class Address implements CastsAttributes
     {
@@ -301,6 +302,10 @@ As an example, we will define a custom cast class that casts multiple model valu
          */
         public function set($model, $key, $value, $attributes)
         {
+            if (! $value instanceof Address) {
+                throw InvalidArgumentException('Value is not an Address instance.');
+            }
+
             return [
                 'address_line_one' => $value->lineOne,
                 'address_line_two' => $value->lineTwo,


### PR DESCRIPTION
When setting cast value objects, the value needs to be an instance of said value object. Otherwise the model's `$classCastCache` won't be cleared if another type is used and unexpected results will occur.

See https://github.com/laravel/framework/issues/33302