### PR TITLE
Update pusher/pusher-php-server dependency to ^5.0

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -77,7 +77,7 @@ You will also need to configure and run a [queue worker](/docs/{{version}}/queue
 
 If you plan to broadcast your events using [Pusher Channels](https://pusher.com/channels), you should install the Pusher Channels PHP SDK using the Composer package manager:
 
-    composer require pusher/pusher-php-server "~4.0"
+    composer require pusher/pusher-php-server "^5.0"
 
 Next, you should configure your Pusher Channels credentials in the `config/broadcasting.php` configuration file. An example Pusher Channels configuration is already included in this file, allowing you to quickly specify your key, secret, and application ID. Typically, these values should be set via the `PUSHER_APP_KEY`, `PUSHER_APP_SECRET`, and `PUSHER_APP_ID` [environment variables](/docs/{{version}}/configuration#environment-configuration):
 


### PR DESCRIPTION
The laravel/framework now supports the latest version of the pusher library. https://github.com/laravel/framework/commit/3404185fbe36139dfbe6d0d9595811b41ee53068