### PR TITLE
Cache: database driver does not implement LockProvider interface

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -270,20 +270,7 @@ In contrast, this statement would remove only caches tagged with `authors`, so `
 <a name="atomic-locks"></a>
 ## Atomic Locks
 
-> {note} To utilize this feature, your application must be using the `memcached`, `dynamodb`, `redis`, `database`, or `array` cache driver as your application's default cache driver. In addition, all servers must be communicating with the same central cache server.
-
-<a name="lock-driver-prerequisites"></a>
-### Driver Prerequisites
-
-#### Database
-
-When using the `database` cache driver, you will need to setup a table to contain the cache locks. You'll find an example `Schema` declaration for the table below:
-
-    Schema::create('cache_locks', function ($table) {
-        $table->string('key')->primary();
-        $table->string('owner');
-        $table->integer('expiration');
-    });
+> {note} To utilize this feature, your application must be using the `memcached`, `dynamodb`, `redis`, or `array` cache driver as your application's default cache driver. In addition, all servers must be communicating with the same central cache server.
 
 <a name="managing-locks"></a>
 ### Managing Locks


### PR DESCRIPTION
Database cache driver does not support locking:

<img width="377" alt="Screenshot 2020-08-12 at 19 49 23" src="https://user-images.githubusercontent.com/47173071/90043603-ff24ca00-dcd4-11ea-9dbd-87c3301bbf15.png">

<img width="386" alt="Screenshot 2020-08-12 at 19 53 45" src="https://user-images.githubusercontent.com/47173071/90043961-8f630f00-dcd5-11ea-8ef3-fef1abc3413f.png">


