### PR TITLE
[8.x] Uses array destructuring instead of list()

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1471,11 +1471,11 @@ To pad to the left, you should specify a negative size. No padding will take pla
 <a name="method-partition"></a>
 #### `partition()` {#collection-method}
 
-The `partition` method may be combined with the `list` PHP function to separate elements that pass a given truth test from those that do not:
+The `partition` method may be combined with the array destructuring PHP feature to separate elements that pass a given truth test from those that do not:
 
     $collection = collect([1, 2, 3, 4, 5, 6]);
 
-    list($underThree, $equalOrAboveThree) = $collection->partition(function ($i) {
+    [$underThree, $equalOrAboveThree] = $collection->partition(function ($i) {
         return $i < 3;
     });
 

--- a/collections.md
+++ b/collections.md
@@ -1471,7 +1471,7 @@ To pad to the left, you should specify a negative size. No padding will take pla
 <a name="method-partition"></a>
 #### `partition()` {#collection-method}
 
-The `partition` method may be combined with the array destructuring PHP feature to separate elements that pass a given truth test from those that do not:
+The `partition` method may be combined with PHP array destructuring to separate elements that pass a given truth test from those that do not:
 
     $collection = collect([1, 2, 3, 4, 5, 6]);
 


### PR DESCRIPTION
This pull request improves the `partition` documentation by using "array destructuring" instead of the "list()" method.