### PR TITLE
[5.8] update Prefer String And Array Classes Over Helpers

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -528,6 +528,10 @@ All `array_*` and `str_*` global helpers [have been deprecated](https://github.c
 
 The impact of this change has been marked as `medium` since the helpers have been moved to the new [laravel/helpers](https://github.com/laravel/helpers) package which offers a backwards compatibility layer for all of the global array and string functions.
 
+After updating Laravel do not forget to clear the views that were compiled using the old helper methods.
+
+    php artisan view:clear
+
 <a name="deferred-service-providers"></a>
 #### Deferred Service Providers
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -528,7 +528,7 @@ All `array_*` and `str_*` global helpers [have been deprecated](https://github.c
 
 The impact of this change has been marked as `medium` since the helpers have been moved to the new [laravel/helpers](https://github.com/laravel/helpers) package which offers a backwards compatibility layer for all of the global array and string functions.
 
-After updating Laravel do not forget to clear the views that were compiled using the old helper methods.
+If you choose to update your Laravel application's views to use the class based methods, you should clear your compiled views which may still be using the global helpers:
 
     php artisan view:clear
 


### PR DESCRIPTION
I ran exactly into that problem while updating from 5.x to 8

Can you please label the the pull request ‘hacktoberfest-accepted’

https://hacktoberfest.digitalocean.com/hacktoberfest-update