### PR TITLE
Fix typo in Fortify docs

### DIFF
--- a/fortify.md
+++ b/fortify.md
@@ -430,7 +430,7 @@ If the request was not successful, the user will be redirected back to the reque
 
 To finish implementing our application's password reset functionality, we need to instruct Fortify how to return our "reset password" view.
 
-All of Fortify's view's rendering logic may be customized using the appropriate methods available via the `Laravel\Fortify\Fortify` class. Typically, you should call this method from the `boot` method of your application's `App\Providers\FortifyServiceProvider` class:
+All of Fortify's view rendering logic may be customized using the appropriate methods available via the `Laravel\Fortify\Fortify` class. Typically, you should call this method from the `boot` method of your application's `App\Providers\FortifyServiceProvider` class:
 
 ```php
 use Laravel\Fortify\Fortify;


### PR DESCRIPTION
`All of Fortify's view's rendering logic` --> `All of Fortify's view rendering logic`