### PR TITLE
add re-keying warning for null key on prepend method

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1515,6 +1515,8 @@ You may also pass a second argument to set the key of the prepended item:
 
     // ['zero' => 0, 'one' => 1, 'two' => 2]
 
+Warning, passing a null key value will re-key the collection and disassociate existing key values.
+
 <a name="method-pull"></a>
 #### `pull()` {#collection-method}
 


### PR DESCRIPTION
I explained in more detail on my comment on the originating PR - https://github.com/laravel/framework/pull/10811 - that using a null key value with the prepend method can produce unintended results which I think we may want to warn folks about. Feel free to reword/reformat as appropriate. Thanks for your consideration.  