### PR TITLE
[8.x] Clarify `insertOrIgnore` is not just duplicate record errors

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -819,7 +819,7 @@ The `insertOrIgnore` method will ignore errors while inserting records into the 
         ['id' => 2, 'email' => 'archer@example.com'],
     ]);
 
-> {note} `insertOrIgnore` will ignore duplicate records **and** may have other side effects depending on database engine. For example, `insertOrIgnore` will [bypass MySQL's strict mode](https://dev.mysql.com/doc/refman/en/sql-mode.html#ignore-effect-on-execution) and silently fail for some errors.
+> {note} `insertOrIgnore` will ignore duplicate records **and** may have other side effects depending on database engine. For example, `insertOrIgnore` will [bypass MySQL's strict mode](https://dev.mysql.com/doc/refman/en/sql-mode.html#ignore-effect-on-execution) and may silently allow invalid data.
 
 <a name="auto-incrementing-ids"></a>
 #### Auto-Incrementing IDs

--- a/queries.md
+++ b/queries.md
@@ -819,7 +819,7 @@ The `insertOrIgnore` method will ignore errors while inserting records into the 
         ['id' => 2, 'email' => 'archer@example.com'],
     ]);
 
-> {note} `insertOrIgnore` will ignore duplicate records **and** may have other side effects depending on database engine. For example, `insertOrIgnore` will [bypass MySQL's strict mode](https://dev.mysql.com/doc/refman/en/sql-mode.html#ignore-effect-on-execution) and may silently allow invalid data.
+> {note} `insertOrIgnore` will ignore duplicate records and also may ignore other types of errors depending on the database engine. For example, `insertOrIgnore` will [bypass MySQL's strict mode](https://dev.mysql.com/doc/refman/en/sql-mode.html#ignore-effect-on-execution).
 
 <a name="auto-incrementing-ids"></a>
 #### Auto-Incrementing IDs

--- a/queries.md
+++ b/queries.md
@@ -819,7 +819,7 @@ The `insertOrIgnore` method will ignore errors while inserting records into the 
         ['id' => 2, 'email' => 'archer@example.com'],
     ]);
 
-> {note} `insertOrIgnore` will ignore duplicate records **and** may have other side effects depending on database engine. For example, `insertOrIgnore` will [bypass MySQL's strict mode](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#ignore-effect-on-execution) and silently fail for some errors.
+> {note} `insertOrIgnore` will ignore duplicate records **and** may have other side effects depending on database engine. For example, `insertOrIgnore` will [bypass MySQL's strict mode](https://dev.mysql.com/doc/refman/en/sql-mode.html#ignore-effect-on-execution) and silently fail for some errors.
 
 <a name="auto-incrementing-ids"></a>
 #### Auto-Incrementing IDs

--- a/queries.md
+++ b/queries.md
@@ -812,12 +812,14 @@ You may insert several records at once by passing an array of arrays. Each array
         ['email' => 'janeway@example.com', 'votes' => 0],
     ]);
 
-The `insertOrIgnore` method will ignore duplicate record errors while inserting records into the database:
+The `insertOrIgnore` method will ignore errors while inserting records into the database:
 
     DB::table('users')->insertOrIgnore([
         ['id' => 1, 'email' => 'sisko@example.com'],
         ['id' => 2, 'email' => 'archer@example.com'],
     ]);
+
+> {note} `insertOrIgnore` will ignore duplicate records **and** may have other side effects depending on database engine. For example, `insertOrIgnore` will [bypass MySQL's strict mode](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#ignore-effect-on-execution) and silently fail for some errors.
 
 <a name="auto-incrementing-ids"></a>
 #### Auto-Incrementing IDs


### PR DESCRIPTION
The `insertOrIgnore` method is very helpful, but it is important to understand the consequences. The method is accurately described in code as:

```php
/**
 * Insert new records into the database while ignoring errors.
 */
public function insertOrIgnore(array $values)
```

However, the documentation describes it _in the context of duplicate errors_:

```markdown
The insertOrIgnore method will ignore duplicate record errors while inserting records into the database:
```

The statement may be interpreted as `insertOrIgnore` being equivalent to something like `skipOnDuplicate`. Unfortunately, `insertOrIgnore` has a number of consequences -- depending on database engine -- such as bypassing multiple MySQL Strict-mode restrictions: it is important that it is **not** considered equivalent to something like `skipOnDuplicate`.

The link in the warning to the MySQL documentation is without version (i.e: a link to the latest documentation) because this behaviour has been stable across multiple versions ([5.7](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#ignore-effect-on-execution), [8.0](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#ignore-effect-on-execution)) but we could change the link to `5.7` since that is the minimum recommended version for Laravel 8.0 -- if a link to external documentation must be pinned to a version.

[1] List of errors ignored by `ignore` as of MySQL version 5.7:
```
ER_BAD_NULL_ERROR
ER_DUP_ENTRY
ER_DUP_ENTRY_WITH_KEY_NAME
ER_DUP_KEY
ER_NO_PARTITION_FOR_GIVEN_VALUE
ER_NO_PARTITION_FOR_GIVEN_VALUE_SILENT
ER_NO_REFERENCED_ROW_2
ER_ROW_DOES_NOT_MATCH_GIVEN_PARTITION_SET
ER_ROW_IS_REFERENCED_2
ER_SUBQUERY_NO_1_ROW
ER_VIEW_CHECK_FAILED
```