### PR TITLE
[8.x] Remove reference to HTML's step

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1003,7 +1003,7 @@ The field under validation must have a minimum _value_. Strings, numerics, array
 <a name="multiple-of"></a>
 #### multiple_of:_value_
 
-The field under validation must be a multiple of _value_. This can be useful when validating a number input that utilises the `step` attribute.
+The field under validation must be a multiple of _value_.
 
 <a name="rule-not-in"></a>
 #### not_in:_foo_,_bar_,...


### PR DESCRIPTION
>  This can be useful when validating a number input that utilises the `step` attribute.

This would lead users to expect consistency with how the attribute works in HTML. However, HTML's step works relative to `min`, while this does not. For example, if `min=10 step=3` HTML would allow 10, 13, 16, ... while Laravel's validator with `'min:10', 'multiple_of:3'` would allow 12, 15, 18, ...

13 is not a multiple of 3, so it would also be confusing if the behaviour of `multiple_of:3` was changed to accept that, unless it gets renamed to `step` 🤔