### PR TITLE
[8.x] Add assertNothingQueued to Mail Mocking

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -376,6 +376,8 @@ If you are queueing mailables for delivery in the background, you should use the
 
     Mail::assertNotQueued(OrderShipped::class);
 
+    Mail::assertNothingQueued();
+
 You may pass a closure to the `assertSent` or `assertNotSent` methods in order to assert that a mailable was sent that passes a given "truth test". If at least one mailable was sent that passes the given truth test then the assertion will be successful:
 
     Mail::assertSent(function (OrderShipped $mail) use ($order) {


### PR DESCRIPTION
PR adds missing documentation of [`assertNothingQueued()`](https://github.com/laravel/framework/blob/0d601f598a2434b8b126c06af75a0f089b10a102/src/Illuminate/Support/Testing/Fakes/MailFake.php#L174).