### PR TITLE
Add note on using dropForeign method

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -518,6 +518,8 @@ To drop a foreign key, you may use the `dropForeign` method, passing the foreign
 Alternatively, you may pass an array containing the column name that holds the foreign key to the `dropForeign` method. The array will be automatically converted using the constraint name convention used by Laravel's schema builder:
 
     $table->dropForeign(['user_id']);
+    
+> {note} The `dropForeign` method doesn't drop the actual foreign key column, to do so you should add `$table->dropColumn('user_id')` after the `dropForeign` method.
 
 You may enable or disable foreign key constraints within your migrations by using the following methods:
 


### PR DESCRIPTION
Reading the [docs](https://laravel.com/docs/8.x/migrations#foreign-key-constraints) I was confused why after rolling back a migration using `dropForeign` method I had success but the field in the database was still there.

After experimenting a bit I noticed that we **must** always use `dropColumn` alongside this method to properly delete the foreign constraint and the column.

**Note:** as I don't have a good English vocabulary I would appreciate if you would review this address any points related to this PR.