### PR TITLE
Fix faulty link in cashier-paddle

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -1180,4 +1180,4 @@ Alternatively, you can perform more precise customization by catching the [`subs
 
 While testing, you should manually test your billing flow to make sure your integration works as expected.
 
-For automated tests, including those executed within a CI environment, you may use [Laravel's HTTP Client](/docs//{{version}}/http-client#testing) to fake HTTP calls made to Paddle. Although this does not test the actual responses from Paddle, it does provide a way to test your application without actually calling Paddle's API.
+For automated tests, including those executed within a CI environment, you may use [Laravel's HTTP Client](/docs/{{version}}/http-client#testing) to fake HTTP calls made to Paddle. Although this does not test the actual responses from Paddle, it does provide a way to test your application without actually calling Paddle's API.


### PR DESCRIPTION
Noticed a faulty link when reading the docs.

The link on https://laravel.com/docs/8.x/cashier-paddle#testing to  Laravel's HTTP Client