### PR TITLE
Remove Extending trials and past-due-status

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -27,7 +27,6 @@
 - [Subscription Trials](#subscription-trials)
     - [With Payment Method Up Front](#with-payment-method-up-front)
     - [Without Payment Method Up Front](#without-payment-method-up-front)
-    - [Extending Trials](#extending-trials)
 - [Handling Paddle Webhooks](#handling-paddle-webhooks)
     - [Defining Webhook Event Handlers](#defining-webhook-event-handlers)
     - [Failed Subscriptions](#handling-failed-subscriptions)
@@ -492,7 +491,6 @@ A complete list of available scopes is available below:
     Subscription::query()->onGracePeriod();
     Subscription::query()->notOnGracePeriod();
 
-<a name="past-due-status"></a>
 #### Past Due Status
 
 If a payment fails for a subscription, it will be marked as `past_due`. When your subscription is in this state it will not be active until the customer has updated their payment information. You may determine if a subscription is past due using the `pastDue` method on the subscription instance:


### PR DESCRIPTION
- Remove `Extending Trials` from the table of contents because the section does not exist, that method does not exist in the package.
- Remove the reference to `past-due-status` in the table of contents that does not show H4 titles.