### PR TITLE
[8.x] Temporary URLs in S3: Update request parameters example

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -210,7 +210,10 @@ If you need to specify additional [S3 request parameters](https://docs.aws.amazo
     $url = Storage::temporaryUrl(
         'file.jpg',
         now()->addMinutes(5),
-        ['ResponseContentDisposition' => 'attachment; filename=file2.jpg']
+        [
+            'ResponseContentType' => 'application/octet-stream',
+            'ResponseContentDisposition' => 'attachment; filename=file2.jpg',
+        ]
     );
 
 #### URL Host Customization

--- a/filesystem.md
+++ b/filesystem.md
@@ -210,7 +210,7 @@ If you need to specify additional [S3 request parameters](https://docs.aws.amazo
     $url = Storage::temporaryUrl(
         'file.jpg',
         now()->addMinutes(5),
-        ['ResponseContentType' => 'application/octet-stream']
+        ['ResponseContentDisposition' => 'attachment; filename=file2.jpg']
     );
 
 #### URL Host Customization


### PR DESCRIPTION
In Temporary URLs section, while explaining the third additional S3 Request parameters, The current example educates the user in a quick glance how to customize the `Content-Type` response to a different MIME type.

While this illustrates the customization ability, I believe an example of `Specifying A File Name` (which is already documented for file uploads) might be more useful.