### PR TITLE
[7.x] Make using attributes and directives on components clear

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -667,6 +667,8 @@ All of the attributes that are not part of the component's constructor will auto
     <div {{ $attributes }}>
         <!-- Component Content -->
     </div>
+    
+> {note} Using `{{ $attributes }}` or directives like `@env` etc directly on a component isn't supported at this time.
 
 #### Default / Merged Attributes
 

--- a/blade.md
+++ b/blade.md
@@ -668,7 +668,7 @@ All of the attributes that are not part of the component's constructor will auto
         <!-- Component Content -->
     </div>
     
-> {note} Using `{{ $attributes }}` or directives like `@env` etc directly on a component isn't supported at this time.
+> {note} Using `{{ $attributes }}`, directives like `@env` etc or the display syntax (`{{ }}` and `{!! !!}`) directly on a component isn't supported at this time.
 
 #### Default / Merged Attributes
 

--- a/blade.md
+++ b/blade.md
@@ -668,7 +668,7 @@ All of the attributes that are not part of the component's constructor will auto
         <!-- Component Content -->
     </div>
     
-> {note} Using `{{ $attributes }}`, directives like `@env` etc or the display syntax (`{{ }}` and `{!! !!}`) directly on a component isn't supported at this time.
+> {note} Echoing variables (`{{ $attributes }}`) or using directives such as `@env` directly on a component is not supported at this time.
 
 #### Default / Merged Attributes
 


### PR DESCRIPTION
We've had quite some reports in the last couple of months of people who asked why they couldn't use these. Hoping this at least makes them aware before they try it out. We can remove the `{{ $attributes }}` part at least in the Laravel 8 docs.