### PR TITLE
[7.x] Cache: dynamodb doesn't support tags

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -236,7 +236,7 @@ When the `cache` function is called without any arguments, it returns an instanc
 <a name="cache-tags"></a>
 ## Cache Tags
 
-> {note} Cache tags are not supported when using the `file` or `database` cache drivers. Furthermore, when using multiple tags with caches that are stored "forever", performance will be best with a driver such as `memcached`, which automatically purges stale records.
+> {note} Cache tags are not supported when using the `file`, `dynamodb`, or `database` cache drivers. Furthermore, when using multiple tags with caches that are stored "forever", performance will be best with a driver such as `memcached`, which automatically purges stale records.
 
 <a name="storing-tagged-cache-items"></a>
 ### Storing Tagged Cache Items


### PR DESCRIPTION
The [dynamodb cache driver](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Cache/DynamoDbStore.php) does not have a `tags` method, thus it currently throws `BadMethodCallException : This cache store does not support tagging.` This change clarifies that the driver doesn't support tags (although I don't see why `TagSet` wouldn't work for DynamoDb).