### PR TITLE
[8.x] Clarify UUID's and one-of-many with PostgreSQL

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -318,7 +318,7 @@ public function largestOrder()
 }
 ```
 
-> {note} It's not possible to use Has One Or Many in combination with UUID's in PostgreSQL because of PostgreSQL's lack of an implementation of `MAX` for UUID's. You can, however, create your own `MAX` implementation in PostgreSQL if you want.
+> {note} It's not possible to use one-of-many relationships in combination with UUID's in PostgreSQL because of PostgreSQL's lack of an implementation of `MAX` for UUID's. You can, however, create your own `MAX` implementation in PostgreSQL if you want.
 
 <a name="advanced-has-one-of-many-relationships"></a>
 #### Advanced Has One Of Many Relationships

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -318,6 +318,8 @@ public function largestOrder()
 }
 ```
 
+> {note} It's not possible to use Has One Or Many in combination with UUID's in PostgreSQL because of PostgreSQL's lack of an implementation of `MAX` for UUID's. You can, however, create your own `MAX` implementation in PostgreSQL if you want.
+
 <a name="advanced-has-one-of-many-relationships"></a>
 #### Advanced Has One Of Many Relationships
 


### PR DESCRIPTION
It's at the moment not possible to use UUID's in combination with one-of-many in PostgreSQL because of PostgreSQL's lack of an implementation of `MAX` for UUID's. Other engine's like MySQL do support this. I am not aware of an alternative for PostgreSQL to find the max UUID. Therefor I think it's important to document this.

See the related issue here: https://github.com/laravel/framework/issues/37854