### PR TITLE
[8.x] Add callout for ordering ambiguous route definitions

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -71,6 +71,8 @@ Sometimes you may need to register a route that responds to multiple HTTP verbs.
         //
     });
 
+> {tip} When defining multiple routes that share the same URI, the methods `get`, `post`, `put`, `patch`, `delete`, and `options` must be called before methods `any`, `match`, and `redirect`. This ensures the incoming request is matched with the correct route.
+
 <a name="dependency-injection"></a>
 #### Dependency Injection
 

--- a/routing.md
+++ b/routing.md
@@ -71,7 +71,7 @@ Sometimes you may need to register a route that responds to multiple HTTP verbs.
         //
     });
 
-> {tip} When defining multiple routes that share the same URI, the methods `get`, `post`, `put`, `patch`, `delete`, and `options` must be called before methods `any`, `match`, and `redirect`. This ensures the incoming request is matched with the correct route.
+> {tip} When defining multiple routes that share the same URI, routes using the `get`, `post`, `put`, `patch`, `delete`, and `options` methods should be defined before routes using the `any`, `match`, and `redirect` methods. This ensures the incoming request is matched with the correct route.
 
 <a name="dependency-injection"></a>
 #### Dependency Injection


### PR DESCRIPTION
Covers https://github.com/laravel/framework/issues/37639

Five failed pull requests (+ Dries' unsubmitted dev branch) have been attempted for that issue but I think this is just a problem with routes being defined in an ambiguous order.

When defining multiple routes sharing the same URI, their call order will affect which route the incoming request is matched with. The specific route definition should be defined before any general route. If defined in the opposite order, command `php artisan route:cache` can cause the general route to always override the specific route.

### e.g., `GET /foo`

#### :x: general route followed by specific route is nondeterministic

```php
Route::any('/foo', function () {
    // GET /foo matched after 'php artisan route:cache'
});

Route::get('/foo', function () {
    // GET /foo matched without 'php artisan route:cache'
});
```

#### :heavy_check_mark: specific route followed by general route is deterministic

```php
Route::get('/foo', function () {
    // GET /foo always matched
});

Route::any('/foo', function () {
    //
});
```