### PR TITLE
[8.x] Clarify integer rule

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -985,7 +985,7 @@ The field under validation must exist in _anotherfield_'s values.
 
 The field under validation must be an integer.
 
-> {note} This validation rule does not verify that the input is of the "integer" variable type, only that the input is a string or numeric value that contains an integer.
+> {note} This validation rule does not verify that the input is of the "integer" variable type, only that the input is of a type accepted by PHP's `FILTER_VALIDATE_INT` rule. If you need to validate the input as being a number please use this rule in combination with [the `numeric` validation rule](#rule-numeric).
 
 <a name="rule-ip"></a>
 #### ip


### PR DESCRIPTION
The integer validation rule still causes confusion sometimes. I've tried to reword the note on it to make it more clear what the rule exactly does and guide people to the `numeric` rule which is probably what they need in combination with this.

See https://github.com/laravel/framework/issues/36321