### PR TITLE
Include a Note that Breeze Should Be Run on New Application

### DIFF
--- a/starter-kits.md
+++ b/starter-kits.md
@@ -47,6 +47,8 @@ npm run dev
 php artisan migrate
 ```
 
+> {note} You should not execute `php artisan breeze:install` on an existing Laravel project which will overwrite some of the existing files. If you have a backup or have committed to the code to your version control and you are sure that you can easily rollback the changes, only then run the command and then resolve the conflicting files.
+
 Next, you may navigate to your application's `/login` or `/register` URLs in your web browser. All of Breeze's routes are defined within the `routes/auth.php` file.
 
 > {tip} To learn more about compiling your application's CSS and JavaScript, check out the [Laravel Mix documentation](/docs/{{version}}/mix#running-mix).


### PR DESCRIPTION
I noted that running breeze install command on an existing application overwrites the existing files which will be quite undesirable if the developer doesn't have any backup of the existing project. I personally could have lost some progress on the project because I was not careful enough to read the instruction in the docs that it should be run on a new Laravel project however, it should also be considered that the documentation didn't emphasize this limitation enough. With the addition of the new note, it is hoped that other developers will take note of such disastrous consequence.