### PR TITLE
[8.x] Update few test cases to follow snake_case naming convention

### DIFF
--- a/console-tests.md
+++ b/console-tests.md
@@ -32,7 +32,7 @@ You may test this command with the following test which utilizes the `expectsQue
      *
      * @return void
      */
-    public function testConsoleCommand()
+    public function test_console_command()
     {
         $this->artisan('question')
              ->expectsQuestion('What is your name?', 'Taylor Otwell')

--- a/database-testing.md
+++ b/database-testing.md
@@ -47,7 +47,7 @@ Before proceeding much further, let's discuss how to reset your database after e
          *
          * @return void
          */
-        public function testBasicExample()
+        public function test_basic_example()
         {
             $response = $this->get('/');
 

--- a/dusk.md
+++ b/dusk.md
@@ -232,7 +232,7 @@ To get started, let's write a test that verifies we can log into our application
          *
          * @return void
          */
-        public function testBasicExample()
+        public function test_basic_example()
         {
             $user = User::factory()->create([
                 'email' => 'taylor@laravel.com',

--- a/http-tests.md
+++ b/http-tests.md
@@ -192,7 +192,7 @@ After making a test request to your application, the `dump`, `dumpHeaders`, and 
          *
          * @return void
          */
-        public function testBasicTest()
+        public function test_basic_test()
         {
             $response = $this->get('/');
 

--- a/testing.md
+++ b/testing.md
@@ -56,7 +56,7 @@ Once the test has been generated, you may define test methods as you normally wo
          *
          * @return void
          */
-        public function testBasicTest()
+        public function test_basic_test()
         {
             $this->assertTrue(true);
         }


### PR DESCRIPTION
As I understand since the big documentation overhaul test case naming convention has changed to `snake_case`, some tests cases were still following `camelCase` convention.