### PR TITLE
Add isNot method in eloquent documentation comparing section

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1062,13 +1062,20 @@ Once the expected arguments have been added to your scope method's signature, yo
 <a name="comparing-models"></a>
 ## Comparing Models
 
-Sometimes you may need to determine if two models are the "same". The `is` method may be used to quickly verify two models have the same primary key, table, and database connection:
+Sometimes you may need to determine if two models are the "same" or "not same". The `is` method may be used to quickly verify two models have the same primary key, table, and database connection:
 
     if ($post->is($anotherPost)) {
         //
     }
 
-The `is` method is also available when using the `belongsTo`, `hasOne`, `morphTo`, and `morphOne` [relationships](/docs/{{version}}/eloquent-relationships). This method is particularly helpful when you would like to compare a related model without issuing a query to retrieve that model:
+The `isNot` method used to determine if two models are "not same":
+
+    if ($post->isNot($anotherPost)) {
+        //
+    }
+ 
+
+The `is` and `isNot` methods are also available when using the `belongsTo`, `hasOne`, `morphTo`, and `morphOne` [relationships](/docs/{{version}}/eloquent-relationships). This method is particularly helpful when you would like to compare a related model without issuing a query to retrieve that model:
 
     if ($post->author()->is($user)) {
         //


### PR DESCRIPTION
Eloquent doc page has comparing section where it introduces the `is` method. I see `isNot` method is missing. I discover `isNot` method from the Laravel API documentation. I use it quite a lot and thought it should be in the documentation. 

Note: It is my first PR, pardon any mistake. I'm open to redoing/modifications.