### PR TITLE
Add hint about performance when using whereDate etc.

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -571,6 +571,8 @@ The `whereTime` method may be used to compare a column's value against a specifi
                     ->whereTime('created_at', '=', '11:20:45')
                     ->get();
 
+> {note} These methods can result in significant performance degration, because the database can not make use of indexes for the `where` contions!
+
 **whereColumn / orWhereColumn**
 
 The `whereColumn` method may be used to verify that two columns are equal:

--- a/queries.md
+++ b/queries.md
@@ -571,7 +571,7 @@ The `whereTime` method may be used to compare a column's value against a specifi
                     ->whereTime('created_at', '=', '11:20:45')
                     ->get();
 
-> {note} These methods can result in significant performance degration, because the database can not make use of indexes for the `where` contions!
+> {note} These methods can result in significant performance degration, because the database can not make use of indexes for the `where` conditions!
 
 **whereColumn / orWhereColumn**
 


### PR DESCRIPTION
Unfortunately I see these methods a lot in Laravel tutorials and in real project. People dont know what they are doing, but think this is just a fancy way to query the database.

But if you depend on indexes for database performance, because there is a signifiat amount of data and a significant load, these methods can make the query really slow and even break the application.