### PR TITLE
Remove use of $request in password reset closure

### DIFF
--- a/passwords.md
+++ b/passwords.md
@@ -120,7 +120,7 @@ Of course, we need to define a route to actually handle the password reset form 
 
         $status = Password::reset(
             $request->only('email', 'password', 'password_confirmation', 'token'),
-            function ($user, $password) use ($request) {
+            function ($user, $password) {
                 $user->forceFill([
                     'password' => Hash::make($password)
                 ])->setRememberToken(Str::random(60));


### PR DESCRIPTION
In the closure for handling the password reset, `use ($request)` is written. However, the request instance is not used in the closure.