### PR TITLE
[8.x] Remove note about Git protocol

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -206,8 +206,6 @@ The created repository will then be available at `https://github.com/<your-accou
 laravel new example-app --github="--public --team laravel"
 ```
 
-> {note} You may experience issues with the `github` flag if your system's Git protocol is set to `https`. If you're prompted for your GitHub username and password during the installation, try setting your system's Git protocol to `ssh` by running `gh config set git_protocol ssh --host github.com`.
-
 <a name="initial-configuration"></a>
 ## Initial Configuration
 


### PR DESCRIPTION
With the just released Installer patch this note isn't necessary anymore.