### PR TITLE
[8.x] Clarify unless rules

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -931,7 +931,7 @@ The field under validation will be excluded from the request data returned by th
 <a name="rule-exclude-unless"></a>
 #### exclude_unless:_anotherfield_,_value_
 
-The field under validation will be excluded from the request data returned by the `validate` and `validated` methods unless _anotherfield_'s field is equal to _value_.
+The field under validation will be excluded from the request data returned by the `validate` and `validated` methods unless _anotherfield_'s field is equal to _value_. This also means _anotherfield_ must be present in the request data unless _value_ is `null`.
 
 <a name="rule-exists"></a>
 #### exists:_table_,_column_
@@ -1200,7 +1200,7 @@ If you would like to construct a more complex condition for the `required_if` ru
 <a name="rule-required-unless"></a>
 #### required_unless:_anotherfield_,_value_,...
 
-The field under validation must be present and not empty unless the _anotherfield_ field is equal to any _value_.
+The field under validation must be present and not empty unless the _anotherfield_ field is equal to any _value_. This also means _anotherfield_ must be present in the request data unless _value_ is `null`.
 
 <a name="rule-required-with"></a>
 #### required_with:_foo_,_bar_,...

--- a/validation.md
+++ b/validation.md
@@ -931,7 +931,7 @@ The field under validation will be excluded from the request data returned by th
 <a name="rule-exclude-unless"></a>
 #### exclude_unless:_anotherfield_,_value_
 
-The field under validation will be excluded from the request data returned by the `validate` and `validated` methods unless _anotherfield_'s field is equal to _value_. This also means _anotherfield_ must be present in the request data unless _value_ is `null`.
+The field under validation will be excluded from the request data returned by the `validate` and `validated` methods unless _anotherfield_'s field is equal to _value_. If _value_ is `null` (`exclude_unless:name,null`), the field under validation will be excluded unless the comparison field is `null` or the comparison field is missing from the request data.
 
 <a name="rule-exists"></a>
 #### exists:_table_,_column_
@@ -1200,7 +1200,7 @@ If you would like to construct a more complex condition for the `required_if` ru
 <a name="rule-required-unless"></a>
 #### required_unless:_anotherfield_,_value_,...
 
-The field under validation must be present and not empty unless the _anotherfield_ field is equal to any _value_. This also means _anotherfield_ must be present in the request data unless _value_ is `null`.
+The field under validation must be present and not empty unless the _anotherfield_ field is equal to any _value_. This also means _anotherfield_ must be present in the request data unless _value_ is `null`. If _value_ is `null` (`required_unless:name,null`), the field under validation will be required unless the comparison field is `null` or the comparison field is missing from the request data.
 
 <a name="rule-required-with"></a>
 #### required_with:_foo_,_bar_,...


### PR DESCRIPTION
Clarifies unless rules when _anotherfield_ is missing from the request data and the separate behavior for `null`.