### PR TITLE
Note about RefreshDatabase trait for using seed features in tests

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -555,7 +555,7 @@ If you would like to use [database seeders](/docs/{{version}}/seeding) to popula
         }
     }
 
-Alternatively, you may instruct Laravel to automatically seed the database before each test. You may accomplish this by defining a `$seed` property on your base test class:
+Alternatively, you may instruct Laravel to automatically seed the database before each test that uses the `RefreshDatabase` trait. You may accomplish this by defining a `$seed` property on your base test class:
 
     <?php
 
@@ -575,7 +575,7 @@ Alternatively, you may instruct Laravel to automatically seed the database befor
         protected $seed = true;
     }
 
-When the `$seed` property is `true`, the test will run the `Database\Seeders\DatabaseSeeder` class before each test. However, you may specify a specific seeder that should be executed by defining a `$seeder` property on your test class:
+When the `$seed` property is `true`, the test will run the `Database\Seeders\DatabaseSeeder` class before each test that uses the `RefreshDatabase` trait. However, you may specify a specific seeder that should be executed by defining a `$seeder` property on your test class:
 
     use Database\Seeders\OrderStatusSeeder;
 


### PR DESCRIPTION
The `$seed` and `$seeder` properties work only if `RefreshDatabase` trait is used in a test.

As confirmed [here](https://github.com/laravel/docs/commit/967b638e518654120735c13f40c4b7495b5b3dd8#commitcomment-51165186).