### PR TITLE
use `class` constant to coordinate with other parts of document

### DIFF
--- a/container.md
+++ b/container.md
@@ -228,7 +228,7 @@ Sometimes you may have two classes that utilize the same interface, but you wish
 
 Sometimes you may have a class that receives some injected classes, but also needs an injected primitive value such as an integer. You may easily use contextual binding to inject any value your class may need:
 
-    $this->app->when('App\Http\Controllers\UserController')
+    $this->app->when(UserController::class)
               ->needs('$variableName')
               ->give($value);
 


### PR DESCRIPTION
All other parts where using ::class to get qualified class name. current PR coordinates this part of documentation with the whole