### PR TITLE
Resolve issue with vendor folder permissions

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -141,6 +141,7 @@ You may install the application's dependencies by navigating to the application'
 
 ```nothing
 docker run --rm \
+    -u "$(id -u):$(id -g)" \
     -v $(pwd):/opt \
     -w /opt \
     laravelsail/php80-composer:latest \


### PR DESCRIPTION
Resolve issue with vendor folder permissions for existing application. Currently the vendor folder is created under the root user. Fixed it to install under the current system user.

**Preconditions:**

- OS: Ubuntu 18.04.5 LTS
- Current system user: non root user

**Steps:**

1. Run composer install for existing project:
    ```
    docker run --rm \
        -v $(pwd):/opt \
        -w /opt \
        laravelsail/php80-composer:latest \
        composer install
    ```
2. Check ./vendor folder permission:
    ```
    ls -l ./
    ```
    ```
    drwxr-xr-x 52 root  root    4096 apr  2 23:25 vendor/
    ```

- **Expected result:** ./vendor folder has current system user and group
- **Actual result:** ./vendor folder has root user and group