### PR TITLE
[8.x] Add Guzzle ^6.5 version constraint to upgrade

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -66,6 +66,8 @@ In addition, the Laravel installer has been updated to support `composer create-
 
 Finally, examine any other third-party packages consumed by your application and verify you are using the proper version for Laravel 8 support.
 
+> {tip} If any third-party packages do not yet have Guzzle 7 support, then you may use the `^6.5.5|^7.0.1` version constraint.
+
 ### Collections
 
 #### The `isset` Method


### PR DESCRIPTION
A tip should be added clarifying that Guzzle 6 is not unsupported as the updated dependency implies. As [pointed out by Graham](https://github.com/guzzle/command/pull/40#issuecomment-695216164), the docs are missleading and Laravel suggests the [`^6.5.5|^7.0.1`](https://github.com/laravel/framework/blob/8.x/composer.json#L135) constraint.