### PR TITLE
[7.x] date serialization bit removed as no longer relevant

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -140,7 +140,7 @@ As noted above, when retrieving attributes that are listed in your `$dates` prop
 
 #### Date Formats
 
-By default, timestamps are formatted as `'Y-m-d H:i:s'`. If you need to customize the timestamp format, set the `$dateFormat` property on your model. This property determines how date attributes are stored in the database, as well as their format when the model is serialized to an array or JSON:
+By default, timestamps are formatted as `'Y-m-d H:i:s'`. If you need to customize the timestamp format, set the `$dateFormat` property on your model. This property determines how date attributes are stored in the database:
 
     <?php
 


### PR DESCRIPTION
removed bit about $dateFormat being for date serialization as it is now dictated by serializeDate()

disclaimer: Not 100% about this