### PR TITLE
Add missing auth:clear-resets command.

### DIFF
--- a/passwords.md
+++ b/passwords.md
@@ -8,6 +8,7 @@
     - [Requesting The Password Reset Link](#requesting-the-password-reset-link)
     - [Resetting The Password](#resetting-the-password)
 - [Customization](#password-customization)
+- [Flushing Expired Tokens](#flush-expired-tokens)
 
 <a name="introduction"></a>
 ## Introduction
@@ -187,3 +188,14 @@ You may easily modify the notification class used to send the password reset lin
 
         $this->notify(new ResetPasswordNotification($url));
     }
+
+<a name="flush-expired-tokens"></a>
+## Flushing Expired Tokens
+
+Password reset tokens that have expired will still be present within your database. To easily flush these records, use the following artisan command:
+
+    php artisan auth:clear-resets
+
+If you would like to automate this process, consider adding the command to your [scheduler](/docs/{{version}}/scheduling):
+
+    $schedule->command('auth:clear-resets')->everyFifteenMinutes();

--- a/passwords.md
+++ b/passwords.md
@@ -7,8 +7,8 @@
 - [Routing](#routing)
     - [Requesting The Password Reset Link](#requesting-the-password-reset-link)
     - [Resetting The Password](#resetting-the-password)
+- [Deleting Expired Tokens](#deleting-expired-tokens)
 - [Customization](#password-customization)
-- [Flushing Expired Tokens](#flush-expired-tokens)
 
 <a name="introduction"></a>
 ## Introduction
@@ -145,6 +145,17 @@ The `reset` method returns a "status" slug. This status may be translated using 
 
 Before moving on, you may be wondering how Laravel knows how to retrieve the user record from your application's database when calling the `Password` facade's `reset` method. The Laravel password broker utilizes your authentication system's "user providers" to retrieve database records. The user provider used by the password broker is configured within the `passwords` configuration array of your `config/auth.php` configuration file. To learn more about writing custom user providers, consult the [authentication documentation](/docs/{{version}}/authentication#adding-custom-user-providers).
 
+<a name="deleting-expired-tokens"></a>
+## Deleting Expired Tokens
+
+Password reset tokens that have expired will still be present within your database. However, you may easily delete these records using the `auth:clear-resets` Artisan command:
+
+    php artisan auth:clear-resets
+
+If you would like to automate this process, consider adding the command to your application's [scheduler](/docs/{{version}}/scheduling):
+
+    $schedule->command('auth:clear-resets')->everyFifteenMinutes();
+
 <a name="password-customization"></a>
 ## Customization
 
@@ -188,14 +199,3 @@ You may easily modify the notification class used to send the password reset lin
 
         $this->notify(new ResetPasswordNotification($url));
     }
-
-<a name="flush-expired-tokens"></a>
-## Flushing Expired Tokens
-
-Password reset tokens that have expired will still be present within your database. To easily flush these records, use the following artisan command:
-
-    php artisan auth:clear-resets
-
-If you would like to automate this process, consider adding the command to your [scheduler](/docs/{{version}}/scheduling):
-
-    $schedule->command('auth:clear-resets')->everyFifteenMinutes();


### PR DESCRIPTION
I often find people asking about creating custom commands to clear expired records from the `password_resets` table, not knowing a command already exists. 