### PR TITLE
fix: update socialite providers URL

### DIFF
--- a/socialite.md
+++ b/socialite.md
@@ -15,7 +15,7 @@
 
 In addition to typical, form based authentication, Laravel also provides a simple, convenient way to authenticate with OAuth providers using [Laravel Socialite](https://github.com/laravel/socialite). Socialite currently supports authentication with Facebook, Twitter, LinkedIn, Google, GitHub, GitLab and Bitbucket.
 
-> {tip} Adapters for other platforms are listed at the community driven [Socialite Providers](https://socialiteproviders.netlify.com/) website.
+> {tip} Adapters for other platforms are listed at the community driven [Socialite Providers](https://socialiteproviders.com/) website.
 
 <a name="upgrading-socialite"></a>
 ## Upgrading Socialite


### PR DESCRIPTION
We've updated the domain where the socialite providers docs live, this updates that to match 👍