### PR TITLE
Add sail installation heading for existing user.

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -34,6 +34,9 @@ Laravel Sail is supported on macOS, Linux, and Windows (via WSL2).
 <a name="installation"></a>
 ## Installation & Setup
 
+<a name="for-new-application"></a>
+### For New Application
+
 Laravel Sail is automatically installed with all new Laravel applications so you may start using it immediately. To learn how to create a new Laravel application, please consult Laravel's [installation documentation](/docs/{{version}}/installation) for your operating system. During installation, you will be asked to choose which Sail supported services your application will be interacting with.
 
 <a name="installing-sail-into-existing-applications"></a>


### PR DESCRIPTION
I have been using Laravel for a long time.
I was reading the documentation of sail because I wanted to use sail newly.
On the way, I jumped to INSTALLATION and got lost.

It would be nice to have a heading for starting a new project.
Because such a heading would be a good reminder that I don't need to read the first paragraph of "Installation & Setup".

How about this change?