### PR TITLE
[8.x] Update blade.md

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -901,7 +901,7 @@ If you would like an attribute other than `class` to have its default value and 
 
 You may filter attributes using the `filter` method. This method accepts a closure which should return `true` if you wish to retain the attribute in the attribute bag:
 
-    {{ $attributes->filter(fn ($value, $key) => $key == 'foo') }}
+    {{ $attributes->filter(function ($value, $key) { return $key == 'foo'; } }}
 
 For convenience, you may use the `whereStartsWith` method to retrieve all attributes whose keys begin with a given string:
 


### PR DESCRIPTION
The shorthand function statement requires PHP 7.4 but Laravel 8 still supports PHP 7.3. Whoever will copy this code snippet will need to refactor on PHP 7.3.