### PR TITLE
[8.x] Update routing.md

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -160,7 +160,7 @@ For convenience, some commonly used regular expression patterns have helper meth
 
     Route::get('user/{id}/{name}', function ($id, $name) {
         //
-    })->whereNumeric('id')->whereAlpha('name');
+    })->whereNumber('id')->whereAlpha('name');
 
     Route::get('user/{id}', function ($id) {
         //


### PR DESCRIPTION
when i use whereNumeric method appears with me **Method Illuminate\Routing\Route::whereNumeric does not exist**.

it should be whereNumber not whereNumeric