### PR TITLE
[8.x] Fix docs according to the recently added `queueForget()` method

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -130,9 +130,9 @@ You may remove a cookie by expiring it via the `withoutCookie` method of an outg
 
     return response('Hello World')->withoutCookie('name');
 
-If you do not yet have an instance of the outgoing response, you may use the `Cookie` facade's `queue` method to expire a cookie:
+If you do not yet have an instance of the outgoing response, you may use the `Cookie` facade's `queueForget` method to expire a cookie:
 
-    Cookie::queue(Cookie::forget('name'));
+    Cookie::queueForget('name');
 
 <a name="cookies-and-encryption"></a>
 ### Cookies & Encryption


### PR DESCRIPTION
This PR fixes the docs according to the [recently added `Cookie::queueForget()` method](https://github.com/laravel/framework/pull/37072).