### PR TITLE
[8.x] Fix unit testing by group example command

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -68,4 +68,4 @@ In addition to the `phpunit` command, you may use the `test` Artisan command to 
 
 Any arguments that can be passed to the `phpunit` command may also be passed to the Artisan `test` command:
 
-    php artisan test --group=feature --stop-on-failure
+    php artisan test --testsuite=Feature --stop-on-failure


### PR DESCRIPTION
`php artisan test --group=feature` vs `php artisan test --testsuite=Feature` (fresh Laravel install) :

<img width="250" alt="pr-illustration" src="https://user-images.githubusercontent.com/7080564/97695640-a5969500-1aa4-11eb-8bbb-39a933dbcc42.png">
