### PR TITLE
Adds missing protected declaration on fillable example

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -660,7 +660,7 @@ When assigning JSON columns, each column's mass assignable key must be specified
      *
      * @var array
      */
-    $fillable = [
+    protected $fillable = [
         'options->enabled',
     ];
 


### PR DESCRIPTION
I think this `$fillable` example is missing a `protected` declaration.