### PR TITLE
[8.x] Add MSSQL driver notes to System Requirements section

### DIFF
--- a/database.md
+++ b/database.md
@@ -40,6 +40,11 @@ To enable foreign key constraints for SQLite connections, you should set the `DB
 
     DB_FOREIGN_KEYS=true
 
+<a name="mssql-configuration"></a>
+#### Microsoft SQL Server Configuration
+
+To use a Microsoft SQL Server database, you should ensure you have the `sqlsrv` and `pdo_sqlsrv` PHP extensions installed, as well as any dependencies they may have such as the Microsoft SQL ODBC driver.
+
 <a name="configuration-using-urls"></a>
 #### Configuration Using URLs
 

--- a/database.md
+++ b/database.md
@@ -43,7 +43,7 @@ To enable foreign key constraints for SQLite connections, you should set the `DB
 <a name="mssql-configuration"></a>
 #### Microsoft SQL Server Configuration
 
-To use a Microsoft SQL Server database, you should ensure you have the `sqlsrv` and `pdo_sqlsrv` PHP extensions installed, as well as any dependencies they may have such as the Microsoft SQL ODBC driver.
+To use a Microsoft SQL Server database, you should ensure that you have the `sqlsrv` and `pdo_sqlsrv` PHP extensions installed as well as any dependencies they may require such as the Microsoft SQL ODBC driver.
 
 <a name="configuration-using-urls"></a>
 #### Configuration Using URLs

--- a/installation.md
+++ b/installation.md
@@ -31,6 +31,8 @@ However, if you are not using Homestead, you will need to make sure your server 
 - XML PHP Extension
 </div>
 
+If you are using Laravel with a Microsoft SQL Server database, it is highly recommended that you install the sqlsrv and pdo_sqlsrv drivers as well as the Microsoft SQL ODBC driver. While Laravel will work out of the box without these drivers, you will likely run into issues if you don't use these drivers.
+
 <a name="installing-laravel"></a>
 ### Installing Laravel
 

--- a/installation.md
+++ b/installation.md
@@ -31,8 +31,6 @@ However, if you are not using Homestead, you will need to make sure your server 
 - XML PHP Extension
 </div>
 
-If you are using Laravel with a Microsoft SQL Server database, it is highly recommended that you install the sqlsrv and pdo_sqlsrv drivers as well as the Microsoft SQL ODBC driver. While Laravel will work out of the box without these drivers, you will likely run into issues if you don't use these drivers.
-
 <a name="installing-laravel"></a>
 ### Installing Laravel
 


### PR DESCRIPTION
After struggling with this today, I wanted to see if this had a place in the documentation.

Out of the box, Laravel will use `pdo_odbc` to connect to a MSSQL database and this will work...until you start running into really annoying to troubleshoot bugs. For example, if you use `pdo_odbc`, datetime fields will appear in the database as `Y-m-d H:i:s.v`, but when you attempt to access those dates through the driver, it drops the milliseconds, which Carbon is expecting based on the Laravel SQL Server Grammar, so you get a cryptic "Data Missing" error.

Once you install the `sqlsrv` and `pdo_sqlsrv` drivers, the behavior works as expected. There is another bug regarding how UUIDs are returned from the database, you need a special PDO directive to make them work if you're not using these drivers. These are only two bugs I know of, but it sure seems like best practice to be using the MS SQL drivers rather than relying on `pdo_odbc` if you intend on using a MSSQL database. Because `pdo_odbc` works out of the box, I was not aware I didn't have the right drivers and figured maybe others are unaware as well, hence this PR.

I am open to suggestions, moving this to a different spot, whatever makes sense. To start I didn't make this particularly verbose, but if more detail is desired please let me know, I'm happy to expand on what I wrote.