### PR TITLE
[8.x] Improve Example ModelObserver Registration

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1216,6 +1216,8 @@ To register an observer, you need to call the `observe` method on the model you 
      */
     public function boot()
     {
+        parent::boot();
+        
         User::observe(UserObserver::class);
     }
 


### PR DESCRIPTION
This adds `parent::boot()` call to example of registering a model observer within the EventServiceProvider. I know this is a somewhat obvious element to registering things in the `boot()` method, but it caught me today and want to pitch this clarity as a suggestion.

Happy to submit this change to `7.x` branch as well if it's a +1.

cc: @roberto-aguilar 