### PR TITLE
[8.x] Update optional() example

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -2653,7 +2653,7 @@ The `optional` function accepts any argument and allows you to access properties
 The `optional` function also accepts a Closure as its second argument. The Closure will be invoked if the value provided as the first argument is not null:
 
     return optional(User::find($id), function ($user) {
-        return new DummyUser;
+        return $user->name;
     });
 
 <a name="method-policy"></a>


### PR DESCRIPTION
I find the `optional()` example when a Closure is provided as a second argument quite confusing. The callback is only executed if the user is not `null`. For that reason, returning a `DummyUser` seems silly. Returning a DummyUser would make sense if `optional`'s callback was used to determine the fallback value. But the fallback value is always `null` when a Closure is provided.

A more realistic example is:
```php
return optional(User::find($id), function ($user) {
    return $user->name
});
```

which is equivalent to the previous example:
```php
return optional(User::find($id))->name;
```

and makes a lot more sense from a practical viewpoint.