### PR TITLE
[8.x] Document composite keys unavailability for Eloquent models

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -158,6 +158,8 @@ If your model's primary key is not an integer, you should define a protected `$k
          */
         protected $keyType = 'string';
     }
+    
+> {note} Please note that composite primary keys are not supported for Eloquent models.
 
 <a name="timestamps"></a>
 ### Timestamps


### PR DESCRIPTION
I didn't realise this wasn't documented yet so it's probably best that we add a note to the docs here.