### PR TITLE
[8.x] Broad directory permission to bootstrap

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -83,7 +83,7 @@ All of the configuration files for the Laravel framework are stored in the `conf
 
 #### Directory Permissions
 
-After installing Laravel, you may need to configure some permissions. Directories within the `storage` and the `bootstrap/cache` directories should be writable by your web server or Laravel will not run. If you are using the [Homestead](/docs/{{version}}/homestead) virtual machine, these permissions should already be set.
+After installing Laravel, you may need to configure some permissions. Directories within the `storage` and the `bootstrap` directories should be writable by your web server or Laravel will not run. If you are using the [Homestead](/docs/{{version}}/homestead) virtual machine, these permissions should already be set.
 
 #### Application Key
 


### PR DESCRIPTION
This may be necessary to avoid issues with new artisan down command introduced by https://github.com/laravel/framework/pull/33560

From the original PR:

> In addition, a new bootstrap/maintenance.php file is written. This file is loaded before Composer in the framework's index.php file and is able to render the template and exit with zero dependencies. Composer and Laravel are never loaded.

Another option would be to move `bootstrap/maintenance.php` to `bootstrap/cache/maintenance.php` (no permissions changes required here) or include a note in [Maintenance Mode](https://laravel.com/docs/master/configuration#maintenance-mode) docs.