### PR TITLE
[8.x] Remove production warning notice from Dusk docs

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -60,8 +60,6 @@ To get started, you should add the `laravel/dusk` Composer dependency to your pr
 
     composer require --dev laravel/dusk
 
-> {note} If you are manually registering Dusk's service provider, you should **never** register it in your production environment, as doing so could lead to arbitrary users being able to authenticate with your application.
-
 After installing the Dusk package, execute the `dusk:install` Artisan command. The `dusk:install` command will create a `tests/Browser` directory and an example Dusk test:
 
     php artisan dusk:install


### PR DESCRIPTION
In the current version of DuskServiceProvider, the login routes are only registered when not in production.

https://github.com/laravel/dusk/blob/6.x/src/DuskServiceProvider.php#L17

So this warning should not be needed anymore.