### PR TITLE
[8.x] Adds `Password` rule object documentation 

### DIFF
--- a/passwords.md
+++ b/passwords.md
@@ -107,6 +107,7 @@ Of course, we need to define a route to actually handle the password reset form 
 
     use Illuminate\Auth\Events\PasswordReset;
     use Illuminate\Http\Request;
+    use Illuminate\Validation\Rules\Password;
     use Illuminate\Support\Facades\Hash;
     use Illuminate\Support\Facades\Password;
     use Illuminate\Support\Str;
@@ -115,7 +116,7 @@ Of course, we need to define a route to actually handle the password reset form 
         $request->validate([
             'token' => 'required',
             'email' => 'required|email',
-            'password' => 'required|min:8|confirmed',
+            'password' => ['required', 'confirmed', Password::min(8)->mixedCase()->symbols()],
         ]);
 
         $status = Password::reset(

--- a/passwords.md
+++ b/passwords.md
@@ -107,10 +107,10 @@ Of course, we need to define a route to actually handle the password reset form 
 
     use Illuminate\Auth\Events\PasswordReset;
     use Illuminate\Http\Request;
-    use Illuminate\Validation\Rules\Password;
     use Illuminate\Support\Facades\Hash;
     use Illuminate\Support\Facades\Password;
     use Illuminate\Support\Str;
+    use Illuminate\Validation\Rules\Password;
 
     Route::post('/reset-password', function (Request $request) {
         $request->validate([

--- a/passwords.md
+++ b/passwords.md
@@ -110,13 +110,12 @@ Of course, we need to define a route to actually handle the password reset form 
     use Illuminate\Support\Facades\Hash;
     use Illuminate\Support\Facades\Password;
     use Illuminate\Support\Str;
-    use Illuminate\Validation\Rules\Password;
 
     Route::post('/reset-password', function (Request $request) {
         $request->validate([
             'token' => 'required',
             'email' => 'required|email',
-            'password' => ['required', 'confirmed', Password::min(8)->mixedCase()->symbols()],
+            'password' => 'required|min:8|confirmed',
         ]);
 
         $status = Password::reset(

--- a/validation.md
+++ b/validation.md
@@ -1453,7 +1453,7 @@ By default, if a password appears at least once in a data leak, it will be consi
     // Ensure the given password has not been compromised 3 times in the same data leak
     Password::min(8)->uncompromised(3);
 
-Of course, may chain all the methods specified above:
+Of course, you may chain all the methods specified above:
 
     Password::min(8)
         ->letters()

--- a/validation.md
+++ b/validation.md
@@ -25,6 +25,7 @@
 - [Available Validation Rules](#available-validation-rules)
 - [Conditionally Adding Rules](#conditionally-adding-rules)
 - [Validating Arrays](#validating-arrays)
+- [Validating Passwords](#validating-passwords)
 - [Custom Validation Rules](#custom-validation-rules)
     - [Using Rule Objects](#using-rule-objects)
     - [Using Closures](#using-closures)
@@ -1411,6 +1412,55 @@ Likewise, you may use the `*` character when specifying [custom validation messa
             'unique' => 'Each person must have a unique email address',
         ]
     ],
+
+<a name="validating-passwords"></a>
+## Validating Passwords
+
+To ensure that passwords have an adequate level of complexity, you may use Laravel's `Password` rule object:
+
+    use Illuminate\Support\Facades\Validator;
+    use Illuminate\Validation\Rules\Password;
+
+    $validator = Validator::make($request->all(), [
+        'password' => ['required', 'confirmed', Password::min(8)],
+    ]);
+
+The `Password` rule object allows you to easily customize the password complexity requirements for your application:
+
+    // Require at least 8 characters...
+    Password::min(8)
+
+    // Require at least one letter...
+    Password::min(8)->letters()
+
+    // Require at least one uppercase and one lowercase letter...
+    Password::min(8)->mixedCase()
+
+    // Require at least one number...
+    Password::min(8)->numbers()
+
+    // Require at least one symbol...
+    Password::min(8)->symbols()
+
+In addition, you may also want to ensure a password has not been compromised in data leaks by using the `uncompromised` method:
+
+    Password::min(8)->uncompromised()
+
+Internally, the `Password` rule object uses what is known as a [k-Anonymity](https://en.wikipedia.org/wiki/K-anonymity) model that allows for the password to be looked up on the [haveibeenpwned.com](https://haveibeenpwned.com) service without giving up the user's privacy or security.
+
+By default, if a password appears at least once in a data leak, it will be considered compromised. You can customize this threshold by using the first argument of the `uncompromised` method:
+
+    // Ensure the given password has not been compromised 3 times in the same data leak
+    Password::min(8)->uncompromised(3);
+
+Of course, may chain all the methods specified above:
+
+    Password::min(8)
+        ->letters()
+        ->mixedCase()
+        ->numbers()
+        ->symbols()
+        ->uncompromised()
 
 <a name="custom-validation-rules"></a>
 ## Custom Validation Rules

--- a/validation.md
+++ b/validation.md
@@ -1425,7 +1425,7 @@ To ensure that passwords have an adequate level of complexity, you may use Larav
         'password' => ['required', 'confirmed', Password::min(8)],
     ]);
 
-The `Password` rule object allows you to easily customize the password complexity requirements for your application:
+The `Password` rule object allows you to easily customize the password complexity requirements for your application, such as specifying that passwords require at least one letter, number, symbol, or characters with mixed casing:
 
     // Require at least 8 characters...
     Password::min(8)
@@ -1442,18 +1442,18 @@ The `Password` rule object allows you to easily customize the password complexit
     // Require at least one symbol...
     Password::min(8)->symbols()
 
-In addition, you may also want to ensure a password has not been compromised in data leaks by using the `uncompromised` method:
+In addition, you may ensure that a password has not been compromised in a public password data breach leak using the `uncompromised` method:
 
     Password::min(8)->uncompromised()
 
-Internally, the `Password` rule object uses what is known as a [k-Anonymity](https://en.wikipedia.org/wiki/K-anonymity) model that allows for the password to be looked up on the [haveibeenpwned.com](https://haveibeenpwned.com) service without giving up the user's privacy or security.
+Internally, the `Password` rule object uses the [k-Anonymity](https://en.wikipedia.org/wiki/K-anonymity) model to determine if a password has been leaked via the [haveibeenpwned.com](https://haveibeenpwned.com) service without sacrificing the user's privacy or security.
 
-By default, if a password appears at least once in a data leak, it will be considered compromised. You can customize this threshold by using the first argument of the `uncompromised` method:
+By default, if a password appears at least once in a data leak, it will be considered compromised. You can customize this threshold using the first argument of the `uncompromised` method:
 
-    // Ensure the given password has not been compromised 3 times in the same data leak
+    // Ensure the password appears less than 3 times in the same data leak...
     Password::min(8)->uncompromised(3);
 
-Of course, you may chain all the methods specified above:
+Of course, you may chain all the methods in the examples above:
 
     Password::min(8)
         ->letters()


### PR DESCRIPTION
This pull request adds documentation about the `Password` rule object: https://github.com/laravel/framework/pull/36960.