### PR TITLE
[8.x] Add documentation surrounding stripe checkout session id callback.

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -1595,6 +1595,29 @@ When a customer visits this route they will be redirected to Stripe's Checkout p
         ]);
     });
 
+Additionally you may add a template variable to your success url `{CHECKOUT_SESSION_ID}` when you create the Checkout Session. Note that this is a literal string and must be added exactly as you see it here. 
+
+> {note} Do not substitute it with a Checkout Session ID — this template is handled by Stripe directly
+
+    use Illuminate\Http\Request;
+    use Stripe\Checkout\Session;
+    use Stripe\Customer;
+
+    Route::get('/product-checkout', function (Request $request) {
+        return $request->user()->checkout(['price_tshirt' => 1], [
+            'success_url' => route('your-success-route' . '?session_id={CHECKOUT_SESSION_ID}'),
+            'cancel_url' => route('your-cancel-route'),
+        ]);
+    });
+
+    Route::get('/success', function (Request $request) {
+        $session = Session::retrieve($request->get('session_id'));
+        $customer = Customer::retrieve($session->customer);
+
+        return view('checkout.success', ['customerName' => $customer->name]);
+    })->name('your-success-route');
+
+
 <a name="checkout-promotion-codes"></a>
 #### Promotion Codes
 

--- a/billing.md
+++ b/billing.md
@@ -1595,9 +1595,7 @@ When a customer visits this route they will be redirected to Stripe's Checkout p
         ]);
     });
 
-Additionally you may add a template variable to your success url `{CHECKOUT_SESSION_ID}` when you create the Checkout Session. Note that this is a literal string and must be added exactly as you see it here. 
-
-> {note} Do not substitute it with a Checkout Session ID — this template is handled by Stripe directly
+When defining your `success_url` checkout option, you may instruct Stripe to add the checkout session ID as a query string parameter when invoking your URL. To do so, add the literal string `{CHECKOUT_SESSION_ID}` to your `success_url` query string. Stripe will replace this placeholder with the actual checkout session ID:
 
     use Illuminate\Http\Request;
     use Stripe\Checkout\Session;
@@ -1605,18 +1603,17 @@ Additionally you may add a template variable to your success url `{CHECKOUT_SESS
 
     Route::get('/product-checkout', function (Request $request) {
         return $request->user()->checkout(['price_tshirt' => 1], [
-            'success_url' => route('your-success-route' . '?session_id={CHECKOUT_SESSION_ID}'),
-            'cancel_url' => route('your-cancel-route'),
+            'success_url' => route('checkout-success'.'?session_id={CHECKOUT_SESSION_ID}'),
+            'cancel_url' => route('checkout-cancel'),
         ]);
     });
 
-    Route::get('/success', function (Request $request) {
+    Route::get('/checkout-success', function (Request $request) {
         $session = Session::retrieve($request->get('session_id'));
         $customer = Customer::retrieve($session->customer);
 
         return view('checkout.success', ['customerName' => $customer->name]);
-    })->name('your-success-route');
-
+    })->name('checkout-success');
 
 <a name="checkout-promotion-codes"></a>
 #### Promotion Codes


### PR DESCRIPTION
Please feel free to make any adjustments, not sure if leaving this separate from above snippet was repetitive or not.
This is based off the following documentation: `https://stripe.com/docs/payments/checkout/custom-success-page`