### PR TITLE
[8.x] Updating docs related to composer.json changes and seeders/factories

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -111,7 +111,7 @@ Seeders and factories now use namespaced classes. To accommodate for these chang
 
 The previous `database/seeds` directory should be renamed to `database/seeders`.
 
-In addition, these new namespaced classes should be autoloaded from your `composer.json` file:
+In your `composer.json` file, remove `classmap` block from the `autoload` section and add the new namespaced classes:
 
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
When I went to update my application I got the following error in my terminal:
![image](https://user-images.githubusercontent.com/8125119/92787354-a184ab80-f36e-11ea-8fdb-9140232f5260.png)

It makes sense considering the line above said to rename `database/seeds` to `database/seeders`, but to be honest I wasn't aware that this block was in the `composer.json` file.

This is a minor inconvenience at best and I just rewrote line 114 to make mention of it.