### PR TITLE
[Sail] Add documentation about WWWUSER & WWWGROUP params

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -21,6 +21,7 @@
 - [PHP Versions](#sail-php-versions)
 - [Sharing Your Site](#sharing-your-site)
 - [Customization](#sail-customization)
+- [Permissions and user mapping](#sail-user-permissions)
 
 <a name="introduction"></a>
 ## Introduction
@@ -315,3 +316,15 @@ After running this command, the Dockerfiles and other configuration files used b
 ```bash
 sail build --no-cache
 ```
+
+<a name="sail-user-permissions"></a>
+## Permissions and user mapping
+
+Sail provides two parameters `WWWUSER` and `WWWGROUP` to set the IDs of the `sail` user and group inside the container. Those parameters shall be set with numerical values inside your `.env` file : 
+
+```
+WWWGROUP=1000
+WWWUSER=1000
+```
+
+The above example is a good way to map the container `sail` user/group with your local Ubuntu user/group (usually 1000). Then, you gain full access to resources created by the webserver running inside the caontainer and shared through the Docker volume.

--- a/sail.md
+++ b/sail.md
@@ -327,4 +327,4 @@ WWWGROUP=1000
 WWWUSER=1000
 ```
 
-The above example is a good way to map the container `sail` user/group with your local Ubuntu user/group (usually 1000). Then, you gain full access to resources created by the webserver running inside the caontainer and shared through the Docker volume.
+The above example is a good way to map the container `sail` user/group with your local Ubuntu user/group (usually 1000). Then, you gain full access to resources created by the webserver running inside the container and shared through the Docker volume.


### PR DESCRIPTION
Hello Laravel,
I had troubles with permissions between my host and my sail-8.0/app container. So I dived into Sail Docker files and saw the commands aiming to change `sail` user and group IDs according to `WWWUSER` and `WWWGROUP` params.

It looks like other people had the same issues : https://laracasts.com/discuss/channels/laravel/groupadd-invalid-group-id-sail

So I decided to propose a small update of Sail documentation since the commands to handle this are already implemented.

Feel free to edit.

Hope you'll find it useful.

