### PR TITLE
[8.x] Explain middleware not ran when faking HTTP client

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -212,7 +212,7 @@ For example, to instruct the HTTP client to return empty, `200` status code resp
 
     $response = Http::post(...);
     
-> {note} When faking requests, any middleware applied to the HTTP client isn't run. You should set expectations for your faked responses as if these middleware have run correctly.
+> {note} When faking requests, HTTP client middleware are not executed. You should define expectations for faked responses as if these middleware have run correctly.
 
 #### Faking Specific URLs
 

--- a/http-client.md
+++ b/http-client.md
@@ -211,6 +211,8 @@ For example, to instruct the HTTP client to return empty, `200` status code resp
     Http::fake();
 
     $response = Http::post(...);
+    
+> {note} When faking requests, any middleware applied to the HTTP client isn't run. You should set expectations for your faked responses as if these middleware have run correctly.
 
 #### Faking Specific URLs
 


### PR DESCRIPTION
Explanation for https://github.com/laravel/framework/issues/34505 & https://github.com/laravel/framework/pull/34666