### PR TITLE
[8.x] Revert "[Cashier] Missing mandatory parameters to downloadInvoice"

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -1534,10 +1534,7 @@ From within a route or controller, you may use the `downloadInvoice` method to g
     use Illuminate\Http\Request;
 
     Route::get('/user/invoice/{invoice}', function (Request $request, $invoiceId) {
-        return $request->user()->downloadInvoice($invoiceId, [
-            'vendor' => 'Your Company',
-            'product' => 'Your Product',
-        ]);
+        return $request->user()->downloadInvoice($invoiceId);
     });
 
 By default, all data on the invoice is derived from the customer and invoice data stored in Stripe. However, you can customize some of this data by providing an array as the second argument to the `downloadInvoice` method. This array allows you to customize information such as your company and product details:


### PR DESCRIPTION
Reverts laravel/docs#7173

This isn't correct. In the latest v13 these aren't required anymore. I specifically designed it so this method would be easier to use.