### PR TITLE
Removed deprecated --no-suggest composer flag

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1746,7 +1746,7 @@ To run your Dusk tests on [Travis CI](https://travis-ci.org), use the following 
 
     install:
       - cp .env.testing .env
-      - travis_retry composer install --no-interaction --prefer-dist --no-suggest
+      - travis_retry composer install --no-interaction --prefer-dist
       - php artisan key:generate
       - php artisan dusk:chrome-driver
 
@@ -1777,7 +1777,7 @@ If you are using [Github Actions](https://github.com/features/actions) to run yo
               sudo systemctl start mysql
               mysql --user="root" --password="root" -e "CREATE DATABASE 'my-database' character set UTF8mb4 collate utf8mb4_bin;"
           - name: Install Composer Dependencies
-            run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+            run: composer install --no-progress --prefer-dist --optimize-autoloader
           - name: Generate Application Key
             run: php artisan key:generate
           - name: Upgrade Chrome Driver


### PR DESCRIPTION
Copying the GitHub action for instance to run will output

> You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.