### PR TITLE
[8.x] Add composer post-update-cmd for local only Telescope installation

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -155,6 +155,15 @@ To keep the assets up-to-date and avoid issues in future updates, you may add th
         }
     }
 
+    // For Local Only Installation
+    {
+        "scripts": {
+            "post-update-cmd": [
+                "[ $COMPOSER_DEV_MODE -eq 0 ] || php artisan telescope:publish --ansi"
+            ]
+        }
+    }
+
 <a name="filtering"></a>
 ## Filtering
 


### PR DESCRIPTION
Add an example on how to update Telescope when a Local Only Installation is being used.

If composer is not running in dev mode, then skip running the `telescope:publish` command.

[Stack Overflow source](https://stackoverflow.com/a/53022623/1129035)