### PR TITLE
redirect to dashboard instead home after verifying

### DIFF
--- a/verification.md
+++ b/verification.md
@@ -86,7 +86,7 @@ Next, we need to define a route that will handle requests generated when the use
     Route::get('/email/verify/{id}/{hash}', function (EmailVerificationRequest $request) {
         $request->fulfill();
 
-        return redirect('/home');
+        return redirect('/dashboard');
     })->middleware(['auth', 'signed'])->name('verification.verify');
 
 Before moving on, let's take a closer look at this route. First, you'll notice we are using an `EmailVerificationRequest` request type instead of the typical `Illuminate\Http\Request` instance. The `EmailVerificationRequest` is a [form request](/docs/{{version}}/validation#form-request-validation) that is included with Laravel. This request will automatically take care of validating the request's `id` and `hash` parameters.


### PR DESCRIPTION
just a tiny little thing, but redirecting to /home leads to a 404 in a L8 standard installation; after logging in the user is redirected to /dashboard; and so I think should the user after verifying his/her email. I know the docs say "you may redirect them wherever you wish"
(actually my first pull request; hope doing it right... :-))