### PR TITLE
Adds auxiliary link to Breeze in packages section

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -73,6 +73,7 @@
     - [Database](/docs/{{version}}/database-testing)
     - [Mocking](/docs/{{version}}/mocking)
 - ## Packages
+    - [Breeze](/docs/{{version}}/starter-kits#laravel-breeze)
     - [Cashier (Stripe)](/docs/{{version}}/billing)
     - [Cashier (Paddle)](/docs/{{version}}/cashier-paddle)
     - [Dusk](/docs/{{version}}/dusk)


### PR DESCRIPTION
Super small suggestion to add a link under packages section to info about Breeze.  I realize this is a second entry (similar to how the Dusk docs are wired) but I feel like this will be a common place people look for this.  I know I just did.  =)