### PR TITLE
[7.x] Correcting description for whereDoesntHave

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -977,7 +977,7 @@ If you need even more power, you may use the `whereDoesntHave` and `orWhereDoesn
         $query->where('content', 'like', 'foo%');
     })->get();
 
-You may use "dot" notation to execute a query against a nested relationship. For example, the following query will retrieve all posts with comments from authors that are not banned:
+You may use "dot" notation to execute a query against a nested relationship. For example, the following query will retrieve all posts that have no comments, or where all comments are from banned authors:
 
     use Illuminate\Database\Eloquent\Builder;
 

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -977,7 +977,7 @@ If you need even more power, you may use the `whereDoesntHave` and `orWhereDoesn
         $query->where('content', 'like', 'foo%');
     })->get();
 
-You may use "dot" notation to execute a query against a nested relationship. For example, the following query will retrieve all posts that have no comments, or where all comments are from banned authors:
+You may use "dot" notation to execute a query against a nested relationship. For example, the following query will retrieve all posts that do not have comments and posts that have comments from authors that are not banned:
 
     use Illuminate\Database\Eloquent\Builder;
 


### PR DESCRIPTION
The description of the example using whereDoesntHave with a nested relationship did not correctly describe the behavior of the function. Updated with correct description.

Originally brought to attention by 0xN0 via this [SO Question](https://stackoverflow.com/questions/63064693/laravel-eloquent-wheredoesnthave-documentation-confuses-me)