### PR TITLE
[8.x] Document `Str::markdown()` and `Str::of()->markdown()`

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -1298,6 +1298,11 @@ The `Str::markdown` method converts GitHub flavored markdown into html:
 
     // <h1>Laravel</h1>
 
+    $options = ['html_input' => 'strip'];
+    $html = Str::markdown('# Taylor <b>Otwell</b>', $options);
+
+    // <h1>Taylor Otwell</h1>
+
 <a name="method-str-ordered-uuid"></a>
 #### `Str::orderedUuid()` {#collection-method}
 
@@ -1965,6 +1970,11 @@ The `markdown` method converts GitHub flavored markdown into html:
     $html = Str::of('# Laravel')->markdown();
 
     // <h1>Laravel</h1>
+
+    $options = ['html_input' => 'strip'];
+    $html = Str::of('# Taylor <b>Otwell</b>')->markdown($options);
+
+    // <h1>Taylor Otwell</h1>
 
 <a name="method-fluent-str-match"></a>
 #### `match` {#collection-method}

--- a/helpers.md
+++ b/helpers.md
@@ -163,6 +163,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [limit](#method-fluent-str-limit)
 [lower](#method-fluent-str-lower)
 [ltrim](#method-fluent-str-ltrim)
+[markdown](#method-fluent-str-markdown)
 [match](#method-fluent-str-match)
 [matchAll](#method-fluent-str-match-all)
 [padBoth](#method-fluent-str-padboth)
@@ -1953,6 +1954,17 @@ The `ltrim` method trims the left side of the string:
     $string = Str::of('/Laravel/')->ltrim('/');
 
     // 'Laravel/'
+
+<a name="method-fluent-str-markdown"></a>
+#### `markdown` {#collection-method}
+
+The `markdown` method converts GitHub flavored markdown into html:
+
+    use Illuminate\Support\Str;
+
+    $html = Str::of('# Laravel')->markdown();
+
+    // <h1>Laravel</h1>
 
 <a name="method-fluent-str-match"></a>
 #### `match` {#collection-method}

--- a/helpers.md
+++ b/helpers.md
@@ -105,6 +105,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [Str::length](#method-str-length)
 [Str::limit](#method-str-limit)
 [Str::lower](#method-str-lower)
+[Str::markdown](#method-str-markdown)
 [Str::orderedUuid](#method-str-ordered-uuid)
 [Str::padBoth](#method-str-padboth)
 [Str::padLeft](#method-str-padleft)
@@ -1285,6 +1286,17 @@ The `Str::lower` method converts the given string to lowercase:
 
     // laravel
 
+<a name="method-str-markdown"></a>
+#### `Str::markdown()` {#collection-method}
+
+The `Str::markdown` method converts GitHub flavored markdown into html:
+
+    use Illuminate\Support\Str;
+
+    $html = Str::markdown('# Laravel');
+
+    // <h1>Laravel</h1>
+
 <a name="method-str-ordered-uuid"></a>
 #### `Str::orderedUuid()` {#collection-method}
 
@@ -2273,7 +2285,7 @@ The `tap` method passes the string to the given closure, allowing you to examine
             dump('String after append: ' . $string);
         })
         ->upper();
-    
+
     // LARAVEL FRAMEWORK
 
 <a name="method-fluent-str-title"></a>


### PR DESCRIPTION
Documents https://github.com/laravel/framework/pull/36071
Credit to @amberlampsio

---

**Note:**
- My code examples don't include the trailing `\n` the converter also appends as shown [in the PR tests](https://github.com/laravel/framework/pull/36071/files#diff-be47dbd336aece128f999b4c2d8b4fc7ee809a1d1e0ddd178547542201d4e897R517)
- Might be worth linking to the [converter docs](https://github.com/thephpleague/commonmark#-installation--basic-usage) so developers know all the options available to them
- Might be worth defining what [GitHub Flavored Markdown is versus normal markdown](https://github.com/thephpleague/commonmark#-github-flavored-markdown)