### PR TITLE
[7.x] Update ElasticSearch version

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -297,7 +297,7 @@ Optional software is installed using the "features" setting in your Homestead co
         - crystal: true
         - docker: true
         - elasticsearch:
-            version: 7
+            version: 7.9.0
         - gearman: true
         - golang: true
         - grafana: true


### PR DESCRIPTION
ElasticSearch won't install properly unless full version is specified, the documentation gives a false impression that it will work even if just a major version is specified.