### PR TITLE
docs: update link to Jetstream docs

### DIFF
--- a/starter-kits.md
+++ b/starter-kits.md
@@ -57,4 +57,4 @@ While Laravel Breeze provides a simple and minimal starting point for building a
 
 Jetstream provides a beautifully designed application scaffolding for Laravel and includes login, registration, email verification, two-factor authentication, session management, API support via Laravel Sanctum, and optional team management. Jetstream is designed using [Tailwind CSS](https://tailwindcss.com) and offers your choice of [Livewire](https://laravel-livewire.com) or [Inertia.js](https://inertiajs.com) driven frontend scaffolding.
 
-Complete documentation for installing Laravel Jetstream can be found within the [official Jetstream documentation](https://jetstream.laravel.com/1.x/introduction.html).
+Complete documentation for installing Laravel Jetstream can be found within the [official Jetstream documentation](https://jetstream.laravel.com/2.x/introduction.html).


### PR DESCRIPTION
I wasn't sure if this should be updated to use `2.x` with the existing link, or just point to `jetstream.laravel.com` which automatically redirects to the latest. 🤔