### PR TITLE
[8.x] Explain how to set a specific Postmark message stream

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -74,7 +74,7 @@ Next, install the Guzzle HTTP library and set the `default` option in your `conf
         'token' => env('POSTMARK_TOKEN'),
     ],
 
-Postmark also lets you use different `message streams`. If you'd like to use a specific one, you can define that in your `postmark` mailer in your `config/mail.php` file:
+If you would like to specify the Postmark message stream that should be used by a given mailer, you may add the `message_stream_id` configuration option to the mailer's configuration array. This configuration array can be found in your application's `config/mail.php` configuration file:
 
     'postmark' => [
         'transport' => 'postmark',

--- a/mail.md
+++ b/mail.md
@@ -74,6 +74,15 @@ Next, install the Guzzle HTTP library and set the `default` option in your `conf
         'token' => env('POSTMARK_TOKEN'),
     ],
 
+Postmark also lets you use different `message streams`. If you'd like to use a specific one, you can define that in your `postmark` mailer in your `config/mail.php` file:
+
+    'postmark' => [
+        'transport' => 'postmark',
+        'message_stream_id' => env('POSTMARK_MESSAGE_STREAM_ID'),
+    ],
+
+This way you are also able to set up multiple Postmark mailers with different message streams.
+
 <a name="ses-driver"></a>
 #### SES Driver
 


### PR DESCRIPTION
This PR adds to the docs an explanation of how to set a specific Postmark `message stream`, which is possible since my merged PR on the framework: https://github.com/laravel/framework/pull/35755