### PR TITLE
[8.x] Add undocumented api change to Paginator

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -235,6 +235,10 @@ The paginator now uses the [Tailwind CSS framework](https://tailwindcss.com) for
 
     Paginator::useBootstrap();
 
+**Likelihood Of Impact: Low**
+
+The paginator for `LengthAwarePaginator` returns an additional property `links`. Which returns the items in the paginated list with `url`, `label` and `active` properties.
+
 <a name="queue"></a>
 ### Queue
 


### PR DESCRIPTION
All length paginated endpoints were failing tests because of the meta property change for a project. Probably most don't do that level of testing, so marked it as Low.

Tracked back to this [commit](https://github.com/laravel/framework/commit/13751a187834fabe515c14fb3ac1dc008fd23f37) - looks like it was probably for one of the new frontend components.