### PR TITLE
[8.x] Revert "Update contributions.md"

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -18,7 +18,7 @@ To encourage active collaboration, Laravel strongly encourages pull requests, no
 
 However, if you file a bug report, your issue should contain a title and a clear description of the issue. You should also include as much relevant information as possible and a code sample that demonstrates the issue. The goal of a bug report is to make it easy for yourself - and others - to replicate the bug and develop a fix.
 
-Remember, bug reports are created in the hope that others with the same problem will be able to collaborate with you on solving it. Do not expect that the bug report will automatically see any activity or that others will jump to fix it. Creating a bug report serves to help yourself and others start on the path of fixing the problem. If you want to chip in, you can help out by fixing [any bugs listed in our issue trackers](https://github.com/laravel/framework/issues).
+Remember, bug reports are created in the hope that others with the same problem will be able to collaborate with you on solving it. Do not expect that the bug report will automatically see any activity or that others will jump to fix it. Creating a bug report serves to help yourself and others start on the path of fixing the problem. If you want to chip in, you can help out by fixing [any bugs listed in our issue trackers](https://github.com/issues?q=is%3Aopen+is%3Aissue+label%3Abug+user%3Alaravel).
 
 The Laravel source code is managed on GitHub, and there are repositories for each of the Laravel projects:
 


### PR DESCRIPTION
Reverts laravel/docs#6607

The previous link is working as expected. The new one only shows the issues on framework repository while the old link shows bugs across the entire organisation as intended.