### PR TITLE
Fixed public file permission example to 0644

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -415,7 +415,7 @@ When using the `local` driver, `public` [visibility](#file-visibility) translate
         'root' => storage_path('app'),
         'permissions' => [
             'file' => [
-                'public' => 0664,
+                'public' => 0644,
                 'private' => 0600,
             ],
             'dir' => [


### PR DESCRIPTION
The code example for file and folder permissions had public files set to 0664 when it should be 0644