### PR TITLE
Update upgrade.md to link to tag 7.x of mail config

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -214,7 +214,7 @@ The Zend Diactoros library for generating PSR-7 responses has been deprecated. I
 
 **Likelihood Of Impact: Optional**
 
-In order to support multiple mailers, the default `mail` configuration file has changed in Laravel 7.x to include an array of `mailers`. However, in order to preserve backwards compatibility, the Laravel 6.x format of this configuration file is still supported. So, no changes are **required** when upgrading to Laravel 7.x; however, you may wish to [examine the new `mail` configuration file](https://github.com/laravel/laravel/blob/develop/config/mail.php) structure and update your file to reflect the changes.
+In order to support multiple mailers, the default `mail` configuration file has changed in Laravel 7.x to include an array of `mailers`. However, in order to preserve backwards compatibility, the Laravel 6.x format of this configuration file is still supported. So, no changes are **required** when upgrading to Laravel 7.x; however, you may wish to [examine the new `mail` configuration file](https://github.com/laravel/laravel/blob/{{version}}/config/mail.php) structure and update your file to reflect the changes.
 
 <a name="markdown-mail-template-updates"></a>
 #### Markdown Mail Template Updates


### PR DESCRIPTION
While currently the difference between config/mail.php in Laravel 7 and the develop branch are the same, this could change in the future and could be easily forgotten about. This could prove confusing for users trying to upgrade from 6 to 7 if it is changed to something not compatible in the future.