### PR TITLE
Fix code example for custom casts

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -303,7 +303,7 @@ As an example, we will define a custom cast class that casts multiple model valu
         public function set($model, $key, $value, $attributes)
         {
             if (! $value instanceof Address) {
-                throw InvalidArgumentException('The given value is not an Address instance.');
+                throw new InvalidArgumentException('The given value is not an Address instance.');
             }
 
             return [


### PR DESCRIPTION
This typo was already fixed on the 7.0 branch via #6182. Not sure if it needs to be on master as well, but here it is.