### PR TITLE
Update database-testing.md

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -294,9 +294,9 @@ Laravel provides several database assertions for your [PHPUnit](https://phpunit.
 
 Method  | Description
 ------------- | -------------
+`$this->assertDatabaseCount($table, int $count);`  |  Assert that a table in the database contains the given amount of entries.
 `$this->assertDatabaseHas($table, array $data);`  |  Assert that a table in the database contains the given data.
 `$this->assertDatabaseMissing($table, array $data);`  |  Assert that a table in the database does not contain the given data.
-`$this->assertDatabaseCount($table, int $count);`  |  Assert that a table in the database contains the given amount of entries.
 `$this->assertDeleted($table, array $data);`  |  Assert that the given record has been deleted.
 `$this->assertSoftDeleted($table, array $data);`  |  Assert that the given record has been soft deleted.
 

--- a/database-testing.md
+++ b/database-testing.md
@@ -296,6 +296,7 @@ Method  | Description
 ------------- | -------------
 `$this->assertDatabaseHas($table, array $data);`  |  Assert that a table in the database contains the given data.
 `$this->assertDatabaseMissing($table, array $data);`  |  Assert that a table in the database does not contain the given data.
+`$this->assertDatabaseCount($table, int $count);`  |  Assert that a table in the database contains the given amount of entries.
 `$this->assertDeleted($table, array $data);`  |  Assert that the given record has been deleted.
 `$this->assertSoftDeleted($table, array $data);`  |  Assert that the given record has been soft deleted.
 


### PR DESCRIPTION
After 7.x [InteractsWithDatabase ](https://github.com/laravel/framework/blob/07ee3e820b34df5e422fb868886fd190880dfc7f/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php#L59) testing trait contains aassertDatabaseCount. This is undocumented and now added to the available assertion methods for database testing.