### PR TITLE
[8.x] Drop support for old database versions

### DIFF
--- a/database.md
+++ b/database.md
@@ -15,8 +15,8 @@
 Almost every modern web application interacts with a database. Laravel makes interacting with databases extremely simple across a variety of supported databases using raw SQL, a [fluent query builder](/docs/{{version}}/queries), and the [Eloquent ORM](/docs/{{version}}/eloquent). Currently, Laravel provides first-party support for four databases:
 
 <div class="content-list" markdown="1">
-- MySQL 5.6+ ([Version Policy](https://en.wikipedia.org/wiki/MySQL#Release_history))
-- PostgreSQL 9.4+ ([Version Policy](https://www.postgresql.org/support/versioning/))
+- MySQL 5.7+ ([Version Policy](https://en.wikipedia.org/wiki/MySQL#Release_history))
+- PostgreSQL 9.6+ ([Version Policy](https://www.postgresql.org/support/versioning/))
 - SQLite 3.8.8+
 - SQL Server 2017+ ([Version Policy](https://support.microsoft.com/en-us/lifecycle/search))
 </div>


### PR DESCRIPTION
Bumps the minimum version for database versions which aren't supported anymore.