### PR TITLE
[8.x] Minor update on database docs page

### DIFF
--- a/database.md
+++ b/database.md
@@ -96,7 +96,7 @@ The `sticky` option is an *optional* value that can be used to allow the immedia
 <a name="using-multiple-database-connections"></a>
 ### Using Multiple Database Connections
 
-When using multiple connections, you may access each connection via the `connection` method on the `DB` facade. The `name` passed to the `connection` method should correspond to one of the connections listed in your `config/database.php` configuration file:
+When using multiple connections, you may access each connection via the `connection` method on the `DB` facade. The `name` passed to the `connection` method should correspond to one of the connections either listed your `config/database.php` configuration file, or set at runtime using the [config](/docs/{{version}}/helpers#method-config) helper function:
 
     $users = DB::connection('foo')->select(...);
 


### PR DESCRIPTION
If the DB configurations are set at runtime with the Config facade / config helper then the following statement isn't strictly correct: 
"The name passed to the connection method should correspond to one of the connections listed in your config/database.php configuration file".
ie it could happen that the connection name isn't in the config/database.php file and everything could still work, while the above line suggests that this isn't possible! 