### PR TITLE
[8.x] Clarify `mode` can return multiple values with example

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1404,6 +1404,10 @@ The `mode` method returns the [mode value](https://en.wikipedia.org/wiki/Mode_(s
 
     // [1]
 
+    $mode = collect([1, 1, 2, 2])->mode();
+
+    // [1, 2]
+
 <a name="method-nth"></a>
 #### `nth()` {#collection-method}
 


### PR DESCRIPTION
An example for the `mode` method on the collection when returning multiple values