### PR TITLE
cashier: Update stripe webhook url

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -1188,7 +1188,7 @@ To ensure your application can handle Stripe webhooks, be sure to configure the 
 Since Stripe webhooks need to bypass Laravel's [CSRF protection](/docs/{{version}}/csrf), be sure to list the URI as an exception in your application's `App\Http\Middleware\VerifyCsrfToken` middleware or list the route outside of the `web` middleware group:
 
     protected $except = [
-        'stripe/*',
+        'stripe/webhook/*',
     ];
 
 <a name="defining-webhook-event-handlers"></a>


### PR DESCRIPTION
Hi, @driesvints 

We should only whitelist `stripe/webhook/*` not the whole `stripe/*`, as many of users would be having routes starting with `stripe`

Here are some examples
```
PUT stripe/subscriptions/1
POST stripe/subscriptions/create
DELETE stripe/subscriptions/1
GET stripe/connect-callback
```

Laravel cashier only has one endpoint to be whitelisted.
