### PR TITLE
[8.x] Fix missing Token Class

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -102,7 +102,7 @@ Then, you may instruct Sanctum to use your custom model via the `usePersonalAcce
      */
     public function boot()
     {
-        Sanctum::usePersonalAccessTokenModel(Token::class);
+        Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
     }
 
 <a name="api-token-authentication"></a>


### PR DESCRIPTION
Fix missing Token Class usage on overriding section, use `PersonalAccessToken` directly when use custom `PersonalAccessToken` model on boot