### PR TITLE
[8.x] Update document withCount place snake case format

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1285,7 +1285,7 @@ Instead of passing an array of possible polymorphic models, you may provide `*` 
 <a name="counting-related-models"></a>
 ### Counting Related Models
 
-Sometimes you may want to count the number of related models for a given relationship without actually loading the models. To accomplish this, you may use the `withCount` method. The `withCount` method which will place a `{relation}_count` attribute on the resulting models:
+Sometimes you may want to count the number of related models for a given relationship without actually loading the models. To accomplish this, you may use the `withCount` method. The `withCount` method will take "snake case" name of relation and suffix it with `_count` to place `{relation}_count` attribute on the resulting models:
 
     use App\Models\Post;
 


### PR DESCRIPTION
- I spent almost half an hour to debug reason method withCount not run correctly. Because I used `{relation_count}` with relation in camelCase format. It seems that when calling alias it will be converted to snake case by the library. I find this [issue](https://github.com/laravel/framework/issues/18381) like my problem.
- [Reference](https://github.com/illuminate/database/blob/7ad5b2964080b5e683082ca6532affcb2e7b913a/Eloquent/Concerns/QueriesRelationships.php#L424)