### PR TITLE
[8.x] Fixing anchors

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -1011,7 +1011,7 @@ You may use the `.` character to indicate if a component is nested deeper inside
 <a name="data-properties-attributes"></a>
 #### Data Properties / Attributes
 
-Since anonymous components do not have any associated class, you may wonder how you may differentiate which data should be passed to the component as variables and which attributes should be placed in the component's [attribute bag](#managing-attributes).
+Since anonymous components do not have any associated class, you may wonder how you may differentiate which data should be passed to the component as variables and which attributes should be placed in the component's [attribute bag](#component-attributes).
 
 You may specify which attributes should be considered data variables using the `@props` directive at the top of your component's Blade template. All other attributes on the component will be available via the component's attribute bag. If you wish to give a data variable a default value, you may specify the variable's name as the array key and the default value as the array value:
 

--- a/broadcasting.md
+++ b/broadcasting.md
@@ -211,7 +211,7 @@ Once you have uncommented and adjusted the Echo configuration according to your 
 <a name="concept-overview"></a>
 ## Concept Overview
 
-Laravel's event broadcasting allows you to broadcast your server-side Laravel events to your client-side JavaScript application using a driver-based approach to WebSockets. Currently, Laravel ships with [Pusher Channels](https://pusher.com/channels) and [Ably](https://ably.io) drivers. The events may be easily consumed on the client-side using the [Laravel Echo](#installing-laravel-echo) JavaScript package.
+Laravel's event broadcasting allows you to broadcast your server-side Laravel events to your client-side JavaScript application using a driver-based approach to WebSockets. Currently, Laravel ships with [Pusher Channels](https://pusher.com/channels) and [Ably](https://ably.io) drivers. The events may be easily consumed on the client-side using the [Laravel Echo](#client-side-installation) JavaScript package.
 
 Events are broadcast over "channels", which may be specified as public or private. Any visitor to your application may subscribe to a public channel without any authentication or authorization; however, in order to subscribe to a private channel, a user must be authenticated and authorized to listen on that channel.
 
@@ -442,7 +442,7 @@ Sometimes you want to broadcast your event only if a given condition is true. Yo
 <a name="authorizing-channels"></a>
 ## Authorizing Channels
 
-Private channels require you to authorize that the currently authenticated user can actually listen on the channel. This is accomplished by making an HTTP request to your Laravel application with the channel name and allowing your application to determine if the user can listen on that channel. When using [Laravel Echo](#installing-laravel-echo), the HTTP request to authorize subscriptions to private channels will be made automatically; however, you do need to define the proper routes to respond to these requests.
+Private channels require you to authorize that the currently authenticated user can actually listen on the channel. This is accomplished by making an HTTP request to your Laravel application with the channel name and allowing your application to determine if the user can listen on that channel. When using [Laravel Echo](#client-side-installation), the HTTP request to authorize subscriptions to private channels will be made automatically; however, you do need to define the proper routes to respond to these requests.
 
 <a name="defining-authorization-routes"></a>
 ### Defining Authorization Routes

--- a/configuration.md
+++ b/configuration.md
@@ -5,7 +5,6 @@
     - [Environment Variable Types](#environment-variable-types)
     - [Retrieving Environment Configuration](#retrieving-environment-configuration)
     - [Determining The Current Environment](#determining-the-current-environment)
-    - [Hiding Environment Variables From Debug Pages](#hiding-environment-variables-from-debug)
 - [Accessing Configuration Values](#accessing-configuration-values)
 - [Configuration Caching](#configuration-caching)
 - [Debug Mode](#debug-mode)

--- a/requests.md
+++ b/requests.md
@@ -5,7 +5,7 @@
     - [Accessing The Request](#accessing-the-request)
     - [Request Path & Method](#request-path-and-method)
     - [Request Headers](#request-headers)
-    - [Request IP Address](#request-ip)
+    - [Request IP Address](#request-ip-address)
     - [Content Negotiation](#content-negotiation)
     - [PSR-7 Requests](#psr7-requests)
 - [Input](#input)

--- a/validation.md
+++ b/validation.md
@@ -21,7 +21,7 @@
 - [Working With Error Messages](#working-with-error-messages)
     - [Specifying Custom Messages In Language Files](#specifying-custom-messages-in-language-files)
     - [Specifying Attributes In Language Files](#specifying-attribute-in-language-files)
-    - [Specifying Values In Language Files](#specifying-values-replacements-in-language-files)
+    - [Specifying Values In Language Files](#specifying-values-in-language-files)
 - [Available Validation Rules](#available-validation-rules)
 - [Conditionally Adding Rules](#conditionally-adding-rules)
 - [Validating Arrays](#validating-arrays)


### PR DESCRIPTION
This PR fixes anchors in the following files:
- `blade.md`
- `broadcasting.md`
- `configuration.md`
Here the whole section _Hiding Environment Variables From Debug Pages_ is missing, so I removed the link. 
You might want to restore the section instead.
- `requests.md`
- `validation.md`

I used [a simple  script](https://gist.github.com/andreich1980/a58deabb237e13c162b581530d262b93) to find broken anchors