### PR TITLE
[8.x] Use fully qualified namespace in Sanctum

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -222,10 +222,8 @@ First, you should configure which domains your SPA will be making requests from.
 
 Next, you should add Sanctum's middleware to your `api` middleware group within your `app/Http/Kernel.php` file. This middleware is responsible for ensuring that incoming requests from your SPA can authenticate using Laravel's session cookies, while still allowing requests from third parties or mobile applications to authenticate using API tokens:
 
-    use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
-
     'api' => [
-        EnsureFrontendRequestsAreStateful::class,
+        \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
         'throttle:api',
         \Illuminate\Routing\Middleware\SubstituteBindings::class,
     ],


### PR DESCRIPTION
Use the fully qualified namespace in the "Sanctum Middle" section to be consistent with the other example shown in the "Installation" section