### PR TITLE
[8.x] Update wording of Elasticsearch versions in Homestead docs

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -337,7 +337,7 @@ The default MongoDB installation will set the database username to `homestead` a
 <a name="elasticsearch"></a>
 #### Elasticsearch
 
-You may specify a supported version of Elasticsearch, which may be a major version or an exact version number (major.minor.patch). The default installation will create a cluster named 'homestead'. You should never give Elasticsearch more than half of the operating system's memory, so make sure your Homestead machine has at least twice the Elasticsearch allocation.
+You may specify a supported version of Elasticsearch, which must be an exact version number (major.minor.patch). The default installation will create a cluster named 'homestead'. You should never give Elasticsearch more than half of the operating system's memory, so make sure your Homestead machine has at least twice the Elasticsearch allocation.
 
 > {tip} Check out the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current) to learn how to customize your configuration.
 


### PR DESCRIPTION
This PR is the result of the following discussion: https://github.com/laravel/homestead/pull/1555