### PR TITLE
Fix grammar in requests.md

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -156,7 +156,7 @@ The `hasHeader` method may be used to determine if the request contains a given 
         //
     }
 
-For convenience, the `bearerToken` may be used to retreive a bearer token from the `Authorization` header. If no such header is present, an empty string will be returned:
+For convenience, the `bearerToken` method may be used to retrieve a bearer token from the `Authorization` header. If no such header is present, an empty string will be returned:
 
     $token = $request->bearerToken();
 

--- a/requests.md
+++ b/requests.md
@@ -156,7 +156,7 @@ The `hasHeader` method may be used to determine if the request contains a given 
         //
     }
 
-For convenience, the `bearerToken` may be used to a bearer token from the `Authorization` header. If no such header is present, an empty string will be returned:
+For convenience, the `bearerToken` may be used to retreive a bearer token from the `Authorization` header. If no such header is present, an empty string will be returned:
 
     $token = $request->bearerToken();
 


### PR DESCRIPTION
Added **retrieve**

The sentence should be: **For convenience, the `bearerToken` may be used to retrieve a bearer...**

See [here](https://laravel.com/docs/8.x/requests#request-headers)

![Screenshot 2021-02-14 120041](https://user-images.githubusercontent.com/19666053/107874820-9ead5a00-6ebc-11eb-99fd-e441c98bb3ff.jpg)

