### PR TITLE
[8.x] Use full Sanctum middleware namespace for consistency

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -60,8 +60,6 @@ Finally, you should run your database migrations. Sanctum will create one databa
 
 Next, if you plan to utilize Sanctum to authenticate an SPA, you should add Sanctum's middleware to your `api` middleware group within your `app/Http/Kernel.php` file:
 
-    use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
-
     'api' => [
         \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
         'throttle:api',

--- a/sanctum.md
+++ b/sanctum.md
@@ -63,7 +63,7 @@ Next, if you plan to utilize Sanctum to authenticate an SPA, you should add Sanc
     use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 
     'api' => [
-        EnsureFrontendRequestsAreStateful::class,
+        \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
         'throttle:api',
         \Illuminate\Routing\Middleware\SubstituteBindings::class,
     ],


### PR DESCRIPTION
This updates the Sanctum middleware to show the full namespace to be consistent with other middleware in the Kernel and documentation.