### PR TITLE
[7.x] Remove old releases

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -18,10 +18,6 @@ For LTS releases, such as Laravel 6, bug fixes are provided for 2 years and secu
 
 | Version | Release | Bug Fixes Until | Security Fixes Until |
 | --- | --- | --- | --- |
-| 5.5 (LTS) | August 30th, 2017 | August 30th, 2019 | August 30th, 2020 |
-| 5.6 | February 7th, 2018 | August 7th, 2018 | February 7th, 2019 |
-| 5.7 | September 4th, 2018 | March 4th, 2019 | September 4th, 2019 |
-| 5.8 | February 26th, 2019 | August 26th, 2019 | February 26th, 2020 |
 | 6 (LTS) | September 3rd, 2019 | September 3rd, 2021 | September 3rd, 2022 |
 | 7 | March 3rd, 2020 | September 10th, 2020 | March 3rd, 2021 |
 | 8 | September 8th, 2020 | March 8th, 2021 | September 8th, 2021 |


### PR DESCRIPTION
Since 5.5 is now officially fully EoL we can remove these versions I think.