### PR TITLE
[8.x] Document users must use `nunomaduro/collision: ^5.3` for Parallel Testing in L8

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -89,7 +89,7 @@ Any arguments that can be passed to the `phpunit` command may also be passed to 
 <a name="running-tests-in-parallel"></a>
 ### Running Tests In Parallel
 
-By default, Laravel and PHPUnit execute your tests sequentially within a single process. However, you may greatly reduce the amount of time it takes to run your tests by running tests simultaneously across multiple processes. To get started, include the `--parallel` option when executing the `test` Artisan command:
+By default, Laravel and PHPUnit execute your tests sequentially within a single process. However, you may greatly reduce the amount of time it takes to run your tests by running tests simultaneously across multiple processes. To get started, make sure you are using at least `^5.3` of `nunomaduro/collision` package in your composer.json file. And then include the `--parallel` option when executing the `test` Artisan command:
 
     php artisan test --parallel
 

--- a/testing.md
+++ b/testing.md
@@ -89,7 +89,7 @@ Any arguments that can be passed to the `phpunit` command may also be passed to 
 <a name="running-tests-in-parallel"></a>
 ### Running Tests In Parallel
 
-By default, Laravel and PHPUnit execute your tests sequentially within a single process. However, you may greatly reduce the amount of time it takes to run your tests by running tests simultaneously across multiple processes. To get started, make sure you are using at least `^5.3` of `nunomaduro/collision` package in your composer.json file. And then include the `--parallel` option when executing the `test` Artisan command:
+By default, Laravel and PHPUnit execute your tests sequentially within a single process. However, you may greatly reduce the amount of time it takes to run your tests by running tests simultaneously across multiple processes. To get started, make sure you are using at least `^5.3` of `nunomaduro/collision` package in your composer.json file. Then include the `--parallel` option when executing the `test` Artisan command:
 
     php artisan test --parallel
 

--- a/testing.md
+++ b/testing.md
@@ -89,7 +89,7 @@ Any arguments that can be passed to the `phpunit` command may also be passed to 
 <a name="running-tests-in-parallel"></a>
 ### Running Tests In Parallel
 
-By default, Laravel and PHPUnit execute your tests sequentially within a single process. However, you may greatly reduce the amount of time it takes to run your tests by running tests simultaneously across multiple processes. To get started, ensure your application depends on version `^5.3` of the `nunomaduro/collision` package. Then, include the `--parallel` option when executing the `test` Artisan command:
+By default, Laravel and PHPUnit execute your tests sequentially within a single process. However, you may greatly reduce the amount of time it takes to run your tests by running tests simultaneously across multiple processes. To get started, ensure your application depends on version `^5.3` or greater of the `nunomaduro/collision` package. Then, include the `--parallel` option when executing the `test` Artisan command:
 
     php artisan test --parallel
 

--- a/testing.md
+++ b/testing.md
@@ -89,7 +89,7 @@ Any arguments that can be passed to the `phpunit` command may also be passed to 
 <a name="running-tests-in-parallel"></a>
 ### Running Tests In Parallel
 
-By default, Laravel and PHPUnit execute your tests sequentially within a single process. However, you may greatly reduce the amount of time it takes to run your tests by running tests simultaneously across multiple processes. To get started, make sure you are using at least `^5.3` of `nunomaduro/collision` package in your composer.json file. Then include the `--parallel` option when executing the `test` Artisan command:
+By default, Laravel and PHPUnit execute your tests sequentially within a single process. However, you may greatly reduce the amount of time it takes to run your tests by running tests simultaneously across multiple processes. To get started, ensure your application depends on version `^5.3` of the `nunomaduro/collision` package. Then, include the `--parallel` option when executing the `test` Artisan command:
 
     php artisan test --parallel
 


### PR DESCRIPTION
Parallel Testing was originally created for Laravel 9, then back-ported to Laravel 8. Due to this, earlier versions (5.0, 5.1, 5.2) of `nunomaduro/collision` package had a restriction to only use `--parallel` option on Laravel 9, but version 5.3 removed that restriction. 

We need to let users know in case they are using version < 5.3 of collision and trying to use Parallel Testing.

Edit:

Link below shows comparison of collision version 5.2 to 5.3. Checkout `src/Adapters/Laravel/Commands/TestCommand.php` file at line 74 for the removal of restriction.

https://github.com/nunomaduro/collision/compare/v5.2.0...v5.3.0