### PR TITLE
Add information about several database connections to database testing section

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -66,6 +66,9 @@ It is often useful to reset your database after each test so that data from a pr
             // ...
         }
     }
+    
+> {tip} If you want to test code, which uses several database connections for one table, replace `RefreshDatabase`
+> with `DatabaseMigrations` trait
 
 <a name="creating-factories"></a>
 ## Creating Factories


### PR DESCRIPTION
I ran into the problem when I was testing code with multiple database connections and couldn't find it in the documentation. It would be nice to add this to save people time