### PR TITLE
Factory states: Add tip for using dynamic data

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -158,7 +158,7 @@ If your state transformation requires access to the other attributes defined by 
         });
     }
 
-> {tip} If you are generating dynamic values within the state transformation method, you will need to pass a callback rather than modifying `$this->state` directly, as this causes the callback to be run every time a model is created.
+> {tip} If you want to use Faker or otherwise generate dynamic values within the state transformation method, you will need to pass a callback rather than modifying `$this->state` directly.
 
 <a name="factory-callbacks"></a>
 ### Factory Callbacks

--- a/database-testing.md
+++ b/database-testing.md
@@ -158,6 +158,8 @@ If your state transformation requires access to the other attributes defined by 
         });
     }
 
+> {tip} If you are generating dynamic values within the state transformation method, you will need to pass a callback rather than modifying `$this->state` directly, as this causes the callback to be run every time a model is created.
+
 <a name="factory-callbacks"></a>
 ### Factory Callbacks
 


### PR DESCRIPTION
This is a gotcha with the new factories in 8.x. When generating dynamic data within a state transformation, e.g.:

```
public function anonymous()
    {
        $uuid = Str::uuid();
        return $this->state([
            'name' => 'anonymous_user_' . $uuid,
            'email' => $uuid . '@anonymous.com',
            'is_anonymous' => true,
            'password' => Hash::make(Str::random(10)),
        ]);
    }
```

The method only runs once however many models you're creating. So generating 100 instances of that state will create 100 models each with the same uuid.

Using a callback fixes that.