### PR TITLE
[7.x] Add DetectsApplicationNamespace section

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -238,6 +238,16 @@ Laravel 7.x doesn't provide `swift.mailer` and `swift.transport` container bindi
 
 The deprecated `Illuminate\Http\Resources\Json\Resource` class has been removed. Your resources should extend the `Illuminate\Http\Resources\Json\JsonResource` class instead.
 
+### Console
+
+#### The `DetectsApplicationNamespace` Trait
+
+**Likelihood Of Impact: Low**
+
+The deprecated `Illuminate\Console\DetectsApplicationNamespace` trait has been removed. You may now use `Illuminate\Container\Container` instead:
+
+    Container::getInstance()->getNamespace();
+
 ### Routing
 
 #### The Router `getRoutes` Method


### PR DESCRIPTION
The `DetectsApplicationNamespace` trait has been removed on Laravel 7 https://github.com/laravel/framework/commit/74f3975e0879b97e5ba3fb3a018976b1afb887d2#diff-c17f57d8e225ed7ad5c603b4944c94dc