### PR TITLE
[8.x] fix typo in http-tests.md

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -632,7 +632,7 @@ For example, if the JSON response returned by your application contains the foll
 
 You may assert that the JSON structure matches your expectations like so:
 
-    $response->assertJsonStruture([
+    $response->assertJsonStructure([
         'user' => [
             'name',
         ]


### PR DESCRIPTION
Nothing special, just a little typo fix  `assertJsonStruture` -> `assertJsonStructure`