### PR TITLE
Add Str::startsWith array example

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -1537,6 +1537,8 @@ The `Str::startsWith` method determines if the given string begins with the give
 
     // true
 
+If an array of possible values is passed, the `startsWith` method will return `true` if the string begins with any of the given values:
+
     $result = Str::startsWith('This is my name', ['This', 'That', 'There']);
 
     // true

--- a/helpers.md
+++ b/helpers.md
@@ -1537,6 +1537,10 @@ The `Str::startsWith` method determines if the given string begins with the give
 
     // true
 
+    $result = Str::startsWith('This is my name', ['This', 'That', 'There']);
+
+    // true
+
 <a name="method-studly-case"></a>
 #### `Str::studly()` {#collection-method}
 


### PR DESCRIPTION
Adds example showing the ability to pass multiple needles to Str::startWith.