### PR TITLE
routing: Add regex constraint example when customizing the model key

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -180,6 +180,10 @@ You may constrain the format of your route parameters using the `where` method o
     Route::get('/user/{id}/{name}', function ($id, $name) {
         //
     })->where(['id' => '[0-9]+', 'name' => '[a-z]+']);
+    
+    Route::get('/user/{user:email}', function ($post) {
+        //
+    })->where(['user' => '.+@.+');
 
 For convenience, some commonly used regular expression patterns have helper methods that allow you to quickly add pattern constraints to your routes:
 


### PR DESCRIPTION
When using a regex constraint and customizing the key of a route parameter, you must only refer the first part (before `:`) as the name.

I'm not sure a paragraph is needed but I think an snippet example can help.