### PR TITLE
[8.x] Provide an example of multi-word model-to-table mapping

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -68,7 +68,7 @@ Now, let's look at an example `Flight` model, which we will use to retrieve and 
 
 #### Table Names
 
-Note that we did not tell Eloquent which table to use for our `Flight` model. By convention, the "snake case", plural name of the class will be used as the table name unless another name is explicitly specified. So, in this case, Eloquent will assume the `Flight` model stores records in the `flights` table. If you had a model named `AirTrafficController`, Eloquent would look for an `air_traffic_controllers` table.
+Note that we did not tell Eloquent which table to use for our `Flight` model. By convention, the "snake case", plural name of the class will be used as the table name unless another name is explicitly specified. So, in this case, Eloquent will assume the `Flight` model stores records in the `flights` table, while an `AirTrafficController` model would store records in an `air_traffic_controllers` table.
 
 You can manually specify a table name by defining a `table` property on your model:
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -68,7 +68,9 @@ Now, let's look at an example `Flight` model, which we will use to retrieve and 
 
 #### Table Names
 
-Note that we did not tell Eloquent which table to use for our `Flight` model. By convention, the "snake case", plural name of the class will be used as the table name unless another name is explicitly specified. So, in this case, Eloquent will assume the `Flight` model stores records in the `flights` table. You may specify a custom table by defining a `table` property on your model:
+Note that we did not tell Eloquent which table to use for our `Flight` model. By convention, the "snake case", plural name of the class will be used as the table name unless another name is explicitly specified. So, in this case, Eloquent will assume the `Flight` model stores records in the `flights` table. If you had a model named `AirTrafficController`, Eloquent would look for an `air_traffic_controllers` table.
+
+You can manually specify a table name by defining a `table` property on your model:
 
     <?php
 


### PR DESCRIPTION
The existing Eloquent model example is `Flights` being mapped to a `flights` table. Back when I was learning Eloquent by reading an earlier version of these docs, it wasn't immediately obvious to me how a `MultiWordModel` would get mapped to a `multi_word_models` table.

I didn't want to change `Flights` to a multi-word model, since it's used in a ton of other places in the docs, so I just added a quick example of `AirTrafficController` being mapped to `air_traffic_controllers`. The combination of the simple and slightly-more-complex examples should give people confidence about how Laravel maps models to table names.