### PR TITLE
[8.x] Add name to overwritten Cashier Paddle webhook

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -969,7 +969,7 @@ Next, define a route to your Cashier webhook controller within your application'
 
     use App\Http\Controllers\WebhookController;
 
-    Route::post('/paddle/webhook', WebhookController::class);
+    Route::post('/paddle/webhook', WebhookController::class)->name('cashier.webhook');
 
 Cashier emits a `Laravel\Paddle\Events\WebhookReceived` event when a webhook is received and a `Laravel\Paddle\Events\WebhookHandled` event when a webhook was handled. Both events contain the full payload of the Paddle webhook.
 


### PR DESCRIPTION
When overwriting Cashier routes, it's important that the default name also stays in place.