### PR TITLE
[7.x] Add Laravel Echo to Contribution Guide

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -29,6 +29,7 @@ The Laravel source code is managed on GitHub, and there are repositories for eac
 - [Laravel Dusk](https://github.com/laravel/dusk)
 - [Laravel Cashier Stripe](https://github.com/laravel/cashier)
 - [Laravel Cashier Paddle](https://github.com/laravel/cashier-paddle)
+- [Laravel Echo](https://github.com/laravel/echo)
 - [Laravel Envoy](https://github.com/laravel/envoy)
 - [Laravel Framework](https://github.com/laravel/framework)
 - [Laravel Homestead](https://github.com/laravel/homestead)


### PR DESCRIPTION
The current [list of GitHub repositories](https://laravel.com/docs/7.x/contributions#bug-reports) for Laravel projects is missing an entry for Laravel Echo.