### PR TITLE
[7.x] Document passing plain text view to MailMessage

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -224,7 +224,23 @@ Instead of defining the "lines" of text in the notification class, you may use t
         );
     }
 
-In addition, you may return a [mailable object](/docs/{{version}}/mail) from the `toMail` method:
+You may specify a plain-text view for the mail message by passing the view name as the second element of an array that is given to the `view` method of the `MailMessage`:
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)->view(
+            ['emails.name.html', 'emails.name.plain'], 
+            ['invoice' => $this->invoice]
+        );
+    }
+
+In addition, you may return a full [mailable object](/docs/{{version}}/mail) from the `toMail` method:
 
     use App\Mail\InvoicePaid as Mailable;
 
@@ -237,21 +253,6 @@ In addition, you may return a [mailable object](/docs/{{version}}/mail) from the
     public function toMail($notifiable)
     {
         return (new Mailable($this->invoice))->to($notifiable->email);
-    }
-    
-And if you wanted to specify a plain text view separately you can pass it as the second element of an array to the first argument of the `view` method:
-
-    /**
-     * Get the mail representation of the notification.
-     *
-     * @param  mixed  $notifiable
-     * @return \Illuminate\Notifications\Messages\MailMessage
-     */
-    public function toMail($notifiable)
-    {
-        return (new MailMessage)->view(
-            ['emails.name.html', 'emails.name.plain'], ['invoice' => $this->invoice]
-        );
     }
 
 <a name="error-messages"></a>

--- a/notifications.md
+++ b/notifications.md
@@ -238,6 +238,21 @@ In addition, you may return a [mailable object](/docs/{{version}}/mail) from the
     {
         return (new Mailable($this->invoice))->to($notifiable->email);
     }
+    
+And if you wanted to specify a plain text view separately you can pass it as the second element of an array to the first argument of the `view` method:
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)->view(
+            ['emails.name.html', 'emails.name.plain'], ['invoice' => $this->invoice]
+        );
+    }
 
 <a name="error-messages"></a>
 #### Error Messages


### PR DESCRIPTION
Documents how people can pass a plain text view for a MailMessage. Will prevent confusion from: https://github.com/laravel/framework/pull/33816