### PR TITLE
[8.x] Added a semicolon after assertJsonPath method

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -240,7 +240,7 @@ If you would like to verify that the JSON response contains some given data at a
 
             $response
                 ->assertStatus(201)
-                ->assertJsonPath('team.owner.name', 'foo')
+                ->assertJsonPath('team.owner.name', 'foo');
         }
     }
 


### PR DESCRIPTION
Added a semicolon after `assertJsonPath()` method because seems necessary.