### PR TITLE
[8.x] Clarify defining recipients when using Mailables in mail notifications

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -308,6 +308,29 @@ In addition, you may return a full [mailable object](/docs/{{version}}/mail) fro
                     ->to($notifiable->email);
     }
 
+When using a `Mailable` instead of a `MailMessage`, the receiver should be explicitly defined on the `Mailable` itself. [Overwriting `routeNotificationForMail`](#customizing-the-recipient) on an Eloquent model or using [on-demand notifications](#on-demand-notifications) don't allow you to specify the receiver in this case. Instead you should always use the `to` method on the `Mailable` to define the receiver based on the `$notifiable`.
+
+The above example already shows how this can be done for regular notifiable models. For on-demand notifications you may derive the email address(es) by checking the `AnonymousNotifiable` type:
+    
+    use App\Mail\InvoicePaid as InvoicePaidMailable;
+    use Illuminate\Notifications\AnonymousNotifiable;
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return Mailable
+     */
+    public function toMail($notifiable)
+    {
+        $recipient = $notifiable instanceof AnonymousNotifiable
+            ? $notifiable->routeNotificationFor('mail')
+            : $notifiable->email;
+
+        return (new InvoicePaidMailable($this->invoice))
+                    ->to($recipient);
+    }
+
 <a name="error-messages"></a>
 #### Error Messages
 


### PR DESCRIPTION
I took a very very deep dive into the behavior of defining recipients when using Mailables instead of MailMessages in mail notifications and came to the following conclusion: when using Mailables the recipients are always defined explicitly by using the `->to` method on the mailable based on the notifiable.

This means that in the case for regular notifiable models the `routeNotificationForMail` method (or default of `->email` for that matter) and for the case of on-demand notifications the recipient defined by the notifiable needs to be explicitly passed to the mailable.

I was genuinely confused myself at first after reviewing the following issue: https://github.com/laravel/framework/issues/36115. I believe adding this extra part to the docs here can clarify a lot for our users.