### PR TITLE
Clarify setting expiry on WithoutOverlapping middleware

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -489,6 +489,20 @@ If you wish to immediately delete any overlapping jobs so that they will not be 
         return [(new WithoutOverlapping($this->order->id))->dontRelease()];
     }
 
+You may also set an expiry by using the `expireAfter` method:
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array
+     */
+    public function middleware()
+    {
+        return [(new WithoutOverlapping($this->order->id))->expireAfter(180)];
+    }
+
+In the code above, any jobs that are picked up by the queue worker 3 minutes after this job starts processing, will be allowed to be processed. If your jobs are timing out, you should set an expiry slightly above the job timeout, so that subsequent jobs are not prevented from processing.
+
 > {note} The `WithoutOverlapping` middleware requires a cache driver that supports [locks](/docs/{{version}}/cache#atomic-locks). Currently, the `memcached`, `redis`, `dynamodb`, `database`, `file`, and `array` cache drivers support atomic locks.
 
 <a name="throttling-exceptions"></a>


### PR DESCRIPTION
Re-attempt of https://github.com/laravel/docs/pull/7024 based on https://github.com/laravel/framework/issues/37060.

## Summary:

The `WithoutOverlapping` middleware works by acquiring a cache lock. If an exception is thrown by the job, the lock is immediately released using a try finally block. However, if a job times out, the lock is only released after its expiry (default expiry is set to never expire). This can be an issue on job timeouts as subsequent jobs are prevented from being processing in such a situation.

This PR makes a note of how to add an expiry (currently missing from the docs) and also advises to set the expiry slightly over the job timeout (maybe ~1 sec above) if the job does tend to timeout to avoid this issue.