### PR TITLE
Updating 'use Exception' to 'use Throwable' in queues

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -816,7 +816,7 @@ You may define a `failed` method directly on your job class, allowing you to per
 
     use App\AudioProcessor;
     use App\Podcast;
-    use Exception;
+    use Throwable;
     use Illuminate\Bus\Queueable;
     use Illuminate\Contracts\Queue\ShouldQueue;
     use Illuminate\Queue\InteractsWithQueue;


### PR DESCRIPTION
Hello @driesvints,

just a super minor fix: In the queue documentation an example still included `Exception` while `Throwable` was used otherwise.

Cheers,
Peter

