### PR TITLE
[8.x] remove unused link to Password Confirmation

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -8,7 +8,6 @@
     - [Authenticating](#included-authenticating)
     - [Retrieving The Authenticated User](#retrieving-the-authenticated-user)
     - [Protecting Routes](#protecting-routes)
-    - [Password Confirmation](#password-confirmation)
     - [Login Throttling](#login-throttling)
 - [Manually Authenticating Users](#authenticating-users)
     - [Remembering Users](#remembering-users)


### PR DESCRIPTION
does this not exist anymore?