### PR TITLE
[8.x] Fixed accessor comparison attribute

### DIFF
--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -141,7 +141,7 @@ Occasionally, when converting models to arrays or JSON, you may wish to add attr
          */
         public function getIsAdminAttribute()
         {
-            return $this->attributes['admin'] === 'yes';
+            return $this->attributes['admin'] = 'yes';
         }
     }
 


### PR DESCRIPTION
Changed typo in doc, to define the accessor, we should do an assignment and not a comparison