### PR TITLE
[8.x] Removed the ' after class

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -411,7 +411,7 @@ To manually log users out of your application, you may use the `logout` method o
 
 Laravel also provides a mechanism for invalidating and "logging out" a user's sessions that are active on other devices without invalidating the session on their current device. This feature is typically utilized when a user is changing or updating their password and you would like to invalidate sessions on other devices while keeping the current device authenticated.
 
-Before getting started, you should make sure that the `Illuminate\Session\Middleware\AuthenticateSession` middleware is present and un-commented in your `app/Http/Kernel.php` class' `web` middleware group:
+Before getting started, you should make sure that the `Illuminate\Session\Middleware\AuthenticateSession` middleware is present and un-commented in your `app/Http/Kernel.php` class `web` middleware group:
 
     'web' => [
         // ...

--- a/broadcasting.md
+++ b/broadcasting.md
@@ -401,7 +401,7 @@ Next, register your channel in your `routes/channels.php` file:
 
     Broadcast::channel('order.{order}', OrderChannel::class);
 
-Finally, you may place the authorization logic for your channel in the channel class' `join` method. This `join` method will house the same logic you would have typically placed in your channel authorization Closure. You may also take advantage of channel model binding:
+Finally, you may place the authorization logic for your channel in the channel class `join` method. This `join` method will house the same logic you would have typically placed in your channel authorization Closure. You may also take advantage of channel model binding:
 
     <?php
 

--- a/container.md
+++ b/container.md
@@ -258,7 +258,7 @@ If you are in a location of your code that does not have access to the `$app` va
 
     $api = resolve('HelpSpot\API');
 
-If some of your class' dependencies are not resolvable via the container, you may inject them by passing them as an associative array into the `makeWith` method:
+If some of your class dependencies are not resolvable via the container, you may inject them by passing them as an associative array into the `makeWith` method:
 
     $api = $this->app->makeWith('HelpSpot\API', ['id' => 1]);
 

--- a/contracts.md
+++ b/contracts.md
@@ -22,14 +22,14 @@ All of the Laravel contracts live in [their own GitHub repository](https://githu
 
 Laravel's [facades](/docs/{{version}}/facades) and helper functions provide a simple way of utilizing Laravel's services without needing to type-hint and resolve contracts out of the service container. In most cases, each facade has an equivalent contract.
 
-Unlike facades, which do not require you to require them in your class' constructor, contracts allow you to define explicit dependencies for your classes. Some developers prefer to explicitly define their dependencies in this way and therefore prefer to use contracts, while other developers enjoy the convenience of facades.
+Unlike facades, which do not require you to require them in your class constructor, contracts allow you to define explicit dependencies for your classes. Some developers prefer to explicitly define their dependencies in this way and therefore prefer to use contracts, while other developers enjoy the convenience of facades.
 
 > {tip} Most applications will be fine regardless of whether you prefer facades or contracts. However, if you are building a package, you should strongly consider using contracts since they will be easier to test in a package context.
 
 <a name="when-to-use-contracts"></a>
 ## When To Use Contracts
 
-As discussed elsewhere, much of the decision to use contracts or facades will come down to personal taste and the tastes of your development team. Both contracts and facades can be used to create robust, well-tested Laravel applications. As long as you are keeping your class' responsibilities focused, you will notice very few practical differences between using contracts and facades.
+As discussed elsewhere, much of the decision to use contracts or facades will come down to personal taste and the tastes of your development team. Both contracts and facades can be used to create robust, well-tested Laravel applications. As long as you are keeping your class responsibilities focused, you will notice very few practical differences between using contracts and facades.
 
 However, you may still have several questions regarding contracts. For example, why use interfaces at all? Isn't using interfaces more complicated? Let's distill the reasons for using interfaces to the following headings: loose coupling and simplicity.
 

--- a/mail.md
+++ b/mail.md
@@ -110,14 +110,14 @@ In Laravel, each type of email sent by your application is represented as a "mai
 <a name="writing-mailables"></a>
 ## Writing Mailables
 
-All of a mailable class' configuration is done in the `build` method. Within this method, you may call various methods such as `from`, `subject`, `view`, and `attach` to configure the email's presentation and delivery.
+All of a mailable class configuration is done in the `build` method. Within this method, you may call various methods such as `from`, `subject`, `view`, and `attach` to configure the email's presentation and delivery.
 
 <a name="configuring-the-sender"></a>
 ### Configuring The Sender
 
 #### Using The `from` Method
 
-First, let's explore configuring the sender of the email. Or, in other words, who the email is going to be "from". There are two ways to configure the sender. First, you may use the `from` method within your mailable class' `build` method:
+First, let's explore configuring the sender of the email. Or, in other words, who the email is going to be "from". There are two ways to configure the sender. First, you may use the `from` method within your mailable class `build` method:
 
     /**
      * Build the message.
@@ -143,7 +143,7 @@ In addition, you may define a global "reply_to" address within your `config/mail
 <a name="configuring-the-view"></a>
 ### Configuring The View
 
-Within a mailable class' `build` method, you may use the `view` method to specify which template should be used when rendering the email's contents. Since each email typically uses a [Blade template](/docs/{{version}}/blade) to render its contents, you have the full power and convenience of the Blade templating engine when building your email's HTML:
+Within a mailable class `build` method, you may use the `view` method to specify which template should be used when rendering the email's contents. Since each email typically uses a [Blade template](/docs/{{version}}/blade) to render its contents, you have the full power and convenience of the Blade templating engine when building your email's HTML:
 
     /**
      * Build the message.
@@ -177,7 +177,7 @@ If you would like to define a plain-text version of your email, you may use the 
 
 #### Via Public Properties
 
-Typically, you will want to pass some data to your view that you can utilize when rendering the email's HTML. There are two ways you may make data available to your view. First, any public property defined on your mailable class will automatically be made available to the view. So, for example, you may pass data into your mailable class' constructor and set that data to public properties defined on the class:
+Typically, you will want to pass some data to your view that you can utilize when rendering the email's HTML. There are two ways you may make data available to your view. First, any public property defined on your mailable class will automatically be made available to the view. So, for example, you may pass data into your mailable class constructor and set that data to public properties defined on the class:
 
     <?php
 
@@ -229,7 +229,7 @@ Once the data has been set to a public property, it will automatically be availa
 
 #### Via The `with` Method:
 
-If you would like to customize the format of your email's data before it is sent to the template, you may manually pass your data to the view via the `with` method. Typically, you will still pass data via the mailable class' constructor; however, you should set this data to `protected` or `private` properties so the data is not automatically made available to the template. Then, when calling the `with` method, pass an array of data that you wish to make available to the template:
+If you would like to customize the format of your email's data before it is sent to the template, you may manually pass your data to the view via the `with` method. Typically, you will still pass data via the mailable class constructor; however, you should set this data to `protected` or `private` properties so the data is not automatically made available to the template. Then, when calling the `with` method, pass an array of data that you wish to make available to the template:
 
     <?php
 
@@ -286,7 +286,7 @@ Once the data has been passed to the `with` method, it will automatically be ava
 <a name="attachments"></a>
 ### Attachments
 
-To add attachments to an email, use the `attach` method within the mailable class' `build` method. The `attach` method accepts the full path to the file as its first argument:
+To add attachments to an email, use the `attach` method within the mailable class `build` method. The `attach` method accepts the full path to the file as its first argument:
 
     /**
      * Build the message.


### PR DESCRIPTION
Don't know if this is a spelling thing or it was just a search replace issue in the past. But I don't see a `'` everywhere, for example I don't see it here: https://laravel.com/docs/8.x/blade (search for `class constructor`).

If this one gets merged I can create PR's for the other branches?