### PR TITLE
[8.x] adjust variable on sometimes rule example

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1475,7 +1475,7 @@ Alternatively, you may use the `exclude_unless` rule to not validate a given fie
 
 In some situations, you may wish to run validation checks against a field **only** if that field is present in the data being validated. To quickly accomplish this, add the `sometimes` rule to your rule list:
 
-    $v = Validator::make($request->all(), [
+    $v = Validator::make($data, [
         'email' => 'sometimes|required|email',
     ]);
 


### PR DESCRIPTION
adjust `$data` variable instead of `$request->all()` on sometimes rule example

as the text below said

In the example above, the `email` field will only be validated if it is present in the `$data` array.