### PR TITLE
Update IRC support link

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -57,7 +57,7 @@ Laravel's GitHub issue trackers are not intended to provide Laravel help or supp
 - [StackOverflow](https://stackoverflow.com/questions/tagged/laravel)
 - [Discord](https://discordapp.com/invite/KxwQuKb)
 - [Larachat](https://larachat.co)
-- [IRC](https://webchat.freenode.net/?nick=artisan&channels=%23laravel&prompt=1)
+- [IRC](https://web.libera.chat/?nick=artisan&channels=#laravel)
 </div>
 
 <a name="core-development-discussion"></a>


### PR DESCRIPTION
Freenode's webchat no longer connects to its own network (see screenshot), so this PR updates the IRC support link to point to Libera's webchat instead. See also laravelio/laravel.io#635

![image](https://user-images.githubusercontent.com/1521802/123721668-b4755780-d87e-11eb-9229-3d662fc45e12.png)
