### PR TITLE
Fix Stripe session_id param in success URL

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -1603,7 +1603,7 @@ When defining your `success_url` checkout option, you may instruct Stripe to add
 
     Route::get('/product-checkout', function (Request $request) {
         return $request->user()->checkout(['price_tshirt' => 1], [
-            'success_url' => route('checkout-success'.'?session_id={CHECKOUT_SESSION_ID}'),
+            'success_url' => route('checkout-success') . '?session_id={CHECKOUT_SESSION_ID}',
             'cancel_url' => route('checkout-cancel'),
         ]);
     });


### PR DESCRIPTION
The route helper returns an invalid route error if the session_id param is appended inside the helper. The param must be appended to the string outside of the helper.