### PR TITLE
Add parenthesis to end of `Str::wordCount` heading

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -1660,7 +1660,7 @@ The `Str::uuid` method generates a UUID (version 4):
     return (string) Str::uuid();
 
 <a name="method-str-word-count"></a>
-#### `Str::wordCount` {#collection-method}
+#### `Str::wordCount()` {#collection-method}
 
 The `Str::wordCount` method returns the number of words that a string contains:
 


### PR DESCRIPTION
To match the other helpers.

![image](https://user-images.githubusercontent.com/19637309/136178995-219ee49d-4cd1-428d-992b-2f0452700280.png)
