### PR TITLE
Fixing typo introduced by c919d4

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1361,7 +1361,7 @@ Like the `loadCount` method, deferred versions of these methods are also availab
 
     $post->loadSum('comments', 'votes');
 
-If you're combining these aggregate methods with a `select` statement, ensure that you call the aggregate methods methods after the `select` method:
+If you're combining these aggregate methods with a `select` statement, ensure that you call the aggregate methods after the `select` method:
 
     $posts = Post::select(['title', 'body'])
                     ->withExists('comments')


### PR DESCRIPTION
Hello,

there is a typo in eloquent-reationships.md after the formatting of c919d4.

it's not really worth a PR so i made a comment on that commit but i don't think anyone saw it,

so i made this pr.

feel free to merge this pr or fix the typo directly.

thanks.