### PR TITLE
Document `Session::now($key, $value)`

### DIFF
--- a/session.md
+++ b/session.md
@@ -181,8 +181,10 @@ Sometimes you may wish to store items in the session for the next request. You m
 
     $request->session()->flash('status', 'Task was successful!');
 
-If you need to persist your flash data for several requests, you may use the `reflash` method, which will keep all of the flash data for an additional request. If you only need to keep specific flash data, you may use the `keep` method:
+If you need to persist your flash data for just the current request, you may use the `now` method. If you need to persist your flash data for several requests, you may use the `reflash` method, which will keep all of the flash data for an additional request. If you only need to keep specific flash data, you may use the `keep` method:
 
+    $request->session()->now('status', 'Task was successful!');
+    
     $request->session()->reflash();
 
     $request->session()->keep(['username', 'email']);


### PR DESCRIPTION
- Document [`Session::now($key, $value)`](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Session/Store.php#L363-L375)
  - Solved a recent problem whereby data was persisting over two requests: https://stackoverflow.com/questions/14517809/laravels-flash-session-stores-data-twice?#answer-49626423
  - There also seem to be other SO questions querying the difference between `flash()` and `now()`: https://stackoverflow.com/questions/58593433/laravel-difference-between-session-flash-and-session-now