### PR TITLE
Fix very small typo

### DIFF
--- a/lifecycle.md
+++ b/lifecycle.md
@@ -18,7 +18,7 @@ The goal of this document is to give you a good, high-level overview of how the 
 
 The entry point for all requests to a Laravel application is the `public/index.php` file. All requests are directed to this file by your web server (Apache / Nginx) configuration. The `index.php` file doesn't contain much code. Rather, it is a starting point for loading the rest of the framework.
 
-The `index.php` file loads the Composer generated autoloader definition, and then retrieves an instance of the Laravel application from `bootstrap/app.php` script. The first action taken by Laravel itself is to create an instance of the application / [service container](/docs/{{version}}/container).
+The `index.php` file loads the Composer generated autoloader definition, and then retrieves an instance of the Laravel application from `bootstrap/app.php`. The first action taken by Laravel itself is to create an instance of the application / [service container](/docs/{{version}}/container).
 
 ### HTTP / Console Kernels
 


### PR DESCRIPTION
  * The word "script" in this sentence is out of place because the sentence is referring to `bootstrap/app.php` as a distinct thing,
     but it would be alright to say "the `bootstrap/app.php` script".
  * Removing the word "script" seems like the better choice because now it matches the phrasing of the next paragraph that says,
    "let's just focus on the HTTP kernel, which is located in `app/Http/Kernel.php`"