### PR TITLE
Updated Laravel Valet with instructions on how to use the new `.valetphprc` file with `valet use`

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -96,11 +96,12 @@ Valet allows you to switch PHP versions using the `valet use php@version` comman
 
     valet use php
 
-> {note} Valet only serves one PHP version at a time, even if you have multiple PHP versions installed.
 
-Valet can also get a specified PHP version from a `.valetphprc` file in the root of your project which can be read by using the `valet use` command. You just need to specifiy the PHP version to use in the file:
+Valet can also get a specified PHP version from a `.valetphprc` file in the root of your project which can be read by using the `valet use` command on its own. You just need to specifiy the PHP version to use in the file:
 
     php@7.2
+
+> {note} Valet only serves one PHP version at a time, even if you have multiple PHP versions installed.
 
 <a name="database"></a>
 #### Database

--- a/valet.md
+++ b/valet.md
@@ -98,6 +98,10 @@ Valet allows you to switch PHP versions using the `valet use php@version` comman
 
 > {note} Valet only serves one PHP version at a time, even if you have multiple PHP versions installed.
 
+Valet can also get a specified PHP version from a `.valetphprc` file in the root of your project which can be read by using the `valet use` command. You just need to specifiy the PHP version to use in the file:
+
+    php@7.2
+
 <a name="database"></a>
 #### Database
 

--- a/valet.md
+++ b/valet.md
@@ -96,10 +96,11 @@ Valet allows you to switch PHP versions using the `valet use php@version` comman
 
     valet use php
 
-
-Valet can also get a specified PHP version from a `.valetphprc` file in the root of your project which can be read by using the `valet use` command on its own. You just need to specifiy the PHP version to use in the file:
+You may also create a `.valetphprc` file in the root of your project. The `.valetphprc` file should contain the PHP version the site should use:
 
     php@7.2
+
+Once this file has been created, you may simply execute the `valet use` command and the command will determine the site's preferred PHP version by reading the file.
 
 > {note} Valet only serves one PHP version at a time, even if you have multiple PHP versions installed.
 


### PR DESCRIPTION
This update to the docs describes how you can specify the PHP version at a project level with a `.valetphprc` file that was added as a feature in Laravel Valet v2.16.0 https://github.com/laravel/valet/releases/tag/v2.16.0