### PR TITLE
[8.x] Update support policy

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -14,11 +14,11 @@ When referencing the Laravel framework or its components from your application o
 <a name="support-policy"></a>
 ## Support Policy
 
-For LTS releases, such as Laravel 6, bug fixes are provided for 2 years and security fixes are provided for 3 years. These releases provide the longest window of support and maintenance. For general releases, bug fixes are provided for 6 months and security fixes are provided for 1 year. For all additional libraries, including Lumen, only the latest release receives bug fixes. In addition, please review the database versions [supported by Laravel](/docs/{{version}}/database#introduction).
+For LTS releases, such as Laravel 6, bug fixes are provided for 2 years and security fixes are provided for 3 years. These releases provide the longest window of support and maintenance. For general releases, bug fixes are provided for 7 months and security fixes are provided for 1 year. For all additional libraries, including Lumen, only the latest release receives bug fixes. In addition, please review the database versions [supported by Laravel](/docs/{{version}}/database#introduction).
 
 | Version | Release | Bug Fixes Until | Security Fixes Until |
 | --- | --- | --- | --- |
-| 6 (LTS) | September 3rd, 2019 | September 3rd, 2021 | September 3rd, 2022 |
+| 6 (LTS) | September 3rd, 2019 | October 5th, 2021 | September 3rd, 2022 |
 | 7 | March 3rd, 2020 | October 6th, 2020 | March 3rd, 2021 |
 | 8 | September 8th, 2020 | April 6th, 2021 | September 8th, 2021 |
 


### PR DESCRIPTION
Two changes here:

- We decided recently to always provide at least one month of support for a previous major version series after a new one was released to give people some time to transition. Which means we provide bug fixes up to 7 months after a new major release was done.
- In regard to the above I've extended the bug fixing period for Laravel 6 LTS by one month so people have time to upgrade to the new Laravel 10 LTS version.