### PR TITLE
[6.x] Fixes broken Passport API cookie security fix handling

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -46,6 +46,8 @@ PHP 7.1 will no longer be actively maintained as of December 2019. Therefore, La
 
 Update your `laravel/framework` dependency to `^6.0` in your `composer.json` file.
 
+If it exists, update your `laravel/passport` dependency to `^9.3.2` in your `composer.json` file.
+
 Next, examine any 3rd party packages consumed by your application and verify you are using the proper version for Laravel 6 support.
 
 ### Authorization

--- a/upgrade.md
+++ b/upgrade.md
@@ -44,9 +44,7 @@ PHP 7.1 will no longer be actively maintained as of December 2019. Therefore, La
 <a name="updating-dependencies"></a>
 ### Updating Dependencies
 
-Update your `laravel/framework` dependency to `^6.0` in your `composer.json` file.
-
-If it exists, update your `laravel/passport` dependency to `^9.3.2` in your `composer.json` file.
+Update your `laravel/framework` dependency to `^6.0` in your `composer.json` file. If installed, update your `laravel/passport` dependency to `^9.3.2` in your `composer.json` file.
 
 Next, examine any 3rd party packages consumed by your application and verify you are using the proper version for Laravel 6 support.
 


### PR DESCRIPTION
Recently Passport 7.x, 8.x & 9.x added a CookieValuePrefix as a security measure. This broke cookie token handling deep inside `auth:api`.

Fix is in Passport 9.3.2. Please merge this documentation fix so people who upgrade to LTS get informed.

Ref: https://github.com/laravel/framework/issues/34227