### PR TITLE
Add trait to broadcastVia example

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -652,13 +652,14 @@ If your application interacts with multiple broadcast connections and you want t
 
     broadcast(new OrderShipmentStatusUpdated($update))->via('pusher');
 
-Alternatively, you may specify the event's broadcast connection by calling the `broadcastVia` method within the event's constructor:
+Alternatively, you may specify the event's broadcast connection by calling the `broadcastVia` method within the event's constructor. However, before doing so, you should ensure that the event class uses the `InteractsWithBroadcasting` trait:
 
     <?php
 
     namespace App\Events;
 
     use Illuminate\Broadcasting\Channel;
+    use Illuminate\Broadcasting\InteractsWithBroadcasting;
     use Illuminate\Broadcasting\InteractsWithSockets;
     use Illuminate\Broadcasting\PresenceChannel;
     use Illuminate\Broadcasting\PrivateChannel;

--- a/broadcasting.md
+++ b/broadcasting.md
@@ -667,6 +667,8 @@ Alternatively, you may specify the event's broadcast connection by calling the `
 
     class OrderShipmentStatusUpdated implements ShouldBroadcast
     {
+        use InteractsWithBroadcasting;
+        
         /**
          * Create a new event instance.
          *


### PR DESCRIPTION
The method is undefined without this trait. It should be included in the docs.