### PR TITLE
[8.x] Document missing Telescope Batch Watcher and View Watcher

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -12,6 +12,7 @@
     - [Batches](#filtering-batches)
 - [Tagging](#tagging)
 - [Available Watchers](#available-watchers)
+    - [Batch Watcher](#batch-watcher)
     - [Cache Watcher](#cache-watcher)
     - [Command Watcher](#command-watcher)
     - [Dump Watcher](#dump-watcher)
@@ -27,6 +28,7 @@
     - [Redis Watcher](#redis-watcher)
     - [Request Watcher](#request-watcher)
     - [Schedule Watcher](#schedule-watcher)
+    - [View Watcher](#view-watcher)
 - [Displaying User Avatars](#displaying-user-avatars)
 
 <a name="introduction"></a>
@@ -254,6 +256,11 @@ Some watchers also allow you to provide additional customization options:
         ...
     ],
 
+<a name="batch-watcher"></a>
+### Batch Watcher
+
+The batch watcher records the batch data, queue and connection when a batch of jobs is dispatched.
+
 <a name="cache-watcher"></a>
 ### Cache Watcher
 
@@ -368,6 +375,11 @@ The request watcher records the request, headers, session, and response data ass
 ### Schedule Watcher
 
 The schedule watcher records the command and output of any scheduled tasks run by your application.
+
+<a name="view-watcher"></a>
+### View Watcher
+
+The view watcher records the view, path, view data and view composers when rendering any kind of view, including partials, layouts or full views.
 
 <a name="displaying-user-avatars"></a>
 ## Displaying User Avatars

--- a/telescope.md
+++ b/telescope.md
@@ -259,7 +259,7 @@ Some watchers also allow you to provide additional customization options:
 <a name="batch-watcher"></a>
 ### Batch Watcher
 
-The batch watcher records the batch data, queue and connection when a batch of jobs is dispatched.
+The batch watcher records information about queued batches, including the job and connection information.
 
 <a name="cache-watcher"></a>
 ### Cache Watcher
@@ -379,7 +379,7 @@ The schedule watcher records the command and output of any scheduled tasks run b
 <a name="view-watcher"></a>
 ### View Watcher
 
-The view watcher records the view, path, view data and view composers when rendering any kind of view, including partials, layouts or full views.
+The view watcher records the view name, path, data, and "composers" used when rendering views.
 
 <a name="displaying-user-avatars"></a>
 ## Displaying User Avatars


### PR DESCRIPTION
Documents two missing watchers in the Telescope docs: Batch Watcher and View Watcher