### PR TITLE
[7.x] Update wording for Cashier Paddle docs

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -908,7 +908,7 @@ Both of these methods will return an instance of `Laravel\Paddle\Payment`; howev
 
 Sometimes, payments for subscriptions. When this happens, we recommend to let Paddle handle the payment failures for you. In this case, you may [setup Paddle's automatic billing emails](https://vendors.paddle.com/subscription-settings) in your Paddle dashboard.
 
-Alternatively, you can also opt to take control yourself by implementing the [`subscription_payment_failed`](https://developer.paddle.com/webhook-reference/subscription-alerts/subscription-payment-failed) webhook:
+Alternatively, you can also opt to take control yourself by implementing the [`subscription_payment_failed`](https://developer.paddle.com/webhook-reference/subscription-alerts/subscription-payment-failed) webhook and enabling the "Subscription Payment Failed" option in Webhook settings of your Paddle dashboard:
 
     <?php
 

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -906,7 +906,7 @@ Both of these methods will return an instance of `Laravel\Paddle\Payment`; howev
 <a name="handling-failed-payments"></a>
 ## Handling Failed Payments
 
-Sometimes, payments for subscriptions. When this happens, we recommend to let Paddle handle the payment failures for you. In this case, you may [setup Paddle's automatic billing emails](https://vendors.paddle.com/subscription-settings) in your Paddle dashboard.
+Sometimes, subscription payments fail for various reasons, e.g. customer's credit card has insufficient funds or has expired. When this happens, we recommend to let Paddle handle the payment failures for you. In this case, you may [setup Paddle's automatic billing emails](https://vendors.paddle.com/subscription-settings) in your Paddle dashboard.
 
 Alternatively, you can also opt to take control yourself by implementing the [`subscription_payment_failed`](https://developer.paddle.com/webhook-reference/subscription-alerts/subscription-payment-failed) webhook and enabling the "Subscription Payment Failed" option in Webhook settings of your Paddle dashboard:
 


### PR DESCRIPTION
You had a missing word in the first sentence:

> Sometimes, payments for subscriptions.

I've added just a bit of explanation on when subscription payments can fail.