### PR TITLE
Dusk - correct order of assertions

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -888,9 +888,9 @@ Dusk provides a variety of assertions that you may make against your application
 [assertSelected](#assert-selected)
 [assertNotSelected](#assert-not-selected)
 [assertSelectHasOptions](#assert-select-has-options)
-[assertSelectMissingOption](#assert-select-missing-option)
 [assertSelectMissingOptions](#assert-select-missing-options)
 [assertSelectHasOption](#assert-select-has-option)
+[assertSelectMissingOption](#assert-select-missing-option)
 [assertValue](#assert-value)
 [assertAttribute](#assert-attribute)
 [assertAriaAttribute](#assert-aria-attribute)
@@ -1213,13 +1213,6 @@ Assert that the given array of values are available to be selected:
 
     $browser->assertSelectHasOptions($field, $values);
 
-<a name="assert-select-missing-option"></a>
-#### assertSelectMissingOption
-
-Assert that the given value is not available to be selected:
-
-    $browser->assertSelectMissingOption($field, $value);
-
 <a name="assert-select-missing-options"></a>
 #### assertSelectMissingOptions
 
@@ -1233,6 +1226,13 @@ Assert that the given array of values are not available to be selected:
 Assert that the given value is available to be selected on the given field:
 
     $browser->assertSelectHasOption($field, $value);
+
+<a name="assert-select-missing-option"></a>
+#### assertSelectMissingOption
+
+Assert that the given value is not available to be selected:
+
+    $browser->assertSelectMissingOption($field, $value);
 
 <a name="assert-value"></a>
 #### assertValue


### PR DESCRIPTION
1. `assertSelectHasOptions`
1. `assertSelectMissingOptions`
1. `assertSelectHasOption`
1. `assertSelectMissingOption`

---

Previously:

1. `assertSelectHasOptions`
1. `assertSelectMissingOption`
1. `assertSelectMissingOptions`
1. `assertSelectHasOption`