### PR TITLE
Fix type of "$headers" for trust proxies middleware

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -427,7 +427,7 @@ To solve this, you may use the `App\Http\Middleware\TrustProxies` middleware tha
         /**
          * The headers that should be used to detect proxies.
          *
-         * @var string
+         * @var int
          */
         protected $headers = Request::HEADER_X_FORWARDED_ALL;
     }


### PR DESCRIPTION
The type of `$headers` property is actually `int` not `string`. It's already changed in the middleware [sources](https://github.com/laravel/laravel/blob/master/app/Http/Middleware/TrustProxies.php#L20)