### PR TITLE
[8.x] Remove test from seeding docs

### DIFF
--- a/seeding.md
+++ b/seeding.md
@@ -9,7 +9,7 @@
 <a name="introduction"></a>
 ## Introduction
 
-Laravel includes the ability to seed your database with test data using seed classes. All seed classes are stored in the `database/seeders` directory. By default, a `DatabaseSeeder` class is defined for you. From this class, you may use the `call` method to run other seed classes, allowing you to control the seeding order.
+Laravel includes the ability to seed your database with data using seed classes. All seed classes are stored in the `database/seeders` directory. By default, a `DatabaseSeeder` class is defined for you. From this class, you may use the `call` method to run other seed classes, allowing you to control the seeding order.
 
 > {tip} [Mass assignment protection](/docs/{{version}}/eloquent#mass-assignment) is automatically disabled during database seeding.
 


### PR DESCRIPTION
Removed the word `test` from the seeder introduction. Seeders can also be used to seed the database with non-test data.