### PR TITLE
Array key validation

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -791,6 +791,22 @@ The field under validation must be entirely alpha-numeric characters.
 
 The field under validation must be a PHP `array`.
 
+When the `array` rule is defined with parameters, each key in the input array must be present within the list of values provided to the rule. In the following example, the `is_admin` key in the input array is invalid since it is not contained in the list of keys provided to the `array` rule:
+
+    use Illuminate\Support\Facades\Validator;
+
+    $input = [
+        'user' => [
+            'username' => 'taylor',
+            'locale' => 'en',
+            'is_admin' => true,
+        ],
+    ];
+
+    Validator::make($input, [
+        'user' => 'array:username,locale',
+    ]);
+
 <a name="rule-bail"></a>
 #### bail
 


### PR DESCRIPTION
This PR adds a bit of documentation for the ability to validate that array keys must be present in a list ([source code](https://github.com/laravel/framework/blob/6a42e1216210b3ad3f738ab27e51e850190d9a1f/src/Illuminate/Validation/Concerns/ValidatesAttributes.php#L295-L306) and [tests](https://github.com/laravel/framework/blob/6a42e1216210b3ad3f738ab27e51e850190d9a1f/tests/Validation/ValidationValidatorTest.php#L703-L718))

This feature was also present in Laravel 7 ([source code](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Validation/Concerns/ValidatesAttributes.php#L323-L334))