### PR TITLE
[8.x] Need Slash before class otherwise throws error

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -400,7 +400,7 @@ To register an explicit binding, use the router's `model` method to specify the 
      */
     public function boot()
     {
-        Route::model('user', App\Models\User::class);
+        Route::model('user', \App\Models\User::class);
 
         // ...
     }


### PR DESCRIPTION
When trying to Explicitly Bind a model you need to make sure you add a "backslash" before class.

"App\Models\model::class" -> "\App\Models\model::class"

Throws error "App\Providers\App\Models\model".