### PR TITLE
Added SCA info on Cashier Stripe

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -1519,7 +1519,7 @@ There are currently two types of payment exceptions which extend `IncompletePaym
 <a name="strong-customer-authentication"></a>
 ## Strong Customer Authentication
 
-If your business is based in Europe you will need to abide by the EU's Strong Customer Authentication (SCA) regulations. These regulations were imposed in September 2019 by the European Union to prevent payment fraud. Luckily, Stripe and Cashier are prepared for building SCA compliant applications.
+If your business or one of your customers is based in Europe you will need to abide by the EU's Strong Customer Authentication (SCA) regulations. These regulations were imposed in September 2019 by the European Union to prevent payment fraud. Luckily, Stripe and Cashier are prepared for building SCA compliant applications.
 
 > {note} Before getting started, review [Stripe's guide on PSD2 and SCA](https://stripe.com/guides/strong-customer-authentication) as well as their [documentation on the new SCA APIs](https://stripe.com/docs/strong-customer-authentication).
 


### PR DESCRIPTION
SCA (Strong Customer Authentication) is there to protect European customers. Even more important than where the merchant is living is the location of the customers.