### PR TITLE
[8.x] Document path() method

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -10,6 +10,7 @@
 - [Retrieving Files](#retrieving-files)
     - [Downloading Files](#downloading-files)
     - [File URLs](#file-urls)
+    - [File Paths](#file-paths)
     - [File Metadata](#file-metadata)
 - [Storing Files](#storing-files)
     - [File Uploads](#file-uploads)
@@ -228,6 +229,15 @@ If you would like to pre-define the host for file URLs generated using the `Stor
         'url' => env('APP_URL').'/storage',
         'visibility' => 'public',
     ],
+
+<a name="file-paths"></a>
+### File Paths
+
+You may use the `path` method to get the path for the given file. If you are using the `local` driver, this will return an absolute path on the filesystem to the file. If you are using the `s3` driver, the relative path to the file in the S3 bucket will be returned:
+
+    use Illuminate\Support\Facades\Storage;
+
+    $path = Storage::path('file.jpg');
 
 <a name="file-metadata"></a>
 ### File Metadata


### PR DESCRIPTION
This PR documents the `Storage::path()` method and explains how the path is returned whether `local` or `s3` driver is used. I assumed this should be documented, as there are some components that require absolute path when accessing files (attaching files in notifications), and I feel `storage_path('app/'.$path)` is a bit clumsy.