### PR TITLE
[8.x] Generalize CSS occurrences 

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -80,7 +80,7 @@ If you are unsure if your feature qualifies as a major or minor, please ask Tayl
 <a name="compiled-assets"></a>
 ## Compiled Assets
 
-If you are submitting a change that will affect a compiled file, such as most of the files in `resources/sass` or `resources/js` of the `laravel/laravel` repository, do not commit the compiled files. Due to their large size, they cannot realistically be reviewed by a maintainer. This could be exploited as a way to inject malicious code into Laravel. In order to defensively prevent this, all compiled files will be generated and committed by Laravel maintainers.
+If you are submitting a change that will affect a compiled file, such as most of the files in `resources/css` or `resources/js` of the `laravel/laravel` repository, do not commit the compiled files. Due to their large size, they cannot realistically be reviewed by a maintainer. This could be exploited as a way to inject malicious code into Laravel. In order to defensively prevent this, all compiled files will be generated and committed by Laravel maintainers.
 
 <a name="security-vulnerabilities"></a>
 ## Security Vulnerabilities

--- a/structure.md
+++ b/structure.md
@@ -63,7 +63,7 @@ The `public` directory contains the `index.php` file, which is the entry point f
 <a name="the-resources-directory"></a>
 #### The Resources Directory
 
-The `resources` directory contains your views as well as your raw, un-compiled assets such as LESS, SASS, or JavaScript. This directory also houses all of your language files.
+The `resources` directory contains your views as well as your raw, un-compiled assets such as CSS or JavaScript. This directory also houses all of your language files.
 
 <a name="the-routes-directory"></a>
 #### The Routes Directory


### PR DESCRIPTION
The change to the contributions docs is obvious since the skeleton doesn't has a sass directory anymore. The one to the resources directories is similar. I removed LESS and SASS from being mentioned to group them as "CSS" which is more conform the current directory name.

I left all other occurrences of SASS in the docs because the parts where they were mentioned still warranted their context.