### PR TITLE
[8.x] Document `viaConnection` method on event listeners

### DIFF
--- a/events.md
+++ b/events.md
@@ -336,6 +336,18 @@ If you would like to define the listener's queue at runtime, you may define a `v
         return 'listeners';
     }
 
+To define the listener's queue connection at runtime, you may define a `viaConnection` method on the listener:
+
+    /**
+     * Get the name of the listener's queue connection.
+     *
+     * @return string
+     */
+    public function viaConnection()
+    {
+        return 'redis';
+    }
+
 <a name="conditionally-queueing-listeners"></a>
 #### Conditionally Queueing Listeners
 


### PR DESCRIPTION
https://github.com/laravel/framework/pull/38005 added ability to specify queued event listener's connection at runtime by implementing `viaConnection` method. This PR documents that functionality.