### PR TITLE
Document optional console argument arrays

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -274,6 +274,10 @@ When calling this method, the `user` arguments may be passed in order to the com
 
     php artisan mail:send foo bar
 
+This can be combined with the optional argument definition to allow zero or more instances of the argument:
+
+    mail:send {user?*}
+
 <a name="option-arrays"></a>
 #### Option Arrays
 


### PR DESCRIPTION
Currently, the documentation does not specify how to combine the Artisan Console's optional arguments with the argument arrays. This adds a simple explanation and example based on the current implementation that works in the framework.