### PR TITLE
[8.x] Add Meilisearch to "Optional Features" section

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -109,6 +109,7 @@ Homestead runs on any Windows, macOS, or Linux system and includes Nginx, PHP, M
 - Grafana
 - InfluxDB
 - MariaDB
+- Meilisearch
 - MinIO
 - MongoDB
 - Neo4j
@@ -307,6 +308,7 @@ Optional software is installed using the `features` option within your `Homestea
         - grafana: true
         - influxdb: true
         - mariadb: true
+        - meilisearch: true
         - minio: true
         - mongodb: true
         - neo4j: true


### PR DESCRIPTION
Meilisearch has been added in Homestead (https://github.com/laravel/homestead/commit/646f19ee84b0286354621106c74d1e049b21b60a), and this PR adds a little information in the documentation on how to enable it.