### PR TITLE
[8.x] Add clarifying note about queued Notifications

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -155,6 +155,8 @@ You may pass an array to the `delay` method to specify the delay amount for spec
         'sms' => now()->addMinutes(10),
     ]));
 
+> {note} A separate queued job will be created for each combination of recipient and channel. For example, if you have 3 recipients and 2 channels, you will see 6 total entries in your queue.
+
 <a name="customizing-notification-channel-queues"></a>
 #### Customizing Notification Channel Queues
 

--- a/notifications.md
+++ b/notifications.md
@@ -155,7 +155,7 @@ You may pass an array to the `delay` method to specify the delay amount for spec
         'sms' => now()->addMinutes(10),
     ]));
 
-> {note} A separate queued job will be created for each combination of recipient and channel. For example, if you have 3 recipients and 2 channels, you will see 6 total entries in your queue.
+When queueing notifications, a queued job will be created for each recipient and channel combination. For example, six jobs will be dispatched to the queue if your notification has three recipients and two channels.
 
 <a name="customizing-notification-channel-queues"></a>
 #### Customizing Notification Channel Queues


### PR DESCRIPTION
This confused me for a couple hours today. I was only creating one Notification, but was seeing it show up in my queue multiple times.  After some digging and testing, it became more clear that a queue entry is made for every combination of recipients and channels. Documenting it so people understand what's happening.