### PR TITLE
Update broken link to Symfony upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -64,7 +64,7 @@ Of course, don't forget to examine any 3rd party packages consumed by your appli
 
 #### Symfony 4
 
-All of the underlying Symfony components used by Laravel have been upgraded to the Symfony `^4.0` release series. If you are directly interacting with Symfony components within your application, you should review the [Symfony change log](https://github.com/symfony/symfony/blob/master/UPGRADE-4.0.md).
+All of the underlying Symfony components used by Laravel have been upgraded to the Symfony `^4.0` release series. If you are directly interacting with Symfony components within your application, you should review the [Symfony change log](https://github.com/symfony/symfony/blob/4.0/UPGRADE-4.0.md).
 
 #### PHPUnit
 


### PR DESCRIPTION
Current `master` branch in the Symfony project doesn't have an `UPGRADE-4.0.md` file so it gives a 404 error.

Link updated.