### PR TITLE
[8.x] Adds note about phpredis class conflict

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -114,6 +114,8 @@ The following dependencies are needed for the listed queue drivers:
 - Redis: `predis/predis ~1.0` or phpredis PHP extension
 </div>
 
+> {note} Using the phpredis extension will require you to rename the `Redis` Facade alias in your `app.php` config file, because it will conflict with the installed PHP `Redis` class name
+
 <a name="creating-jobs"></a>
 ## Creating Jobs
 


### PR DESCRIPTION
The default `Redis` Facade name conflicts with the class of the phpredis PHP extension (ref https://github.com/laravel/framework/issues/32007#issuecomment-600441581). I encountered this issue updating Homestead recently and I felt this note could save somebody else some time.