### PR TITLE
[8.x] Indicate PHP 8.1 support available for sail

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -294,7 +294,7 @@ sail tinker
 <a name="sail-php-versions"></a>
 ## PHP Versions
 
-Sail currently supports serving your application via PHP 8.1, PHP 8.0 or PHP 7.4, with the default being 8.0. To change the PHP version that is used to serve your application, you should update the `build` definition of the `laravel.test` container in your application's `docker-compose.yml` file:
+Sail currently supports serving your application via PHP 8.1, PHP 8.0, or PHP 7.4. The default PHP version used by Sail is currently PHP 8.0. To change the PHP version that is used to serve your application, you should update the `build` definition of the `laravel.test` container in your application's `docker-compose.yml` file:
 
 ```yaml
 # PHP 8.1


### PR DESCRIPTION
Following https://github.com/laravel/sail/pull/254