### PR TITLE
fixed typo in blade.md

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -53,7 +53,7 @@ Two of the primary benefits of using Blade are _template inheritance_ and _secti
         <body>
             @section('sidebar')
                 This is the master sidebar.
-            @show
+            @endsection
 
             <div class="container">
                 @yield('content')


### PR DESCRIPTION
It is like this 

```blade
@section('sidebar')
            This is the master sidebar.
@show
```

should be 

```blade
@section('sidebar')
            This is the master sidebar.
@endsection
```