### PR TITLE
Added notice about Laravel UI

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -31,7 +31,7 @@ Laravel 8 continues the improvements made in Laravel 7.x by introducing Laravel 
 
 _Laravel Jetstream was written by [Taylor Otwell](https://github.com/taylorotwell)_.
 
-[Laravel Jetstream](https://jetstream.laravel.com) is a beautifully designed application scaffolding for Laravel. Jetstream provides the perfect starting point for your next project and includes login, registration, email verification, two-factor authentication, session management, API support via Laravel Sanctum, and optional team management. Laravel Jetstream replaces and improves upon the legacy authentication UI scaffolding available for previous versions of Laravel. 
+[Laravel Jetstream](https://jetstream.laravel.com) is a beautifully designed application scaffolding for Laravel. Jetstream provides the perfect starting point for your next project and includes login, registration, email verification, two-factor authentication, session management, API support via Laravel Sanctum, and optional team management. Laravel Jetstream replaces and improves upon the legacy authentication UI scaffolding available for previous versions of Laravel.
 
 Jetstream is designed using [Tailwind CSS](https://tailwindcss.com) and offers your choice of [Livewire](https://laravel-livewire.com) or [Inertia](https://inertiajs.com) scaffolding.
 

--- a/releases.md
+++ b/releases.md
@@ -31,9 +31,11 @@ Laravel 8 continues the improvements made in Laravel 7.x by introducing Laravel 
 
 _Laravel Jetstream was written by [Taylor Otwell](https://github.com/taylorotwell)_.
 
-[Laravel Jetstream](https://jetstream.laravel.com) is a beautifully designed application scaffolding for Laravel. Jetstream provides the perfect starting point for your next project and includes login, registration, email verification, two-factor authentication, session management, API support via Laravel Sanctum, and optional team management. Laravel Jetstream replaces and improves upon the legacy authentication UI scaffolding available for previous versions of Laravel.
+[Laravel Jetstream](https://jetstream.laravel.com) is a beautifully designed application scaffolding for Laravel. Jetstream provides the perfect starting point for your next project and includes login, registration, email verification, two-factor authentication, session management, API support via Laravel Sanctum, and optional team management. Laravel Jetstream replaces and improves upon the legacy authentication UI scaffolding available for previous versions of Laravel. 
 
 Jetstream is designed using [Tailwind CSS](https://tailwindcss.com) and offers your choice of [Livewire](https://laravel-livewire.com) or [Inertia](https://inertiajs.com) scaffolding.
+
+For Auth scaffolding, you can still use [Laravel UI](https://github.com/laravel/ui) package in Laravel 8, but it is considered legacy and not planned to be maintained further.
 
 ### Models Directory
 


### PR DESCRIPTION
From what I've read on my Youtube channel and Twitter, people don't understand that you still can use Laravel UI with Laravel 8. It's not mentioned anywhere in the docs.

So I think this notice would be helpful to those coming from Laravel 7 scaffolding. I'm just not sure about the exact wording, sorry if I misphrased something, feel free to edit.

Thanks for considering!