### PR TITLE
[8.x] Updated Homestead Docs for PHP 8 & Ubuntu

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -59,8 +59,10 @@ Homestead runs on any Windows, Mac, or Linux system, and includes Nginx, PHP, My
 </style>
 
 <div id="software-list" markdown="1">
-- Ubuntu 18.04
+- Ubuntu 18.04 (branch: master)
+- Ubuntu 20.04 (branch: 20.04)
 - Git
+- PHP 8.0
 - PHP 7.4
 - PHP 7.3
 - PHP 7.2

--- a/homestead.md
+++ b/homestead.md
@@ -59,8 +59,8 @@ Homestead runs on any Windows, Mac, or Linux system, and includes Nginx, PHP, My
 </style>
 
 <div id="software-list" markdown="1">
-- Ubuntu 18.04 (branch: master)
-- Ubuntu 20.04 (branch: 20.04)
+- Ubuntu 18.04 (`master` branch)
+- Ubuntu 20.04 (`20.04` branch)
 - Git
 - PHP 8.0
 - PHP 7.4


### PR DESCRIPTION
Updated Ubuntu versions and added PHP 8 to the stack.