### PR TITLE
[8.x] Fix wording of `whereNull` and `whereNotNull` methods

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -2770,7 +2770,7 @@ This method has the same signature as the [`whereNotIn`](#method-wherenotin) met
 <a name="method-wherenotnull"></a>
 #### `whereNotNull()` {#collection-method}
 
-The `whereNotNull` method removes items from the collection where the given key is not `null`:
+The `whereNotNull` method returns items from the collection where the given key is not `null`:
 
     $collection = collect([
         ['name' => 'Desk'],
@@ -2792,7 +2792,7 @@ The `whereNotNull` method removes items from the collection where the given key 
 <a name="method-wherenull"></a>
 #### `whereNull()` {#collection-method}
 
-The `whereNull` method removes items from the collection where the given key is `null`:
+The `whereNull` method returns items from the collection where the given key is `null`:
 
     $collection = collect([
         ['name' => 'Desk'],


### PR DESCRIPTION
I had to read these a couple times through, but these descriptions are at worst wrong, and at best very confusing, so trying to fix them.

The `whereNull` returns a new collection whose values of the given field **are** `null`, so it is removing ones that **are not** `null`.

The `whereNotNull` returns a new collection whose values of the given field **are not** `null`, so it is removing ones that **are** `null`.