### PR TITLE
[8.x] Add default configuration documentation

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -66,6 +66,8 @@ After installation, the primary Horizon configuration option that you should fam
 
 When you start Horizon, it will use the worker process configuration options for the environment that your application is running on. Typically, the environment is determined by the value of the `APP_ENV` [environment variable](/docs/{{version}}/configuration#determining-the-current-environment). For example, the default `local` Horizon environment is configured to start three worker processes and automatically balance the number of worker processes assigned to each queue. The default `production` environment is configured to start a maximum of 10 worker processes and automatically balance the number of worker processes assigned to each queue.
 
+You may configure `defaults` queue on horizon `defaults` confiugration. You may set empty array, if you don't want to set the default configuration.
+
 > {note} You should ensure that the `environments` portion of your `horizon` configuration file contains an entry for each [environment](/docs/{{version}}/configuration#environment-configuration) on which you plan to run Horizon.
 
 <a name="supervisors"></a>

--- a/horizon.md
+++ b/horizon.md
@@ -66,7 +66,7 @@ After installation, the primary Horizon configuration option that you should fam
 
 When you start Horizon, it will use the worker process configuration options for the environment that your application is running on. Typically, the environment is determined by the value of the `APP_ENV` [environment variable](/docs/{{version}}/configuration#determining-the-current-environment). For example, the default `local` Horizon environment is configured to start three worker processes and automatically balance the number of worker processes assigned to each queue. The default `production` environment is configured to start a maximum of 10 worker processes and automatically balance the number of worker processes assigned to each queue.
 
-You may configure `defaults` queue on horizon `defaults` confiugration. You may set empty array, if you don't want to set the default configuration.
+You may configure the `defaults` queue on horizon `defaults` configuration. You may set an empty array if you don't want to set the `defaults` queues. If you set the `defaults` queue, the queue will run on every supervisor.
 
 > {note} You should ensure that the `environments` portion of your `horizon` configuration file contains an entry for each [environment](/docs/{{version}}/configuration#environment-configuration) on which you plan to run Horizon.
 


### PR DESCRIPTION
Add documentation for this PR. https://github.com/laravel/horizon/pull/869

It's confusing for the user with multiple supervisors running and the default queues is on every supervisors.