### PR TITLE
[8.x] Added example usage for `whereAlphaNumeric`

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -161,6 +161,10 @@ For convenience, some commonly used regular expression patterns have helper meth
     Route::get('user/{id}/{name}', function ($id, $name) {
         //
     })->whereNumber('id')->whereAlpha('name');
+    
+    Route::get('user/{name}', function ($name) {
+    //
+    })->whereAlphaNumeric('name');
 
     Route::get('user/{id}', function ($id) {
         //

--- a/routing.md
+++ b/routing.md
@@ -163,7 +163,7 @@ For convenience, some commonly used regular expression patterns have helper meth
     })->whereNumber('id')->whereAlpha('name');
     
     Route::get('user/{name}', function ($name) {
-    //
+        //
     })->whereAlphaNumeric('name');
 
     Route::get('user/{id}', function ($id) {


### PR DESCRIPTION
Added example usage for `Illuminate\Routing\CreatesRegularExpressionRouteConstraints::whereAlphaNumeric()` which was added by https://github.com/laravel/framework/pull/35154.