### PR TITLE
Revert "[8.x] Clarify that Faker is unavailable in States unless a closure is used"

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -142,7 +142,7 @@ State manipulation methods allow you to define discrete modifications that can b
         ]);
     }
 
-If your state transformation requires access to the other attributes defined by the factory (including `$faker`), you may pass a callback to the `state` method. The callback will receive the array of raw attributes defined for the factory:
+If your state transformation requires access to the other attributes defined by the factory, you may pass a callback to the `state` method. The callback will receive the array of raw attributes defined for the factory:
 
     /**
      * Indicate that the user is suspended.


### PR DESCRIPTION
Reverts laravel/docs#6329 due to https://github.com/laravel/framework/pull/34298