### PR TITLE
[8.x] Improve dynamic relationship example

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -936,6 +936,20 @@ You may determine the morph alias of a given model at runtime using the model's 
 
 > {note} When adding a "morph map" to your existing application, every morphable `*_type` column value in your database that still contains a fully-qualified class will need to be converted to its "map" name.
 
+Furthermore, you may use an anonymous PHP class when giving a Model to your relation definition.
+
+```
+    use Illuminate\Database\Eloquent\Model;
+    
+    $customerModel = new class extends Model {
+        protected $table = 'customers';
+    }
+    
+    Order::resolveRelationUsing('customer', function ($orderModel) use ($customerModel) {
+        return $orderModel->belongsTo($customerModel, 'customer_id');
+    });
+```
+
 <a name="dynamic-relationships"></a>
 ### Dynamic Relationships
 


### PR DESCRIPTION
Add an example to the dynamic relationship using an anonymous PHP class.

In real case usage, this feature was useful when migrating a payment method provided by a third-party package where models and relations were not available anymore.