### PR TITLE
[8.x] Fix incorrect closure reference

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -270,7 +270,7 @@ If you would simply like to assert that an event listener is listening to a give
 
     Event::assertListening(
         OrderShipped::class,
-        [SendShipmentNotification::class, 'handle']
+        SendShipmentNotification::class
     );
 
 > {note} After calling `Event::fake()`, no event listeners will be executed. So, if your tests use model factories that rely on events, such as creating a UUID during a model's `creating` event, you should call `Event::fake()` **after** using your factories.


### PR DESCRIPTION
The current example doesn't works as you can only pass a class name. I do see references to matching closure based listeners in the source code of `assertListening` but I'm unsure how that would work.

See https://github.com/laravel/framework/issues/36939