### PR TITLE
Add "Default Site" / fallback section to Valet docs (7.x)

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -9,6 +9,7 @@
     - [The "Link" Command](#the-link-command)
     - [Securing Sites With TLS](#securing-sites)
 - [Sharing Sites](#sharing-sites)
+- [Serving a Default Site](#serving-a-default-site)
 - [Site Specific Environment Variables](#site-specific-environment-variables)
 - [Proxying Services](#proxying-services)
 - [Custom Valet Drivers](#custom-valet-drivers)
@@ -185,6 +186,13 @@ If you wish to allow other devices on your local network to access the Valet sit
 If you have not run `valet secure` on the project, you can open up network access for all non-HTTPS sites by editing the `/usr/local/etc/nginx/valet/valet.conf` file. However, if you're serving the project site over HTTPS (you have run `valet secure` for the site) then you should edit the `~/.config/valet/Nginx/app-name.test` file.
 
 Once you have updated your Nginx configuration, run the `valet restart` command to apply the configuration changes.
+
+<a name="serving-a-default-site"></a>
+## Serving A Default Site
+
+Sometimes, you may wish to configure Valet to serve a "default" site instead of a `404` when visiting an unknown `test` domain. To accomplish this, you may add a `default` option to your `~/.config/valet/config.json` configuration file containing the path to the site that should function as your default site:
+
+    "default": "/Users/Sally/Sites/foo",
 
 <a name="site-specific-environment-variables"></a>
 ## Site Specific Environment Variables


### PR DESCRIPTION
This was added in 6.x just a day before 7.x was released so it didn't make it into the 7.x or 8.x docs.

6.x version: https://github.com/laravel/docs/pull/5828/commits
8.x PR: https://github.com/laravel/docs/pull/6956