### PR TITLE
[8.x] Document rendering signed route failures

### DIFF
--- a/urls.md
+++ b/urls.md
@@ -138,6 +138,22 @@ Once you have registered the middleware in your kernel, you may attach it to a r
     Route::post('/unsubscribe/{user}', function (Request $request) {
         // ...
     })->name('unsubscribe')->middleware('signed');
+    
+<a name="rendering-signed-route-failures"></a>
+#### Rendering Signed Route Failures
+
+When a person hits a signed url that has expired they'll be greeted with a 403 error page. You can customize how this page looks by catching the `InvalidSignatureException` exception in your exception handler and returning a custom view like so:
+
+    use Illuminate\Routing\Exceptions\InvalidSignatureException;
+
+    public function render($request, Throwable $exception)
+    {
+        if ($exception instanceof InvalidSignatureException) {
+            return response()->view('errors.link-expired')->setStatusCode(Response::HTTP_FORBIDDEN);
+        }
+
+        // ...
+    }
 
 <a name="urls-for-controller-actions"></a>
 ## URLs For Controller Actions

--- a/urls.md
+++ b/urls.md
@@ -139,20 +139,23 @@ Once you have registered the middleware in your kernel, you may attach it to a r
         // ...
     })->name('unsubscribe')->middleware('signed');
     
-<a name="rendering-signed-route-failures"></a>
-#### Rendering Signed Route Failures
+<a name="responding-to-invalid-signed-routes"></a>
+#### Responding To Invalid Signed Routes
 
-When a person hits a signed url that has expired they'll be greeted with a 403 error page. You can customize how this page looks by catching the `InvalidSignatureException` exception in your exception handler and returning a custom view like so:
+When someone visits a signed URL that has expired, they will receive a generic error page for the `403` HTTP status code. However, you can customize this behavior by defining a custom "renderable" closure for the `InvalidSignatureException` exception in your exception handler. This closure should return an HTTP response:
 
     use Illuminate\Routing\Exceptions\InvalidSignatureException;
 
-    public function render($request, Throwable $exception)
+    /**
+     * Register the exception handling callbacks for the application.
+     *
+     * @return void
+     */
+    public function register()
     {
-        if ($exception instanceof InvalidSignatureException) {
-            return response()->view('errors.link-expired')->setStatusCode(Response::HTTP_FORBIDDEN);
-        }
-
-        // ...
+        $this->renderable(function (InvalidSignatureException $e) {
+            return response()->view('error.link-expired', [], 403);
+        });
     }
 
 <a name="urls-for-controller-actions"></a>


### PR DESCRIPTION
After experiencing https://freek.dev/1977-dealing-with-expired-signed-urls-in-laravel?preview_secret=I9e6ZvUlTU I felt it might be worth to document this. Thanks to @freekmurze 

Although I feel like we could do better out of the box with a better message for the 403 exception? 🤔