### PR TITLE
Update scheduling.md

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -231,7 +231,7 @@ If needed, you may specify how many minutes must pass before the "without overla
 <a name="running-tasks-on-one-server"></a>
 ### Running Tasks On One Server
 
-> {note} To utilize this feature, your application must be using the `memcached` or `redis` cache driver as your application's default cache driver. In addition, all servers must be communicating with the same central cache server.
+> {note} To utilize this feature, your application must be using the `database`, `memcached` or `redis` cache driver as your application's default cache driver. In addition, all servers must be communicating with the same central cache server.
 
 If your application is running on multiple servers, you may limit a scheduled job to only execute on a single server. For instance, assume you have a scheduled task that generates a new report every Friday night. If the task scheduler is running on three worker servers, the scheduled task will run on all three servers and generate the report three times. Not good!
 

--- a/scheduling.md
+++ b/scheduling.md
@@ -231,7 +231,7 @@ If needed, you may specify how many minutes must pass before the "without overla
 <a name="running-tasks-on-one-server"></a>
 ### Running Tasks On One Server
 
-> {note} To utilize this feature, your application must be using the `database`, `memcached` or `redis` cache driver as your application's default cache driver. In addition, all servers must be communicating with the same central cache server.
+> {note} To utilize this feature, your application must be using the `database`, `memcached`, or `redis` cache driver as your application's default cache driver. In addition, all servers must be communicating with the same central cache server.
 
 If your application is running on multiple servers, you may limit a scheduled job to only execute on a single server. For instance, assume you have a scheduled task that generates a new report every Friday night. If the task scheduler is running on three worker servers, the scheduled task will run on all three servers and generate the report three times. Not good!
 


### PR DESCRIPTION
Since https://github.com/laravel/framework/pull/32639 has added [atomic locks](https://laravel.com/docs/7.x/cache#atomic-locks) to the `database` driver I *believe* the current scheduling documentation regarding [run tasks on one server](https://laravel.com/docs/7.x/scheduling#running-tasks-on-one-server) is no longer correct.

See https://github.com/laravel/framework/discussions/33216 for further details.