### PR TITLE
updated docs to include information about what merging attributes doe…

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -726,6 +726,24 @@ The final, rendered HTML of the component will appear like the following:
         <!-- Contents of the $message variable -->
     </div>
 
+When passing through attributes that are not `class` they will be overwritten:
+
+    <div {{ $attributes->merge(['data-id' => 'alert']) }}>
+        {{ $message }}
+    </div>
+
+The `data-id` attribute is overwritten when we consume the component like so:
+
+    <x-alert data-id="success">
+        {{ $message }}
+    </x-alert>
+
+The final, rendered HTML of the component will appear like the following:
+
+    <div data-id="success">
+        <!-- Contents of the $message variable -->
+    </div>
+
 #### Filtering Attributes
 
 You may filter attributes using the `filter` method. This method accepts a Closure which should return `true` if you wish to retain the attribute in the attribute bag:

--- a/blade.md
+++ b/blade.md
@@ -726,7 +726,7 @@ The final, rendered HTML of the component will appear like the following:
         <!-- Contents of the $message variable -->
     </div>
 
-#### Non-Class Attributes
+#### Non-Class Attribute Merging
 
 When merging attributes that are not `class` attributes, the values provided to the `merge` method will be considered the "default" values of attribute which can be overwritten by the component's consumer. Unlike `class` attributes, non-class attributes are not appended to each other. For example, an `button` component may look like the following:
 

--- a/blade.md
+++ b/blade.md
@@ -726,23 +726,25 @@ The final, rendered HTML of the component will appear like the following:
         <!-- Contents of the $message variable -->
     </div>
 
-When passing through attributes that are not `class` they will be overwritten:
+#### Non-Class Attributes
 
-    <div {{ $attributes->merge(['data-id' => 'alert']) }}>
-        {{ $message }}
-    </div>
+When merging attributes that are not `class` attributes, the values provided to the `merge` method will be considered the "default" values of attribute which can be overwritten by the component's consumer. Unlike `class` attributes, non-class attributes are not appended to each other. For example, an `button` component may look like the following:
 
-The `data-id` attribute is overwritten when we consume the component like so:
+    <button {{ $attributes->merge(['type' => 'button']) }}>
+        {{ $slot }}
+    </button>
 
-    <x-alert data-id="success">
-        {{ $message }}
-    </x-alert>
+To render the button component with a custom `type`, it may be specified when consuming the component. If no type is specified, the `button` type will be used:
 
-The final, rendered HTML of the component will appear like the following:
+    <x-button type="submit">
+        Submit
+    </x-button>
 
-    <div data-id="success">
-        <!-- Contents of the $message variable -->
-    </div>
+The rendered HTML of the `button` component in this example would be:
+
+    <button type="submit">
+        Submit
+    </button>
 
 #### Filtering Attributes
 


### PR DESCRIPTION
This is in reference to issue in laravel/ideas#2345.

If it explains somewhere else in the docs that `class` attribute is merged differently then this is wholly unnecessary. But it would have saved me some time today if I had known that `class` was special cased. 