### PR TITLE
Fixing internal jump anchor

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -711,7 +711,7 @@ By default, Stripe will prorate charges when adding or removing plans from a sub
 
 #### Quantities
 
-If you would like to update quantities on individual subscription plans, you may do so using the [existing quantity methods](subscription-quantity) and passing the name of the plan as an additional argument to the method:
+If you would like to update quantities on individual subscription plans, you may do so using the [existing quantity methods](#subscription-quantity) and passing the name of the plan as an additional argument to the method:
 
     $user = User::find(1);
 


### PR DESCRIPTION
Hey @driesvints 

I've noticed an internal jump anchor not working (missing #). It's currently treated as an internal link, which is broken. This PR fixes it.

Peter