### PR TITLE
Fix typo

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -204,7 +204,7 @@ Instead of using the `--git` flag, you may also use the `--github` flag to creat
 laravel new example-app --github
 ```
 
-The created repository will then be available at `https://github.com/<your-account>/my-app.com`. The `github` flag assumes you have properly installed the [GitHub CLI](https://cli.github.com) and are authenticated with GitHub. Additionally, you should have `git` installed and properly configured. If needed, you can pass additional flags that supported by the GitHub CLI:
+The created repository will then be available at `https://github.com/<your-account>/example-app`. The `github` flag assumes you have properly installed the [GitHub CLI](https://cli.github.com) and are authenticated with GitHub. Additionally, you should have `git` installed and properly configured. If needed, you can pass additional flags that supported by the GitHub CLI:
 
 ```bash
 laravel new example-app --github="--public"


### PR DESCRIPTION
The created repository's name should be `example-app`.