### PR TITLE
TelescopeServiceProvider registered twice in example

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -73,7 +73,6 @@ After running `telescope:install`, you should remove the `TelescopeServiceProvid
     {
         if ($this->app->isLocal()) {
             $this->app->register(\Laravel\Telescope\TelescopeServiceProvider::class);
-            $this->app->register(TelescopeServiceProvider::class);
         }
     }
 


### PR DESCRIPTION
As per title, I've removed one of the mentions and left in the more descriptive reference.