### PR TITLE
[8.x] Add whereDoesntStartWith to blade attributes section

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -800,6 +800,10 @@ For convenience, you may use the `whereStartsWith` method to retrieve all attrib
 Using the `first` method, you may render the first attribute in a given attribute bag:
 
     {{ $attributes->whereStartsWith('wire:model')->first() }}
+    
+For completeness, you may also use `whereDoesntStartWith` to exclude all attributes whose keys begin with a given string:
+
+    {{ $attributes->whereDoesntStartWith('wire:model') }}
 
 If you would like to check if an attribute is present on the component, you may use the `has` method. This method accepts the attribute name as its only argument and returns a boolean indicating whether or not the attribute is present:
 

--- a/blade.md
+++ b/blade.md
@@ -797,13 +797,13 @@ For convenience, you may use the `whereStartsWith` method to retrieve all attrib
 
     {{ $attributes->whereStartsWith('wire:model') }}
 
+Conversely, the `whereDoesntStartWith` method may be used to exclude all attributes whose keys begin with a given string:
+
+    {{ $attributes->whereDoesntStartWith('wire:model') }}
+
 Using the `first` method, you may render the first attribute in a given attribute bag:
 
     {{ $attributes->whereStartsWith('wire:model')->first() }}
-    
-For completeness, you may also use `whereDoesntStartWith` to exclude all attributes whose keys begin with a given string:
-
-    {{ $attributes->whereDoesntStartWith('wire:model') }}
 
 If you would like to check if an attribute is present on the component, you may use the `has` method. This method accepts the attribute name as its only argument and returns a boolean indicating whether or not the attribute is present:
 


### PR DESCRIPTION
Add `whereDoesntStartWith()` line to Blade - Retrieving & Filtering attributes section.