### PR TITLE
Alias for published sail script

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -64,7 +64,7 @@ By default, Sail commands are invoked using the `vendor/bin/sail` script that is
 However, instead of repeatedly typing `vendor/bin/sail` to execute Sail commands, you may wish to configure a Bash alias that allows you to execute Sail's commands more easily:
 
 ```bash
-alias sail='bash vendor/bin/sail'
+alias sail='[ -f sail ] && bash sail || bash vendor/bin/sail'
 ```
 
 Once the Bash alias has been configured, you may execute Sail commands by simply typing `sail`. The remainder of this documentation's examples will assume that you have configured this alias:


### PR DESCRIPTION
In laravel/sail#201 appends publish sail script. Without [this changes](https://github.com/laravel/sail/pull/201/commits/692adb345528e7294339d11a2302cc8d7280a6ef) you can't use alias with published script.