### PR TITLE
[8.x] Fix the database type mentioned in the note of Eloquent::upsert

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -748,7 +748,7 @@ If you would like to perform multiple "upserts" in a single query, then you shou
         ['departure' => 'Chicago', 'destination' => 'New York', 'price' => 150]
     ], ['departure', 'destination'], ['price']);
 
-> {note} All databases systems except SQL Server require the columns in the second argument provided to the `upsert` method to have a "primary" or "unique" index.
+> {note} All databases systems except MySQL require the columns in the second argument provided to the `upsert` method to have a "primary" or "unique" index.
 
 <a name="deleting-models"></a>
 ## Deleting Models


### PR DESCRIPTION
The [documentation](https://laravel.com/docs/8.x/eloquent#upserts) of `Eloquent::upsert` states that it is not necessary to set the second argument when using SQL Server.
But when I read the code, the `uniqueBy` argument passed is used by the [`SQLServerGrammer::compileUpsert`](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php#L155-L175), but not by the [`MySQLGrammer::compileUpsert`](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php#L378-L418) method.
Also, as far as I've read the code, there's no place where the uniqueBy variable is used except in the compileUpsert method.
Therefore, isn't it necessary to set the second argument when using MySQL?

Please close this PR if my thoughts are wrong.
(If anyone is familiar with SQL Server, please let me know if this fix is ​​correct.)