### PR TITLE
[8.x] Fix mobile horizontal scroll on Sanctum page

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -75,7 +75,9 @@ Next, if you plan to utilize Sanctum to authenticate an SPA, you should add Sanc
 <a name="migration-customization"></a>
 #### Migration Customization
 
-If you are not going to use Sanctum's default migrations, you should call the `Sanctum::ignoreMigrations` method in the `register` method of your `App\Providers\AppServiceProvider` class. You may export the default migrations by executing the following command: `php artisan vendor:publish --tag=sanctum-migrations`
+If you are not going to use Sanctum's default migrations, you should call the `Sanctum::ignoreMigrations` method in the `register` method of your `App\Providers\AppServiceProvider` class. You may export the default migrations by executing the following command:
+
+    php artisan vendor:publish --tag=sanctum-migrations
 
 <a name="configuration"></a>
 ## Configuration


### PR DESCRIPTION
## Issue
The current Sanctum page has a horizontal scroll on mobile devices as you can see on the screenshot below:

<img width="350" alt="horizontal-scroll" src="https://user-images.githubusercontent.com/11693661/104018024-76de1e80-51b9-11eb-9209-86670648cb46.png">

## Fix
I replaced the `<code>` tag with a `<pre>` one to avoid the overflow.