### PR TITLE
[8.x] Add note to not use hasOne of many relation in PostgresSQL

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -318,6 +318,8 @@ public function largestOrder()
 }
 ```
 
+> {note} As max,min aggregate function does not support UUID datatype in PostgreSQL database. You should not use Has One Of Many relationship if you're using UUID as a primary key in PostgreSQL database.
+
 <a name="advanced-has-one-of-many-relationships"></a>
 #### Advanced Has One Of Many Relationships
 


### PR DESCRIPTION
As mentioned in issue https://github.com/laravel/framework/issues/37854.
and in the following comment https://github.com/laravel/framework/pull/37362#issuecomment-846138526.
I noticed that Has One Of Many relationships is not working in PostgresSQL if we are using UUID as a primary key.

> Regarding UUIDs, they are sortable by using (string) Str::orderedUuid() as your model UUIDs instead of the typical (string) Str::uuid().

I have used Str::orderedUuid() to generate the models primary key but still, this issue is there.
Until this issue get's resolved we should display the note on the website to save some debugging time for other users.

