### PR TITLE
[8.x] Add a note about Symfony's different default attribute for confirm()

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -368,6 +368,9 @@ If necessary, you may specify that the confirmation prompt should return `true` 
         //
     }
 
+> {note} If you are using `$this->output->confirm()` this behavior is the opposite in Symfony and it will default to `true`
+
+
 <a name="auto-completion"></a>
 #### Auto-Completion
 


### PR DESCRIPTION
See

https://github.com/laravel/framework/blob/8.x/src/Illuminate/Console/Concerns/InteractsWithIO.php#L131
https://github.com/symfony/console/blame/5.x/Style/SymfonyStyle.php#L291

Which is confusing

Superseeds #7045