### PR TITLE
[8.x] The correct parameter is the "ownerKey" not "otherKey"

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -131,7 +131,7 @@ If your parent model does not use `id` as its primary key, or you wish to join t
      */
     public function user()
     {
-        return $this->belongsTo('App\Models\User', 'foreign_key', 'other_key');
+        return $this->belongsTo('App\Models\User', 'foreign_key', 'owner_key');
     }
 
 <a name="one-to-many"></a>
@@ -221,7 +221,7 @@ If your parent model does not use `id` as its primary key, or you wish to join t
      */
     public function post()
     {
-        return $this->belongsTo('App\Models\Post', 'foreign_key', 'other_key');
+        return $this->belongsTo('App\Models\Post', 'foreign_key', 'owner_key');
     }
 
 <a name="many-to-many"></a>


### PR DESCRIPTION
While playing with the relationships, my IDE told me that after the "foreignKey" parameter is the "ownerKey" parameter not the "otherKey" in the "belongsTo" method for the model relationships.