### PR TITLE
[8.x] Update the docs to reflect the merge of reduceWithKeys into the existing reduce method

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -164,7 +164,6 @@ For the majority of the remaining collection documentation, we'll discuss each m
 [put](#method-put)
 [random](#method-random)
 [reduce](#method-reduce)
-[reduceWithKeys](#method-reducewithkeys)
 [reject](#method-reject)
 [replace](#method-replace)
 [replaceRecursive](#method-replacerecursive)

--- a/collections.md
+++ b/collections.md
@@ -164,6 +164,7 @@ For the majority of the remaining collection documentation, we'll discuss each m
 [put](#method-put)
 [random](#method-random)
 [reduce](#method-reduce)
+[reduceWithKeys](#method-reducewithkeys)
 [reject](#method-reject)
 [replace](#method-replace)
 [replaceRecursive](#method-replacerecursive)
@@ -1704,6 +1705,28 @@ The value for `$carry` on the first iteration is `null`; however, you may specif
     }, 4);
 
     // 10
+
+<a name="method-reducewithkeys"></a>
+#### `reduceWithKeys()` {#collection-method}
+
+The `reduceWithKeys` method reduces an associative collection to a single value, passing the result of previous iterations along with each key / value pair to the given callback:
+
+    $collection = collect([
+        'usd' => 1400,
+        'gbp' => 1200,
+        'eur' => 1000,
+    ]);
+    $ratio = [
+        'usd' => 1,
+        'gbp' => 1.37,
+        'eur' => 1.22,
+    ];
+
+    $collection->reduceWithKeys(function ($carry, $value, $key) use ($ratio) {
+        return $carry + $value * $ratio[$key];
+    }, 0);
+
+    // 4264
 
 <a name="method-reject"></a>
 #### `reject()` {#collection-method}

--- a/collections.md
+++ b/collections.md
@@ -1706,16 +1706,14 @@ The value for `$carry` on the first iteration is `null`; however, you may specif
 
     // 10
 
-<a name="method-reducewithkeys"></a>
-#### `reduceWithKeys()` {#collection-method}
-
-The `reduceWithKeys` method reduces an associative collection to a single value, passing the result of previous iterations along with each key / value pair to the given callback:
+The `reduce` method also passes array keys in associative collections to the given callback:
 
     $collection = collect([
         'usd' => 1400,
         'gbp' => 1200,
         'eur' => 1000,
     ]);
+
     $ratio = [
         'usd' => 1,
         'gbp' => 1.37,
@@ -1723,8 +1721,8 @@ The `reduceWithKeys` method reduces an associative collection to a single value,
     ];
 
     $collection->reduceWithKeys(function ($carry, $value, $key) use ($ratio) {
-        return $carry + $value * $ratio[$key];
-    }, 0);
+        return $carry + ($value * $ratio[$key]);
+    });
 
     // 4264
 

--- a/mocking.md
+++ b/mocking.md
@@ -222,7 +222,7 @@ The `Bus` facade's `assertBatched` method may be used to assert that a [batch of
 <a name="event-fake"></a>
 ## Event Fake
 
-When testing code that dispatches events, you may wish to instruct Laravel to not actually execute the event's listeners. Using the `Event` facade's `fake` method, you may prevent listeners from executing, execute the code under test, and then assert which events were dispatched by your application using the `assertDispatched` and `assertNotDispatched` methods:
+When testing code that dispatches events, you may wish to instruct Laravel to not actually execute the event's listeners. Using the `Event` facade's `fake` method, you may prevent listeners from executing, execute the code under test, and then assert which events were dispatched by your application using the `assertDispatched`, `assertNotDispatched`, and `assertNothingDispatched` methods:
 
     <?php
 
@@ -254,6 +254,9 @@ When testing code that dispatches events, you may wish to instruct Laravel to no
 
             // Assert an event was not dispatched...
             Event::assertNotDispatched(OrderFailedToShip::class);
+            
+            // Assert that no events were dispatched...
+            Event::assertNothingDispatched();
         }
     }
 


### PR DESCRIPTION
This updates Collection docs to reflect latest changes in `reduce`

As discussed here: https://github.com/laravel/framework/pull/35839
The new pull request to framework here: https://github.com/laravel/framework/pull/35878
Previous change to the docs that was merged and needs to be updated because the underlying changed was reverted here: https://github.com/laravel/docs/pull/6740