### PR TITLE
specific env file with server variable APP_ENV set

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -30,6 +30,8 @@ If you are developing with a team, you may wish to continue including a `.env.ex
 
 > {tip} Any variable in your `.env` file can be overridden by external environment variables such as server-level or system-level environment variables.
 
+> {note} If the environment variable `APP_ENV` exists on server-level or system-level than the `.env.{APP_ENV}` file will be used instead of the `.env` file.
+
 <a name="environment-file-security"></a>
 #### Environment File Security
 


### PR DESCRIPTION
In https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php, method checkForSpecificEnvironmentFile($app) a specific env file is used, when `Env::get('APP_ENV')` is present: `.env.{$environment}` instead of `.env`. This caused me hours of debugging, because I assumed, that always ".env" is used as filename. Therefore I suggest an addition to the documentation.

Regards, Ralf