### PR TITLE
[8.x] Fix usage of Collection's `reduceWithKeys()` in the `reduce()` description

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1723,7 +1723,7 @@ The `reduce` method also passes array keys in associative collections to the giv
         'eur' => 1.22,
     ];
 
-    $collection->reduceWithKeys(function ($carry, $value, $key) use ($ratio) {
+    $collection->reduce(function ($carry, $value, $key) use ($ratio) {
         return $carry + ($value * $ratio[$key]);
     });
 


### PR DESCRIPTION
One of the examples for the [Collection's `reduce` method](https://laravel.com/docs/8.x/collections#method-reduce) uses the `reduceWithKeys` method; this PR fixes that.

PS: These two methods are [100% identical](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Collections/Traits/EnumeratesValues.php#L736-L763) under the hood:

![reduce-vs-reduceWithKeys](https://user-images.githubusercontent.com/1286821/115595296-6d4b7300-a2df-11eb-8b21-3668c94b28b5.png)

So, I think we could simply call the `reduce` method from the `reduceWithKeys` to make it obvious _(I'll create a PR)_.