### PR TITLE
Correct facade name in dispatching batches example

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -708,7 +708,7 @@ To dispatch a batch of jobs, you should use `batch` method of the `Bus` facade. 
     use App\Jobs\ProcessPodcast;
     use App\Podcast;
     use Illuminate\Bus\Batch;
-    use Illuminate\Support\Facades\Batch;
+    use Illuminate\Support\Facades\Bus;
     use Throwable;
 
     $batch = Bus::batch([


### PR DESCRIPTION
The dispatching batches example incorrectly imports the facade as: `Illuminate\Support\Facades\Batch`, however, the correct name is `Illuminate\Support\Facades\Bus`.

This typo also causes a duplicate symbol exception with line immediately preceding it: `Illuminate\Bus\Batch`.