### PR TITLE
[8.x] Updated code block example on using event subscriber

### DIFF
--- a/events.md
+++ b/events.md
@@ -510,8 +510,12 @@ Alternatively, your subscriber's `subscribe` method may return an array of event
     public function subscribe()
     {
         return [
-            Login::class => [UserEventSubscriber::class, 'handleUserLogin'],
-            Logout::class => [UserEventSubscriber::class, 'handleUserLogout'],
+            Login::class => [
+                [UserEventSubscriber::class, 'handleUserLogin']
+            ],
+            Logout::class => [
+                [UserEventSubscriber::class, 'handleUserLogout']
+            ],
         ];
     }
 

--- a/events.md
+++ b/events.md
@@ -513,6 +513,7 @@ Alternatively, your subscriber's `subscribe` method may return an array of event
             Login::class => [
                 [UserEventSubscriber::class, 'handleUserLogin']
             ],
+
             Logout::class => [
                 [UserEventSubscriber::class, 'handleUserLogout']
             ],


### PR DESCRIPTION
The event dispatcher checks if `subscribe` method returns an array and if it does, it expects the returned array from the `subscribe` method to return an array of `events => listeners`

Reference: https://github.com/laravel/framework/blob/8.x/src/Illuminate/Events/Dispatcher.php#L176-L182

