### PR TITLE
[8.x] Fix typo (missing semicolon in one of the examples)

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1036,7 +1036,7 @@ Sometimes you may wish to manually release a job back onto the queue so that it 
 
 By default, the `release` method will release the job back onto the queue for immediate processing. However, by passing an integer to the `release` method you may instruct the queue to not make the job available for processing until a given number of seconds has elapsed:
 
-    $this->release(10)
+    $this->release(10);
 
 <a name="manually-failing-a-job"></a>
 #### Manually Failing A Job


### PR DESCRIPTION
Just a small fix to add a semicolon in one of the examples.