### PR TITLE
[8.x] Change all use of test.com to example.com 

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -29,7 +29,7 @@ To make requests, you may use the `get`, `post`, `put`, `patch`, and `delete` me
 
     use Illuminate\Support\Facades\Http;
 
-    $response = Http::get('http://test.com');
+    $response = Http::get('http://example.com');
 
 The `get` method returns an instance of `Illuminate\Http\Client\Response`, which provides a variety of methods that may be used to inspect the response:
 
@@ -46,14 +46,14 @@ The `get` method returns an instance of `Illuminate\Http\Client\Response`, which
 
 The `Illuminate\Http\Client\Response` object also implements the PHP `ArrayAccess` interface, allowing you to access JSON response data directly on the response:
 
-    return Http::get('http://test.com/users/1')['name'];
+    return Http::get('http://example.com/users/1')['name'];
 
 <a name="request-data"></a>
 ### Request Data
 
 Of course, it is common when using `POST`, `PUT`, and `PATCH` to send additional data with your request. So, these methods accept an array of data as their second argument. By default, data will be sent using the `application/json` content type:
 
-    $response = Http::post('http://test.com/users', [
+    $response = Http::post('http://example.com/users', [
         'name' => 'Steve',
         'role' => 'Network Administrator',
     ]);
@@ -63,7 +63,7 @@ Of course, it is common when using `POST`, `PUT`, and `PATCH` to send additional
 
 When making `GET` requests, you may either append a query string to the URL directly or pass an array of key / value pairs as the second argument to the `get` method:
 
-    $response = Http::get('http://test.com/users', [
+    $response = Http::get('http://example.com/users', [
         'name' => 'Taylor',
         'page' => 1,
     ]);
@@ -73,7 +73,7 @@ When making `GET` requests, you may either append a query string to the URL dire
 
 If you would like to send data using the `application/x-www-form-urlencoded` content type, you should call the `asForm` method before making your request:
 
-    $response = Http::asForm()->post('http://test.com/users', [
+    $response = Http::asForm()->post('http://example.com/users', [
         'name' => 'Sara',
         'role' => 'Privacy Consultant',
     ]);
@@ -85,7 +85,7 @@ You may use the `withBody` method if you would like to provide a raw request bod
 
     $response = Http::withBody(
         base64_encode($photo), 'image/jpeg'
-    )->post('http://test.com/photo');
+    )->post('http://example.com/photo');
 
 <a name="multi-part-requests"></a>
 #### Multi-Part Requests
@@ -94,7 +94,7 @@ If you would like to send files as multi-part requests, you should call the `att
 
     $response = Http::attach(
         'attachment', file_get_contents('photo.jpg'), 'photo.jpg'
-    )->post('http://test.com/attachments');
+    )->post('http://example.com/attachments');
 
 Instead of passing the raw contents of a file, you may also pass a stream resource:
 
@@ -102,7 +102,7 @@ Instead of passing the raw contents of a file, you may also pass a stream resour
 
     $response = Http::attach(
         'attachment', $photo, 'photo.jpg'
-    )->post('http://test.com/attachments');
+    )->post('http://example.com/attachments');
 
 <a name="headers"></a>
 ### Headers
@@ -112,7 +112,7 @@ Headers may be added to requests using the `withHeaders` method. This `withHeade
     $response = Http::withHeaders([
         'X-First' => 'foo',
         'X-Second' => 'bar'
-    ])->post('http://test.com/users', [
+    ])->post('http://example.com/users', [
         'name' => 'Taylor',
     ]);
 
@@ -200,7 +200,7 @@ You may specify additional [Guzzle request options](http://docs.guzzlephp.org/en
 
     $response = Http::withOptions([
         'debug' => true,
-    ])->get('http://test.com/users');
+    ])->get('http://example.com/users');
 
 <a name="testing"></a>
 ## Testing
@@ -292,14 +292,14 @@ The `assertSent` method accepts a callback which will be given an `Illuminate\Ht
 
     Http::withHeaders([
         'X-First' => 'foo',
-    ])->post('http://test.com/users', [
+    ])->post('http://example.com/users', [
         'name' => 'Taylor',
         'role' => 'Developer',
     ]);
 
     Http::assertSent(function ($request) {
         return $request->hasHeader('X-First', 'foo') &&
-               $request->url() == 'http://test.com/users' &&
+               $request->url() == 'http://example.com/users' &&
                $request['name'] == 'Taylor' &&
                $request['role'] == 'Developer';
     });
@@ -308,13 +308,13 @@ If needed, you may assert that a specific request was not sent using the `assert
 
     Http::fake();
 
-    Http::post('http://test.com/users', [
+    Http::post('http://example.com/users', [
         'name' => 'Taylor',
         'role' => 'Developer',
     ]);
 
     Http::assertNotSent(function (Request $request) {
-        return $request->url() === 'http://test.com/posts';
+        return $request->url() === 'http://example.com/posts';
     });
 
 Or, if you would like to assert that no requests were sent, you may use the `assertNothingSent` method:


### PR DESCRIPTION
The Docs page for Http-Client uses test.com instead of example.com

Test.com is a real registered website that someone owns and potentially does not desire unwanted traffic.

[Example.com is a reserved Top and Second Level Domain ](https://tools.ietf.org/html/rfc2606) designed for exactly this purpose, eg as an example domain.

This pull request updates all occurrences of test.com to example.com.  

I searched the entire documentation but this seems to be the only page this is relevant to.