### PR TITLE
[8.x] Improve manual authentication example

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -250,7 +250,7 @@ We will access Laravel's authentication services via the `Auth` [facade](/docs/{
             }
 
             return back()->withErrors([
-                'email' => __('auth.failed')
+                'email' => 'The provided credentials do not match our records.',
             ]);
         }
     }

--- a/authentication.md
+++ b/authentication.md
@@ -239,8 +239,8 @@ We will access Laravel's authentication services via the `Auth` [facade](/docs/{
         public function authenticate(Request $request)
         {
             $credentials = $request->validate([
-                'email'    => ['required', 'email'],
-                'password' => ['required']
+                'email' => ['required', 'email'],
+                'password' => ['required'],
             ]);
 
             if (Auth::attempt($credentials)) {

--- a/authentication.md
+++ b/authentication.md
@@ -238,7 +238,10 @@ We will access Laravel's authentication services via the `Auth` [facade](/docs/{
          */
         public function authenticate(Request $request)
         {
-            $credentials = $request->only('email', 'password');
+            $credentials = $request->validate([
+                'email'    => ['required', 'email'],
+                'password' => ['required']
+            ]);
 
             if (Auth::attempt($credentials)) {
                 $request->session()->regenerate();
@@ -247,7 +250,7 @@ We will access Laravel's authentication services via the `Auth` [facade](/docs/{
             }
 
             return back()->withErrors([
-                'email' => 'The provided credentials do not match our records.',
+                'email' => __('auth.failed')
             ]);
         }
     }


### PR DESCRIPTION
Changed the manual authentication example:

Two parts:
• Validate the post data coming in exists, and the email is an email.
• Pass a translated error message (shipped standard in lang/en/auth.php)

I realise it's not required, but it shows some best practice perhaps for other routes - we don't assume data exists, and blindly pass it to a function. The translation part introduces how translations can be used from the start in an application, very easily.