### PR TITLE
[8.x] decodeResponseJson is a breaking change

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -362,12 +362,12 @@ The `Illuminate\Contracts\Session\Session` contract has received a new `pull` me
 
 ### Testing
 
-<a name="assert-exact-json-method"></a>
+<a name="decode-response-json-method"></a>
 #### The `decodeResponseJson` Method
 
-**Likelihood Of Impact: High**
+**Likelihood Of Impact: Low**
 
-The `decodeResponseJson` method now will not take parameters anymore, it will only print the full json, you may use the `json` method instead.
+The `decodeResponseJson` method that belongs to the `Illuminate\Testing\TestResponse` class no longer accepts any arguments. Please consider using the `json` method instead.
 
 <a name="assert-exact-json-method"></a>
 #### The `assertExactJson` Method

--- a/upgrade.md
+++ b/upgrade.md
@@ -363,6 +363,13 @@ The `Illuminate\Contracts\Session\Session` contract has received a new `pull` me
 ### Testing
 
 <a name="assert-exact-json-method"></a>
+#### The `decodeResponseJson` Method
+
+**Likelihood Of Impact: High**
+
+The `decodeResponseJson` method now will not take parameters anymore, it will only print the full json, you may use the `json` method instead.
+
+<a name="assert-exact-json-method"></a>
 #### The `assertExactJson` Method
 
 **Likelihood Of Impact: Medium**


### PR DESCRIPTION
As decodeResponseJson does not requires paramaters anymore, we should instead, use `json`