### PR TITLE
Fixes default Octane port

### DIFF
--- a/octane.md
+++ b/octane.md
@@ -82,7 +82,7 @@ After installing the RoadRunner binary, you may exit your Sail shell session. Yo
 Next, update the `command` directive of your application's `docker/supervisord.conf` file so that Sail serves your application using Octane instead of the PHP development server:
 
 ```ini
-command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --server=roadrunner --host=0.0.0.0 --port=8000
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=8000
 ```
 
 Finally, ensure the `rr` binary is executable and build your Sail images:

--- a/octane.md
+++ b/octane.md
@@ -82,7 +82,7 @@ After installing the RoadRunner binary, you may exit your Sail shell session. Yo
 Next, update the `command` directive of your application's `docker/supervisord.conf` file so that Sail serves your application using Octane instead of the PHP development server:
 
 ```ini
-command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --server=roadrunner --host=0.0.0.0 --port=80
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --server=roadrunner --host=0.0.0.0 --port=8000
 ```
 
 Finally, ensure the `rr` binary is executable and build your Sail images:
@@ -116,7 +116,7 @@ Alternatively, you may develop your Swoole based Octane application using [Larav
 Next, update the `command` directive of your application's `docker/supervisord.conf` file so that Sail serves your application using Octane instead of the PHP development server:
 
 ```ini
-command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --server=swoole --host=0.0.0.0 --port=80
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --server=swoole --host=0.0.0.0 --port=8000
 ```
 
 Finally, build your Sail images:


### PR DESCRIPTION
This pull request fixes the default Octane port should use. Examples - such the Nginx template - expect Octane to be using the port `8000`.

In addition, it adds the `--rpc-port` option that should be used when roadrunner.

Addresses: https://github.com/laravel/octane/issues/276.