### PR TITLE
Add reference to model events and describe different between -ed and -ing events

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1131,7 +1131,7 @@ The `is` and `isNot` methods are also available when using the `belongsTo`, `has
 
 Eloquent models dispatch several events, allowing you to hook into the following moments in a model's lifecycle: `retrieved`, `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`, and `replicating`.
 
-The `retrieved` event will dispatch when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will dispatch. The `updating` / `updated` events will dispatch when an existing model is modified and the `save` method is called. The `saving` / `saved` events will dispatch when a model is created or updated - even if the model's attributes have not been changed. Events with `-ing` is fired before changes to the model are persisted, while events with `-ed` is fired after changes to the model are persisted.
+The `retrieved` event will dispatch when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will dispatch. The `updating` / `updated` events will dispatch when an existing model is modified and the `save` method is called. The `saving` / `saved` events will dispatch when a model is created or updated - even if the model's attributes have not been changed. Events with `-ing` are fired before changes to the model are persisted, while events with `-ed` are fired after changes to the model are persisted.
 
 To start listening to model events, define a `$dispatchesEvents` property on your Eloquent model. This property maps various points of the Eloquent model's lifecycle to your own [event classes](/docs/{{version}}/events). Each model event class should expect to receive an instance of the affected model via its constructor:
 
@@ -1261,7 +1261,7 @@ This command will place the new observer in your `App/Observers` directory. If t
         }
     }
 
-> {tip} There are additional event functions an observer can implement like `creating`, `saved` and `retrieved`, there are described under [events](#events).
+> {tip} There are additional event functions an observer can implement like `saving` and `retrieved`. They are described under [events](#events).
 
 To register an observer, you need to call the `observe` method on the model you wish to observe. You may register observers in the `boot` method of your application's `App\Providers\EventServiceProvider` service provider:
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -1131,7 +1131,7 @@ The `is` and `isNot` methods are also available when using the `belongsTo`, `has
 
 Eloquent models dispatch several events, allowing you to hook into the following moments in a model's lifecycle: `retrieved`, `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`, and `replicating`.
 
-The `retrieved` event will dispatch when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will dispatch. The `updating` / `updated` events will dispatch when an existing model is modified and the `save` method is called. The `saving` / `saved` events will dispatch when a model is created or updated - even if the model's attributes have not been changed. Events with `-ing` are fired before changes to the model are persisted, while events with `-ed` are fired after changes to the model are persisted.
+The `retrieved` event will dispatch when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will dispatch. The `updating` / `updated` events will dispatch when an existing model is modified and the `save` method is called. The `saving` / `saved` events will dispatch when a model is created or updated - even if the model's attributes have not been changed. Event names ending with `-ing` are dispatched before any changes to the model are persisted, while events ending with `-ed` are dispatched after the changes to the model are persisted.
 
 To start listening to model events, define a `$dispatchesEvents` property on your Eloquent model. This property maps various points of the Eloquent model's lifecycle to your own [event classes](/docs/{{version}}/events). Each model event class should expect to receive an instance of the affected model via its constructor:
 
@@ -1261,8 +1261,6 @@ This command will place the new observer in your `App/Observers` directory. If t
         }
     }
 
-> {tip} There are additional event functions an observer can implement like `saving` and `retrieved`. They are described under [events](#events).
-
 To register an observer, you need to call the `observe` method on the model you wish to observe. You may register observers in the `boot` method of your application's `App\Providers\EventServiceProvider` service provider:
 
     use App\Models\User;
@@ -1277,6 +1275,8 @@ To register an observer, you need to call the `observe` method on the model you 
     {
         User::observe(UserObserver::class);
     }
+
+> {tip} There are additional events an observer can listen to, such as `saving` and `retrieved`. These events are described within the [events](#events) documentation.
 
 <a name="observers-and-database-transactions"></a>
 #### Observers & Database Transactions

--- a/eloquent.md
+++ b/eloquent.md
@@ -1131,7 +1131,7 @@ The `is` and `isNot` methods are also available when using the `belongsTo`, `has
 
 Eloquent models dispatch several events, allowing you to hook into the following moments in a model's lifecycle: `retrieved`, `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`, and `replicating`.
 
-The `retrieved` event will dispatch when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will dispatch. The `updating` / `updated` events will dispatch when an existing model is modified and the `save` method is called. The `saving` / `saved` events will dispatch when a model is created or updated - even if the model's attributes have not been changed.
+The `retrieved` event will dispatch when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will dispatch. The `updating` / `updated` events will dispatch when an existing model is modified and the `save` method is called. The `saving` / `saved` events will dispatch when a model is created or updated - even if the model's attributes have not been changed. Events with `-ing` is fired before changes to the model are persisted, while events with `-ed` is fired after changes to the model are persisted.
 
 To start listening to model events, define a `$dispatchesEvents` property on your Eloquent model. This property maps various points of the Eloquent model's lifecycle to your own [event classes](/docs/{{version}}/events). Each model event class should expect to receive an instance of the affected model via its constructor:
 
@@ -1260,6 +1260,8 @@ This command will place the new observer in your `App/Observers` directory. If t
             //
         }
     }
+
+> {tip} There are additional event functions an observer can implement like `creating`, `saved` and `retrieved`, there are described under [events](#events).
 
 To register an observer, you need to call the `observe` method on the model you wish to observe. You may register observers in the `boot` method of your application's `App\Providers\EventServiceProvider` service provider:
 


### PR DESCRIPTION
- Added a tip to observer, to state the all model event functions can be implemented.
- Added definition of the difference between `-ed` and `-ing` events.

---

I found that many colleagues didn't realise the observer can implement the other model event function, therefore it should maybe be more explicit.
I'm open to changing the wording, if need be.