### PR TITLE
Update collections: nested arguments in `pluck`

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1445,12 +1445,12 @@ You may also specify how you wish the resulting collection to be keyed:
 
     // ['prod-100' => 'Desk', 'prod-200' => 'Chair']
 
-It supports nested key arguments:
+The `pluck` method also supports retrieving nested values using "dot" notation:
 
     $collection = collect([
         [
             'speakers' => [
-                'first_day' => ['Rosa','Judith'],
+                'first_day' => ['Rosa', 'Judith'],
                 'second_day' => ['Angela', 'Kathleen'],
             ],
         ],

--- a/collections.md
+++ b/collections.md
@@ -1436,7 +1436,15 @@ The `pluck` method retrieves all of the values for a given key:
     $plucked->all();
 
     // ['Desk', 'Chair']
-    
+
+You may also specify how you wish the resulting collection to be keyed:
+
+    $plucked = $collection->pluck('name', 'product_id');
+
+    $plucked->all();
+
+    // ['prod-100' => 'Desk', 'prod-200' => 'Chair']
+
 It supports nested key arguments:
 
     $collection = collect([
@@ -1453,14 +1461,6 @@ It supports nested key arguments:
     $plucked->all();
 
     // ['Rosa', 'Judith']
-
-You may also specify how you wish the resulting collection to be keyed:
-
-    $plucked = $collection->pluck('name', 'product_id');
-
-    $plucked->all();
-
-    // ['prod-100' => 'Desk', 'prod-200' => 'Chair']
 
 If duplicate keys exist, the last matching element will be inserted into the plucked collection:
 

--- a/collections.md
+++ b/collections.md
@@ -1436,6 +1436,23 @@ The `pluck` method retrieves all of the values for a given key:
     $plucked->all();
 
     // ['Desk', 'Chair']
+    
+It supports nested key arguments:
+
+    $collection = collect([
+        [
+            'speakers' => [
+                'first_day' => ['Rosa','Judith'],
+                'second_day' => ['Angela', 'Kathleen'],
+            ],
+        ],
+    ]);
+
+    $plucked = $collection->pluck('speakers.first_day');
+
+    $plucked->all();
+
+    // ['Rosa', 'Judith']
 
 You may also specify how you wish the resulting collection to be keyed:
 


### PR DESCRIPTION
I discovered this awesome feature today by just trying it out because why not (I guess I read it somewhere and forgot). I was surprised to see undocumented so here it is… 🙂