### PR TITLE
Added docs to make using selenium-chrome-debug easier in sail

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -252,6 +252,32 @@ Finally, you may run your Dusk test suite by starting Sail and running the `dusk
 
     sail dusk
 
+
+<a name="laravel-dusk-debug"></a>
+### Visualizing Browser Tests
+
+It can be helpful to watch your tests in a browser while they run. Selenium provide a [debug version](https://github.com/SeleniumHQ/docker-selenium#debugging) of their container which runs a VNC server so you can view the desktop.
+
+To use it change the image in your `selenium` service to `selenium-chrome-debug` and [expose port 5900](https://docs.docker.com/compose/compose-file/compose-file-v3/#ports). Optionally you can specify a desktop resolution.
+
+```yaml
+selenium:
+    image: 'selenium/standalone-chrome-debug'
+    ports:
+        - "5900:5900"
+    environment:
+        SCREEN_HEIGHT: '1080' # Optional
+        SCREEN_WIDTH: '1920' # Optional
+```
+
+> {tip} Don't forget to run `sail up --build`
+
+Before running your tests connect to your container's desktop using a [VNC client](https://www.tightvnc.com/) then, pass the `--browse` flag to dusk temporarally disable headless mode in Dusk.
+
+    sail dusk --browse
+
+> {tip} To disable headless mode permanently add  `DUSK_HEADLESS_DISABLED=true` .to your `.env`.
+
 <a name="previewing-emails"></a>
 ## Previewing Emails
 


### PR DESCRIPTION
Hey,

This is an updated version of https://github.com/laravel/docs/pull/7230 based on the feedback there.

I struggled to get enough information into a `tip` which was easy to read and also clear, so I've expanded it into a section (alongside the Laravel Dusk one underneath the "Running Tests" heading).

Is this useful enough to enough people to warrant a paragraph or shall I try again with just a tip?