### PR TITLE
captalize `Extension` word in a item in installation.md required extensions

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -22,7 +22,7 @@ However, if you are not using Homestead, you will need to make sure your server 
 - PHP >= 7.3
 - BCMath PHP Extension
 - Ctype PHP Extension
-- Fileinfo PHP extension
+- Fileinfo PHP Extension
 - JSON PHP Extension
 - Mbstring PHP Extension
 - OpenSSL PHP Extension


### PR DESCRIPTION
an item in installation required extensions list is not sync with anothers. this changed from 'extension' to 'Extension' to be sync with another items in list.