### PR TITLE
[7.x] Update eloquent.md

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -237,6 +237,8 @@ Once you have created a model and [its associated database table](/docs/{{versio
     foreach ($flights as $flight) {
         echo $flight->name;
     }
+    
+> {note} You can also use the `query` and `newQuery` methods to start building fresh queries on a model. However, these methods are not meant to be overridden in your own models as that could lead to unexpected and broken behavior.
 
 #### Adding Additional Constraints
 


### PR DESCRIPTION
Warns about overriding `query` and `newQuery`. I wasn't sure of either adding a note or a new section on the usage of `query` & `newQuery` so feel free to provide feedback about that.

See https://github.com/laravel/framework/issues/33695