### PR TITLE
Update sanctum configuration

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -246,6 +246,8 @@ Finally, you should ensure your application's session cookie domain configuratio
 
     'domain' => '.domain.com',
 
+You don't need to configure the `domain` option if you are using `localhost` for local development.
+
 <a name="spa-authenticating"></a>
 ### Authenticating
 


### PR DESCRIPTION
Make it clear that you don't need to configure `domain` option if you are using `localhost` for local development.