### PR TITLE
[7.x] Fix Notification::assertToSent method arguments.

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -273,7 +273,8 @@ You may use the `Notification` facade's `fake` method to prevent notifications f
             // Assert a specific type of notification was sent meeting the given truth test...
             Notification::assertSentTo(
                 $user,
-                function (OrderShipped $notification, $channels) use ($order) {
+                OrderShipped::class,
+                function ($notification, $channels) use ($order) {
                     return $notification->order->id === $order->id;
                 }
             );


### PR DESCRIPTION
According to source code the method signature is: assertSentTo(mixed $notifiable, string $notification, callable $callback = null).

In the mocking documentation it is being used with a callable as the second argument and no third argument.