### PR TITLE
Document `assertValueIsNot()` and `assertAttributeContains()`

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -703,7 +703,7 @@ You may occasionally need to execute assertions outside of the current scope. Yo
 <a name="waiting-for-elements"></a>
 ### Waiting For Elements
 
-When testing applications that use JavaScript extensively, it often becomes necessary to "wait" for certain elements or data to be available before proceeding with a test. Dusk makes this a cinch. Using a variety of methods, you may wait for elements to be visible on the page or even wait until a given JavaScript expression evaluates to `true`.
+When testing applications that use JavaScript extensively, it often becomes necessary to "wait" for certain elements or data to be available before proceeding with a test. Dusk makes this a cinch. Using a variety of methods, you may wait for elements to become visible on the page or even wait until a given JavaScript expression evaluates to `true`.
 
 <a name="waiting"></a>
 #### Waiting


### PR DESCRIPTION
Document the following Dusk PRs:

- [`assertValueIsNot()`](https://github.com/laravel/dusk/pull/929)
- [`assertAttributeContains()`](https://github.com/laravel/dusk/pull/931)