### PR TITLE
Added tip for working with null value for Cache remember and rememberForever functions

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -173,6 +173,8 @@ You may use the `rememberForever` method to retrieve an item from the cache or s
         return DB::table('users')->get();
     });
 
+> {tip} If the value (null) is stored in the cache, the callback is executed every time.
+
 <a name="retrieve-delete"></a>
 #### Retrieve & Delete
 


### PR DESCRIPTION
Hi, when I'm worked with Cache::remember function, I'm noticed behavior that is not described in the documentation, but is very important.

I'm found the issue which describes the problem.
https://github.com/laravel/framework/issues/31312