### PR TITLE
Clarify `env` behaviour

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -106,7 +106,7 @@ To give your application a speed boost, you should cache all of your configurati
 
 You should typically run the `php artisan config:cache` command as part of your production deployment process. The command should not be run during local development as configuration options will frequently need to be changed during the course of your application's development.
 
-> {note} If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded and all calls to the `env` function will return `null`.
+> {note} If you execute the `config:cache` command during your deployment process, you should be aware that it caches the values returned by the `env` function and the config will no longer be dynamic. Moreover, once the configuration has been cached, the `.env` file will not be loaded and calls to the `env` function will only return external environment variables if such are present.
 
 <a name="debug-mode"></a>
 ## Debug Mode

--- a/configuration.md
+++ b/configuration.md
@@ -106,7 +106,7 @@ To give your application a speed boost, you should cache all of your configurati
 
 You should typically run the `php artisan config:cache` command as part of your production deployment process. The command should not be run during local development as configuration options will frequently need to be changed during the course of your application's development.
 
-> {note} If you execute the `config:cache` command during your deployment process, you should be aware that it caches the values returned by the `env` function and the config will no longer be dynamic. Moreover, once the configuration has been cached, the `.env` file will not be loaded and calls to the `env` function will only return external environment variables if such are present.
+> {note} If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded; therefore, the `env` function will only return external, system level environment variables.
 
 <a name="debug-mode"></a>
 ## Debug Mode


### PR DESCRIPTION
The current note says that all calls to `env` would return true, but in fact it can contain the variables from the environment.

```sh
$ php artisan tinker
Psy Shell v0.10.5 (PHP 8.0.2 — cli) by Justin Hileman
>>> env('DB_HOST')
=> "127.0.0.1"
>>> ^D
Exit:  Ctrl+D

$ php artisan config:cache
Configuration cache cleared!
Configuration cached successfully!
$ php artisan tinker
Psy Shell v0.10.5 (PHP 8.0.2 — cli) by Justin Hileman
>>> env('DB_HOST')
=> null
>>> ^D
Exit:  Ctrl+D

$ export DB_HOST="127.0.0.1"
$ php artisan tinker
Psy Shell v0.10.5 (PHP 8.0.2 — cli) by Justin Hileman
>>> env('DB_HOST')
=> "127.0.0.1"
```

The other (in my opinion more problematic) issue is that it's not entirely clear that the config is not merely combined, but the functions are also executed and stored. And thus one can't use config caching if they need to pass some of the config (e.g. DB creds) from the server.