### PR TITLE
[8.x] Add note about URL generation for controller actions

### DIFF
--- a/urls.md
+++ b/urls.md
@@ -149,6 +149,8 @@ If the controller method accepts route parameters, you may pass them as the seco
 
     $url = action([UserController::class, 'profile'], ['id' => 1]);
 
+> {note} Routes need to be registered for the `action` to generate the URL.
+
 <a name="default-values"></a>
 ## Default Values
 


### PR DESCRIPTION
This section was a bit confusing so added a note that routes need to be registered for the `action()` function to generate a URL for a given controller action.