### PR TITLE
[7.x] Suggest asset publishing Composer hook

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -102,7 +102,7 @@ Horizon exposes a dashboard at `/horizon`. By default, you will only be able to 
 
 When upgrading to a new major version of Horizon, it's important that you carefully review [the upgrade guide](https://github.com/laravel/horizon/blob/master/UPGRADE.md).
 
-In addition, you should re-publish Horizon's assets:
+In addition, when upgrading to any new Horizon version, you should re-publish Horizon's assets:
 
     php artisan horizon:publish
     

--- a/horizon.md
+++ b/horizon.md
@@ -110,9 +110,7 @@ To keep the assets up-to-date and avoid issues in future updates, we highly reco
 
     {
         "scripts": {
-            "post-autoload-dump": [
-                "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-                "@php artisan package:discover --ansi",
+            "post-update-cmd": [
                 "@php artisan horizon:publish --ansi"
             ]
         }

--- a/horizon.md
+++ b/horizon.md
@@ -105,6 +105,18 @@ When upgrading to a new major version of Horizon, it's important that you carefu
 In addition, you should re-publish Horizon's assets:
 
     php artisan horizon:publish
+    
+To keep the assets up-to-date and avoid issues in future updates, we highly recommend adding the command to the `post-autoload-dump` scripts in your `composer.json` file:
+
+    {
+        "scripts": {
+            "post-autoload-dump": [
+                "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+                "@php artisan package:discover --ansi",
+                "@php artisan horizon:publish --ansi"
+            ]
+        }
+    }
 
 <a name="running-horizon"></a>
 ## Running Horizon

--- a/horizon.md
+++ b/horizon.md
@@ -105,8 +105,8 @@ When upgrading to a new major version of Horizon, it's important that you carefu
 In addition, when upgrading to any new Horizon version, you should re-publish Horizon's assets:
 
     php artisan horizon:publish
-    
-To keep the assets up-to-date and avoid issues in future updates, we highly recommend adding the command to the `post-update-cmd` scripts in your `composer.json` file:
+
+To keep the assets up-to-date and avoid issues in future updates, you may add the command to the `post-update-cmd` scripts in your `composer.json` file:
 
     {
         "scripts": {

--- a/horizon.md
+++ b/horizon.md
@@ -106,7 +106,7 @@ In addition, when upgrading to any new Horizon version, you should re-publish Ho
 
     php artisan horizon:publish
     
-To keep the assets up-to-date and avoid issues in future updates, we highly recommend adding the command to the `post-autoload-dump` scripts in your `composer.json` file:
+To keep the assets up-to-date and avoid issues in future updates, we highly recommend adding the command to the `post-update-cmd` scripts in your `composer.json` file:
 
     {
         "scripts": {

--- a/telescope.md
+++ b/telescope.md
@@ -141,9 +141,7 @@ To keep the assets up-to-date and avoid issues in future updates, we highly reco
 
     {
         "scripts": {
-            "post-autoload-dump": [
-                "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-                "@php artisan package:discover --ansi",
+            "post-update-cmd": [
                 "@php artisan telescope:publish --ansi"
             ]
         }

--- a/telescope.md
+++ b/telescope.md
@@ -5,8 +5,8 @@
     - [Configuration](#configuration)
     - [Data Pruning](#data-pruning)
     - [Migration Customization](#migration-customization)
+    - [Dashboard Authorization](#dashboard-authorization)
 - [Upgrading Telescope](#upgrading-telescope)
-- [Dashboard Authorization](#dashboard-authorization)
 - [Filtering](#filtering)
     - [Entries](#filtering-entries)
     - [Batches](#filtering-batches)
@@ -106,28 +106,9 @@ Without pruning, the `telescope_entries` table can accumulate records very quick
 By default, all entries older than 24 hours will be pruned. You may use the `hours` option when calling the command to determine how long to retain Telescope data. For example, the following command will delete all records created over 48 hours ago:
 
     $schedule->command('telescope:prune --hours=48')->daily();
-    
-<a name="upgrading-telescope"></a>
-## Upgrading Telescope
-
-When upgrading to a new version of Telescope, you should re-publish Telescope's assets:
-
-    php artisan telescope:publish
-
-To keep the assets up-to-date and avoid issues in future updates, we highly recommend adding the command to the `post-autoload-dump` scripts in your `composer.json` file:
-
-    {
-        "scripts": {
-            "post-autoload-dump": [
-                "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-                "@php artisan package:discover --ansi",
-                "@php artisan telescope:publish --ansi"
-            ]
-        }
-    }
 
 <a name="dashboard-authorization"></a>
-## Dashboard Authorization
+### Dashboard Authorization
 
 Telescope exposes a dashboard at `/telescope`. By default, you will only be able to access this dashboard in the `local` environment. Within your `app/Providers/TelescopeServiceProvider.php` file, there is a `gate` method. This authorization gate controls access to Telescope in **non-local** environments. You are free to modify this gate as needed to restrict access to your Telescope installation:
 
@@ -148,6 +129,25 @@ Telescope exposes a dashboard at `/telescope`. By default, you will only be able
     }
 
 > {note} You should ensure you change your `APP_ENV` environment variable to `production` in your production environment. Otherwise, your Telescope installation will be publicly available.
+    
+<a name="upgrading-telescope"></a>
+## Upgrading Telescope
+
+When upgrading to a new version of Telescope, you should re-publish Telescope's assets:
+
+    php artisan telescope:publish
+
+To keep the assets up-to-date and avoid issues in future updates, we highly recommend adding the command to the `post-autoload-dump` scripts in your `composer.json` file:
+
+    {
+        "scripts": {
+            "post-autoload-dump": [
+                "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+                "@php artisan package:discover --ansi",
+                "@php artisan telescope:publish --ansi"
+            ]
+        }
+    }
 
 <a name="filtering"></a>
 ## Filtering

--- a/telescope.md
+++ b/telescope.md
@@ -137,7 +137,7 @@ When upgrading to a new version of Telescope, you should re-publish Telescope's 
 
     php artisan telescope:publish
 
-To keep the assets up-to-date and avoid issues in future updates, we highly recommend adding the command to the `post-autoload-dump` scripts in your `composer.json` file:
+To keep the assets up-to-date and avoid issues in future updates, we highly recommend adding the command to the `post-update-cmd` scripts in your `composer.json` file:
 
     {
         "scripts": {

--- a/telescope.md
+++ b/telescope.md
@@ -5,6 +5,7 @@
     - [Configuration](#configuration)
     - [Data Pruning](#data-pruning)
     - [Migration Customization](#migration-customization)
+- [Upgrading Telescope](#upgrading-telescope)
 - [Dashboard Authorization](#dashboard-authorization)
 - [Filtering](#filtering)
     - [Entries](#filtering-entries)
@@ -49,12 +50,6 @@ After installing Telescope, publish its assets using the `telescope:install` Art
     php artisan telescope:install
 
     php artisan migrate
-
-#### Updating Telescope
-
-When updating Telescope, you should re-publish Telescope's assets:
-
-    php artisan telescope:publish
 
 ### Installing Only In Specific Environments
 
@@ -111,6 +106,25 @@ Without pruning, the `telescope_entries` table can accumulate records very quick
 By default, all entries older than 24 hours will be pruned. You may use the `hours` option when calling the command to determine how long to retain Telescope data. For example, the following command will delete all records created over 48 hours ago:
 
     $schedule->command('telescope:prune --hours=48')->daily();
+    
+<a name="upgrading-telescope"></a>
+## Upgrading Telescope
+
+When upgrading to a new version of Telescope, you should re-publish Telescope's assets:
+
+    php artisan telescope:publish
+
+To keep the assets up-to-date and avoid issues in future updates, we highly recommend adding the command to the `post-autoload-dump` scripts in your `composer.json` file:
+
+    {
+        "scripts": {
+            "post-autoload-dump": [
+                "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+                "@php artisan package:discover --ansi",
+                "@php artisan telescope:publish --ansi"
+            ]
+        }
+    }
 
 <a name="dashboard-authorization"></a>
 ## Dashboard Authorization

--- a/telescope.md
+++ b/telescope.md
@@ -129,7 +129,7 @@ Telescope exposes a dashboard at `/telescope`. By default, you will only be able
     }
 
 > {note} You should ensure you change your `APP_ENV` environment variable to `production` in your production environment. Otherwise, your Telescope installation will be publicly available.
-    
+
 <a name="upgrading-telescope"></a>
 ## Upgrading Telescope
 
@@ -137,7 +137,7 @@ When upgrading to a new version of Telescope, you should re-publish Telescope's 
 
     php artisan telescope:publish
 
-To keep the assets up-to-date and avoid issues in future updates, we highly recommend adding the command to the `post-update-cmd` scripts in your `composer.json` file:
+To keep the assets up-to-date and avoid issues in future updates, you may add the `telescope:publish` command to the `post-update-cmd` scripts in your application's `composer.json` file:
 
     {
         "scripts": {


### PR DESCRIPTION
This PR adds the suggestion of hooking up the `telescope:publish` and `horizon:publish` commands to the app's `composer.json`'s `post-autoload-dump` list. This will make sure that assets are always kept up to date and prevents breakage of the dashboards. This was inspired by Livewire's docs: https://laravel-livewire.com/docs/installation

Added a new "Upgrading Telescope" section to be in line with other first party docs.

I've also moved "Dashboard Authorization" in the Telescope docs one level down to be in sync with Horizon's docs.