### PR TITLE
[6.x] update Prefer String And Array Classes Over Helpers

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -285,6 +285,10 @@ All `str_` and `array_` helpers have been moved to the new `laravel/helpers` Com
 
     composer require laravel/helpers
 
+If you do not use the new `laravel/helpers` package do not forget to clear the views that were compiled using the old helper methods after updating to Laravel 6.x.
+
+    php artisan view:clear
+
 ### Localization
 
 <a name="trans-and-trans-choice"></a>

--- a/upgrade.md
+++ b/upgrade.md
@@ -285,7 +285,7 @@ All `str_` and `array_` helpers have been moved to the new `laravel/helpers` Com
 
     composer require laravel/helpers
 
-If you do not use the new `laravel/helpers` package do not forget to clear the views that were compiled using the old helper methods after updating to Laravel 6.x.
+If you choose to update your Laravel application's views to use the class based methods, you should clear your compiled views which may still be using the global helpers:
 
     php artisan view:clear
 


### PR DESCRIPTION
I ran exactly into that problem while updating from 5.x to 8

Can you please label the the pull request ‘hacktoberfest-accepted’

https://hacktoberfest.digitalocean.com/hacktoberfest-update