### PR TITLE
[8.x] Clarify required timestamp columns for pivot tables

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -328,6 +328,8 @@ By default, only the model keys will be present on the `pivot` object. If your p
 If you want your pivot table to have automatically maintained `created_at` and `updated_at` timestamps, use the `withTimestamps` method on the relationship definition:
 
     return $this->belongsToMany('App\Models\Role')->withTimestamps();
+    
+> {note} When using timestamps on pivot tables, they are expected to have both `created_at` and `updated_at` timestamp columns. You cannot just have a `created_at` column.
 
 #### Customizing The `pivot` Attribute Name
 

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -329,7 +329,7 @@ If you want your pivot table to have automatically maintained `created_at` and `
 
     return $this->belongsToMany('App\Models\Role')->withTimestamps();
     
-> {note} When using timestamps on pivot tables, they are expected to have both `created_at` and `updated_at` timestamp columns. You cannot just have a `created_at` column.
+> {note} When using timestamps on pivot tables, the table is required to have both `created_at` and `updated_at` timestamp columns.
 
 #### Customizing The `pivot` Attribute Name
 


### PR DESCRIPTION
After researching https://github.com/laravel/framework/issues/34548 I've come to the conclusion that pivot tables always require both a `created_at` and `updated_at` column because of their behavior of inheriting parent timestamp column names. This isn't immediately clear because for regular Eloquent models you can disable them by setting `static::CREATED_AT` and/or `static::UPDATED_AT` to `null`. So it's best to clarify the specific behavior here.

It could also be that we just don't support setting these constants to `null` in the first place and that both a `created_at` and `updated_at` column are always required? If so, then I think we should explicitly state that somewhere in the docs.