### PR TITLE
[8.x] Clarify 3D Secure

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -1528,7 +1528,7 @@ If your business is based in Europe you will need to abide by the EU's Strong Cu
 
 SCA regulations often require extra verification in order to confirm and process a payment. When this happens, Cashier will throw a `Laravel\Cashier\Exceptions\PaymentActionRequired` exception that informs you that extra verification is needed. More information on how to handle these exceptions be found can be found in the documentation on [handling failed payments](#handling-failed-payments).
 
-These screens which invoke a confirmation prompt will require additionally authentication, like [3D Secure 2](https://stripe.com/en-be/guides/3d-secure-2). Often these prompts are tailored to a specific bank or card issuer's payment flow. They differ a lot and depending on the issuer the experience can include additional card confirmation, a temporary small charge, separate device authentication or something else. Stripe will handle this flow for you but you should inform your customers that they can expect these additional confirmations.
+Payment confirmation screens presented by Stripe or Cashier may be tailored to a specific bank or card issuer's payment flow and can include additional card confirmation, a temporary small charge, separate device authentication, or other forms of verification.
 
 <a name="incomplete-and-past-due-state"></a>
 #### Incomplete and Past Due State

--- a/billing.md
+++ b/billing.md
@@ -1528,6 +1528,8 @@ If your business is based in Europe you will need to abide by the EU's Strong Cu
 
 SCA regulations often require extra verification in order to confirm and process a payment. When this happens, Cashier will throw a `Laravel\Cashier\Exceptions\PaymentActionRequired` exception that informs you that extra verification is needed. More information on how to handle these exceptions be found can be found in the documentation on [handling failed payments](#handling-failed-payments).
 
+These screens which invoke a confirmation prompt will require additionally authentication, like [3D Secure 2](https://stripe.com/en-be/guides/3d-secure-2). Often these prompts are tailored to a specific bank or card issuer's payment flow. They differ a lot and depending on the issuer the experience can include additional card confirmation, a temporary small charge, separate device authentication or something else. Stripe will handle this flow for you but you should inform your customers that they can expect these additional confirmations.
+
 <a name="incomplete-and-past-due-state"></a>
 #### Incomplete and Past Due State
 


### PR DESCRIPTION
This is an attempt to clarify 3D Secure screens. These screens often contain vastly different ways of confirming payments depending on the issuer or bank. A small note about this in the docs can't hurt and should help inform app developers to clarify this before a customer initiates a payment.

When this PR is merged and cleaned up I'll send follow up PR's to Cashier Paddle, Spark Stripe and Spark Paddle docs.