### PR TITLE
[8.x] Document unprepared statements and implicit commits

### DIFF
--- a/database.md
+++ b/database.md
@@ -179,6 +179,15 @@ Some database statements do not return any value. For these types of operations,
 
     DB::statement('drop table users');
 
+<a name="running-an-unprepared-statement"></a>
+#### Running An Unprepared Statement
+
+Sometimes you may want to run a statement without binding any value. For these types of operations, you may use the `unprepared` method on the `DB` facade:
+
+    DB::unprepared('update users set votes = 100 where name = "john"');
+    
+Please note that these statements don't bind values like their counterparts above. They could open up your app to SQL injection and should be used very carefully.
+
 <a name="listening-for-query-events"></a>
 ## Listening For Query Events
 

--- a/database.md
+++ b/database.md
@@ -188,6 +188,17 @@ Sometimes you may want to run a statement without binding any value. For these t
     
 Please note that these statements don't bind values like their counterparts above. They could open up your app to SQL injection and should be used very carefully.
 
+<a name="implicit-commits-in-transactions"></a>
+#### Implicit Commits In Transactions
+
+When running raw queries in transactions it's important to note that you must be careful to not use statements that cause [implicit commits](https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html) from happening. These sort of statements will cause the database engine to indirectly commit your your entire transaction, leaving your app in an invalid state. This can also cause tests that rely on the `DatabaseTransactions` trait to be broken. 
+
+An example of such a statement could be:
+
+    DB::unprepared('create table a (col varchar(1) null)');
+
+Please reference the MySQL manual for [a list of all statements](https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html) that can cause implicit commits from happening.
+
 <a name="listening-for-query-events"></a>
 ## Listening For Query Events
 


### PR DESCRIPTION
This PR is a response to the following issue: https://github.com/laravel/framework/issues/35380

After careful evaluation I decided that it'd be best to simply document this behavior than to work around it in the framework. The commit for `unprepared` can be removed if you don't think it's wise to document that method. But the behavior of implicit commits in regard to transactions should best be documented I believe. Afaik it's only MySQL/MariaDB related so we could note that as well perhaps. I'll leave it up to you to decide on that.