### PR TITLE
[8.x] Document Artisan Events - take 2

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -19,6 +19,7 @@
 - [Programmatically Executing Commands](#programmatically-executing-commands)
     - [Calling Commands From Other Commands](#calling-commands-from-other-commands)
 - [Stub Customization](#stub-customization)
+- [Events](#events)
 
 <a name="introduction"></a>
 ## Introduction
@@ -530,3 +531,8 @@ The Artisan console's `make` commands are used to create a variety of classes, s
     php artisan stub:publish
 
 The published stubs will be located within a `stubs` directory in the root of your application. Any changes you make to these stubs will be reflected when you generate their corresponding classes using Artisan `make` commands.
+
+<a name="events"></a>
+## Events
+
+Artisan dispatches three events when running commands: `Illuminate\Console\Events\ArtisanStarting`, `Illuminate\Console\Events\CommandStarting` and `Illuminate\Console\Events\CommandFinished`. The `ArtisanStarting` event is dispatched immediately when Artisan starts running. Next, the `CommandStarting` event is dispatched right before a command runs. Finally, the `CommandFinished` event is dispatched once a command finishes executing.


### PR DESCRIPTION
Submitting this one again since something seems to have gone wrong in the original PR (#6432). I am not actually removing any lines from the file, even though the GitHub diff view makes it appear that way.

If you look at the rich diff view and the line count you can see that this diff only adds content.

Anyways: this diff documents the previously undocumented events that Artisan dispatches when a command is run.

### Plain Diff
<img width="1662" alt="Screenshot 2020-10-02 at 10 43 48" src="https://user-images.githubusercontent.com/203914/94910173-3d9c6100-049c-11eb-9f64-15c8e0cccc95.png">

### Rich Diff
<img width="1667" alt="Screenshot 2020-10-02 at 10 43 42" src="https://user-images.githubusercontent.com/203914/94910207-4a20b980-049c-11eb-87cf-c351b6725686.png">
