### PR TITLE
[7.x] Fix constrained() usage

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -495,7 +495,7 @@ Since this syntax is rather verbose, Laravel provides additional, terser methods
 The `foreignId` method is an alias for `unsignedBigInteger` while the `constrained` method will use convention to determine the table and column name being referenced. If your table name does not match the convention, you may specify the table name by passing it as an argument to the `constrained` method:
 
     Schema::table('posts', function (Blueprint $table) {
-        $table->foreignId('user_id')->constrained('users_table');
+        $table->foreignId('user_id')->constrained('users');
     });
 
 


### PR DESCRIPTION
Following the documentation I write:

```
$table->foreignId('avatar_id')->nullable()->constrained('images_table');
```

But get errors:

```
SQLSTATE[HY000]: General error: 1215 Cannot add foreign key constraint (SQL: alter table `users` add constraint `users_avatar_id_foreign` foreign key (`avatar_id`) references `images_table` (`id`))
```

Then I changed to:

```
$table->foreignId('avatar_id')->nullable()->constrained('images');
```

And it works.

I checked [the source code](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php#L37) of the function. The first parameter is `$table`, no need of `_table` suffix.