### PR TITLE
[8.x] Add cache driver requirement note to WithoutOverlapping middleware

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -358,6 +358,8 @@ If you wish to immediately delete any overlapping jobs, you may use the `dontRel
         return [(new WithoutOverlapping($this->order->id))->dontRelease()];
     }
 
+> {note} The `WithoutOverlapping` middleware requires a cache driver that supports [locks](/docs/{{version}}/cache#atomic-locks).
+
 <a name="dispatching-jobs"></a>
 ## Dispatching Jobs
 


### PR DESCRIPTION
Adds a note to say that `WithoutOverlapping` middleware requires a cache driver that supports locks. Ref: https://github.com/laravel/docs/pull/6505#issuecomment-715374207