### PR TITLE
[7.x] Added Zip PHP Extension to requirements list

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -29,6 +29,7 @@ However, if you are not using Homestead, you will need to make sure your server 
 - PDO PHP Extension
 - Tokenizer PHP Extension
 - XML PHP Extension
+- ZIP PHP Extension
 </div>
 
 <a name="installing-laravel"></a>


### PR DESCRIPTION
To install Laravel installer the ZIP PHP Extension is needed. It was not mentioned in the list of requirements.