### PR TITLE
Using Factories: replace times() with count() for consistency

### DIFF
--- a/seeding.md
+++ b/seeding.md
@@ -69,7 +69,7 @@ For example, let's create 50 users that each have one related post:
     public function run()
     {
         User::factory()
-                ->times(50)
+                ->count(50)
                 ->hasPosts(1)
                 ->create();
     }


### PR DESCRIPTION
Noticed that `times()` and `count()` are doing the same thing, with `times()` just calling the `count()`:

```
     * @param  int  $count
     * @return static
     */
    public static function times(int $count)
    {
        return static::new()->count($count);
    }
```


So to avoid confusion, I suggest sticking to `count()` in all documentation.