### PR TITLE
[8.x] Add a clarifying note about `push`

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1422,6 +1422,8 @@ If you would like to `save` your model and all of its associated relationships, 
 
     $post->push();
 
+> {note} The `push` method will only apply the `save` method to related models that are loaded in memory. When replicating a model using `replicate`, it will not replicate relationships from the original model that have not already been loaded.
+
 <a name="the-create-method"></a>
 ### The Create Method
 


### PR DESCRIPTION
I'm not sure if this is the best way to clarify this.

Generally, in the context of `replicate()`, the following text is misleading in it's broadness:

> If you would like to `save` your model and all of its associated relationships, you may use the `push` method:

In this context, the text above would lead you to believe many-to-many relationships would also be replicated by calling `push`:

    $newModel = Post::find($postId)->replicate();
    $newModel->push();

But, as far as I can tell, that's not the case.

I assume it would work as expected for relationships where a foreign ID exists on the `Post` model though (e.g. `post.user_id`), as that's basically a local attribute. But not for relationships where the foreign key is elsewhere, as far as I can understand.

Also, it wouldn't work for a related model that is in memory but not actually there as a result of loading through it's associating relationship on `Post`. If it was retrieved from the database in some other way, independent of the `Post` model, `push` wouldn't affect it as far as I can see.