### PR TITLE
[8.x] Document that only one request is supported per test method

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -75,7 +75,7 @@ Instead of returning an `Illuminate\Http\Response` instance, test request method
         }
     }
 
-> {note} Avoid making multiple requests in the same test method.  This is not supported.
+In general, each of your tests should only make one request to your application. Unexpected behavior may occur if multiple requests are executed within a single test method.
 
 > {tip} For convenience, the CSRF middleware is automatically disabled when running tests.
 

--- a/http-tests.md
+++ b/http-tests.md
@@ -75,6 +75,8 @@ Instead of returning an `Illuminate\Http\Response` instance, test request method
         }
     }
 
+> {note} Avoid making multiple requests in the same test method.  This is not supported.
+
 > {tip} For convenience, the CSRF middleware is automatically disabled when running tests.
 
 <a name="customizing-request-headers"></a>


### PR DESCRIPTION
The test framework included with Laravel enters undefined behavior should multiple requests be performed in the same test method, as the framework only boots once per test method (https://github.com/laravel/framework/issues/27060).  For example, Sanctum may behave unrealistically when this guidance is not followed (https://github.com/laravel/sanctum/issues/272#issuecomment-853902783).