### PR TITLE
[7.x] Use Throwable instead of Exception in failed() methods in code examples

### DIFF
--- a/events.md
+++ b/events.md
@@ -367,7 +367,7 @@ Sometimes your queued event listeners may fail. If queued listener exceeds the m
          * Handle a job failure.
          *
          * @param  \App\Events\OrderShipped  $event
-         * @param  \Exception  $exception
+         * @param  \Throwable  $exception
          * @return void
          */
         public function failed(OrderShipped $event, $exception)

--- a/queues.md
+++ b/queues.md
@@ -808,7 +808,7 @@ If you require more complex logic for determining the retry delay, you may defin
 <a name="cleaning-up-after-failed-jobs"></a>
 ### Cleaning Up After Failed Jobs
 
-You may define a `failed` method directly on your job class, allowing you to perform job specific clean-up when a failure occurs. This is the perfect location to send an alert to your users or revert any actions performed by the job. The `Exception` that caused the job to fail will be passed to the `failed` method:
+You may define a `failed` method directly on your job class, allowing you to perform job specific clean-up when a failure occurs. This is the perfect location to send an alert to your users or revert any actions performed by the job. The `Throwable` exception that caused the job to fail will be passed to the `failed` method:
 
     <?php
 
@@ -853,10 +853,10 @@ You may define a `failed` method directly on your job class, allowing you to per
         /**
          * Handle a job failure.
          *
-         * @param  \Exception  $exception
+         * @param  \Throwable  $exception
          * @return void
          */
-        public function failed(Exception $exception)
+        public function failed(Throwable $exception)
         {
             // Send user notification of failure, etc...
         }


### PR DESCRIPTION
This PR uses `Throwable` type instead of `Exception` in `failed()` methods in code examples.

This is because the framework [is passing](https://github.com/laravel/framework/blob/99c74a8eb040e9e030a121ffc27139c09e6fb93e/src/Illuminate/Queue/Jobs/Job.php#L192) `Throwable`, not `Exception`.