### PR TITLE
Missing broadcasting method and scoped instances docs

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -844,6 +844,14 @@ If you plan to explicitly return a channel instance from your model's `broadcast
 return [new Channel($this->user)];
 ```
 
+If you need access to the channel name of a model, you may use the `broadcastChannel()` method from any model instance:
+
+```php
+$user->broadcastChannel()
+```
+
+This method returns the string `App.Models.User.1` for a `App\Models\User` model with an `id` of `1`.
+
 <a name="model-broadcasting-event-conventions"></a>
 #### Event Conventions
 

--- a/container.md
+++ b/container.md
@@ -150,6 +150,18 @@ The `singleton` method binds a class or interface into the container that should
         return new Transistor($app->make(PodcastParser::class));
     });
 
+<a name="binding-scoped"></a>
+#### Binding Scoped Instances
+
+The `scoped` method binds a class or interface into the container that should only be resolved one time inside the same context. Differently than the `singleton` method, instances registered with the `scoped` method will be flushed whenever the Laravel Application switches contexts, such as when a Laravel Octane Worker processes a new request or when Laravel Queue Worker processes a new Job:
+
+    use App\Services\Transistor;
+    use App\Services\PodcastParser;
+
+    $this->app->scoped(Transistor::class, function ($app) {
+        return new Transistor($app->make(PodcastParser::class));
+    });
+
 <a name="binding-instances"></a>
 #### Binding Instances
 


### PR DESCRIPTION
### Added

- Adds a reference to the `$model->broadcastChannel()` method available on any Eloquent model as for `^8.45`. I suggest this method in the Turbo Laravel documentation, so thought it would be useful to be documented. This can be useful when passing down the Echo channel name to Inertia.js pages or something like that;
- Adds references to scoped instances in the container;