### PR TITLE
[8.x] Add missing article

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -173,7 +173,7 @@ You may call the `input` method without any arguments in order to retrieve all o
 
 #### Retrieving Input From The Query String
 
-While the `input` method retrieves values from entire request payload (including the query string), the `query` method will only retrieve values from the query string:
+While the `input` method retrieves values from the entire request payload (including the query string), the `query` method will only retrieve values from the query string:
 
     $name = $request->query('name');
 


### PR DESCRIPTION
  * The word "the" is missing before "entire request payload". Even though so many noun phrases in this sentence are already preceded with "the", the only noun phrase where "the" seems optional is "values". Anywhere else, it seems quite necessary.