### PR TITLE
[8.x] Updated a few factory declarations to the new syntax

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -211,7 +211,7 @@ To get started, let's write a test that verifies we can log into our application
          */
         public function testBasicExample()
         {
-            $user = factory(User::class)->create([
+            $user = User::factory()->create([
                 'email' => 'taylor@laravel.com',
             ]);
 

--- a/facades.md
+++ b/facades.md
@@ -218,7 +218,7 @@ When the real-time facade is used, the publisher implementation will be resolved
          */
         public function test_podcast_can_be_published()
         {
-            $podcast = factory(Podcast::class)->create();
+            $podcast = Podcast::factory()->create();
 
             Publisher::shouldReceive('publish')->once()->with($podcast);
 


### PR DESCRIPTION
I was updating a project to laravel 8 and I noticed some of the docs pages had references to the old factory syntax.