### PR TITLE
Update sail.md

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -145,7 +145,7 @@ docker run --rm \
     -v $(pwd):/opt \
     -w /opt \
     laravelsail/php80-composer:latest \
-    composer install
+    composer install --ignore-platform-reqs
 ```
 
 <a name="executing-artisan-commands"></a>


### PR DESCRIPTION
The `--ignore-platform-reqs` is needed to bootstrap the vendor directory on Windows because the `laravelsail/php80-composer` image does not have the common PHP extensions that many popular packages need, such as `ext-intl`.

Once the sail containers are built, it would be a good idea to run a `composer update` through sail (without the `--ignore-platform-reqs` option), just to make sure all the PHP extensions that the dependencies need really are available. Not sure if that should be added as a note too?