### PR TITLE
Reminder to confirm the referer header is present

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -239,6 +239,8 @@ In addition, you should enable the `withCredentials` option on your application'
 
     axios.defaults.withCredentials = true;
 
+If your application makes server side requests in order to server side render content make sure the `referer` header is correctly filled with your application domain.
+
 Finally, you should ensure your application's session cookie domain configuration supports any subdomain of your root domain. You may accomplish this by prefixing the domain with a leading `.` within your application's `config/session.php` configuration file:
 
     'domain' => '.domain.com',


### PR DESCRIPTION
Hi! 

Some new frontend frameworks like nextjs allow users to make client and server side requests.
After following the docs to configure Sanctum I realized my application could do client side requests but no server side requests.

After a lot of trial and error I've decided to dig deeper into Sanctum to debug the issue and found out that the reason was that when nextjs was making server side requests the request ended up with no "referer" header.

I believe other people had similar issues, for instance here https://github.com/laravel/sanctum/issues/229

I propose that we add some note to the docs about this issue. 
