### PR TITLE
Fix volume mount for symlinked directories.

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -146,8 +146,8 @@ You may install the application's dependencies by navigating to the application'
 ```nothing
 docker run --rm \
     -u "$(id -u):$(id -g)" \
-    -v $(pwd):/opt \
-    -w /opt \
+    -v $(pwd):/var/www/html \
+    -w /var/www/html \
     laravelsail/php80-composer:latest \
     composer install --ignore-platform-reqs
 ```


### PR DESCRIPTION
When using the docker method to install composer dependencies with Sail, if any of the dependencies use symlinks then the path mapping breaks when `sail up -d` is run. 

Sail operates in `/var/www/html` but the read me uses `/opt` for the composer install. In a situation where there's a local package dependency, the composer install will use relative paths for `/opt` for the package location and not `/var/www/html` where the rest of the code base sits. 

While this is an edge case, by having the read me use the website working directory `/var/www/html` it overcomes potential issues caused by symlink references in composer.