### PR TITLE
Homestead update documentation for v11 release

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -746,7 +746,7 @@ Next, you need to update the Homestead source code. If you cloned the repository
 
 These commands pull the latest Homestead code from the GitHub repository, fetches the latest tags, and then checks out the latest tagged release. You can find the latest stable release version on the [GitHub releases page](https://github.com/laravel/homestead/releases).
 
-If you have installed Homestead via your project's `composer.json` file, you should ensure your `composer.json` file contains `"laravel/homestead": "^10"` and update your dependencies:
+If you have installed Homestead via your project's `composer.json` file, you should ensure your `composer.json` file contains `"laravel/homestead": "^11"` and update your dependencies:
 
     composer update
 


### PR DESCRIPTION
Updated Homestead udpate documentation to fit for v11.0.0 release of Laravel Homestead.