### PR TITLE
[8.x] Typo - 'HelpSpot\API' to 'Transistor'

### DIFF
--- a/container.md
+++ b/container.md
@@ -338,7 +338,7 @@ You may use the `make` method to resolve a class instance from the container. Th
 
     $api = $this->app->make(Transistor::class);
 
-If some of your class' dependencies are not resolvable via the container, you may inject them by passing them as an associative array into the `makeWith` method. For example, we may manually pass the `$id` constructor argument required by the `HelpSpot\API` service:
+If some of your class' dependencies are not resolvable via the container, you may inject them by passing them as an associative array into the `makeWith` method. For example, we may manually pass the `$id` constructor argument required by the `Transistor` service:
 
     use App\Services\Transistor;
 
@@ -419,7 +419,7 @@ The service container fires an event each time it resolves an object. You may li
     use App\Services\Transistor;
 
     $this->app->resolving(Transistor::class, function ($api, $app) {
-        // Called when container resolves objects of type "HelpSpot\API"...
+        // Called when container resolves objects of type "Transistor"...
     });
 
     $this->app->resolving(function ($object, $app) {

--- a/container.md
+++ b/container.md
@@ -336,20 +336,20 @@ You may use the `make` method to resolve a class instance from the container. Th
 
     use App\Services\Transistor;
 
-    $api = $this->app->make(Transistor::class);
+    $transistor = $this->app->make(Transistor::class);
 
 If some of your class' dependencies are not resolvable via the container, you may inject them by passing them as an associative array into the `makeWith` method. For example, we may manually pass the `$id` constructor argument required by the `Transistor` service:
 
     use App\Services\Transistor;
 
-    $api = $this->app->makeWith(Transistor::class, ['id' => 1]);
+    $transistor = $this->app->makeWith(Transistor::class, ['id' => 1]);
 
 If you are outside of a service provider in a location of your code that does not have access to the `$app` variable, you may use the `App` [facade](/docs/{{version}}/facades) to resolve a class instance from the container:
 
     use App\Services\Transistor;
     use Illuminate\Support\Facades\App;
 
-    $api = App::make(Transistor::class);
+    $transistor = App::make(Transistor::class);
 
 If you would like to have the Laravel container instance itself injected into a class that is being resolved by the container, you may type-hint the `Illuminate\Container\Container` class on your class' constructor:
 
@@ -418,7 +418,7 @@ The service container fires an event each time it resolves an object. You may li
 
     use App\Services\Transistor;
 
-    $this->app->resolving(Transistor::class, function ($api, $app) {
+    $this->app->resolving(Transistor::class, function ($transistor, $app) {
         // Called when container resolves objects of type "Transistor"...
     });
 


### PR DESCRIPTION
In Laravel 7.x Service Container docs, 'HelpSpot\API' was used as a sample class.

In Laravel 8.x Service Container docs, the sample class was switched to 'Transistor'.

The old sample class 'HelpSpot\API' is accidentally still used in two places. In four places, the old variable name `$api` is used aswell, this pull request will fix mentioned typos.