### PR TITLE
[7.x] Document days() method

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -163,13 +163,13 @@ Method  | Description
 `->when(Closure);`  |  Limit the task based on a truth test
 `->environments($env);`  |  Limit the task to specific environments
 
-#### Specific Day Constraints
+#### Day Constraints
 
-The `days` method may be used to limit the execution of a task to specific days of the week. For example, to schedule a command to run hourly on Sundays and Wednesdays:
+The `days` method may be used to limit the execution of a task to specific days of the week. For example, you may schedule a command to run hourly on Sundays and Wednesdays:
 
     $schedule->command('reminders:send')
                     ->hourly()
-                    ->days([0,3]);
+                    ->days([0, 3]);
 
 #### Between Time Constraints
 

--- a/scheduling.md
+++ b/scheduling.md
@@ -158,9 +158,18 @@ Method  | Description
 `->thursdays();`  |  Limit the task to Thursday
 `->fridays();`  |  Limit the task to Friday
 `->saturdays();`  |  Limit the task to Saturday
+`->days(array|mixed);`  |  Limit the task to specific days
 `->between($start, $end);`  |  Limit the task to run between start and end times
 `->when(Closure);`  |  Limit the task based on a truth test
 `->environments($env);`  |  Limit the task to specific environments
+
+#### Specific Day Constraints
+
+The `days` method may be used to limit the execution of a task to specific days of the week. For example, to schedule a command to run hourly on Sundays and Wednesdays:
+
+    $schedule->command('reminders:send')
+                    ->hourly()
+                    ->days([0,3]);
 
 #### Between Time Constraints
 


### PR DESCRIPTION
This PR adds documentation for the scheduler's `days()` method. 