### PR TITLE
Suggest using `nullable()` when adding `failed_jobs.uuid`

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -238,7 +238,7 @@ If you plan to use the [job batching](/docs/{{version}}/queues#job-batching) fea
     use Illuminate\Support\Facades\Schema;
 
     Schema::table('failed_jobs', function (Blueprint $table) {
-        $table->string('uuid')->after('id')->unique();
+        $table->string('uuid')->after('id')->nullable()->unique();
     });
 
 Next, the `failed.driver` configuration option within your `queue` configuration file should be updated to `database-uuids`.


### PR DESCRIPTION
If there are failed jobs in your database table when you run the migration without the `nullable()` default, the migration will fail to run due to duplicate empty string UUIDs (default being `''` when not explicitly defined).

This aims to provide a "safer" suggestion when adding the migration as part of an upgrade to Laravel 8.x
