### PR TITLE
Add Link to Laravel Sail

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -37,6 +37,7 @@ The Laravel source code is managed on GitHub, and there are repositories for eac
 - [Laravel Horizon](https://github.com/laravel/horizon)
 - [Laravel Jetstream](https://github.com/laravel/jetstream)
 - [Laravel Passport](https://github.com/laravel/passport)
+- [Laravel Sail](https://github.com/laravel/sail)
 - [Laravel Sanctum](https://github.com/laravel/sanctum)
 - [Laravel Scout](https://github.com/laravel/scout)
 - [Laravel Socialite](https://github.com/laravel/socialite)


### PR DESCRIPTION
All the github links to laravel projects are included except for laravel Sail. 

This is just an addition for Laravel Sail