### PR TITLE
Fix documentation error dynamoDB cache

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -89,7 +89,7 @@ For more information on configuring Redis, consult its [Laravel documentation pa
 
 Before using the [DynamoDB](https://aws.amazon.com/dynamodb) cache driver, you must create a DynamoDB table to store all of the cached data. Typically, this table should be named `cache`. However, you should name the table based on the value of the `stores.dynamodb.table` configuration value within your application's `cache` configuration file.
 
-This table should also have a string partition key with a name that corresponds to the value of the `stores.dynamodb.key` configuration item within your application's `cache` configuration file. By default, the partition key should be named `key`.
+This table should also have a string partition key with a name that corresponds to the value of the `stores.dynamodb.attributes.key` configuration item within your application's `cache` configuration file. By default, the partition key should be named `key`.
 
 <a name="cache-usage"></a>
 ## Cache Usage


### PR DESCRIPTION
Within this paragraph 

> This table should also have a string partition key with a name that corresponds to the value of the `stores.dynamodb.key` configuration item within your application's cache configuration file. By default, the partition key should be named key.

The table key is intended. However, the mentioned config is for aws client configuration. The config that should be used to change the table partition key, would be `stores.dynamodb.attributes.key`. 


See `vendor/laravel/framework/src/Illuminate/Cache/CacheManager.php:246` 
```
 new DynamoDbStore(
                $client,
                $config['table'],
                $config['attributes']['key'] ?? 'key',
                $config['attributes']['value'] ?? 'value',
                $config['attributes']['expiration'] ?? 'expires_at',
                $this->getPrefix($config)
            )
```