### PR TITLE
Add information about channel.stopListening(event)

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -26,7 +26,6 @@
     - [Customizing The Connection](#customizing-the-connection)
 - [Receiving Broadcasts](#receiving-broadcasts)
     - [Listening For Events](#listening-for-events)
-    - [Stop listening For Active Events](#stop-listening-for-events)
     - [Leaving A Channel](#leaving-a-channel)
     - [Namespaces](#namespaces)
 - [Presence Channels](#presence-channels)
@@ -707,9 +706,9 @@ Echo.private(`orders.${this.order.id}`)
 ```
 
 <a name="stop-listening-for-events"></a>
-### Stop Listening For Active Events
+#### Stop Listening For Events
 
-There's an situations when you want to stop to listen to any active events on any channel but don't leave the channel. You need to provide channel name and the *event name*
+If you would like to stop listening to a given event without [leaving the channel](#leaving-a-channel), you may use the `stopListening` method:
 
 ```js
 Echo.private(`orders.${this.order.id}`)


### PR DESCRIPTION
I have never seen any documentation an info about the method *stopListening* on channel to cancel the listen to an event.
Add info about it.