### PR TITLE
fix bad sample code

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -163,7 +163,7 @@ The `lazy` method works similarly to [the `chunk` method](#chunking-results) in 
 ```php
 use Illuminate\Support\Facades\DB;
 
-DB::table('users')->lazy()->each(function ($user) {
+DB::table('users')->orderBy('id')->lazy()->each(function ($user) {
     //
 });
 ```


### PR DESCRIPTION
When I run these sample codes in my local environment, it throws an exception:

```
  • Tests\Feature\Database\QueryBuilderTest > lazy
   RuntimeException

  You must specify an orderBy clause when using this function.
```

My English is not good, so I didn’t add some explanatory text in the context.
