### PR TITLE
Fix method doc for return value

### DIFF
--- a/events.md
+++ b/events.md
@@ -623,7 +623,7 @@ If your event listener methods are defined within the subscriber itself, you may
          * Register the listeners for the subscriber.
          *
          * @param  \Illuminate\Events\Dispatcher  $events
-         * @return void
+         * @return array
          */
         public function subscribe($events)
         {


### PR DESCRIPTION
The subscribe method in the example returns an array and is not void.