### PR TITLE
Fix incorrect Artisan schedule method name

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -126,7 +126,7 @@ Method  | Description
 `->weeklyOn(1, '8:00');`  |  Run the task every week on Monday at 8:00
 `->monthly();`  |  Run the task on the first day of every month at 00:00
 `->monthlyOn(4, '15:00');`  |  Run the task every month on the 4th at 15:00
-`->monthlyOnLastDay('15:00');` | Run the task on the last day of the month at 15:00
+`->lastDayOfMonth('15:00');` | Run the task on the last day of the month at 15:00
 `->quarterly();` |  Run the task on the first day of every quarter at 00:00
 `->yearly();`  |  Run the task on the first day of every year at 00:00
 `->timezone('America/New_York');` | Set the timezone


### PR DESCRIPTION
This PR corrects the schedule `monthlyOnLastDay` to `lastDayOfMonth`. Attempting to use the schedule as documented results in an exception

![Screenshot from 2020-07-28 07-21-08](https://user-images.githubusercontent.com/1250252/88627455-3f186a00-d0a4-11ea-8ac1-8dc093db44b8.png)
