### PR TITLE
[8.x] Clarify promotion codes

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -635,13 +635,11 @@ If you would like to apply a coupon when creating the subscription, you may use 
          ->withCoupon('code')
          ->create($paymentMethod);
 
-Or, if you would like to apply a [Stripe promotion code](https://stripe.com/docs/billing/subscriptions/discounts/codes), you may use the `withPromotionCode` method:
+Or, if you would like to apply a [Stripe promotion code](https://stripe.com/docs/billing/subscriptions/discounts/codes), you may use the `withPromotionCode` method. The given promotion code ID should be the Stripe API ID assigned to the promotion code and not the customer facing promotion code:
 
     $user->newSubscription('default', 'price_monthly')
          ->withPromotionCode('promo_code')
          ->create($paymentMethod);
-
-This needs to be the API ID of the promo code and not the customer facing code.
 
 <a name="adding-subscriptions"></a>
 #### Adding Subscriptions


### PR DESCRIPTION
It's not clear atm that this needs to be the API ID and not the customer facing code.

https://github.com/laravel/cashier-stripe/issues/852#issuecomment-945004850