### PR TITLE
fixed unrealistic age restriction in Defining Middleware example

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -26,7 +26,7 @@ To create a new middleware, use the `make:middleware` Artisan command:
 
     php artisan make:middleware CheckAge
 
-This command will place a new `CheckAge` class within your `app/Http/Middleware` directory. In this middleware, we will only allow access to the route if the supplied `age` is greater than 200. Otherwise, we will redirect the users back to the `home` URI:
+This command will place a new `CheckAge` class within your `app/Http/Middleware` directory. In this middleware, we will only allow access to the route if the supplied `age` is greater than 20. Otherwise, we will redirect the users back to the `home` URI:
 
     <?php
 
@@ -45,7 +45,7 @@ This command will place a new `CheckAge` class within your `app/Http/Middleware`
          */
         public function handle($request, Closure $next)
         {
-            if ($request->age <= 200) {
+            if ($request->age <= 20) {
                 return redirect('home');
             }
 
@@ -53,7 +53,7 @@ This command will place a new `CheckAge` class within your `app/Http/Middleware`
         }
     }
 
-As you can see, if the given `age` is less than or equal to `200`, the middleware will return an HTTP redirect to the client; otherwise, the request will be passed further into the application. To pass the request deeper into the application (allowing the middleware to "pass"), call the `$next` callback with the `$request`.
+As you can see, if the given `age` is less than or equal to `20`, the middleware will return an HTTP redirect to the client; otherwise, the request will be passed further into the application. To pass the request deeper into the application (allowing the middleware to "pass"), call the `$next` callback with the `$request`.
 
 It's best to envision middleware as a series of "layers" HTTP requests must pass through before they hit your application. Each layer can examine the request and even reject it entirely.
 


### PR DESCRIPTION
I fixed unrealistic age restriction in example at 'Defining Middleware' section in 'Middleware' topic because age > 200 is unrealistic to give an example. 