### PR TITLE
[8.x] Note that Eloquent routing uses the route key, not primary key

### DIFF
--- a/urls.md
+++ b/urls.md
@@ -82,7 +82,7 @@ Any additional array elements that do not correspond to the route's definition p
 <a name="eloquent-models"></a>
 #### Eloquent Models
 
-You will often be generating URLs using the route key of [Eloquent models](/docs/{{version}}/eloquent). For this reason, you may pass Eloquent models as parameter values. The `route` helper will automatically extract the model's route key:
+You will often be generating URLs using the route key (typically the primary key) of [Eloquent models](/docs/{{version}}/eloquent). For this reason, you may pass Eloquent models as parameter values. The `route` helper will automatically extract the model's route key:
 
     echo route('post.show', ['post' => $post]);
 

--- a/urls.md
+++ b/urls.md
@@ -82,7 +82,7 @@ Any additional array elements that do not correspond to the route's definition p
 <a name="eloquent-models"></a>
 #### Eloquent Models
 
-You will often be generating URLs using the primary key of [Eloquent models](/docs/{{version}}/eloquent). For this reason, you may pass Eloquent models as parameter values. The `route` helper will automatically extract the model's primary key:
+You will often be generating URLs using the route key of [Eloquent models](/docs/{{version}}/eloquent). For this reason, you may pass Eloquent models as parameter values. The `route` helper will automatically extract the model's route key:
 
     echo route('post.show', ['post' => $post]);
 


### PR DESCRIPTION
Using a model as a route parameter per this example doesn't use the primary key of the model - it uses the route key defined by `getRouteKeyName` (which just so happens to be the primary key by default, but isn't always true)