### PR TITLE
[8.x] Add clarification on save() and saveMany() relationship methods

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1533,7 +1533,7 @@ If you need to save multiple related models, you may use the `saveMany` method:
         new Comment(['message' => 'Another new comment.']),
     ]);
 
-The `save` and `saveMany` methods will persist the model instances along with any changes made to them, but will not add the newly persisted models to any in-memory relationships that are already loaded onto the parent model. If you plan on accessing the relationship after using the `save` or `saveMany` methods, you may wish to use the `refresh` method to reload the model and its relationships:
+The `save` and `saveMany` methods will persist the given model instances, but will not add the newly persisted models to any in-memory relationships that are already loaded onto the parent model. If you plan on accessing the relationship after using the `save` or `saveMany` methods, you may wish to use the `refresh` method to reload the model and its relationships:
 
     $post->comments()->save($comment);
 

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1533,7 +1533,7 @@ If you need to save multiple related models, you may use the `saveMany` method:
         new Comment(['message' => 'Another new comment.']),
     ]);
 
-The `save` and `saveMany` methods will not add the new models to any in-memory relationships that are already loaded onto the parent model. If you plan on accessing the relationship after using the `save` or `saveMany` methods, you may wish to use the `refresh` method to reload the model and its relationships:
+The `save` and `saveMany` methods will persist the model instances along with any changes made to them, but will not add the newly persisted models to any in-memory relationships that are already loaded onto the parent model. If you plan on accessing the relationship after using the `save` or `saveMany` methods, you may wish to use the `refresh` method to reload the model and its relationships:
 
     $post->comments()->save($comment);
 


### PR DESCRIPTION
I recently had an experience where I used saveMany to add multiple models to a relationship. Before calling the saveMany() method I altered some properties on the models but did not intend for these changes to be persisted as I only wanted the relationship to be updated. 

From the official documentation, I wrongly understood that the save and saveMany() methods when called only updates the many-to-many relationship and not the models passed to the method as well and worked similarly to the sync() method, with the only difference being saveMany() takes model instances as input instead of an array of model ids. 

I realize the methods do have the word "save" in them, but as a new Laravel developer relying heavily on the documentation, I feel some clarification here would not hurt.