### PR TITLE
Factory configure function return type

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -185,15 +185,12 @@ Factory callbacks are registered using the `afterMaking` and `afterCreating` met
          */
         public function configure()
         {
-            $this->afterMaking(function (User $user) {
+            return $this->afterMaking(function (User $user) {
+                //
+            })->afterCreating(function (User $user) {
                 //
             });
-
-            $this->afterCreating(function (User $user) {
-                //
-            });
-            
-            return $this;
+           
         }
 
         // ...

--- a/database-testing.md
+++ b/database-testing.md
@@ -190,7 +190,6 @@ Factory callbacks are registered using the `afterMaking` and `afterCreating` met
             })->afterCreating(function (User $user) {
                 //
             });
-           
         }
 
         // ...

--- a/database-testing.md
+++ b/database-testing.md
@@ -181,7 +181,7 @@ Factory callbacks are registered using the `afterMaking` and `afterCreating` met
         /**
          * Configure the model factory.
          *
-         * @return void
+         * @return $this
          */
         public function configure()
         {
@@ -192,6 +192,8 @@ Factory callbacks are registered using the `afterMaking` and `afterCreating` met
             $this->afterCreating(function (User $user) {
                 //
             });
+            
+            return $this;
         }
 
         // ...


### PR DESCRIPTION
The docs for Factory configure has a return type void, the `Illuminate\Database\Eloquent\Factories\Factory` defines the configure() function with the return type of the current object.

This PR resolves the example in the docs to include the expected return type.