### PR TITLE
Update 'SetDefaultLocaleForUrls' Path

### DIFF
--- a/urls.md
+++ b/urls.md
@@ -193,7 +193,7 @@ The `$middlewarePriority` property is defined in the base `Illuminate\Foundation
      */
     protected $middlewarePriority = [
         // ...
-         \App\Http\MiddlewareSetDefaultLocaleForUrls::class,
+         \App\Http\Middleware\SetDefaultLocaleForUrls::class,
          \Illuminate\Routing\Middleware\SubstituteBindings::class,
          // ...
     ];


### PR DESCRIPTION
Adding a backslash after `App\Http\Middleware` in `\App\Http\MiddlewareSetDefaultLocaleForUrls::class` to update `SetDefaultLocaleForUrls` middleware path.