### PR TITLE
[8.x] Document Homestead "paravirtualization" setting

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -175,6 +175,15 @@ The `provider` key in your `Homestead.yaml` file indicates which Vagrant provide
 
     provider: virtualbox
 
+<a name="setting-your-paravirtualization-interface"></a>
+#### Setting Your Paravirtualization Interface
+
+The `paravirtualization` key in your `Homestead.yaml` file indicates which paravirtualization interface should be provided to the guest operating system:
+
+    paravirtprovider: hyperv
+
+Supported `paravirtualization` values include: `none`, `default`, `legacy`, `minimal`, `hyperv`, and `kvm` (the default)
+
 <a name="configuring-shared-folders"></a>
 #### Configuring Shared Folders
 


### PR DESCRIPTION
The `paravirtualization` setting, added in [this commit](https://github.com/laravel/homestead/commit/af3a5f1c521f493893762371d894ffe12801c37f), is missing from the docs.

I was trying to get Docker and Vagrant/VirtualBox to run alongside each other on Windows 10 with WSL2/Hyper-V and had to dig through the source to find this option. Documenting it might save users some time and frustration.

