### PR TITLE
[8.x] Document the new --policy option in make:model

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -54,7 +54,7 @@ If you would like to generate a [database migration](/docs/{{version}}/migration
 
     php artisan make:model Flight --migration
 
-You may generate various other types of classes when generating a model, such as factories, seeders, policies and controllers. In addition, these options may be combined to create multiple classes at once:
+You may generate various other types of classes when generating a model, such as factories, seeders, policies, and controllers. In addition, these options may be combined to create multiple classes at once:
 
 ```bash
 # Generate a model and a FlightFactory class...

--- a/eloquent.md
+++ b/eloquent.md
@@ -54,7 +54,7 @@ If you would like to generate a [database migration](/docs/{{version}}/migration
 
     php artisan make:model Flight --migration
 
-You may generate various other types of classes when generating a model, such as factories, seeders, and controllers. In addition, these options may be combined to create multiple classes at once:
+You may generate various other types of classes when generating a model, such as factories, seeders, policies and controllers. In addition, these options may be combined to create multiple classes at once:
 
 ```bash
 # Generate a model and a FlightFactory class...
@@ -69,10 +69,13 @@ php artisan make:model Flight -s
 php artisan make:model Flight --controller
 php artisan make:model Flight -c
 
+# Generate a model and a FlightPolicy class...
+php artisan make:model Flight --policy
+
 # Generate a model and a migration, factory, seeder, and controller...
 php artisan make:model Flight -mfsc
 
-# Shortcut to generate a model, migration, factory, seeder, and controller...
+# Shortcut to generate a model, migration, factory, seeder, policy, and controller...
 php artisan make:model Flight --all
 
 # Generate a pivot model...


### PR DESCRIPTION
Add documentation to the Eloquent page that there exists an option to create policies when creating a model using the `php artisan make:model` command with the new `--policy` flag added in [laravel/framework#38725](https://github.com/laravel/framework/pull/38725)

