### PR TITLE
[5.8] Fix non-active cloudinary link for the Telescope screenshot

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -33,7 +33,7 @@
 Laravel Telescope is an elegant debug assistant for the Laravel framework. Telescope provides insight into the requests coming into your application, exceptions, log entries, database queries, queued jobs, mail, notifications, cache operations, scheduled tasks, variable dumps and more. Telescope makes a wonderful companion to your local Laravel development environment.
 
 <p align="center">
-<img src="https://res.cloudinary.com/dtfbvvkyp/image/upload/v1539110860/Screen_Shot_2018-10-09_at_1.47.23_PM.png" width="600">
+<img src="https://laravel.com/assets/img/examples/Screen_Shot_2018-10-09_at_1.47.23_PM.png" width="600">
 </p>
 
 <a name="installation"></a>


### PR DESCRIPTION
This PR depends on the following PR to be merged first:
laravel/laravel.com-next#128