### PR TITLE
whenFilled and whenHas do not accept a second closure

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -331,14 +331,6 @@ The `whenHas` method will execute the given closure if a value is present on the
         //
     });
 
-A second closure may be passed to the `whenHas` method that will be executed if the specified value is not present on the request:
-
-    $request->whenHas('name', function ($input) {
-        // The "name" value is present...
-    }, function () {
-        // The "name" value is not present...
-    });
-
 The `hasAny` method returns `true` if any of the specified values are present:
 
     if ($request->hasAny(['name', 'email'])) {
@@ -355,14 +347,6 @@ The `whenFilled` method will execute the given closure if a value is present on 
 
     $request->whenFilled('name', function ($input) {
         //
-    });
-
-A second closure may be passed to the `whenFilled` method that will be executed if the specified value is not "filled":
-
-    $request->whenFilled('name', function ($input) {
-        // The "name" value is filled...
-    }, function () {
-        // The "name" value is not filled...
     });
 
 To determine if a given key is absent from the request, you may use the `missing` method:


### PR DESCRIPTION
The docs mention that a second closure can be passed to the two mentioned functions, but the signatures do not bear this out: `public function whenFilled($key, callable $callback)` and `public function whenHas($key, callable $callback)`

Indeed even testing this, the second closure is never executed:
`
$request->whenFilled('archived', function() use (&$filteredStudies) {
    $filteredStudies->where('date_archived', '!=',null);
}, function () use (&$filteredStudies) {
    $filteredStudies->where('date_archived', '=',null);     <---- never executed
});
`

So either to docs need to be updated (this request) or the functions need to be updated.