### PR TITLE
Add some missing helpers

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -109,6 +109,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [Str::padBoth](#method-str-padboth)
 [Str::padLeft](#method-str-padleft)
 [Str::padRight](#method-str-padright)
+[Str::parseCallback](#method-str-parsecallback)
 [Str::plural](#method-str-plural)
 [Str::random](#method-str-random)
 [Str::replaceArray](#method-str-replace-array)
@@ -1335,6 +1336,17 @@ The `Str::padRight` method wraps PHP's `str_pad` function, padding the right sid
     $padded = Str::padRight('James', 10);
 
     // 'James     '
+
+<a name="method-str-parsecallback"></a>
+#### `Str::parseCallback()` {#collection-method}
+
+The `Str::parseCallback` method parses a `Class@method` style callback into a class name and method name:
+
+    use Illuminate\Support\Str;
+
+    $callback = Str::parseCallback('UserController@show');
+
+    // ['UserController', 'show']
 
 <a name="method-str-plural"></a>
 #### `Str::plural()` {#collection-method}

--- a/helpers.md
+++ b/helpers.md
@@ -122,6 +122,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [Str::startsWith](#method-starts-with)
 [Str::studly](#method-studly-case)
 [Str::substr](#method-str-substr)
+[Str::substrCount](#method-str-substrcount)
 [Str::title](#method-title-case)
 [Str::ucfirst](#method-str-ucfirst)
 [Str::upper](#method-str-upper)
@@ -1503,6 +1504,17 @@ The `Str::substr` method returns the portion of string specified by the start an
     $converted = Str::substr('The Laravel Framework', 4, 7);
 
     // Laravel
+
+<a name="method-str-substrcount"></a>
+#### `Str::substrCount()` {#collection-method}
+
+The `Str::substrCount` method returns the number of occurrences of the given value in the given string:
+
+    use Illuminate\Support\Str;
+
+    $count = Str::substrCount('If you never did, you should. These things are fun and fun is good.', 'fun');
+
+    // 2
 
 <a name="method-title-case"></a>
 #### `Str::title()` {#collection-method}

--- a/helpers.md
+++ b/helpers.md
@@ -240,6 +240,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [old](#method-old)
 [optional](#method-optional)
 [policy](#method-policy)
+[queueable](#method-queueable)
 [redirect](#method-redirect)
 [report](#method-report)
 [request](#method-request)
@@ -2674,6 +2675,17 @@ The `optional` function also accepts a closure as its second argument. The closu
 The `policy` method retrieves a [policy](/docs/{{version}}/authorization#creating-policies) instance for a given class:
 
     $policy = policy(App\Models\User::class);
+
+<a name="method-queueable"></a>
+#### `queueable()` {#collection-method}
+
+The `queueable` method creates a new [queued closure event listener](/docs/{{version}}/events#queuable-anonymous-event-listeners):
+
+    $listener = queueable(function (PodcastProcessed $event) {
+        //
+    }));
+
+> {note} Unlike most other helpers, `queueable` is not registered globally. To use it in your application, you must import it with `use function Illuminate\Events\queueable;`.
 
 <a name="method-redirect"></a>
 #### `redirect()` {#collection-method}

--- a/helpers.md
+++ b/helpers.md
@@ -228,7 +228,9 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [cookie](#method-cookie)
 [csrf_field](#method-csrf-field)
 [csrf_token](#method-csrf-token)
+[encrypt](#method-encrypt)
 [dd](#method-dd)
+[decrypt](#method-decrypt)
 [dispatch](#method-dispatch)
 [dispatch_now](#method-dispatch-now)
 [dump](#method-dump)
@@ -2553,6 +2555,13 @@ The `csrf_token` function retrieves the value of the current CSRF token:
 
     $token = csrf_token();
 
+<a name="method-encrypt"></a>
+#### `encrypt()` {#collection-method}
+
+The `encrypt` function [encrypts](/docs/{{version}}/encryption#encrypting-a-value) the given value:
+
+    encrypt($value);
+
 <a name="method-dd"></a>
 #### `dd()` {#collection-method}
 
@@ -2563,6 +2572,13 @@ The `dd` function dumps the given variables and ends execution of the script:
     dd($value1, $value2, $value3, ...);
 
 If you do not want to halt the execution of your script, use the [`dump`](#method-dump) function instead.
+
+<a name="method-decrypt"></a>
+#### `decrypt()` {#collection-method}
+
+The `decrypt` function [decrypts](/docs/{{version}}/encryption#decrypting-a-value) the given value:
+
+    decrypt($value);
 
 <a name="method-dispatch"></a>
 #### `dispatch()` {#collection-method}

--- a/helpers.md
+++ b/helpers.md
@@ -2721,11 +2721,13 @@ The `policy` method retrieves a [policy](/docs/{{version}}/authorization#creatin
 
 The `queueable` method creates a new [queued closure event listener](/docs/{{version}}/events#queuable-anonymous-event-listeners):
 
+    use function Illuminate\Events\queueable;
+
     $listener = queueable(function (PodcastProcessed $event) {
         //
     }));
 
-> {note} Unlike most other helpers, `queueable` is not registered globally. To use it in your application, you must import it with `use function Illuminate\Events\queueable;`.
+> {note} Unlike most other helpers, `queueable` is not registered globally. To use it, you must import it as shown above.
 
 <a name="method-redirect"></a>
 #### `redirect()` {#collection-method}


### PR DESCRIPTION
Adds entries on the Helpers page for `Str::parseCallback`, `Str::substrCount`, `encrypt`, `decrypt`, and `queueable`.