### PR TITLE
Change condition query example code

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -776,7 +776,7 @@ Sometimes you may want certain query clauses to apply to a query based on anothe
     $role = $request->input('role');
 
     $users = DB::table('users')
-                    ->when($role, function ($query, $role) {
+                    ->when($role, function ($query) use ($role) {
                         return $query->where('role_id', $role);
                     })
                     ->get();
@@ -788,7 +788,7 @@ You may pass another closure as the third argument to the `when` method. This cl
     $sortByVotes = $request->input('sort_by_votes');
 
     $users = DB::table('users')
-                    ->when($sortByVotes, function ($query, $sortByVotes) {
+                    ->when($sortByVotes, function ($query) {
                         return $query->orderBy('votes');
                     }, function ($query) {
                         return $query->orderBy('name');


### PR DESCRIPTION
The conditional query example code includes a second param for the callback, but this param does not appear to be used.  Instead it uses the `$value` used for the original condition.

I found this confusing when I tried to implement a conditional query with an `isset` condition, and then used the variable from the `isset` check as the second param.  It was not performing as expected because the callback is using the `$value` not the provided variable.

The proposed change shifts the callback's second param to a `use` statement for the callback, making sure that the variable is unchanged when used in the callback.