### PR TITLE
[8.x] Dusk - document `waitForTextIn` and `tinker` methods

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -16,6 +16,7 @@
     - [Taking A Screenshot](#taking-a-screenshot)
     - [Storing Console Output To Disk](#storing-console-output-to-disk)
     - [Storing Page Source To Disk](#storing-page-source-to-disk)
+    - [Laravel Tinker](#laravel-tinker)
 - [Interacting With Elements](#interacting-with-elements)
     - [Dusk Selectors](#dusk-selectors)
     - [Clicking Links](#clicking-links)
@@ -377,6 +378,15 @@ You may use the `storeConsoleLog` method to write the console output to disk wit
 You may use the `storeSource` method to write the page's current source to disk with the given filename. The page source will be stored within the `tests/Browser/source` directory:
 
     $browser->storeSource('filename');
+
+<a name="laravel-tinker"></a>
+### Laravel Tinker
+
+For those using Tinker you may use the `tinker` method to temporarily pause Dusk and its tests until Tinker can open.
+
+    $browser->visitRoute('login')
+        ->tinker()
+        ->assertSee('Hello World');
 
 <a name="interacting-with-elements"></a>
 ## Interacting With Elements

--- a/dusk.md
+++ b/dusk.md
@@ -87,7 +87,7 @@ If you would like to install a different version of ChromeDriver than what is in
 
     # Install a given version of ChromeDriver for all supported OSs...
     php artisan dusk:chrome-driver --all
-    
+
     # Install the version of ChromeDriver that matches the detected version of Chrome / Chromium for your OS...
     php artisan dusk:chrome-driver --detect
 
@@ -647,8 +647,10 @@ The `waitFor` method may be used to pause the execution of the test until the el
 
 You may also wait until the given selector is missing from the page:
 
+    // Wait a maximum of five seconds until the selector is missing...
     $browser->waitUntilMissing('.selector');
 
+    // Wait a maximum of one second until the selector is missing...
     $browser->waitUntilMissing('.selector', 1);
 
 #### Scoping Selectors When Available

--- a/dusk.md
+++ b/dusk.md
@@ -645,6 +645,14 @@ The `waitFor` method may be used to pause the execution of the test until the el
     // Wait a maximum of one second for the selector...
     $browser->waitFor('.selector', 1);
 
+You may also wait until the selector contains the given text:
+
+    // Wait a maximum of five seconds for the selector to contain the given text...
+    $browser->waitForTextIn('.selector', 'Hello World');
+
+    // Wait a maximum of one second for the selector to contain the given text...
+    $browser->waitForTextIn('.selector', 'Hello World', 1);
+
 You may also wait until the given selector is missing from the page:
 
     // Wait a maximum of five seconds until the selector is missing...


### PR DESCRIPTION
## Dusk

- Document `waitForTextIn` method (https://github.com/laravel/dusk/pull/823)
- Document `tinker` method (https://github.com/laravel/dusk/pull/266)