### PR TITLE
[8.x] fortify.md

### DIFF
--- a/fortify.md
+++ b/fortify.md
@@ -136,7 +136,9 @@ All of the authentication view's rendering logic may be customized using the app
      */
     public function boot()
     {
-        Fortify::loginView(fn () => view('auth.login'));
+        Fortify::loginView(function () {
+            return view('auth.login');
+        });
 
         // ...
     }
@@ -298,7 +300,9 @@ use Laravel\Fortify\Fortify;
  */
 public function boot()
 {
-    Fortify::registerView(fn () => view('auth.register'));
+    Fortify::registerView(function () {
+        return view('auth.register'); 
+    });
 
     // ...
 }
@@ -436,7 +440,9 @@ use Laravel\Fortify\Fortify;
  */
 public function boot()
 {
-    Fortify::verifyEmailView(fn () => view('auth.verify-email'));
+    Fortify::verifyEmailView(function () {
+        return view('auth.verify-email');
+    });
 
     // ...
 }


### PR DESCRIPTION
There are a small documentation inconsistencies for declaring views. Some code examples are in php 7.4 syntax instead of 7.3. 
And, having in mind, that Laravel 8 minimum requirement is php 7.3, then syntax from php 7.4 (new features) are not correct in this context.

Code examples that are NOT OK (7.4 syntax used - closure), are for:
- Login (https://laravel.com/docs/8.x/fortify#authentication)
- Registration (https://laravel.com/docs/8.x/fortify#registration)
- Email Verification (https://laravel.com/docs/8.x/fortify#email-verification)

Code examples that are OK (7.3 syntax), are for:
- Requesting A Password Reset Link (https://laravel.com/docs/8.x/fortify#requesting-a-password-reset-link)
- Resetting The Password (https://laravel.com/docs/8.x/fortify#resetting-the-password) 
- ... 

I did not check the whole documentation, so please do that in the context of php syntax (to be valid with php 7.3). 
Thank you, and best wishes.