### PR TITLE
Update sail.md

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -90,10 +90,10 @@ sail up -d
 
 Once the application's containers have been started, you may access the project in your web browser at: http://localhost.
 
-To stop all of the containers, you may simply press Control + C to stop the container's execution. Or, if the containers are running in the background, you may use the `down` command:
+To stop all of the containers, you may simply press Control + C to stop the container's execution. Or, if the containers are running in the background, you may use the `stop` command:
 
 ```bash
-sail down
+sail stop
 ```
 
 <a name="executing-sail-commands"></a>


### PR DESCRIPTION
Small correction on the stop procedure for containers running in detached mode. 
`down` (current docs) will stop **and** remove containers. The equivalent of `Control + C` would be `stop` which only stops (and doesn't remove). This can be seen in the terminal output when comparing `Control + C`, `stop` and `down`. 

The issue with running `down` is if any pruning is performed, those database volumes are now unlinked to containers and the data will be lost.

References:
 - https://docs.docker.com/compose/reference/down/
 - https://docs.docker.com/compose/reference/stop/