### PR TITLE
Add PHP requirements to installation instructions

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -138,28 +138,46 @@ Once the application's Docker containers have been started, you can access the a
 
 > {tip} To continue learning more about Laravel Sail, review its [complete documentation](/docs/{{version}}/sail).
 
-<a name="installation-via-composer"></a>
-### Installation Via Composer
 
-If your computer already has PHP and Composer installed, you may create a new Laravel project by using Composer directly. After the application has been created, you may start Laravel's local development server using the Artisan CLI's `serve` command:
+<a name="installing-laravel-without-docker"></a>
+## Installing Laravel Without Docker
+
+To run Laravel on your machine, you'll need to ensure you're using <strong>PHP 7.3 or higher</strong>, with the following extensions enabled:
+
+<div class="content-list">
+- BCMath
+- Ctype
+- Fileinfo
+- JSON
+- Mbstring
+- OpenSSL
+- PDO
+- Tokenizer
+- XML
+</div>
+
+You'll also need to have Composer installed as a global dependency.
+
+<a name="via-composer-create-project"></a>
+### Via Composer Create-Project
+
+You may create a new Laravel project by using Composer directly.
 
     composer create-project laravel/laravel example-app
 
+After the application has been created, you may start Laravel's local development server using the Artisan CLI's `serve` command:
+ 
     cd example-app
 
     php artisan serve
 
-<a name="the-laravel-installer"></a>
-#### The Laravel Installer
+<a name="via-the-laravel-installer"></a>
+### Via The Laravel Installer
 
-Or, you may install the Laravel Installer as a global Composer dependency:
+Alternatively, you may install the Laravel Installer as a global Composer dependency:
 
 ```nothing
 composer global require laravel/installer
-
-laravel new example-app
-
-php artisan serve
 ```
 
 Make sure to place Composer's system-wide vendor bin directory in your `$PATH` so the `laravel` executable can be located by your system. This directory exists in different locations based on your operating system; however, some common locations include:
@@ -169,6 +187,14 @@ Make sure to place Composer's system-wide vendor bin directory in your `$PATH` s
 - Windows: `%USERPROFILE%\AppData\Roaming\Composer\vendor\bin`
 - GNU / Linux Distributions: `$HOME/.config/composer/vendor/bin` or `$HOME/.composer/vendor/bin`
 </div>
+
+Once installed, the `laravel new` command will create a fresh Laravel installation in the directory you specify and install any dependencies:
+
+```nothing
+laravel new example-app
+
+php artisan serve
+```
 
 <a name="initial-configuration"></a>
 ## Initial Configuration


### PR DESCRIPTION
I noticed that the new Installation page doesn't include the "Server Requirements" anymore, so I've added it (plus some other changes, see below).

## Why?
I think the server requirements are important.
- As a package dev, I often consult there to know what versions of Laravel will work on my chosen minimum PHP version.
- Also, not everyone uses Docker for development, and so it's important to have this info still easily accessible.
- Finally, when deploying to a server, you want to be sure your PHP versions and extensions match. This is where to easily check.

## Other changes
This PR includes a few more changes. I'd have preferred to discuss them first via issue, but issues aren't allowed in this repo. It's fine if they aren't accepted as-is. I included these changes because I couldn't find a better way to fit the server requirements in without it feeling cramped.

- Moved "Installation via Composer" into a separate section - "Installing Laravel Without Docker". I'm not married to it, but I found that it was less confusing to have the Docker-setup instructions in their own section. That way, the server requirements, composer installation and Laravel installer details have room to breathe, and are also considered first-class options.

- I considered renaming "Your First Laravel Project" to "Your First Laravel Project With Sail", again for clarity (I'm a longtime Laravel user,and I really found the new docs confusing), but I don't know if that's okay.

- I also expanded the non-Docker instructions. They felt a little rushed and less friendly to newcomers, which isn't really the Laravel spirit.