### PR TITLE
[8.x] Using faker method instead of properties

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -88,8 +88,8 @@ To see an example of how to write a factory, take a look at the `database/factor
         public function definition()
         {
             return [
-                'name' => $this->faker->name,
-                'email' => $this->faker->unique()->safeEmail,
+                'name' => $this->faker->name(),
+                'email' => $this->faker->unique()->safeEmail(),
                 'email_verified_at' => now(),
                 'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
                 'remember_token' => Str::random(10),

--- a/releases.md
+++ b/releases.md
@@ -84,8 +84,8 @@ Eloquent [model factories](/docs/{{version}}/database-testing#defining-model-fac
         public function definition()
         {
             return [
-                'name' => $this->faker->name,
-                'email' => $this->faker->unique()->safeEmail,
+                'name' => $this->faker->name(),
+                'email' => $this->faker->unique()->safeEmail(),
                 'email_verified_at' => now(),
                 'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
                 'remember_token' => Str::random(10),


### PR DESCRIPTION
In concordance with [#5583](https://github.com/laravel/laravel/pull/5583), as after Faker PHP 1.14, using properties is deprecated, and it is recommended to use methods instead.

See [#164](https://github.com/FakerPHP/Faker/pull/164) for details.