### PR TITLE
[8.x] Adding Configuring Laravel Dusk with Gitlab CI

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1744,16 +1744,25 @@ If you are using [Github Actions](https://github.com/features/actions) to run yo
 ### Gitlab CI
 
 If you are using [Gitlab CI](https://docs.gitlab.com/ee/ci/) to run your Dusk tests, you may use this configuration file as a starting point, however you need to add some changed to `tests/DuskTestCase.php`, specificlly adding the `--no-sandbox` to the ChromeDriver options. like so 
-        ```php
-        // DuskTestCase.php
-        
+first we change `DuskTestCase.php` into
+
+    <?php
+    .....
+    abstract class DuskTestCase extends BaseTestCase
+    {
+        ....
+        /**
+         * Create the RemoteWebDriver instance.
+         *
+         * @return \Facebook\WebDriver\Remote\RemoteWebDriver
+         */
         protected function driver()
         {
             $options = (new ChromeOptions)->addArguments([
                 '--disable-gpu',
                 '--headless',
                 '--window-size=1920,1080',
-                '--no-sandbox' // <------ this is needed for gitlab
+                '--no-sandbox' // add this for gitlab CI
             ]);
 
             return RemoteWebDriver::create(
@@ -1762,9 +1771,9 @@ If you are using [Gitlab CI](https://docs.gitlab.com/ee/ci/) to run your Dusk te
                 )
             );
         }
-        ```
- 
+    }
 
+then, we can use this `gitlab-ci.yaml` as our starting point for the tests
 
     language: php
 

--- a/dusk.md
+++ b/dusk.md
@@ -45,6 +45,7 @@
     - [Heroku CI](#running-tests-on-heroku-ci)
     - [Travis CI](#running-tests-on-travis-ci)
     - [GitHub Actions](#running-tests-on-github-actions)
+    - [Gitlab CI](#running-tests-on-gitlab-ci)
 
 <a name="introduction"></a>
 ## Introduction
@@ -1738,3 +1739,50 @@ If you are using [Github Actions](https://github.com/features/actions) to run yo
             env:
               APP_URL: "http://127.0.0.1:8000"
             run: php artisan dusk
+    
+<a name="running-tests-on-gitlab-ci"></a>
+### Gitlab CI
+
+If you are using [Gitlab CI](https://docs.gitlab.com/ee/ci/) to run your Dusk tests, you may use this configuration file as a starting point, however you need to add some changed to `tests/DuskTestCase.php`, specificlly adding the `--no-sandbox` to the ChromeDriver options. like so 
+        ```php
+        // DuskTestCase.php
+        
+        protected function driver()
+        {
+            $options = (new ChromeOptions)->addArguments([
+                '--disable-gpu',
+                '--headless',
+                '--window-size=1920,1080',
+                '--no-sandbox' // <------ this is needed for gitlab
+            ]);
+
+            return RemoteWebDriver::create(
+                'http://localhost:9515', DesiredCapabilities::chrome()->setCapability(
+                    ChromeOptions::CAPABILITY, $options
+                )
+            );
+        }
+        ```
+ 
+
+
+    language: php
+
+    stages:
+      - test
+
+     dusk_tests:
+        stage: test
+        image: chilio/laravel-dusk-ci:latest
+        services:
+          - mysql:5.7
+        script:
+          - composer install
+          - configure-laravel
+          - start-nginx-ci-project
+          - cp .env.example .env
+          - php artisan key:generate
+          - php artisan migrate
+          - php artisan dusk
+
+            


### PR DESCRIPTION
motive: as i was googling my way around on how to setup Gitlab Ci with laravel dusk, there were little resources that actually tell you what to do, and i looked at the laravel docs seeing that there is no section for configuring dusk with laravel. so it makes sense that Laravel has this in it's docs.

![tests pass](https://user-images.githubusercontent.com/38360603/93015253-d0687080-f56c-11ea-89a2-7ba0461de243.png)

Thank you for laravel.

Thanks
