### PR TITLE
Remove Confusion of the Union Example

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -2408,7 +2408,7 @@ The `union` method adds the given array to the collection. If the given array co
 
     $collection = collect([1 => ['a'], 2 => ['b']]);
 
-    $union = $collection->union([3 => ['c'], 1 => ['b']]);
+    $union = $collection->union([3 => ['c'], 1 => ['d']]);
 
     $union->all();
 


### PR DESCRIPTION
Developers may get confused with key and value comparison here.
We should keep the values different so that it is clear that `union` merges by key.