### PR TITLE
Use `sail stop` command instead of `sail down` command

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -95,10 +95,10 @@ sail up -d
 
 Once the application's containers have been started, you may access the project in your web browser at: http://localhost.
 
-To stop all of the containers, you may simply press Control + C to stop the container's execution. Or, if the containers are running in the background, you may use the `down` command:
+To stop all of the containers, you may simply press Control + C to stop the container's execution. Or, if the containers are running in the background, you may use the `stop` command:
 
 ```bash
-sail down
+sail stop
 ```
 
 <a name="executing-sail-commands"></a>


### PR DESCRIPTION
The current documentation recommends the use of `sail down` command to stop the containers execution. This command stops and also removes the containers in Docker. A better option would be to use `sail stop` instead which only stops the containers but doesn't remove them.

This is better for using services like Vapor. If you remove the containers next time you need to authenticate again with Vapor before being able to deploy.