### PR TITLE
[8.x] Align sessions table schema with generated schema

### DIFF
--- a/session.md
+++ b/session.md
@@ -45,12 +45,12 @@ The session `driver` configuration option defines where session data will be sto
 When using the `database` session driver, you will need to create a table to contain the session items. Below is an example `Schema` declaration for the table:
 
     Schema::create('sessions', function ($table) {
-        $table->string('id')->unique();
-        $table->foreignId('user_id')->nullable();
+        $table->string('id')->primary();
+        $table->foreignId('user_id')->nullable()->index();
         $table->string('ip_address', 45)->nullable();
         $table->text('user_agent')->nullable();
         $table->text('payload');
-        $table->integer('last_activity');
+        $table->integer('last_activity')->index();
     });
 
 You may use the `session:table` Artisan command to generate this migration:


### PR DESCRIPTION
The example schema for the `sessions` table (when using the `database` session driver) does not match the one that is generated by the artisan command `php artisan session:table`. This PR aligns these two.

The differences are:
 * The `id` column is set as primary key instead of (only) unique.
 * Indices are added to the `user_id` and `last_activity` columns.

I noticed this since I copied the documentation schema and had some concerns about the `gc()` function without the index on `last_activity`.