### PR TITLE
Document refresh option for artisan down command

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -124,7 +124,11 @@ To enable maintenance mode, execute the `down` Artisan command:
 
     php artisan down
 
-You may also provide a `retry` option to the `down` command, which will be set as the `Retry-After` HTTP header's value:
+To make browsers reload the page again after a number of seconds, the `refresh` option can be used to set the `Refresh` HTTP header in maintenance mode:
+
+    php artisan down --refresh=15
+
+You may also provide a `retry` option to the `down` command, which will be set as the `Retry-After` HTTP header's value, although browsers generally ignore this header:
 
     php artisan down --retry=60
 

--- a/configuration.md
+++ b/configuration.md
@@ -124,7 +124,7 @@ To enable maintenance mode, execute the `down` Artisan command:
 
     php artisan down
 
-To make browsers reload the page again after a number of seconds, the `refresh` option can be used to set the `Refresh` HTTP header in maintenance mode:
+If you would like the `Refresh` HTTP header to be sent with all maintenance mode responses, you may provide the `refresh` option when invoking the `down` command. The `Refresh` header will instruct the browser to automatically refresh the page after the specified number of seconds:
 
     php artisan down --refresh=15
 


### PR DESCRIPTION
Release https://github.com/laravel/framework/releases/tag/v8.42.0
included PR https://github.com/laravel/framework/pull/37385 from idea https://github.com/laravel/ideas/issues/2558
that added a `--refresh` option to the `artisan down` command.