### PR TITLE
5.3 Upgrade: Add missing instruction to add new `failed_jobs.exception` column.

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -429,6 +429,12 @@ It is no longer necessary to specify the `--daemon` option when calling the `que
     // Process a single job...
     php artisan queue:work --once
 
+#### Failed Jobs Table
+
+If your application contains a `failed_jobs` table, you should add an `exception` column to the table:
+
+    $table->longText('exception')->after('payload');
+
 #### Database Driver Changes
 
 If you are using the `database` driver to store your queued jobs, you should drop the `jobs_queue_reserved_reserved_at_index` index then drop the `reserved` column from your `jobs` table. This column is no longer required when using the `database` driver. Once you have completed these changes, you should add a new compound index on the `queue` and `reserved_at` columns.


### PR DESCRIPTION
The instruction to add the new `failed_jobs.exception` column is missing from the 5.2 to 5.3 docs. Please see [this 5.3 source code](https://github.com/laravel/framework/blob/v5.3.31/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php#L61-L63) illustrating the insertion into the new `exception` column. 

This instruction already exists in the 5.3 to 5.4 docs, but I would suggest leaving it there for folks who are already on 5.3.