### PR TITLE
Update scope example to use `qualifyColumn` method

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1037,7 +1037,7 @@ The `Scope` interface requires you to implement one method: `apply`. The `apply`
          */
         public function apply(Builder $builder, Model $model)
         {
-            $builder->where('created_at', '<', now()->subYears(2000));
+            $builder->where($model->qualifyColumn('created_at'), '<', now()->subYears(2000));
         }
     }
 


### PR DESCRIPTION
I came across an issue regarding ambiguous where clause and solved this using the built-in `$model->qualifyColumn()` method. I thought the example would be better of using it to mitigate this issue in the future.