### PR TITLE
[8.x] Adds note about missing PHPUnit options when running tests in parallel

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -97,7 +97,7 @@ By default, Laravel will create as many processes as there are available CPU cor
 
     php artisan test --parallel --processes=4
 
-> {note} When running tests in parallel, some PHPUnit options — such us `--do-not-cache-result` — may not be available.
+> {note} When running tests in parallel, some PHPUnit options (such as `--do-not-cache-result`) may not be available.
 
 <a name="parallel-testing-and-databases"></a>
 #### Parallel Testing & Databases

--- a/testing.md
+++ b/testing.md
@@ -97,6 +97,8 @@ By default, Laravel will create as many processes as there are available CPU cor
 
     php artisan test --parallel --processes=4
 
+> {note} When running tests in parallel, some PHPUnit options — such us `--do-not-cache-result` — may not be available.
+
 <a name="parallel-testing-and-databases"></a>
 #### Parallel Testing & Databases
 


### PR DESCRIPTION
This pull request adds a note concerning the missing PHPUnit options when running tests in parallel.