### PR TITLE
Replace "renamed" with "copied" when referring to the .env file

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -20,7 +20,7 @@ All of the configuration files for the Laravel framework are stored in the `conf
 
 It is often helpful to have different configuration values based on the environment where the application is running. For example, you may wish to use a different cache driver locally than you do on your production server.
 
-To make this a cinch, Laravel utilizes the [DotEnv](https://github.com/vlucas/phpdotenv) PHP library by Vance Lucas. In a fresh Laravel installation, the root directory of your application will contain a `.env.example` file. If you install Laravel via Composer, this file will automatically be renamed to `.env`. Otherwise, you should rename the file manually.
+To make this a cinch, Laravel utilizes the [DotEnv](https://github.com/vlucas/phpdotenv) PHP library by Vance Lucas. In a fresh Laravel installation, the root directory of your application will contain a `.env.example` file. If you install Laravel via Composer, this file will automatically be copied to `.env`. Otherwise, you should copy the file manually.
 
 Your `.env` file should not be committed to your application's source control, since each developer / server using your application could require a different environment configuration. Furthermore, this would be a security risk in the event an intruder gains access to your source control repository, since any sensitive credentials would get exposed.
 


### PR DESCRIPTION
I think using the term "copied" when talking about the `.env.example` and `.env` files is more accurate. If a user _were_ to rename `.env.example` to `.env` they might accidentally commit the file deletion (since `.env` is in the `.gitignore`), ending up with no `.env.example` file in the git repo.