### PR TITLE
Add note about phpunit.xml server variables when running Artisan test command

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -85,6 +85,7 @@ Any arguments that can be passed to the `phpunit` command may also be passed to 
 
     php artisan test --testsuite=Feature --stop-on-failure
 
+> {note} When running the `test` Artisan command your service providers will NOT have access to any server variables set in your `phpunit.xml` file.
 
 <a name="running-tests-in-parallel"></a>
 ### Running Tests In Parallel


### PR DESCRIPTION
Added a note to clarify that the Artisan `test` command cannot access `phpunit.xml` server variables from service providers.

See https://github.com/laravel/framework/issues/36530 for the reason behind this note.