### PR TITLE
Use the default traits of User in the example

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -83,7 +83,7 @@ After running the `passport:install` command, add the `Laravel\Passport\HasApiTo
 
     class User extends Authenticatable
     {
-        use HasApiTokens, Notifiable;
+        use HasApiTokens, Notifiable, HasFactory;
     }
 
 Next, you should call the `Passport::routes` method within the `boot` method of your `AuthServiceProvider`. This method will register the routes necessary to issue access tokens and revoke access tokens, clients, and personal access tokens:

--- a/passport.md
+++ b/passport.md
@@ -83,7 +83,7 @@ After running the `passport:install` command, add the `Laravel\Passport\HasApiTo
 
     class User extends Authenticatable
     {
-        use HasApiTokens, Notifiable, HasFactory;
+        use HasApiTokens, HasFactory, Notifiable;
     }
 
 Next, you should call the `Passport::routes` method within the `boot` method of your `AuthServiceProvider`. This method will register the routes necessary to issue access tokens and revoke access tokens, clients, and personal access tokens:


### PR DESCRIPTION
In 8.x the default User model have the `HasFactory` trait by default. 
It should be reflected in the example given by the documentation in the same way as the `Notifiable` one.