### PR TITLE
[8.x] Remove limitation from cursorPaginate()

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -125,7 +125,6 @@ However, cursor pagination has the following limitations:
 
 - Like `simplePaginate`, cursor pagination can only be used to display "Next" and "Previous" links and does not support generating links with page numbers.
 - It requires that the ordering is based on at least one unique column or a combination of columns that are unique.
-- It requires that the "order by" directions (descending / ascending) are the same if there are multiple "order by" clauses.
 - Query expressions in "order by" clauses are supported only if they are aliased and added to the "select" clause as well.
 
 <a name="manually-creating-a-paginator"></a>


### PR DESCRIPTION
If PR https://github.com/laravel/framework/pull/37762 is merged, the limitation on order by clause will no longer be valid.