### PR TITLE
Add missing name arg to One of Many Polymorphic docs

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -895,7 +895,7 @@ Sometimes a model may have many related models, yet you want to easily retrieve 
  */
 public function latestImage()
 {
-    return $this->morphOne(Image::class)->latestOfMany();
+    return $this->morphOne(Image::class, 'imageable')->latestOfMany();
 }
 ```
 
@@ -907,7 +907,7 @@ Likewise, you may define a method to retrieve the "oldest", or first, related mo
  */
 public function oldestImage()
 {
-    return $this->morphOne(Image::class)->oldestOfMany();
+    return $this->morphOne(Image::class, 'imageable')->oldestOfMany();
 }
 ```
 
@@ -921,7 +921,7 @@ For example, using the `ofMany` method, you may retrieve the user's most "liked"
  */
 public function bestImage()
 {
-    return $this->morphOne(Image::class)->ofMany('likes', 'max');
+    return $this->morphOne(Image::class, 'imageable')->ofMany('likes', 'max');
 }
 ```
 


### PR DESCRIPTION
The One of Many Polymorphic [docs](https://laravel.com/docs/8.x/eloquent-relationships#one-of-many-polymorphic-relations) are missing the name argument on the `morphOne()` method. This PR adds a name argument of `imageable`, as it exists in other `morphOne()` examples.