### PR TITLE
[8.x] Localisation namespace

### DIFF
--- a/localization.md
+++ b/localization.md
@@ -187,3 +187,5 @@ If you would like to display the integer value that was passed to the `trans_cho
 Some packages may ship with their own language files. Instead of changing the package's core files to tweak these lines, you may override them by placing files in the `resources/lang/vendor/{package}/{locale}` directory.
 
 So, for example, if you need to override the English translation strings in `messages.php` for a package named `skyrim/hearthfire`, you should place a language file at: `resources/lang/vendor/hearthfire/en/messages.php`. Within this file, you should only define the translation strings you wish to override. Any translation strings you don't override will still be loaded from the package's original language files.
+
+Some packages may use a different namespace than the package name. For example the package `skyrim/hearthfire` may use the `namespace skyrim\Dragonborn;` in its service provider. In this case you should place a language file at `resources/lang/vendor/Dragonborn/en/messages.php`.


### PR DESCRIPTION
Clocked an issue where a package uses a different namespace to the package name. In this case the namespace in the package service provider is used.

Added an addition to the docs for this edge case. Not sure if it something that needs to be fixed in the framework or such an edge case it needs to be looked out for.

The example I'm running off is: https://github.com/ubient/laravel-pwned-passwords/blob/master/src/PwnedPasswordsServiceProvider.php using laravel-pwned-passwords or laravelPwnedPasswords didn't work. It had to be PwnedPasswords.