### PR TITLE
Update sail.md

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -74,7 +74,7 @@ By default, Sail commands are invoked using the `vendor/bin/sail` script that is
 However, instead of repeatedly typing `vendor/bin/sail` to execute Sail commands, you may wish to configure a Bash alias that allows you to execute Sail's commands more easily:
 
 ```bash
-alias sail='[ -f sail ] && bash sail || bash vendor/bin/sail'
+alias sail='bash $([ -f sail ] && echo "sail" || echo "vendor/bin/sail")'
 ```
 
 Once the Bash alias has been configured, you may execute Sail commands by simply typing `sail`. The remainder of this documentation's examples will assume that you have configured this alias:


### PR DESCRIPTION
if `[ -f sail ]` is true (a file named 'sail' exists in the project root) and the `&& bash sail` would be executed, no arguments could be passed to the script.
If you run, for example, `sail up` the argument 'up' would not be passed to the 'sail' file script in the project root.
It however would be passed to the script stored at 'vendor/bin/sail' because then the final part of the alias statement would execute (`|| bash vendor/bin/sail`).
This new alias allows argument passing in both cases.