### PR TITLE
[8.x] add a mention that you don't need separate queue worker with horizon

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -7,6 +7,7 @@
 - [Upgrading Horizon](#upgrading-horizon)
 - [Running Horizon](#running-horizon)
     - [Deploying Horizon](#deploying-horizon)
+    - [Queue worker](#queue-worker)
 - [Tags](#tags)
 - [Notifications](#notifications)
 - [Metrics](#metrics)
@@ -192,6 +193,10 @@ Once the configuration file has been created, you may update the Supervisor conf
     sudo supervisorctl start horizon
 
 For more information on Supervisor, consult the [Supervisor documentation](http://supervisord.org/index.html).
+
+<a name="queue-worker"></a>
+### Queue worker
+As Horizon completely takes over processing jobs as they are pushed onto the queue, you don’t need to run a separate [queue worker](/docs/{{version}}/queues#running-the-queue-worker).
 
 <a name="tags"></a>
 ## Tags


### PR DESCRIPTION
I made the mistake running both. I found out about it by reading @driesvints [blog post](https://medium.com/@driesvints/laravel-horizon-with-forge-and-envoyer-82a7e819d69f) and noticed it's not explained anywhere else.

> Don’t forget that you don’t need to define queues through Forge as Horizon completely takes this over.