### PR TITLE
[8.x] Clarify language filename conflicts

### DIFF
--- a/localization.md
+++ b/localization.md
@@ -97,6 +97,8 @@ Translation files that use translation strings as keys are stored as JSON files 
     {
         "I love programming.": "Me encanta programar."
     }
+    
+> {note} Please note that you cannot use translation strings which conflict with language file names. For example, using `__('Action')` for the "NL" locale while a `nl/action.php` file is defined but without an `nl.json` defined will result in the translator returning the contents of `nl/action.php`.
 
 <a name="retrieving-translation-strings"></a>
 ## Retrieving Translation Strings

--- a/localization.md
+++ b/localization.md
@@ -90,15 +90,17 @@ All language files return an array of keyed strings. For example:
 <a name="using-translation-strings-as-keys"></a>
 ### Using Translation Strings As Keys
 
-For applications with heavy translation requirements, defining every string with a "short key" can become quickly confusing when referencing them in your views. For this reason, Laravel also provides support for defining translation strings using the "default" translation of the string as the key.
+For applications with heavy translation requirements, defining every string with a "short key" can become confusing when referencing the keys in your views. For this reason, Laravel also provides support for defining translation strings using the "default" translation of the string as the key.
 
 Translation files that use translation strings as keys are stored as JSON files in the `resources/lang` directory. For example, if your application has a Spanish translation, you should create a `resources/lang/es.json` file:
 
     {
         "I love programming.": "Me encanta programar."
     }
-    
-> {note} Please note that you cannot use translation strings which conflict with language file names. For example, using `__('Action')` for the "NL" locale while a `nl/action.php` file is defined but without an `nl.json` defined will result in the translator returning the contents of `nl/action.php`.
+
+#### Key / File Conflicts
+
+You should not define translation string keys that conflict with other translation file names. For example, translating `__('Action')` for the "NL" locale while a `nl/action.php` file exists but a `nl.json` file does not exist will result in the translator returning the contents of `nl/action.php`.
 
 <a name="retrieving-translation-strings"></a>
 ## Retrieving Translation Strings


### PR DESCRIPTION
After an internal Slack discussion it seemed best to clarify this gotcha in the docs.