### PR TITLE
Add .error() method to Echo Presence channel documentation

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -704,9 +704,12 @@ To join a presence channel, you may use Echo's `join` method. The `join` method 
         })
         .leaving((user) => {
             console.log(user.name);
+        })
+        .error((error) => {
+            console.error(error);
         });
 
-The `here` callback will be executed immediately once the channel is joined successfully, and will receive an array containing the user information for all of the other users currently subscribed to the channel. The `joining` method will be executed when a new user joins a channel, while the `leaving` method will be executed when a user leaves the channel.
+The `here` callback will be executed immediately once the channel is joined successfully, and will receive an array containing the user information for all of the other users currently subscribed to the channel. The `joining` method will be executed when a new user joins a channel, while the `leaving` method will be executed when a user leaves the channel. The `error` method will be executed when the authentication endpoint returns a HTTP status code that is not 200 or if there is a problem parsing the JSON the endpoint returned.
 
 <a name="broadcasting-to-presence-channels"></a>
 ### Broadcasting To Presence Channels


### PR DESCRIPTION
Adding in .error method to the Broadcasting page for use when connecting to presence channels. I cannot find this method documented anywhere other than the PR when it was added to echo.

Info about when this method is fired has been taken directly from pusher documentation 
- https://pusher.com/docs/channels/using_channels/events#pusher-subscription-error