### PR TITLE
[8.x] Add retry_interval option for phpredis

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -155,7 +155,7 @@ If you plan to use PhpRedis extension along with the `Redis` Facade alias, you s
 
     'RedisManager' => Illuminate\Support\Facades\Redis::class,
 
-In addition to the default `host`, `port`, `database`, and `password` server configuration options, PhpRedis supports the following additional connection parameters: `persistent`, `prefix`, `read_timeout`, `timeout`, and `context`. You may add any of these options to your Redis server configuration in the `config/database.php` configuration file:
+In addition to the default `host`, `port`, `database`, and `password` server configuration options, PhpRedis supports the following additional connection parameters: `persistent`, `prefix`, `read_timeout`, `timeout`, `retry_interval` and `context`. You may add any of these options to your Redis server configuration in the `config/database.php` configuration file:
 
     'default' => [
         'host' => env('REDIS_HOST', 'localhost'),

--- a/redis.md
+++ b/redis.md
@@ -155,7 +155,7 @@ If you plan to use PhpRedis extension along with the `Redis` Facade alias, you s
 
     'RedisManager' => Illuminate\Support\Facades\Redis::class,
 
-In addition to the default `host`, `port`, `database`, and `password` server configuration options, PhpRedis supports the following additional connection parameters: `persistent`, `prefix`, `read_timeout`, `timeout`, `retry_interval` and `context`. You may add any of these options to your Redis server configuration in the `config/database.php` configuration file:
+In addition to the default `host`, `port`, `database`, and `password` server configuration options, PhpRedis supports the following additional connection parameters: `persistent`, `prefix`, `read_timeout`, `retry_interval`, `timeout`, and `context`. You may add any of these options to your Redis server configuration in the `config/database.php` configuration file:
 
     'default' => [
         'host' => env('REDIS_HOST', 'localhost'),


### PR DESCRIPTION
This appears to be a supported option when connecting to Redis using phpredis client
https://github.com/laravel/framework/blob/8.x/src/Illuminate/Redis/Connectors/PhpRedisConnector.php#L124

See `retry_interval`
https://github.com/phpredis/phpredis#connect-open

This is in `ms` and I THINK will happen a max of 10 times, awaiting confirmation on this one - https://github.com/phpredis/phpredis/issues/1883