### PR TITLE
Add saved to the model observer

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1049,6 +1049,17 @@ This command will place the new observer in your `App/Observers` directory. If t
         {
             //
         }
+        
+        /**
+         * Handle the User "saved" event.
+         *
+         * @param  \App\User  $user
+         * @return void
+         */
+        public function saved(User $user)
+        {
+            //
+        }
 
         /**
          * Handle the User "updated" event.


### PR DESCRIPTION
There is a saved observer that isn't referenced in the docs. This PR adds the saved function so people are aware of the `saved` observer function :)