### PR TITLE
Where the term tag[ing] is used before the docs section on tagging a link to the tagging anchor is added

### DIFF
--- a/container.md
+++ b/container.md
@@ -164,7 +164,7 @@ Sometimes you may have a class that receives some injected classes, but also nee
               ->needs('$variableName')
               ->give($value);
 
-Sometimes a class may depend on an array of tagged instances. Using the `giveTagged` method, you may easily inject all of the container bindings with that tag:
+Sometimes a class may depend on an array of [tagged](#tagging) instances. Using the `giveTagged` method, you may easily inject all of the container bindings with that tag:
 
     $this->app->when(ReportAggregator::class)
         ->needs('$reports')
@@ -212,7 +212,7 @@ For convenience, you may also just provide an array of class names to be resolve
 <a name="variadic-tag-dependencies"></a>
 #### Variadic Tag Dependencies
 
-Sometimes a class may have a variadic dependency that is type-hinted as a given class (`Report ...$reports`). Using the `needs` and `giveTagged` methods, you may easily inject all of the container bindings with that tag for the given dependency:
+Sometimes a class may have a variadic dependency that is type-hinted as a given class (`Report ...$reports`). Using the `needs` and `giveTagged` methods, you may easily inject all of the container bindings with that [tag](#tagging) for the given dependency:
 
     $this->app->when(ReportAggregator::class)
         ->needs(Report::class)


### PR DESCRIPTION
When reading this documentation from top-to-bottom the term `tag[ging]`is used and examples are given of using tags _before_ the docs on tagging are presented.  

This PR adds links to the anchors for tagging only to those places where tagging is used before the documentation has been presented.  

Notes on this approach:  one might ask about an 'all or nothing' approach such as `->make` is used often before the actual docs on `make` but it is not referenced by name and only through code which makes linking to the docs unwieldy.  And, should all references to other methods of the container also be cross referenced?  In my reading I did not find any other use of terminology preceding its definition.

