### PR TITLE
[7.x] Dusk - add missing cookie documentation

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -25,6 +25,7 @@
     - [Waiting For Elements](#waiting-for-elements)
     - [Scrolling An Element Into View](#scrolling-an-element-into-view)
     - [Making Vue Assertions](#making-vue-assertions)
+    - [Cookies](#cookies)
 - [Available Assertions](#available-assertions)
 - [Pages](#pages)
     - [Generating Pages](#generating-pages)
@@ -726,6 +727,21 @@ You may assert on the state of the Vue component like so:
                     ->assertVue('user.name', 'Taylor', '@profile-component');
         });
     }
+
+<a name="cookies"></a>
+### Cookies
+
+You may use the `cookie` method to get or set an encrypted cookie's value:
+
+    $browser->cookie('name');
+
+You may use the `addCookie` method to create a new cookie using the given value:
+
+    $browser->addCookie('name', 'value');
+
+You may use the `deleteCookie` method to permanently delete the given cookie:
+
+    $browser->deleteCookie('name');
 
 <a name="available-assertions"></a>
 ## Available Assertions

--- a/dusk.md
+++ b/dusk.md
@@ -735,6 +735,10 @@ You may use the `cookie` method to get or set an encrypted cookie's value:
 
     $browser->cookie('name');
 
+You may use the `plainCookie` method to get or set a plain cookie's value:
+
+    $browser->plainCookie('name');
+
 You may use the `addCookie` method to create a new cookie using the given value:
 
     $browser->addCookie('name', 'value');
@@ -779,7 +783,9 @@ Dusk provides a variety of assertions that you may make against your application
 [assertFragmentBeginsWith](#assert-fragment-begins-with)
 [assertFragmentIsNot](#assert-fragment-is-not)
 [assertHasCookie](#assert-has-cookie)
+[assertHasPlainCookie](#assert-has-plain-cookie)
 [assertCookieMissing](#assert-cookie-missing)
+[assertPlainCookieMissing](#assert-plain-cookie-missing)
 [assertCookieValue](#assert-cookie-value)
 [assertPlainCookieValue](#assert-plain-cookie-value)
 [assertSee](#assert-see)
@@ -962,12 +968,26 @@ Assert that the given cookie is present:
 
     $browser->assertHasCookie($name);
 
+<a name="assert-has-plain-cookie"></a>
+#### assertHasPlainCookie
+
+Assert that the given plain cookie is present:
+
+    $browser->assertHasPlainCookie($name);
+
 <a name="assert-cookie-missing"></a>
 #### assertCookieMissing
 
 Assert that the given cookie is not present:
 
     $browser->assertCookieMissing($name);
+
+<a name="assert-plain-cookie-missing"></a>
+#### assertPlainCookieMissing
+
+Assert that the given plain cookie is not present:
+
+    $browser->assertPlainCookieMissing($name);
 
 <a name="assert-cookie-value"></a>
 #### assertCookieValue


### PR DESCRIPTION
- Document using cookies 🍪
  - [`cookie`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/InteractsWithCookies.php#L19), [`addCookie`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/InteractsWithCookies.php#L72) and [`deleteCookie`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/InteractsWithCookies.php#L95)
- Document using plain cookies including [`assertHasPlainCookie`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/MakesAssertions.php#L69) and [`assertPlainCookieMissing`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/MakesAssertions.php#L99)
  - [`plainCookie`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/InteractsWithCookies.php#L45)