### PR TITLE
[7.x] Improve Horizon 'waits' example

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -267,6 +267,7 @@ You may configure how many seconds are considered a "long wait" within your `con
 
     'waits' => [
         'redis:default' => 60,
+        'redis:critical,high' => 90,
     ],
 
 <a name="metrics"></a>


### PR DESCRIPTION
Because "queue combination" is not quite easy to understand.