### PR TITLE
[8.x] Clarify when env() returns null after caching

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -77,7 +77,7 @@ When deploying your application to production, you should make sure that you run
 
 This command will combine all of Laravel's configuration files into a single, cached file, which greatly reduces the number of trips the framework must make to the filesystem when loading your configuration values.
 
-> {note} If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded and all calls to the `env` function will return `null`.
+> {note} If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded and all calls to the `env` function for `.env` variables will return `null`.
 
 <a name="optimizing-route-loading"></a>
 ### Optimizing Route Loading


### PR DESCRIPTION
I realized that I had misunderstood the current docs for quite a while. I had interpreted the highlighted section below such that `env()` always returns null after running `config:cache`, but this only applies to variables in `.env`, not in the server runtime.

![image](https://user-images.githubusercontent.com/25909128/95832563-b8863700-0d3a-11eb-9e07-a23b0053b6d6.png)

I realize that a common convention is to map runtime environment variables to config values, but I have a use case where that is not possible. Our build process generates a docker image with the `config:cache` already run, before any runtime variables exists.
