### PR TITLE
Add note about Accept header

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -205,7 +205,7 @@ Sanctum also exists to provide a simple method of authenticating single page app
 
 For this feature, Sanctum does not use tokens of any kind. Instead, Sanctum uses Laravel's built-in cookie based session authentication services. This approach to authentication provides the benefits of CSRF protection, session authentication, as well as protects against leakage of the authentication credentials via XSS.
 
-> {note} In order to authenticate, your SPA and API must share the same top-level domain. However, they may be placed on different subdomains. Additionally, you must send the `Accept: application/json` header in your request.
+> {note} In order to authenticate, your SPA and API must share the same top-level domain. However, they may be placed on different subdomains. Additionally, you should ensure that you send the `Accept: application/json` header with your request.
 
 
 <a name="spa-configuration"></a>

--- a/sanctum.md
+++ b/sanctum.md
@@ -205,7 +205,8 @@ Sanctum also exists to provide a simple method of authenticating single page app
 
 For this feature, Sanctum does not use tokens of any kind. Instead, Sanctum uses Laravel's built-in cookie based session authentication services. This approach to authentication provides the benefits of CSRF protection, session authentication, as well as protects against leakage of the authentication credentials via XSS.
 
-> {note} In order to authenticate, your SPA and API must share the same top-level domain. However, they may be placed on different subdomains.
+> {note} In order to authenticate, your SPA and API must share the same top-level domain. However, they may be placed on different subdomains. Additionally, you must send the `Accept: application/json` header in your request.
+
 
 <a name="spa-configuration"></a>
 ### Configuration


### PR DESCRIPTION
I was fishing for an answer for hours all over the web. If you do not send "Accept: application/json" as a header, you get a 200 OK with your skeleton HTML layout as the render. I am using postman and it had "Accept: */*" which gave the a false 200 OK.

If the bearer token passed is not expired and correct, the framework returns a proper response. If the token is mistyped or expired, you get a 200 OK.