### PR TITLE
[8.x] Clarify local scope return type

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1134,7 +1134,7 @@ If you would like to remove several or even all of the query's global scopes, yo
 
 Local scopes allow you to define common sets of query constraints that you may easily re-use throughout your application. For example, you may need to frequently retrieve all users that are considered "popular". To define a scope, prefix an Eloquent model method with `scope`.
 
-Scopes should always return a query builder instance:
+Scopes should always return the same query builder instance or `void`:
 
     <?php
 
@@ -1159,11 +1159,11 @@ Scopes should always return a query builder instance:
          * Scope a query to only include active users.
          *
          * @param  \Illuminate\Database\Eloquent\Builder  $query
-         * @return \Illuminate\Database\Eloquent\Builder
+         * @return void
          */
         public function scopeActive($query)
         {
-            return $query->where('active', 1);
+            $query->where('active', 1);
         }
     }
 


### PR DESCRIPTION
The docs currently state:

> Scopes should always return a query builder instance

But in reality, the [`callScope method`](https://github.com/laravel/framework/blob/6db59afadca28dfdb2f719e7d79f93885ede17e4/src/Illuminate/Database/Eloquent/Builder.php#L1189) expects scopes to modify the provided Eloquent builder object. If you were to, in fact, return a *new* builder for some reason, it would break the `addNewWheresWithinGroup` functionality and potentially have other unexpected behavior (since this method is operating on the original query builder, not the one from the result of calling the scope).

This PR updates the docs to:

> Scopes should always return the same query builder instance or `void`

And also changes one of the code samples to demonstrate the `void` return version of a named scope.