### PR TITLE
Update Faker repository link to FakerPHP/Faker

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -121,7 +121,7 @@ To get started, take a look at the `database/factories/UserFactory.php` file in 
 
 As you can see, in their most basic form, factories are classes that extend Laravel's base factory class and define a `model` property and `definition` method. The `definition` method returns the default set of attribute values that should be applied when creating a model using the factory.
 
-Via the `faker` property, factories have access to the [Faker](https://github.com/fzaninotto/Faker) PHP library, which allows you to conveniently generate various kinds of random data for testing.
+Via the `faker` property, factories have access to the [Faker](https://github.com/FakerPHP/Faker) PHP library, which allows you to conveniently generate various kinds of random data for testing.
 
 > {tip} You can set the Faker locale by adding a `faker_locale` option to your `config/app.php` configuration file.
 


### PR DESCRIPTION
Laravel uses FakerPHP/Faker starting from Version 8. This update is to reflect the changes in the documentation.