### PR TITLE
[8.x] Fix typo: split -> splitIn

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -2045,7 +2045,7 @@ The `splitIn` method breaks a collection into the given number of groups, fillin
 
     $collection = collect([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
-    $groups = $collection->split(3);
+    $groups = $collection->splitIn(3);
 
     $groups->all();
 


### PR DESCRIPTION
See: #6593