### PR TITLE
Add version to SES config example code

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -81,6 +81,7 @@ Next, set the `default` option in your `config/mail.php` configuration file to `
         'key' => 'your-ses-key',
         'secret' => 'your-ses-secret',
         'region' => 'ses-region',  // e.g. us-east-1
+        'version' => 'aws-sdk-api-version', // e.g. 2010-12-01
     ],
 
 If you need to include [additional options](https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-email-2010-12-01.html#sendrawemail) when executing the SES `SendRawEmail` request, you may define an `options` array within your `ses` configuration:


### PR DESCRIPTION
Given that the version is required in AWS SDK configuration, maybe it makes sense to have it in the config example code. That would save some time for the developer to check what key should add to the config array.

Ref:
https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/getting-started_migration.html