### PR TITLE
Fix castUsing signature to respect the Castable inferface

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -427,7 +427,7 @@ Objects that implement the `Castable` interface must define a `castUsing` method
          *
          * @return string
          */
-        public static function castUsing()
+        public static function castUsing(array $arguments)
         {
             return AddressCast::class;
         }

--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -425,6 +425,7 @@ Objects that implement the `Castable` interface must define a `castUsing` method
         /**
          * Get the name of the caster class to use when casting from / to this cast target.
          *
+         * @param  array  $arguments
          * @return string
          */
         public static function castUsing(array $arguments)


### PR DESCRIPTION
`\Illuminate\Contracts\Database\Eloquent\Castable` interface defines the `castUsing` method with an `$arguments` parameter of type array.