### PR TITLE
Wrong return value of sole funciton in example

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1947,7 +1947,7 @@ The `sole` method returns the first element in the collection that passes a give
         return $value === 2;
     });
 
-    // 3
+    // 2
 
 You may also pass a key / value pair to the `sole` method, which will return the first element in the collection that matches the given pair, but only if it exactly one element matches:
 


### PR DESCRIPTION
The current documentation for the `sole` method in Collections has an example which suggests the expected result. However, the expected result seems to be wrong. Instead of (int) 3, I expect (int) 2 to be the result. Implementing the given example confirms this (in Tinker):
```
>>> collect([1, 2, 3, 4])->sole(function ($value, $key) { return $value === 2; });
=> 2
```
The current proposed change is simply to replace "3" by "2" in the documentation.