### PR TITLE
[7.x] Dusk - add missing documentation

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -410,7 +410,13 @@ To click a link, you may use the `clickLink` method on the browser instance. The
 
     $browser->clickLink($linkText);
 
-> {note} This method interacts with jQuery. If jQuery is not available on the page, Dusk will automatically inject it into the page so it is available for the test's duration.
+You may use the `seeLink` method to determine if the link that has the given display text is visible on the page.
+
+    if ($browser->seeLink($linkText)) {
+        // Do something...
+    }
+
+> {note} These methods interact with jQuery. If jQuery is not available on the page, Dusk will automatically inject it into the page so it is available for the test's duration.
 
 <a name="text-values-and-attributes"></a>
 ### Text, Values, & Attributes

--- a/dusk.md
+++ b/dusk.md
@@ -261,6 +261,10 @@ When a test fails, Dusk will automatically resize the browser to fit the content
 
     $browser->disableFitOnFailure();
 
+To undo this behavior you may call the `enableFitOnFailure` method within your test:
+
+    $browser->enableFitOnFailure();
+
 You may use the `move` method to move the browser window to a different position on your screen:
 
     $browser->move(100, 100);

--- a/dusk.md
+++ b/dusk.md
@@ -14,6 +14,7 @@
     - [Database Migrations](#migrations)
     - [Cookies](#cookies)
     - [Taking A Screenshot](#taking-a-screenshot)
+    - [Storing Console Output To Disk](#storing-console-output-to-disk)
 - [Interacting With Elements](#interacting-with-elements)
     - [Dusk Selectors](#dusk-selectors)
     - [Clicking Links](#clicking-links)
@@ -356,6 +357,13 @@ You may use the `deleteCookie` method to delete the given cookie:
 You may use the `screenshot` method to take a screenshot and store it with the given name:
 
     $browser->screenshot('filename');
+
+<a name="storing-console-output-to-disk"></a>
+### Storing Console Output To Disk
+
+You may use the `storeConsoleLog` method to store the console output with the given name to disk:
+
+    $browser->storeConsoleLog('filename');
 
 <a name="interacting-with-elements"></a>
 ## Interacting With Elements

--- a/dusk.md
+++ b/dusk.md
@@ -13,6 +13,7 @@
     - [Authentication](#authentication)
     - [Database Migrations](#migrations)
     - [Cookies](#cookies)
+    - [Taking A Screenshot](#taking-a-screenshot)
 - [Interacting With Elements](#interacting-with-elements)
     - [Dusk Selectors](#dusk-selectors)
     - [Clicking Links](#clicking-links)
@@ -348,6 +349,13 @@ You may use the `plainCookie` method to get or set an unencrypted cookie's value
 You may use the `deleteCookie` method to delete the given cookie:
 
     $browser->deleteCookie('name');
+
+<a name="taking-a-screenshot"></a>
+### Taking A Screenshot
+
+You may use the `screenshot` method to take a screenshot and store it with the given name:
+
+    $browser->screenshot('filename');
 
 <a name="interacting-with-elements"></a>
 ## Interacting With Elements

--- a/dusk.md
+++ b/dusk.md
@@ -15,6 +15,7 @@
     - [Cookies](#cookies)
     - [Taking A Screenshot](#taking-a-screenshot)
     - [Storing Console Output To Disk](#storing-console-output-to-disk)
+    - [Storing Page Source To Disk](#storing-page-source-to-disk)
 - [Interacting With Elements](#interacting-with-elements)
     - [Dusk Selectors](#dusk-selectors)
     - [Clicking Links](#clicking-links)
@@ -364,6 +365,13 @@ You may use the `screenshot` method to take a screenshot and store it with the g
 You may use the `storeConsoleLog` method to store the console output with the given name to disk:
 
     $browser->storeConsoleLog('filename');
+
+<a name="storing-page-source-to-disk"></a>
+### Storing Page Source To Disk
+
+You may use the `storeSource` method to store a snapshot of the page's current source code with the given name to disk:
+
+    $browser->storeSource('filename');
 
 <a name="interacting-with-elements"></a>
 ## Interacting With Elements


### PR DESCRIPTION
- Document:
  - [`screenshot`](https://github.com/laravel/dusk/blob/6.x/src/Browser.php#L372)
  - [`storeConsoleLog`](https://github.com/laravel/dusk/blob/6.x/src/Browser.php#L393)
  - [`storeSource`](https://github.com/laravel/dusk/blob/6.x/src/Browser.php#L414)
  - [`enableFitOnFailure`](https://github.com/laravel/dusk/blob/6.x/src/Browser.php#L311)
  - [`seeLink`](https://github.com/laravel/dusk/blob/6.x/src/Concerns/MakesAssertions.php#L282)