### PR TITLE
[8.x] Add `newLine()` method to Artisan Console docs

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -393,6 +393,12 @@ If you would like to display plain, uncolored console output, use the `line` met
 
     $this->line('Display this on the screen');
 
+To display a blank line, use the `newLine` method:
+
+    $this->newLine();
+
+You may optionally pass an integer to `newLine` to specify how many blank lines you would like to display.
+
 #### Table Layouts
 
 The `table` method makes it easy to correctly format multiple rows / columns of data. Just pass in the headers and rows to the method. The width and height will be dynamically calculated based on the given data:

--- a/artisan.md
+++ b/artisan.md
@@ -393,11 +393,12 @@ If you would like to display plain, uncolored console output, use the `line` met
 
     $this->line('Display this on the screen');
 
-To display a blank line, use the `newLine` method:
+You may use the `newLine` method to display a blank line:
 
     $this->newLine();
 
-You may optionally pass an integer to `newLine` to specify how many blank lines you would like to display.
+    // Write three blank lines...
+    $this->newLine(3);
 
 #### Table Layouts
 


### PR DESCRIPTION
This adds `newLine()` to the Artisan Console docs (from [this PR](https://github.com/laravel/framework/pull/34754))