### PR TITLE
Explained the default flags used by @json

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -147,6 +147,8 @@ However, instead of manually calling `json_encode`, you may use the `@json` Blad
         var app = @json($array, JSON_PRETTY_PRINT);
     </script>
 
+By default the flags it uses are JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT.
+
 > {note} You should only use the `@json` directive to render existing variables as JSON. The Blade templating is based on regular expressions and attempts to pass a complex expression to the directive may cause unexpected failures.
 
 <a name="html-entity-encoding"></a>

--- a/blade.md
+++ b/blade.md
@@ -139,15 +139,13 @@ Sometimes you may pass an array to your view with the intention of rendering it 
         var app = <?php echo json_encode($array); ?>;
     </script>
 
-However, instead of manually calling `json_encode`, you may use the `@json` Blade directive. The `@json` directive accepts the same arguments as PHP's `json_encode` function:
+However, instead of manually calling `json_encode`, you may use the `@json` Blade directive. The `@json` directive accepts the same arguments as PHP's `json_encode` function. By default, the `@json` directive calls the `json_encode` function with the `JSON_HEX_TAG`, `JSON_HEX_APOS`, `JSON_HEX_AMP`, and `JSON_HEX_QUOT` flags:
 
     <script>
         var app = @json($array);
 
         var app = @json($array, JSON_PRETTY_PRINT);
     </script>
-
-By default the flags it uses are JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT.
 
 > {note} You should only use the `@json` directive to render existing variables as JSON. The Blade templating is based on regular expressions and attempts to pass a complex expression to the directive may cause unexpected failures.
 


### PR DESCRIPTION
Helps readers know that the @json directive encodes unsafe entities, and that they don't have to include these flags manually. 

