### PR TITLE
Add docs using 'star' for asserting json structure

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -771,7 +771,7 @@ You may assert that the JSON structure matches your expectations like so:
         ]
     ]);
 
-For example, if the JSON response returned by your application contains array of objects such as:
+Sometimes, JSON responses returned by your application may contain arrays of objects:
 
 ```js
 {
@@ -790,7 +790,7 @@ For example, if the JSON response returned by your application contains array of
 }
 ```
 
-You may assert that the JSON structure matches your expectations like so:
+In this situation, you may use the `*` character to assert against the structure of all of the objects in the array:
 
     $response->assertJsonStructure([
         'user' => [

--- a/http-tests.md
+++ b/http-tests.md
@@ -771,6 +771,37 @@ You may assert that the JSON structure matches your expectations like so:
         ]
     ]);
 
+For example, if the JSON response returned by your application contains array of objects such as:
+
+```js
+{
+    "user": [
+        {
+            "name": "Steve Schoger",
+            "age": 55,
+            "location": "Earth"
+        },  
+        {
+            "name": "Mary Schoger",
+            "age": 60,
+            "location": "Earth"
+        }
+    ]
+}
+```
+
+You may assert that the JSON structure matches your expectations like so:
+
+    $response->assertJsonStructure([
+        'user' => [
+            '*' => [
+                 'name',
+                 'age',
+                 'location'
+            ]
+        ]
+    ]);
+
 <a name="assert-json-validation-errors"></a>
 #### assertJsonValidationErrors
 


### PR DESCRIPTION
I was reading this https://stackoverflow.com/questions/42657551/match-jsonstructure-in-phpunit-test-laravel-5-4
And then I looked at `\Illuminate\Testing\AssertableJsonString::assertStructure` and I found that I can use start "*" to assert multiple array elements.

I can't find it in documentation, but it's very useful