### PR TITLE
[8.x] Add note about inline attachments and previewing

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -656,6 +656,8 @@ When designing a mailable's template, it is convenient to quickly preview the re
         return new App\Mail\InvoicePaid($invoice);
     });
 
+> {note} If you use [inline attachements](#inline-attachments) please note that these cannot be rendered as they use a CID embedded image which only renders in an actual email.
+
 <a name="localizing-mailables"></a>
 ## Localizing Mailables
 

--- a/mail.md
+++ b/mail.md
@@ -656,7 +656,7 @@ When designing a mailable's template, it is convenient to quickly preview the re
         return new App\Mail\InvoicePaid($invoice);
     });
 
-> {note} If you use [inline attachements](#inline-attachments) please note that these cannot be rendered as they use a CID embedded image which only renders in an actual email.
+> {note} [Inline attachements](#inline-attachments) will not be rendered when a mailable is previewed in your browser. To preview these mailables, you should send them to an email testing application such as [MailHog](https://github.com/mailhog/MailHog) or [HELO](https://usehelo.com).
 
 <a name="localizing-mailables"></a>
 ## Localizing Mailables


### PR DESCRIPTION
Previewing mailables with inline attachments will lead to broken images as they use CID embedded images behind the scenes. Viewing these images is only possible in an actual email.

See https://github.com/laravel/framework/issues/35169