### PR TITLE
[8.x] restore Password Confirmation docs

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -182,6 +182,19 @@ When attaching the `auth` middleware to a route, you may also specify which guar
         $this->middleware('auth:api');
     }
 
+<a name="password-confirmation"></a>	
+### Password Confirmation	
+
+Sometimes, you may wish to require the user to confirm their password before accessing a specific area of your application. For example, you may require this before the user modifies any billing settings within the application.	
+
+To accomplish this, Laravel provides a `password.confirm` middleware. Attaching the `password.confirm` middleware to a route will redirect users to a screen where they need to confirm their password before they can continue:	
+
+    Route::get('/settings/security', function () {	
+        // Users must confirm their password before continuing...	
+    })->middleware(['auth', 'password.confirm']);	
+
+After the user has successfully confirmed their password, the user is redirected to the route they originally tried to access. By default, after confirming their password, the user will not have to confirm their password again for three hours. You are free to customize the length of time before the user must re-confirm their password using the `auth.password_timeout` configuration option.
+
 <a name="login-throttling"></a>
 ### Login Throttling
 


### PR DESCRIPTION
I'm not sure why this was removed. Does Jetstream handle this some other way?