### PR TITLE
[8.x] Add session maximum size note with the cookie driver

### DIFF
--- a/session.md
+++ b/session.md
@@ -39,6 +39,9 @@ The session `driver` configuration option defines where session data will be sto
 
 > {tip} The array driver is primarily used during [testing](/docs/{{version}}/testing) and prevents the data stored in the session from being persisted.
 
+
+> {note} The `cookie` driver has a maximum allowed size that is determined by the browser itself. Storing too much data into the session, e.g. [flashing the input](/docs/{{version}}/requests#flashing-input-then-redirecting) on a large form, will result in an empty session.
+
 <a name="driver-prerequisites"></a>
 ### Driver Prerequisites
 


### PR DESCRIPTION
Hi,

I was using the cookie driver on my laravel application and I encountered some problems trying to display errors on a form with some large inputs. I was able to track down the cause to the `cookie` session driver after a very long session of trial-and-errors. [I seeked some help on stackoverflow](https://stackoverflow.com/questions/65905616/laravel-does-not-display-validation-errors-when-using-request-validate/65916121) without much help.

Even after figuring out the error, I only found this on the internet: https://github.com/laravel/framework/issues/18112 

I think it would be useful to document this specific behaviour that may surprise some less-experienced devs such as myself. It would also help developers to make a more informed decisions when selecting the proper driver.

I'm definitely open to some suggestions about a better phrasing for the note.

Hope it helps, 
thank you for your great work