### PR TITLE
[8.x] Added snippet on how to generate UUID for existing failed jobs

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -282,10 +282,12 @@ If you plan to use the [job batching](/docs/{{version}}/queues#job-batching) fea
 
 Next, the `failed.driver` configuration option within your `queue` configuration file should be updated to `database-uuids`.
 
-If you have existing failed jobs, you use Tinker to generate uuid for those rows.
+In addition, you may wish to generate UUIDs for your existing failed jobs:
 
-    DB::table('failed_jobs')->whereNull('uuid')->get()->each(function ($row, $key) {
-        DB::table('failed_jobs')->find($row->id)->update(['uuid' => Illuminate\Support\Str::uuid()]);
+    DB::table('failed_jobs')->whereNull('uuid')->cursor()->each(function ($job) {
+        DB::table('failed_jobs')
+            ->where('id', $job->id)
+            ->update(['uuid' => (string) Illuminate\Support\Str::uuid()]);
     });
 
 <a name="routing"></a>

--- a/upgrade.md
+++ b/upgrade.md
@@ -282,6 +282,12 @@ If you plan to use the [job batching](/docs/{{version}}/queues#job-batching) fea
 
 Next, the `failed.driver` configuration option within your `queue` configuration file should be updated to `database-uuids`.
 
+If you have existing failed jobs, you use Tinker to generate uuid for those rows.
+
+    DB::table('failed_jobs')->whereNull('uuid')->get()->each(function ($row, $key) {
+        DB::table('failed_jobs')->find($row->id)->update(['uuid' => Illuminate\Support\Str::uuid()]);
+    });
+
 <a name="routing"></a>
 ### Routing
 


### PR DESCRIPTION
When adding the UUID during upgrade, existing failed jobs will be left as null and will cause issues. So I added a small snippet you can run in Tinker to generate UUID for existing rows.