### PR TITLE
[8.x] Rewrite event handling docs

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -1358,40 +1358,55 @@ Since Stripe webhooks need to bypass Laravel's [CSRF protection](/docs/{{version
 <a name="defining-webhook-event-handlers"></a>
 ### Defining Webhook Event Handlers
 
-Cashier automatically handles subscription cancellations for failed charges and other common Stripe webhook events. However, if you have additional webhook events you would like to handle, you may do so by extending the Cashier webhook controller.
+Cashier automatically handles subscription cancellations for failed charges and other common Stripe webhook events. However, if you have additional webhook events you would like to handle, you may do so by listening to the Cashier emited events:
 
-Your controller's method names should correspond to Cashier's controller conventions. Specifically, methods should be prefixed with `handle` and the "camel case" name of the webhook you wish to handle. For example, if you wish to handle the `invoice.payment_succeeded` webhook, you should add a `handleInvoicePaymentSucceeded` method to the controller:
+    - `Laravel\Cashier\Events\WebhookReceived`
+    - `Laravel\Cashier\Events\WebhookHandled`
+
+Both events contain the full payload of the Stripe webhook. We can use these to either act before a webhook is handled or after it's handled. For example, if you wish to handle the `invoice.payment_succeeded` webhook, you can create a listener that'll handle this event:
 
     <?php
 
-    namespace App\Http\Controllers;
+    namespace App\Listeners;
 
-    use Laravel\Cashier\Http\Controllers\WebhookController as CashierController;
+    use Laravel\Cashier\Events\WebhookReceived;
 
-    class WebhookController extends CashierController
+    class StripeEventListener
     {
         /**
-         * Handle invoice payment succeeded.
+         * Handle received Stripe webhooks.
          *
-         * @param  array  $payload
-         * @return \Symfony\Component\HttpFoundation\Response
+         * @param  \Laravel\Cashier\Events\WebhookReceived  $event
+         * @return void
          */
-        public function handleInvoicePaymentSucceeded($payload)
+        public function handle(WebhookReceived $event)
         {
-            // Handle the incoming event...
+            if ($event->payload['type'] === 'invoice.payment_succeeded') {
+                // Handle the incoming event...
+            }
         }
     }
 
-Next, define a route to your Cashier webhook controller within your application's `routes/web.php` file. This will overwrite the default route registered by Cashier's service provider:
+Then, hook the event into your `EventServiceProvider`:
 
-    use App\Http\Controllers\WebhookController;
+    <?php
 
-    Route::post(
-        '/stripe/webhook',
-        [WebhookController::class, 'handleWebhook']
-    )->name('cashier.webhook');
+    namespace App\Providers;
 
-> {tip} Cashier emits a `Laravel\Cashier\Events\WebhookReceived` event when a webhook is received and a `Laravel\Cashier\Events\WebhookHandled` event when a webhook was handled by Cashier. Both events contain the full payload of the Stripe webhook.
+    use App\Listeners\StripeEventListener;
+    use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+    use Laravel\Cashier\Events\WebhookReceived;
+
+    class EventServiceProvider extends ServiceProvider
+    {
+        protected $listen = [
+            WebhookReceived::class => [
+                StripeEventListener::class,
+            ],
+        ];
+    }
+
+Now any Stripe webhook that's sent to your app can be listened to and you'll have a convenient place to handle them.
 
 <a name="verifying-webhook-signatures"></a>
 ### Verifying Webhook Signatures

--- a/billing.md
+++ b/billing.md
@@ -1358,12 +1358,12 @@ Since Stripe webhooks need to bypass Laravel's [CSRF protection](/docs/{{version
 <a name="defining-webhook-event-handlers"></a>
 ### Defining Webhook Event Handlers
 
-Cashier automatically handles subscription cancellations for failed charges and other common Stripe webhook events. However, if you have additional webhook events you would like to handle, you may do so by listening to the Cashier emited events:
+Cashier automatically handles subscription cancellations for failed charges and other common Stripe webhook events. However, if you have additional webhook events you would like to handle, you may do so by listening to the following events that are dispatched by Cashier:
 
     - `Laravel\Cashier\Events\WebhookReceived`
     - `Laravel\Cashier\Events\WebhookHandled`
 
-Both events contain the full payload of the Stripe webhook. We can use these to either act before a webhook is handled or after it's handled. For example, if you wish to handle the `invoice.payment_succeeded` webhook, you can create a listener that'll handle this event:
+Both events contain the full payload of the Stripe webhook. For example, if you wish to handle the `invoice.payment_succeeded` webhook, you may register a [listener](/docs/{{version}}/events#defining-listeners) that will handle the event:
 
     <?php
 
@@ -1387,7 +1387,7 @@ Both events contain the full payload of the Stripe webhook. We can use these to 
         }
     }
 
-Then, hook the event into your `EventServiceProvider`:
+Once your listener has been defined, you may register it within your application's `EventServiceProvider`:
 
     <?php
 
@@ -1405,8 +1405,6 @@ Then, hook the event into your `EventServiceProvider`:
             ],
         ];
     }
-
-Now any Stripe webhook that's sent to your app can be listened to and you'll have a convenient place to handle them.
 
 <a name="verifying-webhook-signatures"></a>
 ### Verifying Webhook Signatures

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -941,12 +941,12 @@ Since Paddle webhooks need to bypass Laravel's [CSRF protection](/docs/{{version
 <a name="defining-webhook-event-handlers"></a>
 ### Defining Webhook Event Handlers
 
-Cashier automatically handles subscription cancellation on failed charges and other common Paddle webhooks. However, if you have additional webhook events you would like to handle, you may do so by listening to the Cashier emited events:
+Cashier automatically handles subscription cancellation on failed charges and other common Paddle webhooks. However, if you have additional webhook events you would like to handle, you may do so by listening to the following events that are dispatched by Cashier:
 
     - `Laravel\Cashier\Events\WebhookReceived`
     - `Laravel\Cashier\Events\WebhookHandled`
 
-Both events contain the full payload of the Paddle webhook. We can use these to either act before a webhook is handled or after it's handled. For example, if you wish to handle the `payment_succeeded` webhook, you can create a listener that'll handle this event:
+Both events contain the full payload of the Paddle webhook. For example, if you wish to handle the `invoice.payment_succeeded` webhook, you may register a [listener](/docs/{{version}}/events#defining-listeners) that will handle the event:
 
     <?php
 
@@ -957,7 +957,7 @@ Both events contain the full payload of the Paddle webhook. We can use these to 
     class PaddleEventListener
     {
         /**
-         * Handle received Stripe webhooks.
+         * Handle received Paddle webhooks.
          *
          * @param  \Laravel\Cashier\Events\WebhookReceived  $event
          * @return void
@@ -970,7 +970,7 @@ Both events contain the full payload of the Paddle webhook. We can use these to 
         }
     }
 
-Then, hook the event into your `EventServiceProvider`:
+Once your listener has been defined, you may register it within your application's `EventServiceProvider`:
 
     <?php
 
@@ -988,8 +988,6 @@ Then, hook the event into your `EventServiceProvider`:
             ],
         ];
     }
-
-Now any Paddle webhook that's sent to your app can be listened to and you'll have a convenient place to handle them.
 
 Cashier also emit events dedicated to the type of the received webhook. In addition to the full payload from Paddle, they also contain the relevant models that were used to process the webhook such as the billable model, the subscription, or the receipt:
 


### PR DESCRIPTION
While working on my Cashier talk I realized that the docs are still using the old recommended way of overwriting the Cashier webhook controller while there's a much better and easier alternative to integrate  with the `WebhookReceived` and `WebhookHandled` events.