### PR TITLE
[8.x] Fortify - Mention how to decrypt the recovery codes

### DIFF
--- a/fortify.md
+++ b/fortify.md
@@ -238,10 +238,8 @@ If you are building a JavaScript powered frontend, you may make an XHR GET reque
 You should also display the user's two factor recovery codes. These recovery codes allow the user to authenticate if they lose access to their mobile device. If you are using Blade to render your application's frontend, you may access the recovery codes via the authenticated user instance:
 
 ```php
-(array) $request->user()->two_factor_recovery_codes
+(array) $request->user()->recoveryCodes()
 ```
-
-This will return the recovery codes as an encrypted string. To view the recovery codes as an array, you can decrypt the string, for example, using the `decrypt()` helper method.
 
 If you are building a JavaScript powered frontend, you may make an XHR GET request to the `/user/two-factor-recovery-codes` endpoint. This endpoint will return a JSON array containing the user's recovery codes.
 

--- a/fortify.md
+++ b/fortify.md
@@ -241,6 +241,8 @@ You should also display the user's two factor recovery codes. These recovery cod
 (array) $request->user()->two_factor_recovery_codes
 ```
 
+This will return the recovery codes as an encrypted string. To view the recovery codes as an array, you can decrypt the string, for example, using the `decrypt()` helper method.
+
 If you are building a JavaScript powered frontend, you may make an XHR GET request to the `/user/two-factor-recovery-codes` endpoint. This endpoint will return a JSON array containing the user's recovery codes.
 
 To regenerate the user's recovery codes, your application should make a POST request to the `/user/two-factor-recovery-codes` endpoint.


### PR DESCRIPTION
Hi,

As I've been using this package, I noticed that when I got to the part about displaying the recovery codes, there was no information about how it was returned and what actions had to be taken to view them correctly.

I got my answer via a YouTube channel as I was not aware of the `decrypt()` helper method.

I figured this could be useful information to someone else who, like me, got stuck at it.

I don't know if using the `decrypt()` helper method is the most elegant way to achieve this, but it seems the simplist.

Thanks,

Chris