### PR TITLE
[8.x] Change plural to singular for resource collection.

### DIFF
--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -31,7 +31,7 @@ In addition to generating resources that transform individual models, you may ge
 
 To create a resource collection, you should use the `--collection` flag when creating the resource. Or, including the word `Collection` in the resource name will indicate to Laravel that it should create a collection resource. Collection resources extend the `Illuminate\Http\Resources\Json\ResourceCollection` class:
 
-    php artisan make:resource Users --collection
+    php artisan make:resource User --collection
 
     php artisan make:resource UserCollection
 


### PR DESCRIPTION
Regarding [Resource Collections](https://laravel.com/docs/8.x/eloquent-resources#generating-resource-collections). Example snippets are all singular except for the flag example. Maybe with a specific reason (in that case, sorry), but otherwise this might be more consistent.