### PR TITLE
[7.x] Dusk - add missing documentation

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1287,11 +1287,19 @@ Once a page has been configured, you may navigate to it using the `visit` method
 
     $browser->visit(new Login);
 
+You may use the `visitRoute` method to navigate to a named route:
+
+    $browser->visitRoute('login');
+
 You may navigate "back" and "forward" using the `back` and `forward` methods:
 
     $browser->back();
 
     $browser->forward();
+
+To refresh the page, use the `refresh` method:
+
+    $browser->refresh();
 
 Sometimes you may already be on a given page and need to "load" the page's selectors and methods into the current test context. This is common when pressing a button and being redirected to a given page without explicitly navigating to it. In this situation, you may use the `on` method to load the page:
 

--- a/dusk.md
+++ b/dusk.md
@@ -602,7 +602,7 @@ Occasionally, you may wish to wait for a given selector and then interact with t
 
     $browser->whenAvailable('.modal', function ($modal) {
         $modal->assertSee('Hello World')
-              ->press('OK');
+              ->pressAndWaitFor('OK');
     });
 
 #### Waiting For Text

--- a/dusk.md
+++ b/dusk.md
@@ -245,6 +245,10 @@ You may use the `resize` method to adjust the size of the browser window:
 
     $browser->resize(1920, 1080);
 
+You may use the `move` method to move the browser window to a different position on your screen:
+
+    $browser->move(100, 100);
+
 The `maximize` method may be used to maximize the browser window:
 
     $browser->maximize();

--- a/dusk.md
+++ b/dusk.md
@@ -519,6 +519,10 @@ Or, you may drag an element in a single direction:
     $browser->dragUp('.selector', 10);
     $browser->dragDown('.selector', 10);
 
+Or, you may drag an element by a given offset:
+
+    $browser->dragOffset('.selector', 10, 10);
+
 <a name="javascript-dialogs"></a>
 ### JavaScript Dialogs
 

--- a/dusk.md
+++ b/dusk.md
@@ -484,6 +484,22 @@ The `clickAtPoint` method may be used to "click" on the topmost element at a giv
 
     $browser->clickAtPoint(0, 0);
 
+The `clickAndHold` method may be used to simulate a mouse button being clicked and held down. A subsequent call to the `releaseMouse` method will undo this behavior and release the mouse button:
+
+    $browser->clickAndHold()
+            ->pause(1000)
+            ->releaseMouse();
+
+The `doubleClick` method may be used to simulate the double "click" of a mouse:
+
+    $browser->doubleClick();
+
+The `rightClick` method may be used to simulate the right "click" of a mouse:
+
+    $browser->rightClick();
+
+    $browser->rightClick('.selector');
+
 #### Mouseover
 
 The `mouseover` method may be used when you need to move the mouse over an element matching the given selector:

--- a/dusk.md
+++ b/dusk.md
@@ -373,6 +373,11 @@ Dusk provides several methods for interacting with the current display text, val
     // Set the value...
     $browser->value('selector', 'value');
 
+To get the "value" of an input element that has a given field name, use the `inputValue` method:
+
+    // Retrieve the value of an input element...
+    $inputValue = $browser->inputValue('field');
+
 #### Retrieving Text
 
 The `text` method may be used to retrieve the display text of an element that matches the given selector:

--- a/dusk.md
+++ b/dusk.md
@@ -771,6 +771,9 @@ Dusk provides a variety of assertions that you may make against your application
 [assertButtonDisabled](#assert-button-disabled)
 [assertFocused](#assert-focused)
 [assertNotFocused](#assert-not-focused)
+[assertAuthenticated](#assert-authenticated)
+[assertGuest](#assert-guest)
+[assertAuthenticatedAs](#assert-authenticated-as)
 [assertVue](#assert-vue)
 [assertVueIsNot](#assert-vue-is-not)
 [assertVueContains](#assert-vue-contains)
@@ -1180,6 +1183,27 @@ Assert that the given field is focused:
 Assert that the given field is not focused:
 
     $browser->assertNotFocused($field);
+
+<a name="assert-authenticated"></a>
+#### assertAuthenticated
+
+Assert that the user is authenticated:
+
+    $browser->assertAuthenticated();
+
+<a name="assert-guest"></a>
+#### assertGuest
+
+Assert that the user is not authenticated:
+
+    $browser->assertGuest();
+
+<a name="assert-authenticated-as"></a>
+#### assertAuthenticatedAs
+
+Assert that the user is authenticated as the given user:
+
+    $browser->assertAuthenticatedAs($user);
 
 <a name="assert-vue"></a>
 #### assertVue

--- a/dusk.md
+++ b/dusk.md
@@ -754,6 +754,7 @@ Dusk provides a variety of assertions that you may make against your application
 [assertSelected](#assert-selected)
 [assertNotSelected](#assert-not-selected)
 [assertSelectHasOptions](#assert-select-has-options)
+[assertSelectMissingOption](#assert-select-missing-option)
 [assertSelectMissingOptions](#assert-select-missing-options)
 [assertSelectHasOption](#assert-select-has-option)
 [assertValue](#assert-value)
@@ -1052,6 +1053,13 @@ Assert that the given dropdown does not have the given value selected:
 Assert that the given array of values are available to be selected:
 
     $browser->assertSelectHasOptions($field, $values);
+
+<a name="assert-select-missing-option"></a>
+#### assertSelectMissingOption
+
+Assert that the given value is not available to be selected:
+
+    $browser->assertSelectMissingOption($field, $value);
 
 <a name="assert-select-missing-options"></a>
 #### assertSelectMissingOptions


### PR DESCRIPTION
- Document the following methods available in Dusk:
  - [`assertSelectMissingOption`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/MakesAssertions.php#L514)
  - [`assertAuthenticated`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/InteractsWithAuthentication.php#L64), [`assertGuest`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/InteractsWithAuthentication.php#L77) and [`assertAuthenticatedAs`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/InteractsWithAuthentication.php#L93)
  - [`visitRoute`](https://github.com/laravel/dusk/blob/6.x/src/Browser.php#L172) and [`refresh`](https://github.com/laravel/dusk/blob/6.x/src/Browser.php#L217)  
  - [`inputValue`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/MakesAssertions.php#L336)
  - [`clickAndHold`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/InteractsWithMouse.php#L92), [`releaseMouse`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/InteractsWithMouse.php#L135), [`doubleClick`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/InteractsWithMouse.php#L104) and [`rightClick`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/InteractsWithMouse.php#L117)
  - [`dragOffset`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/InteractsWithElements.php#L407)
  - [`move`](https://github.com/laravel/dusk/blob/6.x/src/Browser.php#L325)
- Add an example of using [`pressAndWaitFor`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/InteractsWithElements.php#L324)