### PR TITLE
Explain how to use a literal dot in a validation rule

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -147,6 +147,13 @@ If your HTTP request contains "nested" parameters, you may specify them in your 
         'author.description' => 'required',
     ]);
 
+On the other hand, if your field name contains a literal dot, you can explicitly prevent this from being interpreted as "dot" syntax:
+
+    $request->validate([
+        'title' => 'required|unique:posts|max:255',
+        'v1\.0' => 'required',
+    ]);
+
 <a name="quick-displaying-the-validation-errors"></a>
 ### Displaying The Validation Errors
 


### PR DESCRIPTION
While writing up a [blog post](https://joelclermont.com/post/2020-09/understanding-dot-notation-in-laravel-validation/) on how to do this, I realized I should also PR the docs too.

Would it be useful to PR older release branches too?