### PR TITLE
[8.x] Remove deprecated header

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -51,7 +51,6 @@ Please ensure, like the configuration below, your web server directs all request
         root /srv/example.com/public;
 
         add_header X-Frame-Options "SAMEORIGIN";
-        add_header X-XSS-Protection "1; mode=block";
         add_header X-Content-Type-Options "nosniff";
 
         index index.php;


### PR DESCRIPTION
This feature has been deprecated (or never implemented) by major browsers.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection

It is superseded by CSP, but I don't think we can suggest a default CSP header that would be more helpful than confusing.