### PR TITLE
[8.x] Combine provider method call paragraphs

### DIFF
--- a/lifecycle.md
+++ b/lifecycle.md
@@ -42,11 +42,9 @@ The method signature for the HTTP kernel's `handle` method is quite simple: it r
 
 One of the most important kernel bootstrapping actions is loading the [service providers](/docs/{{version}}/providers) for your application. All of the service providers for the application are configured in the `config/app.php` configuration file's `providers` array.
 
-Laravel will iterate through this list of providers and instantiate each of them. After instantiating the providers, the `register` method will be called on all of the providers. Then, once all of the providers have been registered, the `boot` method will be called on each provider.
+Laravel will iterate through this list of providers and instantiate each of them. After instantiating the providers, the `register` method will be called on all of the providers. Then, once all of the providers have been registered, the `boot` method will be called on each provider. This is so service providers may depend on every container binding being registered and available by the time their `boot` method is executed.
 
 Service providers are responsible for bootstrapping all of the framework's various components, such as the database, queue, validation, and routing components. Essentially every major feature offered by Laravel is bootstrapped and configured by a service provider. Since they bootstrap and configure so many features offered by the framework, service providers are the most important aspect of the entire Laravel bootstrap process.
-
-You may be wondering why the `register` method of every service provider is called before calling the `boot` method on any service providers. The answer is simple. By calling the `register` method of every service provider first, service providers may depend on every container binding being registered and available by the time the `boot` method is executed.
 
 <a name="routing"></a>
 ### Routing


### PR DESCRIPTION
I found myself reading through the last paragraph of this section a couple of times. I think grouping the two paragraphs about method call order could help with readability and avoids the need to recap on the context (about calling all the `register` methods before any `boot` methods).