### PR TITLE
added specify column alias of Aggregate Functions

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1357,9 +1357,7 @@ In addition to the `withCount` method, Eloquent provides `withMin`, `withMax`, `
         echo $post->comments_sum_votes;
     }
 
-If you don't like a `{relation}_{function}_{column}` attribute on your resulting models, you may specify your own `as` alias:
-
-    use App\Models\Post;
+If you wish to access the result of the aggregate function using another name, you may specify your own alias:
 
     $posts = Post::withSum('comments as total_comments', 'votes')->get();
 

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1357,6 +1357,16 @@ In addition to the `withCount` method, Eloquent provides `withMin`, `withMax`, `
         echo $post->comments_sum_votes;
     }
 
+If you don't like a `{relation}_{function}_{column}` attribute on your resulting models, you may specify your own `as` alias:
+
+    use App\Models\Post;
+
+    $posts = Post::withSum('comments as total_comments', 'votes')->get();
+
+    foreach ($posts as $post) {
+        echo $post->total_comments;
+    }
+
 Like the `loadCount` method, deferred versions of these methods are also available. These additional aggregate operations may be performed on Eloquent models that have already been retrieved:
 
     $post = Post::first();


### PR DESCRIPTION
Hi,

I was using ```withSum()``` aggregate method which gave me ```{relation}_{function}_{column}``` attribute but I didn't like it and wanted to specify column own alias.

I searched through the docs about how to column alias but didn't find anything..

so here is my contribution.

Thanks,
Anees 

sorry for bad English though.