### PR TITLE
[8.x] Note for limitation of 72 characters for bcrypt driver

### DIFF
--- a/hashing.md
+++ b/hashing.md
@@ -58,6 +58,8 @@ If you are using the Bcrypt algorithm, the `make` method allows you to manage th
         'rounds' => 12,
     ]);
 
+> {note} As Laravel `Hash` facade utilizes PHP's `password_hash` function, in combination with the `bcrypt` driver only the first 72 characters of the plain text are hashed. For more information, check out the [official PHP documentation](https://www.php.net/manual/en/function.password-hash.php).
+
 <a name="adjusting-the-argon2-work-factor"></a>
 #### Adjusting The Argon2 Work Factor
 


### PR DESCRIPTION
Add a note that for the bcrypt driver no plain texts longer than 72 characters can be hashed. PHP's `password_hash()` and Laravel won't output a warning in this case but several plain texts longer than 72 characters will then yield the same hash and produce collisions.