### PR TITLE
[8.x] Use sail command instead

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -296,7 +296,7 @@ If you would like to choose the subdomain for your shared site, you may provide 
 Since Sail is just Docker, you are free to customize nearly everything about it. To publish Sail's own Dockerfiles, you may execute the `sail:publish` command:
 
 ```bash
-php artisan sail:publish
+sail artisan sail:publish
 ```
 
 After running this command, the Dockerfiles and other configuration files used by Laravel Sail will be placed within a `docker` directory in your application's root directory. After customizing your Sail installation, you may rebuild your application's containers using the `build` command:


### PR DESCRIPTION
Suggest using the `sail` command is more consistent in this document.