### PR TITLE
Fix expose share command

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -191,7 +191,7 @@ If you have [Expose](https://beyondco.de/docs/expose) installed, you can share y
 
     cd ~/Sites/laravel
 
-    valet expose
+    expose
 
 To stop sharing your site, you may press `Control + C`.
 


### PR DESCRIPTION
There is no `valet expose` command available. In order to share a site through expose, you only have to call `expose` after its installed globally.