### PR TITLE
[8.x] Add assertBatched in Bus Fake example

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -84,6 +84,13 @@ As an alternative to mocking, you may use the `Bus` facade's `fake` method to pr
                 return $job->order->id === $order->id;
             });
 
+            // Assert a specific batch was dispatched meeting the given truth test...
+            Bus::assertBatched(function (Batch $batch) use ($order) {
+                return count($batch->jobs) == 2
+                    && $batch->allowsFailures() 
+                    && $batch->name === 'my-batch';
+            });
+
             // Assert a job was not dispatched...
             Bus::assertNotDispatched(AnotherJob::class);
         }


### PR DESCRIPTION
Hi, I found that there was an assertion specific to batches not shown in the Bus Fake example. Here I just added it in the code block. Not sure it requires a specific paragraph, but let me know.