### PR TITLE
[8.x] Adds the `collect` method to the HTTP Client documentation.

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -35,6 +35,7 @@ The `get` method returns an instance of `Illuminate\Http\Client\Response`, which
 
     $response->body() : string;
     $response->json() : array|mixed;
+    $response->collect() : Illuminate\Support\Collection;
     $response->status() : int;
     $response->ok() : bool;
     $response->successful() : bool;


### PR DESCRIPTION
This adds reference to the new HTTP Client `collect` method added in `8.29.0`

I've kept this quite light, as it seems documentation on the `json` method is pretty lightweight too. I'm happy to write a more in depth paragraph/code examples on both `json` and `collect` if that would be useful?