### PR TITLE
[8.x] Update return type for report method

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -146,7 +146,7 @@ Instead of type-checking exceptions in the exception handler's `register` method
         /**
          * Report the exception.
          *
-         * @return void
+         * @return bool|null
          */
         public function report()
         {
@@ -170,7 +170,7 @@ If your exception contains custom reporting logic that is only necessary when ce
     /**
      * Report the exception.
      *
-     * @return bool|void
+     * @return bool|null
      */
     public function report()
     {


### PR DESCRIPTION
This fixes the incorrect return type for report method on exceptions. A return type can never be `void` in combination with something else. Since the report method allows to either return nothing (`null`) or `false` we should properly indicate those types.

See https://github.com/laravel/framework/issues/36109