### PR TITLE
[8.x] The CreatesApplication trait

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -32,7 +32,7 @@ In addition, you may create a `.env.testing` file in the root of your project. T
 <a name="the-creates-application-trait"></a>
 #### The `CreatesApplication` Trait
 
-Laravel includes with a `CreatesApplication` trait that is applied to your application's base `TestCase` class. This trait contains a `createApplication` method that bootstraps the Laravel application before running your tests. It's important that you leave this trait at its original location as some features, such as Laravel's parallel testing feature, depend on it.
+Laravel includes a `CreatesApplication` trait that is applied to your application's base `TestCase` class. This trait contains a `createApplication` method that bootstraps the Laravel application before running your tests. It's important that you leave this trait at its original location as some features, such as Laravel's parallel testing feature, depend on it.
 
 <a name="creating-tests"></a>
 ## Creating Tests

--- a/testing.md
+++ b/testing.md
@@ -32,7 +32,7 @@ In addition, you may create a `.env.testing` file in the root of your project. T
 <a name="the-creates-application-trait"></a>
 #### The `CreatesApplication` Trait
 
-Laravel ships with a `CreatesApplication` trait that's applied to your base `TestCase.php` class. This trait features a `createApplication` method that bootstrap the Laravel application before running your test. It's important that you leave this trait at its original location as some features, like parallel testing, depend on it.
+Laravel includes with a `CreatesApplication` trait that is applied to your application's base `TestCase` class. This trait contains a `createApplication` method that bootstraps the Laravel application before running your tests. It's important that you leave this trait at its original location as some features, such as Laravel's parallel testing feature, depend on it.
 
 <a name="creating-tests"></a>
 ## Creating Tests

--- a/testing.md
+++ b/testing.md
@@ -29,6 +29,11 @@ You are free to define other testing environment configuration values as necessa
 
 In addition, you may create a `.env.testing` file in the root of your project. This file will be used instead of the `.env` file when running PHPUnit tests or executing Artisan commands with the `--env=testing` option.
 
+<a name="the-creates-application-trait"></a>
+#### The `CreatesApplication` Trait
+
+Laravel ships with a `CreatesApplication` trait that's applied to your base `TestCase.php` class. This trait features a `createApplication` method that bootstrap the Laravel application before running your test. It's important that you leave this trait at its original location as some features, like parallel testing, depend on it.
+
 <a name="creating-tests"></a>
 ## Creating Tests
 


### PR DESCRIPTION
This adds a small section to the docs to make it clear that the original location of the `CreatesApplication` should not be changed as some functionality depends on it.

See https://github.com/laravel/framework/issues/36053