### PR TITLE
Document `AssertableJson`'s whereType and whereAllType

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -395,14 +395,14 @@ However, instead of making two separate calls to the `has` method to assert agai
 <a name="asserting-json-types"></a>
 #### Asserting JSON Types
 
-You may only want to assert that the properties in the JSON response are of a certain type. The `Illuminate\Testing\Fluent\AssertableJson` class provides the `whereType` and `whereAllType` methods for that.
+You may only want to assert that the properties in the JSON response are of a certain type. The `Illuminate\Testing\Fluent\AssertableJson` class provides the `whereType` and `whereAllType` methods for doing just that.
 
     $response->assertJson(fn (AssertableJson $json) => 
         $json->whereType('id', 'integer')
              ->whereAllType(['users.0.name' => 'string', 'meta' => 'array'])
     );
     
-Instead of asserting just _one_ type, this also gives you the option to use union types by either seperating the types with a `|` character, or passing an array of types as the second parameter:
+Instead of asserting just _one_ type, these methods also give you the option to use union types by either seperating the types with a `|` character, or passing an array of types as the second parameter:
 
     $response->assertJson(fn (AssertableJson $json) =>
         $json->whereType('name', 'string|null')

--- a/http-tests.md
+++ b/http-tests.md
@@ -391,6 +391,25 @@ However, instead of making two separate calls to the `has` method to assert agai
                          ->etc()
                  )
         );
+        
+<a name="asserting-json-types"></a>
+#### Asserting JSON Types
+
+You may only want to assert that the properties in the JSON response are of a certain type. The `Illuminate\Testing\Fluent\AssertableJson` class provides the `whereType` and `whereAllType` methods for that.
+
+    $response->assertJson(fn (AssertableJson $json) => 
+        $json->whereType('id', 'integer')
+             ->whereAllType(['users.0.name' => 'string', 'meta' => 'array'])
+    );
+    
+Instead of asserting just _one_ type, this also gives you the option to use union types by either seperating the types with a `|` character, or passing an array of types as the second parameter:
+
+    $response->assertJson(fn (AssertableJson $json) =>
+        $json->whereType('name', 'string|null')
+             ->whereType('id', ['string', 'integer'])
+    );
+    
+You may assert any of the following types using this method: `string`, `integer`, `double`, `boolean`, `array`, and `null`.
 
 <a name="testing-file-uploads"></a>
 ## Testing File Uploads


### PR DESCRIPTION
This PR aims to document the `whereType` and `whereAllType` methods added to the `AssertableJson` class in [this pull request to `laravel/framework`](https://github.com/laravel/framework/pull/36638).