### PR TITLE
[7.x] Remove use AgeScope that isn't used in example

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -984,7 +984,6 @@ Instead of using custom event classes, you may register Closures that execute wh
 
     namespace App;
 
-    use App\Scopes\AgeScope;
     use Illuminate\Database\Eloquent\Model;
 
     class User extends Model


### PR DESCRIPTION
Very small thingy. The `use App\Scopes\AgeScope;` is not used in the example. The statement is probably there because it was copied over from another example.