### PR TITLE
remove ambiguity from yearlyOn() method

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -138,7 +138,7 @@ Method  | Description
 `->lastDayOfMonth('15:00');` | Run the task on the last day of the month at 15:00
 `->quarterly();` |  Run the task on the first day of every quarter at 00:00
 `->yearly();`  |  Run the task on the first day of every year at 00:00
-`->yearlyOn(7, 7, '17:00');`  |  Run the task every year on July 7th at 17:00
+`->yearlyOn(6, 1, '17:00');`  |  Run the task every year on June 1st at 17:00
 `->timezone('America/New_York');` | Set the timezone
 
 These methods may be combined with additional constraints to create even more finely tuned schedules that only run on certain days of the week. For example, to schedule a command to run weekly on Monday:


### PR DESCRIPTION
`->yearlyOn(6, 1, '17:00')` creates cron expression `+expression: "0 17 1 6 *",` which corresponds to 0 minute, 17 hour, day 1, month 6, any year.

From the example in the docs previously it was not possible to know the order of the parameters.