### PR TITLE
[8.x] Clarify that `nullableTimestamps` is an alias of `timestamps`

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -611,7 +611,7 @@ The `multiPolygon` method creates a `MULTIPOLYGON` equivalent column:
 <a name="column-method-nullableTimestamps"></a>
 #### `nullableTimestamps()` {#collection-method}
 
-The `nullableTimestamps` method is an alias of the `timestamps` method:
+The `nullableTimestamps` method is an alias of the [timestamps](#column-method-timestamps) method:
 
     $table->nullableTimestamps(0);
 

--- a/migrations.md
+++ b/migrations.md
@@ -611,7 +611,7 @@ The `multiPolygon` method creates a `MULTIPOLYGON` equivalent column:
 <a name="column-method-nullableTimestamps"></a>
 #### `nullableTimestamps()` {#collection-method}
 
-The method is similar to the [timestamps](#column-method-timestamps) method; however, the column that is created will be "nullable":
+The `nullableTimestamps` method is an alias of the `timestamps` method:
 
     $table->nullableTimestamps(0);
 


### PR DESCRIPTION
The description of `nullableTimestamps` in migrations implied that it behaved differently from `timestamps`. The link to `timestamps` was dropped because I used the same formatting as the description of `foreignId`.