### PR TITLE
Clarify `required_with*` validation rules

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1178,22 +1178,22 @@ The field under validation must be present and not empty unless the _anotherfiel
 <a name="rule-required-with"></a>
 #### required_with:_foo_,_bar_,...
 
-The field under validation must be present and not empty _only if_ any of the other specified fields are present.
+The field under validation must be present and not empty _only if_ any of the other specified fields are present and not empty.
 
 <a name="rule-required-with-all"></a>
 #### required_with_all:_foo_,_bar_,...
 
-The field under validation must be present and not empty _only if_ all of the other specified fields are present.
+The field under validation must be present and not empty _only if_ all of the other specified fields are present and not empty.
 
 <a name="rule-required-without"></a>
 #### required_without:_foo_,_bar_,...
 
-The field under validation must be present and not empty _only when_ any of the other specified fields are not present.
+The field under validation must be present and not empty _only when_ any of the other specified fields are empty or not present.
 
 <a name="rule-required-without-all"></a>
 #### required_without_all:_foo_,_bar_,...
 
-The field under validation must be present and not empty _only when_ all of the other specified fields are not present.
+The field under validation must be present and not empty _only when_ all of the other specified fields are empty or not present.
 
 <a name="rule-same"></a>
 #### same:_field_


### PR DESCRIPTION
My impression from reading the docs was that the specified field needs to be present (in the data array), with its emptiness being irrelevant, in order to force the field under validation to be required.

However, as an example, `required_with` makes the field under validation required only when the specified field is present and not empty.

Adding that the specified field must be not empty makes it more clear, I hope.