### PR TITLE
[7.x] Add: updating/updated only fired if model is dirty

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -962,7 +962,7 @@ Sometimes you may need to determine if two models are the "same". The `is` metho
 
 Eloquent models fire several events, allowing you to hook into the following points in a model's lifecycle: `retrieved`, `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`. Events allow you to easily execute code each time a specific model class is saved or updated in the database. Each event receives the instance of the model through its constructor.
 
-The `retrieved` event will fire when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will fire. If a model already existed in the database and the `save` method is called, the `updating` / `updated` events will fire. However, in both cases, the `saving` / `saved` events will fire.
+The `retrieved` event will fire when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will fire. he `updating` / `updated` events will fire if a model already existed in the database, the `save` method is called and the model is dirty. However, in both cases, the `saving` / `saved` events will fire.
 
 > {note} When issuing a mass update or delete via Eloquent, the `saved`, `updated`, `deleting`, and `deleted` model events will not be fired for the affected models. This is because the models are never actually retrieved when issuing a mass update or delete.
 


### PR DESCRIPTION
I recently found out that `updating`/`updated` are only fired if `save()` is used _and_ the model is dirty, as can be seen [here](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Database/Eloquent/Model.php#L805).

Currently the docs only mention that they're fired if the `save()` is used, which I found confusing as I did use `save()` but `updating`/`updated` were still not fired.

I found out after posting this on SO, [see here](https://stackoverflow.com/questions/62936862/laravel-deleting-cache-working-in-controller-but-not-in-model-closure).