### PR TITLE
[9.x] Revert Laravel 9 prep

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -2,7 +2,7 @@
 
 - [Versioning Scheme](#versioning-scheme)
 - [Support Policy](#support-policy)
-- [Laravel 9](#laravel-9)
+- [Laravel 8](#laravel-8)
 
 <a name="versioning-scheme"></a>
 ## Versioning Scheme
@@ -22,7 +22,334 @@ For LTS releases, such as Laravel 6, bug fixes are provided for 2 years and secu
 | 7 | March 3rd, 2020 | October 6th, 2020 | March 3rd, 2021 |
 | 8 | September 8th, 2020 | April 6th, 2021 | September 8th, 2021 |
 
-<a name="laravel-9"></a>
-## Laravel 9
+<a name="laravel-8"></a>
+## Laravel 8
 
-Coming soon...
+Laravel 8 continues the improvements made in Laravel 7.x by introducing Laravel Jetstream, model factory classes, migration squashing, job batching, improved rate limiting, queue improvements, dynamic Blade components, Tailwind pagination views, time testing helpers, improvements to `artisan serve`, event listener improvements, and a variety of other bug fixes and usability improvements.
+
+### Laravel Jetstream
+
+_Laravel Jetstream was written by [Taylor Otwell](https://github.com/taylorotwell)_.
+
+[Laravel Jetstream](https://github.com/laravel/jetstream) is a beautifully designed application scaffolding for Laravel. Jetstream provides the perfect starting point for your next project and includes login, registration, email verification, two-factor authentication, session management, API support via Laravel Sanctum, and optional team management. Laravel Jetstream replaces and improves upon the legacy authentication UI scaffolding available for previous versions of Laravel.
+
+Jetstream is designed using [Tailwind CSS](https://tailwindcss.com) and offers your choice of [Livewire](https://laravel-livewire.com) or [Inertia](https://inertiajs.com) scaffolding.
+
+### Models Directory
+
+By overwhelming community demand, the default Laravel application skeleton now contains an `app/Models` directory. We hope you enjoy this new home for your Eloquent models! All relevant generator commands have been updated to assume models exist within the `app/Models` directory if it exists. If the directory does not exist, the framework will assume your models should be placed within the `app` directory.
+
+### Model Factory Classes
+
+_Model factory classes were contributed by [Taylor Otwell](https://github.com/taylorotwell)_.
+
+Eloquent [model factories](/docs/{{version}}/database-testing#creating-factories) have been entirely re-written as class based factories and improved to have first-class relationship support. For example, the `UserFactory` included with Laravel is written like so:
+
+    <?php
+
+    namespace Database\Factories;
+
+    use App\Models\User;
+    use Illuminate\Database\Eloquent\Factories\Factory;
+    use Illuminate\Support\Str;
+
+    class UserFactory extends Factory
+    {
+        /**
+         * The name of the factory's corresponding model.
+         *
+         * @var string
+         */
+        protected $model = User::class;
+
+        /**
+         * Define the model's default state.
+         *
+         * @return array
+         */
+        public function definition()
+        {
+            return [
+                'name' => $this->faker->name,
+                'email' => $this->faker->unique()->safeEmail,
+                'email_verified_at' => now(),
+                'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+                'remember_token' => Str::random(10),
+            ];
+        }
+    }
+
+Thanks to the new `HasFactory` trait available on generated models, the model factory may be used like so:
+
+    use App\Models\User;
+
+    User::factory()->count(50)->create();
+
+Since model factories are now simple PHP classes, state transformations may be written as class methods. In addition, you may add any other helper classes to your Eloquent model factory as needed.
+
+For example, your `User` model might have a `suspended` state that modifies one of its default attribute values. You may define your state transformations using the base factory's `state` method. You may name your state method anything you like. After all, it's just a typical PHP method:
+
+    /**
+     * Indicate that the user is suspended.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function suspended()
+    {
+        return $this->state([
+            'account_status' => 'suspended',
+        ]);
+    }
+
+After defining the state transformation method, we may use it like so:
+
+    use App\Models\User;
+
+    User::factory()->count(5)->suspended()->create();
+
+As mentioned, Laravel 8's model factories contain first class support for relationships. So, assuming our `User` model has a `posts` relationship method, we may simply run the following code to generate a user with three posts:
+
+    $users = User::factory()
+                ->hasPosts(3, [
+                    'published' => false,
+                ])
+                ->create();
+
+To ease the upgrade process, the [laravel/legacy-factories](https://github.com/laravel/legacy-factories) package has been released to provide support for the previous iteration of model factories within Laravel 8.x.
+
+Laravel's re-written factories contain many more features that we think you will love. To learn more about model factories, please consult the [database testing documentation](/docs/{{version}}/database-testing#creating-factories).
+
+### Migration Squashing
+
+_Migration squashing was contributed by [Taylor Otwell](https://github.com/taylorotwell)_.
+
+As you build your application, you may accumulate more and more migrations over time. This can lead to your migration directory becoming bloated with potentially hundreds of migrations. If you're using MySQL or PostgreSQL, you may now "squash" your migrations into a single SQL file. To get started, execute the `schema:dump` command:
+
+    php artisan schema:dump
+
+    // Dump the current database schema and prune all existing migrations...
+    php artisan schema:dump --prune
+
+When you execute this command, Laravel will write a "schema" file to your `database/schema` directory. Now, when you attempt to migrate your database and no other migrations have been executed, Laravel will execute the schema file's SQL first. After executing the schema file's commands, Laravel will execute any remaining migrations that were not part of the schema dump.
+
+### Job Batching
+
+_Job batching was contributed by [Taylor Otwell](https://github.com/taylorotwell) & [Mohamed Said](https://github.com/themsaid)_.
+
+Laravel's job batching feature allows you to easily execute a batch of jobs and then perform some action when the batch of jobs has completed executing.
+
+The new `batch` method of the `Bus` facade may be used to dispatch a batch of jobs. Of course, batching is primarily useful when combined with completion callbacks. So, you may use the `then`, `catch`, and `finally` methods to define completion callbacks for the batch. Each of these callbacks will receive an `Illuminate\Bus\Batch` instance when they are invoked:
+
+    use App\Jobs\ProcessPodcast;
+    use App\Podcast;
+    use Illuminate\Bus\Batch;
+    use Illuminate\Support\Facades\Batch;
+    use Throwable;
+
+    $batch = Bus::batch([
+        new ProcessPodcast(Podcast::find(1)),
+        new ProcessPodcast(Podcast::find(2)),
+        new ProcessPodcast(Podcast::find(3)),
+        new ProcessPodcast(Podcast::find(4)),
+        new ProcessPodcast(Podcast::find(5)),
+    ])->then(function (Batch $batch) {
+        // All jobs completed successfully...
+    })->catch(function (Batch $batch, Throwable $e) {
+        // First batch job failure detected...
+    })->finally(function (Batch $batch) {
+        // The batch has finished executing...
+    })->dispatch();
+
+    return $batch->id;
+
+To learn more about job batching, please consult the [queue documentation](/docs/{{version}}/queues#job-batching).
+
+### Improved Rate Limiting
+
+_Rate limiting improvements were contributed by [Taylor Otwell](https://github.com/taylorotwell)_.
+
+Laravel's request rate limiter feature has been augmented with more flexibility and power, while still maintaining backwards compatibility with previous release's `throttle` middleware API.
+
+Rate limiters are defined using the `RateLimiter` facade's `for` method. The `for` method accepts a rate limiter name and a Closure that returns the limit configuration that should apply to routes that are assigned this rate limiter:
+
+    use Illuminate\Cache\RateLimiting\Limit;
+    use Illuminate\Support\Facades\RateLimiter;
+
+    RateLimiter::for('global', function (Request $request) {
+        return Limit::perMinute(1000);
+    });
+
+Since rate limiter callbacks receive the incoming HTTP request instance, you may build the appropriate rate limit dynamically based on the incoming request or authenticated user:
+
+    RateLimiter::for('uploads', function (Request $request) {
+        return $request->user()->vipCustomer()
+                    ? Limit::none()
+                    : Limit::perMinute(100);
+    });
+
+Sometimes you may wish to segment rate limits by some arbitrary value. For example, you may wish to allow users to access a given route 100 times per minute per IP address. To accomplish this, you may use the `by` method when building your rate limit:
+
+    RateLimiter::for('uploads', function (Request $request) {
+        return $request->user()->vipCustomer()
+                    ? Limit::none()
+                    : Limit::perMinute(100)->by($request->ip());
+    });
+
+Rate limiters may be attached to routes or route groups using the `throttle` [middleware](/docs/{{version}}/middleware). The throttle middleware accepts the name of the rate limiter you wish to assign to the route:
+
+    Route::middleware(['throttle:uploads'])->group(function () {
+        Route::post('/audio', function () {
+            //
+        });
+
+        Route::post('/video', function () {
+            //
+        });
+    });
+
+To learn more about rate limiting, please consult the [routing documentation](/docs/{{version}}/routing#rate-limiting).
+
+### Improved Maintenance Mode
+
+_Maintenance mode improvements were contributed by [Taylor Otwell](https://github.com/taylorotwell) with inspiration from [Spatie](https://spatie.be)_.
+
+In previous releases of Laravel, the `php artisan down` maintenance mode feature may be bypassed using an "allow list" of IP addresses that were allowed to access the application. This feature has been removed in favor of a simpler "secret" / token solution.
+
+While in maintenance mode, you may use the `secret` option to specify a maintenance mode bypass token:
+
+    php artisan down --secret="1630542a-246b-4b66-afa1-dd72a4c43515"
+
+After placing the application in maintenance mode, you may navigate to the application URL matching this token and Laravel will issue a maintenance mode bypass cookie to your browser:
+
+    https://example.com/1630542a-246b-4b66-afa1-dd72a4c43515
+
+When accessing this hidden route, you will then be redirected to the `/` route of the application. Once the cookie has been issued to your browser, you will be able to browse the application normally as if it was not in maintenance mode.
+
+#### Pre-Rendering The Maintenance Mode View
+
+If you utilize the `php artisan down` command during deployment, your users may still occasionally encounter errors if they access the application while your Composer dependencies or other infrastructure components are updating. This occurs because a significant part of the Laravel framework must boot in order to determine your application is in maintenance mode and render the maintenance mode view using the templating engine.
+
+For this reason, Laravel now allows you to pre-render a maintenance mode view that will be returned at the very beginning of the request cycle. This view is rendered before any of your application's dependencies have loaded. You may pre-render a template of your choice using the `down` command's `render` option:
+
+    php artisan down --render="errors::503"
+
+### Closure Dispatch / Chain `catch`
+
+_Catch improvements were contributed by [Mohamed Said](https://github.com/themsaid)_.
+
+Using the new `catch` method, you may now provide a Closure that should be executed if a queued Closure fails to complete successfully after exhausting all of your queue's configured retry attempts:
+
+    use Throwable;
+
+    dispatch(function () use ($podcast) {
+        $podcast->publish();
+    })->catch(function (Throwable $e) {
+        // This job has failed...
+    });
+
+### Dynamic Blade Components
+
+_Dynamic Blade components were contributed by [Taylor Otwell](https://github.com/taylorotwell)_.
+
+Sometimes you may need to render a component but not know which component should be rendered until runtime. In this situation, you may now use Laravel's built-in `dynamic-component` component to render the component based on a runtime value or variable:
+
+    <x-dynamic-component :component="$componentName" class="mt-4" />
+
+To learn more about Blade components, please consult the [Blade documentation](/docs/{{version}}/blade#components).
+
+### Event Listener Improvements
+
+_Event listener improvements were contributed by [Taylor Otwell](https://github.com/taylorotwell)_.
+
+Closure based event listeners may now be registered by only passing the Closure to the `Event::listen` method. Laravel will inspect the Closure to determine which type of event the listener handles:
+
+    use App\Events\PodcastProcessed;
+    use Illuminate\Support\Facades\Event;
+
+    Event::listen(function (PodcastProcessed $event) {
+        //
+    });
+
+In addition, Closure based event listeners may now be marked as queueable using the `Illuminate\Events\queueable` function:
+
+    use App\Events\PodcastProcessed;
+    use function Illuminate\Events\queueable;
+    use Illuminate\Support\Facades\Event;
+
+    Event::listen(queueable(function (PodcastProcessed $event) {
+        //
+    }));
+
+Like queued jobs, you may use the `onConnection`, `onQueue`, and `delay` methods to customize the execution of the queued listener:
+
+    Event::listen(queueable(function (PodcastProcessed $event) {
+        //
+    })->onConnection('redis')->onQueue('podcasts')->delay(now()->addSeconds(10)));
+
+If you would like to handle anonymous queued listener failures, you may provide a Closure to the `catch` method while defining the `queueable` listener:
+
+    use App\Events\PodcastProcessed;
+    use function Illuminate\Events\queueable;
+    use Illuminate\Support\Facades\Event;
+    use Throwable;
+
+    Event::listen(queueable(function (PodcastProcessed $event) {
+        //
+    })->catch(function (PodcastProcessed $event, Throwable $e) {
+        // The queued listener failed...
+    }));
+
+### Time Testing Helpers
+
+_Time testing helpers were contributed by [Taylor Otwell](https://github.com/taylorotwell) with inspiration from Ruby on Rails_.
+
+When testing, you may occasionally need to modify the time returned by helpers such as `now` or `Illuminate\Support\Carbon::now()`. Laravel's base feature test class now includes helpers that allow you to manipulate the current time:
+
+    public function testTimeCanBeManipulated()
+    {
+        // Travel into the future...
+        $this->travel(5)->milliseconds();
+        $this->travel(5)->seconds();
+        $this->travel(5)->minutes();
+        $this->travel(5)->hours();
+        $this->travel(5)->days();
+        $this->travel(5)->weeks();
+        $this->travel(5)->years();
+
+        // Travel into the past...
+        $this->travel(-5)->hours();
+
+        // Travel to an explicit time...
+        $this->travelTo(now()->subHours(6));
+
+        // Return back to the present time...
+        $this->travelBack();
+    }
+
+### Artisan `serve` Improvements
+
+_Artisan `serve` improvements were contributed by [Taylor Otwell](https://github.com/taylorotwell)_.
+
+The Artisan `serve` command has been improved with automatic reloading when environment variable changes are detected within your local `.env` file. Previously, the command had to be manually stopped and restarted.
+
+### Tailwind Pagination Views
+
+The Laravel paginator has been updated to use the [Tailwind CSS](https://tailwindcss.com) framework by default. Tailwind CSS is a highly customizable, low-level CSS framework that gives you all of the building blocks you need to build bespoke designs without any annoying opinionated styles you have to fight to override. Of course, Bootstrap 3 and 4 views remain available as well.
+
+### Routing Namespace Updates
+
+In previous releases of Laravel, the `RouteServiceProvider` contained a `$namespace` property. This property's value would automatically be prefixed onto controller route definitions and calls to the `action` helper / `URL::action` method. In Laravel 8.x, this property is `null` by default. This means that no automatic namespace prefixing will be done by Laravel. Therefore, in new Laravel 8.x applications, controller route definitions should be defined using standard PHP callable syntax:
+
+    use App\Http\Controllers\UserController;
+
+    Route::get('/users', [UserController::class, 'index']);
+
+Calls to the `action` related methods should use the same callable syntax:
+
+    action([UserController::class, 'index']);
+
+    return Redirect::action([UserController::class, 'index']);
+
+If you prefer Laravel 7.x style controller route prefixing, you may simply add the `$namespace` property into your application's `RouteServiceProvider`.
+
+> {note} This change only affects new Laravel 8.x applications. Applications upgrading from Laravel 7.x will still have the `$namespace` property in their `RouteServiceProvider`.

--- a/upgrade.md
+++ b/upgrade.md
@@ -1,27 +1,43 @@
 # Upgrade Guide
 
-- [Upgrading To 9.0 From 8.x](#upgrade-9.0)
+- [Upgrading To 8.0 From 7.x](#upgrade-8.0)
 
 <a name="high-impact-changes"></a>
 ## High Impact Changes
 
 <div class="content-list" markdown="1">
-- ...
+- [Model Factories](#model-factories)
+- [Queue `retryAfter` Method](#queue-retry-after-method)
+- [Queue `timeoutAt` Property](#queue-timeout-at-property)
+- [Queue `allOnQueue` and `allOnConnection`](#queue-allOnQueue-allOnConnection)
+- [Pagination Defaults](#pagination-defaults)
+- [Seeder & Factory Namespaces](#seeder-factory-namespaces)
 </div>
 
 <a name="medium-impact-changes"></a>
 ## Medium Impact Changes
 
 <div class="content-list" markdown="1">
-- ...
+- [PHP 7.3.0 Required](#php-7.3.0-required)
+- [Failed Jobs Table Batch Support](#failed-jobs-table-batch-support)
+- [Maintenance Mode Updates](#maintenance-mode-updates)
+- [The `php artisan down --message` Option](#artisan-down-message)
+- [The `assertExactJson` Method](#assert-exact-json-method)
 </div>
 
-<a name="upgrade-9.0"></a>
-## Upgrading To 9.0 From 8.x
+<a name="upgrade-8.0"></a>
+## Upgrading To 8.0 From 7.x
 
-#### Estimated Upgrade Time: ?? Minutes
+#### Estimated Upgrade Time: 15 Minutes
 
 > {note} We attempt to document every possible breaking change. Since some of these breaking changes are in obscure parts of the framework only a portion of these changes may actually affect your application.
+
+<a name="php-7.3.0-required"></a>
+### PHP 7.3.0 Required
+
+**Likelihood Of Impact: Medium**
+
+The new minimum PHP version is now 7.3.0.
 
 <a name="updating-dependencies"></a>
 ### Updating Dependencies
@@ -29,16 +45,313 @@
 Update the following dependencies in your `composer.json` file:
 
 <div class="content-list" markdown="1">
-- ...
+- `guzzlehttp/guzzle` to `^7.0.1`
+- `facade/ignition` to `^2.3.6`
+- `laravel/framework` to `^8.0`
+- `laravel/ui` to `^3.0`
+- `nunomaduro/collision` to `^5.0`
+- `phpunit/phpunit` to `^9.0`
 </div>
 
-The following first-party packages have new major releases to support Laravel 9. If applicable, you should read their individual upgrade guides before upgrading:
+The following first-party packages have new major releases to support Laravel 8. If applicable, you should read their individual upgrade guides before upgrading:
 
 <div class="content-list" markdown="1">
-- ...
+- [Horizon v5.0](https://github.com/laravel/horizon/blob/master/UPGRADE.md)
+- [Passport v10.0](https://github.com/laravel/passport/blob/master/UPGRADE.md)
+- [Socialite v5.0](https://github.com/laravel/socialite/blob/master/UPGRADE.md)
+- [Telescope v4.0](https://github.com/laravel/telescope/releases)
 </div>
 
-Finally, examine any other third-party packages consumed by your application and verify you are using the proper version for Laravel 9 support.
+In addition, the Laravel installer has been updated to support `composer create-project` and Laravel Jetstream. Any installer older than 4.0 will cease to work after October 2020. You should upgrade your global installer to `^4.0` as soon as possible.
+
+Finally, examine any other third-party packages consumed by your application and verify you are using the proper version for Laravel 8 support.
+
+### Collections
+
+#### The `isset` Method
+
+**Likelihood Of Impact: Low**
+
+To be consistent with typical PHP behavior, the `offsetExists` method of `Illuminate\Support\Collection` has been updated to use `isset` instead of `array_key_exists`. This may present a change in behavior when dealing with collection items that have a value of `null`:
+
+    $collection = collect([null]);
+
+    // Laravel 7.x - true
+    isset($collection[0]);
+
+    // Laravel 8.x - false
+    isset($collection[0]);
+
+### Database
+
+<a name="seeder-factory-namespaces"></a>
+#### Seeder & Factory Namespaces
+
+**Likelihood Of Impact: High**
+
+Seeders and factories are now namespaced. To accommodate for these changes, add the `Database\Seeders` namespace to your seeder classes. In addition, the previous `database/seeds` directory should be renamed to `database/seeders`:
+
+    <?php
+
+    namespace Database\Seeders;
+
+    use App\Models\User;
+    use Illuminate\Database\Seeder;
+
+    class DatabaseSeeder extends Seeder
+    {
+        /**
+         * Seed the application's database.
+         *
+         * @return void
+         */
+        public function run()
+        {
+            ...
+        }
+    }
+
+If you are choosing to use the `laravel/legacy-factories` package, no changes to your factory classes are required. However, if you are upgrading your factories, you should add the `Database\Factories` namespace to those classes.
+
+Next, in your `composer.json` file, remove `classmap` block from the `autoload` section and add the new namespaced class directory mappings:
+
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/",
+            "Database\\Factories\\": "database/factories/",
+            "Database\\Seeders\\": "database/seeders/"
+        }
+    },
+
+### Eloquent
+
+<a name="model-factories"></a>
+#### Model Factories
+
+**Likelihood Of Impact: High**
+
+Laravel's [model factories](/docs/{{version}}/database-testing#creating-factories) feature has been totally rewritten to support classes and is not compatible with Laravel 7.x style factories. However, to ease the upgrade process, a new `laravel/legacy-factories` package has been created to continue using your existing factories with Laravel 8.x. You may install this package via Composer:
+
+    composer require laravel/legacy-factories
+
+#### The `Castable` Interface
+
+**Likelihood Of Impact: Low**
+
+The `castUsing` method of the `Castable` interface has been updated to accept an array of arguments. If you are implementing this interface you should update your implementation accordingly:
+
+    public static function castUsing(array $arguments);
+
+#### Increment / Decrement Events
+
+**Likelihood Of Impact: Low**
+
+Proper "update" and "save" related model events will now be dispatched when executing the `increment` or `decrement` methods on Eloquent model instances.
+
+### Events
+
+#### The `Dispatcher` Contract
+
+**Likelihood Of Impact: Low**
+
+The `listen` method of the `Illuminate\Contracts\Events\Dispatcher` contract has been updated to make the `$listener` property optional. This change was made to support automatic detection of handled event types via reflection. If you are manually implementing this interface, you should update your implementation accordingly:
+
+    public function listen($events, $listener = null);
+
+### Framework
+
+<a name="maintenance-mode-updates"></a>
+#### Maintenance Mode Updates
+
+**Likelihood Of Impact: Optional**
+
+The [maintenance mode](/docs/{{version}}/configuration#maintenance-mode) feature of Laravel has been improved in Laravel 8.x. Pre-rendering the maintenance mode template is now supported and eliminates the chances of end users encountering errors during maintenance mode. However, to support this, the following lines must be added to your `public/index.php` file. These lines should be placed directly under the existing `LARAVEL_START` constant definition:
+
+    define('LARAVEL_START', microtime(true));
+
+    if (file_exists(__DIR__.'/../storage/framework/maintenance.php')) {
+        require __DIR__.'/../storage/framework/maintenance.php';
+    }
+
+<a name="artisan-down-message"></a>
+#### The `php artisan down --message` Option
+
+**Likelihood Of Impact: Medium**
+
+The `--message` option of the `php artisan down` command has been removed. As an alternative, consider [pre-rendering your maintenance mode views](/docs/{{version}}/configuration#maintenance-mode) with the message of your choice.
+
+#### Manager `$app` Property
+
+**Likelihood Of Impact: Low**
+
+The previously deprecated `$app` property of the `Illuminate\Support\Manager` class has been removed. If you were relying on this property, you should use the `$container` property instead.
+
+#### The `elixir` Helper
+
+**Likelihood Of Impact: Low**
+
+The previously deprecated `elixir` helper has been removed. Applications still using this method are encouraged to upgrade to [Laravel Mix](https://github.com/JeffreyWay/laravel-mix).
+
+### Mail
+
+#### The `sendNow` Method
+
+**Likelihood Of Impact: Low**
+
+The previously deprecated `sendNow` method has been removed. Instead, please use the `send` method.
+
+### Pagination
+
+<a name="pagination-defaults"></a>
+#### Pagination Defaults
+
+**Likelihood Of Impact: High**
+
+The paginator now uses the [Tailwind CSS framework](https://tailwindcss.com) for its default styling. In order to keep using Bootstrap, you should add the following method call to the `boot` method of your application's `AppServiceProvider`:
+
+    use Illuminate\Pagination\Paginator;
+
+    Paginator::useBootstrap();
+
+### Queue
+
+<a name="queue-retry-after-method"></a>
+#### The `retryAfter` Method
+
+**Likelihood Of Impact: High**
+
+For consistency with other features of Laravel, the `retryAfter` method and `retryAfter` property of queued jobs, mailers, notifications, and listeners has been renamed to `backoff`. You should update the name of this method / property in the relevant classes in your application.
+
+<a name="queue-timeout-at-property"></a>
+#### The `timeoutAt` Property
+
+**Likelihood Of Impact: High**
+
+The `timeoutAt` property of queued jobs, notifications, and listeners has been renamed to `retryUntil`. You should update the name of this property in the relevant classes in your application.
+
+<a name="queue-allOnQueue-allOnConnection"></a>
+#### The `allOnQueue()` / `allOnConnection()` Methods
+
+**Likelihood Of Impact: High**
+
+For consistency with other dispatching methods, the `allOnQueue()` and `allOnConnection()` methods used with job chaining have been removed. You may use the `onQueue()` and `onConnection()` methods instead. These methods should be called before calling the `dispatch` method:
+
+    ProcessPodcast::withChain([
+        new OptimizePodcast,
+        new ReleasePodcast
+    ])->onConnection('redis')->onQueue('podcasts')->dispatch();
+
+<a name="failed-jobs-table-batch-support"></a>
+#### Failed Jobs Table Batch Support
+
+**Likelihood Of Impact: Optional**
+
+If you plan to use the [job batching](/docs/{{version}}/queues#job-batching) features of Laravel 8.x, your `failed_jobs` database table will need to be updated. First, a new `uuid` column should be added to your table:
+
+    use Illuminate\Database\Schema\Blueprint;
+    use Illuminate\Support\Facades\Schema;
+
+    Schema::table('failed_jobs', function (Blueprint $table) {
+        $table->string('uuid')->after('id')->nullable()->unique();
+    });
+
+Next, the `failed.driver` configuration option within your `queue` configuration file should be updated to `database-uuids`.
+
+### Routing
+
+#### Automatic Controller Namespace Prefixing
+
+**Likelihood Of Impact: Optional**
+
+In previous releases of Laravel, the `RouteServiceProvider` class contained a `$namespace` property with a value of `App\Http\Controllers`. This value of this property was used to automatically prefix controller route declarations controller route URL generation such as when calling the `action` helper.
+
+In Laravel 8, this property is set to `null` by default. This allows your controller route declarations to use the standard PHP callable syntax, which provides better support for jumping to the controller class in many IDEs:
+
+    use App\Http\Controllers\UserController;
+
+    // Using PHP callable syntax...
+    Route::get('/users', [UserController::class, 'index']);
+
+    // Using string syntax...
+    Route::get('/users', 'App\Http\Controllers\UserController@index');
+
+In most cases this won't impact applications that are being upgraded because your `RouteServiceProvider` will still contain the `$namespace` property with its previous value. However, if you upgrade your application by creating a brand new Laravel project, you may encounter this as a breaking change.
+
+If you would like to continue using the original auto-prefixed controller routing, you can simply set the value of the `$namespace` property within your `RouteServiceProvider` and update the route registrations within the `boot` method to use the `$namespace` property:
+
+    class RouteServiceProvider extends ServiceProvider
+    {
+        /**
+         * This namespace is applied to your controller routes.
+         *
+         * In addition, it is set as the URL generator's root namespace.
+         *
+         * @var string
+         */
+        protected $namespace = 'App\Http\Controllers';
+
+        /**
+         * Define your route model bindings, pattern filters, etc.
+         *
+         * @return void
+         */
+        public function boot()
+        {
+            $this->configureRateLimiting();
+
+            $this->routes(function () {
+                Route::middleware('web')
+                    ->namespace($this->namespace)
+                    ->group(base_path('routes/web.php'));
+
+                Route::prefix('api')
+                    ->middleware('api')
+                    ->namespace($this->namespace)
+                    ->group(base_path('routes/api.php'));
+        });
+    }
+
+### Scheduling
+
+#### The `cron-expression` Library
+
+**Likelihood Of Impact: Low**
+
+Laravel's dependency on `dragonmantank/cron-expression` has been updated from `2.x` to `3.x`. This should not cause any breaking change in your application unless you are interacting with the `cron-expression` library directly. If you are interacting with this library directly, please review its [change log](https://github.com/dragonmantank/cron-expression/blob/master/CHANGELOG.md).
+
+### Session
+
+#### The `Session` Contract
+
+**Likelihood Of Impact: Low**
+
+The `Illuminate\Contracts\Session\Session` contract has received a new `pull` method. If you are implementing this contract manually, you should update your implementation accordingly:
+
+    /**
+     * Get the value of a given key and then forget it.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function pull($key, $default = null);
+
+### Testing
+
+<a name="assert-exact-json-method"></a>
+#### The `assertExactJson` Method
+
+**Likelihood Of Impact: Medium**
+
+The `assertExactJson` method now requires numeric keys of compared arrays to match and be in the same order. If you would like to compare JSON against an array without requiring numerically keyed arrays to have the same order, you may use the `assertSimilarJson` method instead.
+
+### Validation
+
+### Database Rule Connections
+
+**Likelihood Of Impact: Low**
+
+The `unique` and `exists` rules will now respect the specified connection name (accessed via the model's `getConnectionName` method) of Eloquent models when performing queries.
 
 <a name="miscellaneous"></a>
 ### Miscellaneous


### PR DESCRIPTION
I'm sending this in to revert https://github.com/laravel/docs/pull/6302. I noticed that while merging 8.x into master you almost each time have to resolve merge conflicts. It's probably not worth the hassle in the next 6 months to having to deal with that each time so let's do the Laravel 9 prep work when we get closer to its release date.