### PR TITLE
[8.x] Improve allOnQueue() / allOnConnection() upgrade notes

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -241,7 +241,7 @@ For consistency with other dispatching methods, the `allOnQueue()` and `allOnCon
         new ReleasePodcast
     ])->onConnection('redis')->onQueue('podcasts')->dispatch();
 
-The `allOnQueue()` and `allOnConnection()` still exists when using `dispatch()` helper, which will create an instance of `PendingDispatch`.
+Note that this change only affects code using the `withChain` method. The `allOnQueue()` and `allOnConnection()` are still available when using the global `dispatch()` helper.
 
 <a name="failed-jobs-table-batch-support"></a>
 #### Failed Jobs Table Batch Support

--- a/upgrade.md
+++ b/upgrade.md
@@ -241,7 +241,7 @@ For consistency with other dispatching methods, the `allOnQueue()` and `allOnCon
         new ReleasePodcast
     ])->onConnection('redis')->onQueue('podcasts')->dispatch();
 
-The `allOnQueue()` and `allOnConnection()` still exists when using `dispatch()` helper, which will create an instance of `PendingDuspatch`.
+The `allOnQueue()` and `allOnConnection()` still exists when using `dispatch()` helper, which will create an instance of `PendingDispatch`.
 
 <a name="failed-jobs-table-batch-support"></a>
 #### Failed Jobs Table Batch Support

--- a/upgrade.md
+++ b/upgrade.md
@@ -241,6 +241,8 @@ For consistency with other dispatching methods, the `allOnQueue()` and `allOnCon
         new ReleasePodcast
     ])->onConnection('redis')->onQueue('podcasts')->dispatch();
 
+The `allOnQueue()` and `allOnConnection()` still exists when using `dispatch()` helper, which will create an instance of `PendingDuspatch`.
+
 <a name="failed-jobs-table-batch-support"></a>
 #### Failed Jobs Table Batch Support
 


### PR DESCRIPTION
Hi,

During the upgrade process, we've followed the guide, however we removed the references to the `allOnQueue()` and `allOnConnection()` from our code, but it that stopped the chain to process the next joib in the chain. 

Using these methods with the helper `dispatch()` returned the previous - correct - behaviour.

I don't know if this is going to be the way in the future, but just suggesting a note in the docs to help other people and avoid problems.

Thanks!