### PR TITLE
Instruct users to change image name when customizing Sail

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -392,7 +392,7 @@ Since Sail is just Docker, you are free to customize nearly everything about it.
 sail artisan sail:publish
 ```
 
-After running this command, the Dockerfiles and other configuration files used by Laravel Sail will be placed within a `docker` directory in your application's root directory. After customizing your Sail installation, you should change the image name for the `laravel.test` service in your `docker-compose.yml` file, and then rebuild your application's containers using the `build` command:
+After running this command, the Dockerfiles and other configuration files used by Laravel Sail will be placed within a `docker` directory in your application's root directory. After customizing your Sail installation, you may wish to change the image name for the `laravel.test` service in your application's `docker-compose.yml` file. After doing so, rebuild your application's containers using the `build` command. Assigning a unique name to the `laravel.test` service image is particularly important if you are using Sail to develop multiple Laravel applications on a single machine:
 
 ```bash
 sail build --no-cache


### PR DESCRIPTION
If users are developing multiple apps on the same machine and have customized the Dockerfile for different apps in different ways (or customized one but not another), Docker may use the image from one application to create a container for a different application, when in reality there should be two unique images. Sail is a great tool for users who are just becoming familiar with Docker, and I think this explicit instruction may save some headaches (it would have for me, anyway).