### PR TITLE
[8.x]  Fix Bus namespace 

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -143,7 +143,7 @@ The new `batch` method of the `Bus` facade may be used to dispatch a batch of jo
     use App\Jobs\ProcessPodcast;
     use App\Podcast;
     use Illuminate\Bus\Batch;
-    use Illuminate\Support\Facades\Batch;
+    use Illuminate\Support\Facades\Bus;
     use Throwable;
 
     $batch = Bus::batch([


### PR DESCRIPTION
There is a little mistake importing the Bus Facade