### PR TITLE
[7.x] Warn about cast names that equal relationship names

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -193,6 +193,8 @@ Now the `is_admin` attribute will always be cast to a boolean when you access it
 
 > {note} Attributes that are `null` will not be cast.
 
+> {note} You should never define a cast (or an attribute) that has the same name as a relationship. It is undocumented behavior in Laravel at this point (see [GitHub issue](https://github.com/laravel/framework/issues/32972)).
+
 <a name="custom-casts"></a>
 ### Custom Casts
 


### PR DESCRIPTION
As mentioned in #32972. I hit this "bug" today (the cast was added ages ago and did "work" up to the `7.12` release).