### PR TITLE
[8.x] Add description for the `useCurrentOnUpdate()` modifier

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -328,6 +328,7 @@ Modifier  |  Description
 `->storedAs($expression)`  |  Create a stored generated column (MySQL)
 `->unsigned()`  |  Set INTEGER columns as UNSIGNED (MySQL)
 `->useCurrent()`  |  Set TIMESTAMP columns to use CURRENT_TIMESTAMP as default value
+`->useCurrentOnUpdate()`  |  Set TIMESTAMP columns to use CURRENT_TIMESTAMP when a record is updated
 `->virtualAs($expression)`  |  Create a virtual generated column (MySQL)
 `->generatedAs($expression)`  |  Create an identity column with specified sequence options (PostgreSQL)
 `->always()`  |  Defines the precedence of sequence values over input for an identity column (PostgreSQL)


### PR DESCRIPTION
This PR documents the `useCurrentOnUpdate()` modifier introduced by https://github.com/laravel/framework/pull/35143