### PR TITLE
Adding a mention about select in Other Aggregate Functions

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1360,6 +1360,13 @@ Like the `loadCount` method, deferred versions of these methods are also availab
     $post = Post::first();
 
     $post->loadSum('comments', 'votes');
+    
+Like the `withCount` method, if you're combining these methods with a `select` statement, ensure that you call these methods after the `select` method:
+
+    $posts = Post::select(['title', 'body'])
+                    ->withExists('comments')
+                    ->get();
+
 
 <a name="counting-related-models-on-morph-to-relationships"></a>
 ### Counting Related Models On Morph To Relationships


### PR DESCRIPTION
Hello,

i'm proposing to add a mention in the "Other Aggregate Functions" section about the order of these methods when combining with a select statement.

it's a follow-up of this issue :

https://github.com/laravel/framework/issues/37557

thanks.