### PR TITLE
Updated mail.md (this is not a hacktoberfest PR 😉)

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -158,7 +158,9 @@ When building Laravel applications, each type of email sent by your application 
 <a name="writing-mailables"></a>
 ## Writing Mailables
 
-Once you have generated a mailable class, open it up so we can explore its contents. First, note that all of a mailable class' configuration is done in the `build` method. Within this method, you may call various methods such as `from`, `subject`, `view`, and `attach` to configure the email's presentation and delivery. Note that we are able to type-hint dependencies on the build method of the mailable. The Laravel service container automatically injects these dependencies.
+Once you have generated a mailable class, open it up so we can explore its contents. First, note that all of a mailable class' configuration is done in the `build` method. Within this method, you may call various methods such as `from`, `subject`, `view`, and `attach` to configure the email's presentation and delivery.
+
+> {tip} You may type-hint dependencies on the mailable's `build` method. The Laravel [service container](/docs/{{version}}/container) automatically injects these dependencies.
 
 <a name="configuring-the-sender"></a>
 ### Configuring The Sender


### PR DESCRIPTION
Am I correct that you can inject dependencies into the build method of a mailable?

```php
Container::getInstance()->call([$this, 'build']);
```
https://github.com/laravel/framework/blob/8.x/src/Illuminate/Mail/Mailable.php#L175

This seems to be missing in the documentation. What I've done:

I've added a note about dependency injection. I've copy/pasted the text from the queues page and replaced the method and class name of course. This is my first PR to a Laravel repo, please be kind 😇 