### PR TITLE
Remove factory() from helpers methods

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -227,7 +227,6 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [dump](#method-dump)
 [env](#method-env)
 [event](#method-event)
-[factory](#method-factory)
 [filled](#method-filled)
 [info](#method-info)
 [logger](#method-logger)


### PR DESCRIPTION
This PR removes factory() method from the "Miscellaneous" list of helpers