### PR TITLE
Updating example of @class directive

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -375,7 +375,7 @@ The `@class` directive conditionally compiles a CSS class string. The directive 
     <span @class([
         'p-4',
         'font-bold' => $isActive,
-        'text-gray-500' => !$isActive,
+        'text-gray-500' => ! $isActive,
         'bg-red' => $hasError,
     ])></span>
 

--- a/blade.md
+++ b/blade.md
@@ -375,10 +375,11 @@ The `@class` directive conditionally compiles a CSS class string. The directive 
     <span @class([
         'p-4',
         'font-bold' => $isActive,
+        'text-gray-500' => !$isActive,
         'bg-red' => $hasError,
     ])></span>
 
-    <span class="p-4 bg-red"></span>
+    <span class="p-4 text-gray-500 bg-red"></span>
 
 <a name="including-subviews"></a>
 ### Including Subviews


### PR DESCRIPTION
Updated the example of the @class directive to show that you can use `!` to activate classes in an if-else manner. So in the example, if the `$isActive`  is false, the `font-bold` not show up but additionally the `text-gray-500` class will be rendered.