### PR TITLE
[8.x] Add mention of undocumented `$response->object()` method

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -35,6 +35,7 @@ The `get` method returns an instance of `Illuminate\Http\Client\Response`, which
 
     $response->body() : string;
     $response->json() : array|mixed;
+    $response->object() : object;
     $response->status() : int;
     $response->ok() : bool;
     $response->successful() : bool;


### PR DESCRIPTION
This method exists but is not mentioned in the documentation.