### PR TITLE
[8.x] Added php8.0 to PHP versions section

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -519,6 +519,7 @@ Homestead 6 introduced support for running multiple versions of PHP on the same 
     php7.2 artisan list
     php7.3 artisan list
     php7.4 artisan list
+    php8.0 artisan list
 
 You may change the default version of PHP used by the CLI by issuing the following commands from within your Homestead virtual machine:
 
@@ -528,6 +529,9 @@ You may change the default version of PHP used by the CLI by issuing the followi
     php72
     php73
     php74
+    php80
+
+If the command is not found you may need to rebuild your `aliases` file. If you have modified your `aliases` file back it up before proceeding, then rebuild it by running `bash init.sh` (macOS / Linux) or `init.bat` (Windows). After rebuilding you should run `vagrant destroy && vagrant up`.
 
 <a name="connecting-to-databases"></a>
 ### Connecting To Databases

--- a/homestead.md
+++ b/homestead.md
@@ -531,8 +531,6 @@ You may change the default version of PHP used by the CLI by issuing the followi
     php74
     php80
 
-If the command is not found you may need to rebuild your `aliases` file. If you have modified your `aliases` file back it up before proceeding, then rebuild it by running `bash init.sh` (macOS / Linux) or `init.bat` (Windows). After rebuilding you should run `vagrant destroy && vagrant up`.
-
 <a name="connecting-to-databases"></a>
 ### Connecting To Databases
 


### PR DESCRIPTION
Php8.0 was missing from the PHP Versions section. 
I also added a quick note on how to fix `command not found` when running `php80` , which a lot of people will experience as many upgrade to php8.0