### PR TITLE
[8.x] Add AWS Session Token to the SES Documentation

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -101,7 +101,7 @@ Next, set the `default` option in your `config/mail.php` configuration file to `
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
-To utilize AWS temporary credentials together via a session token, you may add a `token` key to your application's SES configuration:
+To utilize AWS [temporary credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html) via a session token, you may add a `token` key to your application's SES configuration:
 
     'ses' => [
         'key' => env('AWS_ACCESS_KEY_ID'),

--- a/mail.md
+++ b/mail.md
@@ -101,7 +101,7 @@ Next, set the `default` option in your `config/mail.php` configuration file to `
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
-To make use of AWS temporary credentials together with a session token you may add a `token` key to the ses-configuration
+To utilize AWS temporary credentials together via a session token, you may add a `token` key to your application's SES configuration:
 
     'ses' => [
         'key' => env('AWS_ACCESS_KEY_ID'),

--- a/mail.md
+++ b/mail.md
@@ -101,6 +101,15 @@ Next, set the `default` option in your `config/mail.php` configuration file to `
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+To make use of AWS temporary credentials together with a session token you may add a `token` key to the ses-configuration
+
+    'ses' => [
+        'key' => env('AWS_ACCESS_KEY_ID'),
+        'secret' => env('AWS_SECRET_ACCESS_KEY'),
+        'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
+        'token' => env('AWS_SESSION_TOKEN'),
+    ],
+
 If you would like to define [additional options](https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-email-2010-12-01.html#sendrawemail) that Laravel should pass to the AWS SDK's `SendRawEmail` method when sending an email, you may define an `options` array within your `ses` configuration:
 
     'ses' => [


### PR DESCRIPTION
While working on the Symfony Mailer upgrade for Laravel 9.x I saw an undocumented feature of using AWS Session Tokens with temporary credentials which is also available in Laravel 8.x.

This PR adds the feature to the documentation.

Code where the SesTransport is created and the `token` entry of the config can be used if available:
https://github.com/laravel/framework/blob/8.x/src/Illuminate/Mail/MailManager.php#L258-L293

More about temporary credentials here:
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html