### PR TITLE
[8.x] Document horizon:forget

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -11,6 +11,7 @@
 - [Notifications](#notifications)
 - [Metrics](#metrics)
 - [Clearing Jobs From Queues](#clearing-jobs-from-queues)
+- [Deleting Failed Jobs](#deleting-failed-jobs)
 
 <a name="introduction"></a>
 ## Introduction
@@ -297,3 +298,10 @@ If you would like to delete all jobs from the default queue, you may do so using
 You may also provide the `queue` option to delete jobs from a specific queue:
 
     php artisan horizon:clear --queue=emails
+
+<a name="deleting-failed-jobs"></a>
+## Deleting Failed Jobs
+
+If you would like to delete a failed job, you may use the `horizon:forget` command:
+
+    php artisan horizon:forget 5

--- a/queues.md
+++ b/queues.md
@@ -1202,6 +1202,8 @@ To retry all of your failed jobs, execute the `queue:retry` command and pass `al
 
     php artisan queue:retry all
 
+> {tip} When using [Horizon](/docs/{{version}}/horizon), you should use the `horizon:forget` command to delete a failed job instead of the `queue:forget` command.
+
 If you would like to delete a failed job, you may use the `queue:forget` command:
 
     php artisan queue:forget 5


### PR DESCRIPTION
Document the `horizon:forget` command based on https://github.com/laravel/horizon/pull/896