### PR TITLE
[8.x] Clarify upsert index requirement

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -629,7 +629,7 @@ If you would like to perform multiple "upserts" in a single query, then you shou
         ['departure' => 'Chicago', 'destination' => 'New York', 'price' => 150]
     ], ['departure', 'destination'], ['price']);
 
-> {note} All databases except SQL Server require the columns in the second argument of the `upsert` method to have a PRIMARY or UNIQUE index.
+> {note} All databases except SQL Server require the columns in the second argument of the `upsert` method to have a "primary" or "unique" index.
 
 <a name="deleting-models"></a>
 ## Deleting Models

--- a/eloquent.md
+++ b/eloquent.md
@@ -629,6 +629,8 @@ If you would like to perform multiple "upserts" in a single query, then you shou
         ['departure' => 'Chicago', 'destination' => 'New York', 'price' => 150]
     ], ['departure', 'destination'], ['price']);
 
+> {note} All databases except SQL Server require the columns in the second argument of the `upsert` method to have a PRIMARY or UNIQUE index.
+
 <a name="deleting-models"></a>
 ## Deleting Models
 

--- a/queries.md
+++ b/queries.md
@@ -701,6 +701,8 @@ The `upsert` method will insert rows that do not exist and update the rows that 
         ['departure' => 'Chicago', 'destination' => 'New York', 'price' => 150]
     ], ['departure', 'destination'], ['price']);
 
+> {note} All databases except SQL Server require the columns in the second argument of the `upsert` method to have a PRIMARY or UNIQUE index.
+
 #### Auto-Incrementing IDs
 
 If the table has an auto-incrementing id, use the `insertGetId` method to insert a record and then retrieve the ID:

--- a/queries.md
+++ b/queries.md
@@ -701,7 +701,7 @@ The `upsert` method will insert rows that do not exist and update the rows that 
         ['departure' => 'Chicago', 'destination' => 'New York', 'price' => 150]
     ], ['departure', 'destination'], ['price']);
 
-> {note} All databases except SQL Server require the columns in the second argument of the `upsert` method to have a PRIMARY or UNIQUE index.
+> {note} All databases except SQL Server require the columns in the second argument of the `upsert` method to have a "primary" or "unique" index.
 
 #### Auto-Incrementing IDs
 


### PR DESCRIPTION
This PR clarifies how indexes need to be setup to properly use the `uniqueBy` constraints in upsert.

Closes https://github.com/laravel/framework/issues/34850