### PR TITLE
[8.x] Add replace argument to method get in  Facade Lang

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -66,7 +66,7 @@ If necessary, you may define macros that accept additional arguments:
 
     Collection::macro('toLocale', function ($locale) {
         return $this->map(function ($value) use ($locale) {
-            return Lang::get($value, $locale);
+            return Lang::get($value, [], $locale);
         });
     });
 


### PR DESCRIPTION
locale argument is out of order. but in PHP 8 you can set name to argument for example:

![image](https://user-images.githubusercontent.com/17320461/105045663-64979680-5a7d-11eb-9d01-614feed2622d.png)
