### PR TITLE
[9.x] Fix link to API docs

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -89,4 +89,4 @@
     - [Socialite](/docs/{{version}}/socialite)
     - [Telescope](/docs/{{version}}/telescope)
     - [Valet](/docs/{{version}}/valet)
-- [API Documentation](/api/9.x)
+- [API Documentation](/api/master)


### PR DESCRIPTION
The current link leads to a 404 page.