### PR TITLE
[8.x] Update link to Expose

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -195,7 +195,7 @@ To stop sharing your site, you may press `Control + C`.
 <a name="sharing-sites-via-expose"></a>
 ### Sharing Sites Via Expose
 
-If you have [Expose](https://beyondco.de/docs/expose) installed, you can share your site by navigating to the site's directory in your terminal and running the `expose` command. Consult the [Expose documentation](https://beyondco.de/docs/expose/introduction) for information regarding the additional command-line parameters it supports. After sharing the site, Expose will display the sharable URL that you may use on your other devices or amongst team members:
+If you have [Expose](https://expose.dev) installed, you can share your site by navigating to the site's directory in your terminal and running the `expose` command. Consult the [Expose documentation](https://expose.dev/docs) for information regarding the additional command-line parameters it supports. After sharing the site, Expose will display the sharable URL that you may use on your other devices or amongst team members:
 
     cd ~/Sites/laravel
 


### PR DESCRIPTION
We moved Expose to its own domain at https://expose.dev. This PR updates the links in the Valet section to point to the new URL.