### PR TITLE
Url route helper overloading documentation

### DIFF
--- a/urls.md
+++ b/urls.md
@@ -76,6 +76,12 @@ The `route` helper may also be used to generate URLs for routes with multiple pa
     echo route('comment.show', ['post' => 1, 'comment' => 3]);
 
     // http://example.com/post/1/comment/3
+    
+You can also overload the `route` helper, with parameters that are not present in the route. These will instead be added as query parameters.
+
+    echo route('post.show', ['post' => $post, 'search' => 'Laravel']);
+    
+    // http://example.com/post/1?search=Laravel
 
 <a name="signed-urls"></a>
 ### Signed URLs


### PR DESCRIPTION
It is not described in the documentation, that you can overload the route() url helper. If you overload it, the parameters will be added as query parameters. Added section and example for this.

This will avoid people doing something similar to this. Which you can only know if you look deep in the code.

`route('index') . '?search=laravel'`