### PR TITLE
added whereBelongsTo methods in where section of query builder docs introduced in Laravel 8.63.0. 

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -595,6 +595,26 @@ You may also pass an array of column comparisons to the `whereColumn` method. Th
                         ['updated_at', '>', 'created_at'],
                     ])->get();
 
+**whereBelongsTo**
+
+When retrieving `belongsTo` related records, you can usually use the inverse (hasMany) of the relationship, like so:
+    
+    $author->posts()
+
+However, sometimes this is not possible, and you must filter an existing query by its parent record:
+
+    $query->where('author_id', $author->id)
+
+This works, but explicitly depends on the name of foreign key (`author_id`), and the name of the owner key (`id`) in most cases. This is a maintenance burden, as these key names can be changed inside the relationship method and will subsequently become outdated across your entire app. So query builder has `whereBelongsTo`. You may use it like so: 
+
+    $query->whereBelongsTo($author)
+
+It will automatically retrieve the foreign key name from the relationship (`author`), and the correct owner key from the related model (`$author`).
+
+Sometimes, this is not appropriate. If the `$author` is an instance of `App\Models\User`, `whereBelongsTo()` will search for a `user()` relationship that does not exist. In this case, you may manually specify the relationship name:
+
+    $query->whereBelongsTo($author, 'author')
+
 <a name="logical-grouping"></a>
 ### Logical Grouping
 


### PR DESCRIPTION
This PR added the new method `whereBelongsTo` with a description in the **Additional Where Clauses** section of the query builder documentation page.  New feature PR is here https://github.com/laravel/framework/pull/38927
Most of the description is taken from the PR and it feels suitable to me. I'm open to any change for choosing words or the best place for this method. 

Attached is the SS of rendered markdown my PHPStorm. 

![image](https://user-images.githubusercontent.com/54532330/136099053-c2d59d3b-4dcb-4cb4-b0d7-3a901ad57e94.png)

