### PR TITLE
[8.x] Add warning to `migrate:fresh`

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -154,6 +154,8 @@ The `migrate:fresh` command will drop all tables from the database and then exec
 
     php artisan migrate:fresh --seed
 
+> {note} The `migrate:fresh` command does not respect the database prefix. Consider this carefully when developing on a database which is shared by other applications.
+
 <a name="tables"></a>
 ## Tables
 

--- a/migrations.md
+++ b/migrations.md
@@ -154,7 +154,7 @@ The `migrate:fresh` command will drop all tables from the database and then exec
 
     php artisan migrate:fresh --seed
 
-> {note} The `migrate:fresh` command does not respect the database prefix. Consider this carefully when developing on a database which is shared by other applications.
+> {note} The `migrate:fresh` command will drop all database tables regardless of their prefix. This command should be used with caution when developing on a database that is shared with other applications.
 
 <a name="tables"></a>
 ## Tables


### PR DESCRIPTION
For one reason or another you might have tables in the database that you don't want to be managed by Laravel migrations even when developing. In those cases `migrate:fresh` should not be used.

Adding a warning  as suggested in [this comment](https://github.com/laravel/framework/issues/27851#issuecomment-693351362).