### PR TITLE
[7.x] Added missing Auth Events to Authentication Docs

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -653,4 +653,20 @@ Laravel raises a variety of [events](/docs/{{version}}/events) during the authen
         'Illuminate\Auth\Events\PasswordReset' => [
             'App\Listeners\LogPasswordReset',
         ],
+        
+        'Illuminate\Auth\Events\CurrentDeviceLogout' => [
+            'App\Listeners\LogCurrentDeviceLogout',
+        ],
+        
+        'Illuminate\Auth\Events\OtherDeviceLogout' => [
+            'App\Listeners\LogOtherDeviceLogout',
+        ],
+        
+        'Illuminate\Auth\Events\Validated' => [
+            'App\Listeners\LogValidated',
+        ],
+        
+        'Illuminate\Auth\Events\Verified' => [
+            'App\Listeners\LogVerified',
+        ],
     ];

--- a/authentication.md
+++ b/authentication.md
@@ -642,8 +642,24 @@ Laravel raises a variety of [events](/docs/{{version}}/events) during the authen
             'App\Listeners\LogFailedLogin',
         ],
 
+        'Illuminate\Auth\Events\Validated' => [
+            'App\Listeners\LogValidated',
+        ],
+        
+        'Illuminate\Auth\Events\Verified' => [
+            'App\Listeners\LogVerified',
+        ],
+
         'Illuminate\Auth\Events\Logout' => [
             'App\Listeners\LogSuccessfulLogout',
+        ],
+
+        'Illuminate\Auth\Events\CurrentDeviceLogout' => [
+            'App\Listeners\LogCurrentDeviceLogout',
+        ],
+
+        'Illuminate\Auth\Events\OtherDeviceLogout' => [
+            'App\Listeners\LogOtherDeviceLogout',
         ],
 
         'Illuminate\Auth\Events\Lockout' => [
@@ -652,21 +668,5 @@ Laravel raises a variety of [events](/docs/{{version}}/events) during the authen
 
         'Illuminate\Auth\Events\PasswordReset' => [
             'App\Listeners\LogPasswordReset',
-        ],
-        
-        'Illuminate\Auth\Events\CurrentDeviceLogout' => [
-            'App\Listeners\LogCurrentDeviceLogout',
-        ],
-        
-        'Illuminate\Auth\Events\OtherDeviceLogout' => [
-            'App\Listeners\LogOtherDeviceLogout',
-        ],
-        
-        'Illuminate\Auth\Events\Validated' => [
-            'App\Listeners\LogValidated',
-        ],
-        
-        'Illuminate\Auth\Events\Verified' => [
-            'App\Listeners\LogVerified',
         ],
     ];


### PR DESCRIPTION
I have added the missing Auth events available in the API documentation at [https://laravel.com/api/7.x/Illuminate/Auth/Events.html] to the Authentication documentation
