### PR TITLE
[7.x] Add Explicit Warning of Exposed Endpoint in Wrong Environment

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -115,7 +115,11 @@ By default, all entries older than 24 hours will be pruned. You may use the `hou
 <a name="dashboard-authorization"></a>
 ## Dashboard Authorization
 
-Telescope exposes a dashboard at `/telescope`. By default, you will only be able to access this dashboard in the `local` environment. Within your `app/Providers/TelescopeServiceProvider.php` file, there is a `gate` method. This authorization gate controls access to Telescope in **non-local** environments. You are free to modify this gate as needed to restrict access to your Telescope installation:
+Telescope exposes a dashboard at `/telescope`. By default, you will only be able to access this dashboard in the `local` environment. 
+
+> {note} Make sure to change the `APP_ENV` variable to `production` in your production environment. Otherwise, Telescope will publicly expose your request data.
+
+Within your `app/Providers/TelescopeServiceProvider.php` file, there is a `gate` method. This authorization gate controls access to Telescope in **non-local** environments. You are free to modify this gate as needed to restrict access to your Telescope installation:
 
     /**
      * Register the Telescope gate.

--- a/telescope.md
+++ b/telescope.md
@@ -115,11 +115,7 @@ By default, all entries older than 24 hours will be pruned. You may use the `hou
 <a name="dashboard-authorization"></a>
 ## Dashboard Authorization
 
-Telescope exposes a dashboard at `/telescope`. By default, you will only be able to access this dashboard in the `local` environment. 
-
-> {note} Make sure to change the `APP_ENV` variable to `production` in your production environment. Otherwise, Telescope will publicly expose your request data.
-
-Within your `app/Providers/TelescopeServiceProvider.php` file, there is a `gate` method. This authorization gate controls access to Telescope in **non-local** environments. You are free to modify this gate as needed to restrict access to your Telescope installation:
+Telescope exposes a dashboard at `/telescope`. By default, you will only be able to access this dashboard in the `local` environment. Within your `app/Providers/TelescopeServiceProvider.php` file, there is a `gate` method. This authorization gate controls access to Telescope in **non-local** environments. You are free to modify this gate as needed to restrict access to your Telescope installation:
 
     /**
      * Register the Telescope gate.
@@ -136,6 +132,8 @@ Within your `app/Providers/TelescopeServiceProvider.php` file, there is a `gate`
             ]);
         });
     }
+
+> {note} You should ensure you change your `APP_ENV` environment variable to `production` in your production environment. Otherwise, your Telescope installation will be publicly available.
 
 <a name="filtering"></a>
 ## Filtering


### PR DESCRIPTION
Since it was previously pointed out that the default environment in the `.env.example` files will not change in the near future, I think we should at least warn users more explicitly about potential exposure of the Telescope endpoint in production environments if they set their environment incorrectly.

The previous discussions are located here:
- https://github.com/laravel/laravel/pull/5331
- https://github.com/laravel/framework/pull/33384

I hope this is somewhat of a compromise between what @lupinitylabs and I were proposing and what the position of @driesvints and the Laravel team on this issue is.

If you disagree with the exact wording, I'm open to suggestions, of course.