### PR TITLE
Solved Undefined class constant 'VERSION'

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -72,7 +72,7 @@ Once you have configured a queue driver, set the value of the `queue` option in 
 
 When using the Algolia driver, you should configure your Algolia `id` and `secret` credentials in your `config/scout.php` configuration file. Once your credentials have been configured, you will also need to install the Algolia PHP SDK via the Composer package manager:
 
-    composer require algolia/algoliasearch-client-php:^2.2
+    composer require algolia/algoliasearch-client-php
 
 <a name="configuration"></a>
 ## Configuration


### PR DESCRIPTION
`composer require algolia/algoliasearch-client-php:^2.2` throw "VERSION" error because laravel 8 is using "guzzlehttp/guzzle": "^7.0.1". Since Guzzlehttp removed "VERSION" constant from "GuzzleHttp\ClientInterface" from version 7, for this reason this error thrown. When we update the "algoliasearch-client-php" version from 2.2 to 2.7 OR just remove the version option then the issue solved.

`composer require algolia/algoliasearch-client-php:^2.7`

OR 

`composer require algolia/algoliasearch-client-php`