### PR TITLE
[8.x] Add max-time to example Supervisor config

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1008,7 +1008,7 @@ Supervisor configuration files are typically stored in the `/etc/supervisor/conf
 
     [program:laravel-worker]
     process_name=%(program_name)s_%(process_num)02d
-    command=php /home/forge/app.com/artisan queue:work sqs --sleep=3 --tries=3
+    command=php /home/forge/app.com/artisan queue:work sqs --sleep=3 --tries=3 --max-time=3600
     autostart=true
     autorestart=true
     user=forge


### PR DESCRIPTION
Many of us simply copy paste the example Supervisor config mentioned in the Laravel docs. I think we should add the `max-time` option in the example Supervisor config as it's a good practice to avoid memory leaks.