### PR TITLE
[8.x] The `ipAddress` method creates `VARCHAR`, not `INTEGER`

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -517,7 +517,7 @@ The `integer` method creates an `INTEGER` equivalent column:
 <a name="column-method-ipAddress"></a>
 #### `ipAddress()` {#collection-method}
 
-The `ipAddress` method creates an `INTEGER` equivalent column:
+The `ipAddress` method creates a `VARCHAR` equivalent column:
 
     $table->ipAddress('visitor');
 


### PR DESCRIPTION
The description for the Blueprint's `ipAddress` method [says that it creates an `INTEGER` equivalent column](https://laravel.com/docs/8.x/migrations#column-method-ipAddress).

When in reality, for most of the grammars it creates a `VARCHAR` equivalent:
- [MySQL](https://github.com/laravel/framework/blob/597f5ab16d0d2df67e50fedfd2fa66789b29998c/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php#L812-L815)
- [SQLite](https://github.com/laravel/framework/blob/597f5ab16d0d2df67e50fedfd2fa66789b29998c/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php#L734-L737)
- [SqlServer](https://github.com/laravel/framework/blob/597f5ab16d0d2df67e50fedfd2fa66789b29998c/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php#L722-L725)

And only [Postgres has a separate type](https://github.com/laravel/framework/blob/597f5ab16d0d2df67e50fedfd2fa66789b29998c/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php#L821-L824) for that.

So, I think that we could fix the doc to the `VARCHAR` (instead of the `INTEGER`), at least.