### PR TITLE
Describe `has*` and `missing*` on `AssertableJson`

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -344,6 +344,33 @@ In the example above, you may have noticed we invoked the `etc` method at the en
 
 The intention behind this behavior is to protect you from unintentionally exposing sensitive information in your JSON responses by forcing you to either explicitly make an assertion against the attribute or explicitly allow additional attributes via the `etc` method.
 
+<a name="asserting-json-attribute-presence-and-absence"></a>
+#### Asserting JSON attribute presence and absence
+
+To assert that an attribute is present without checking its value you may use the `has` method while `missing` asserts the absence of an attribute:
+
+    $response
+        ->assertJson(fn (AssertableJson $json) =>
+            $json->has('data')
+                 ->missing('message')
+        );
+
+The `hasAll` and `missingAll` methods allow asserting the presence or absence of multiple attributes simultaneously:
+
+    $response
+        ->assertJson(fn (AssertableJson $json) =>
+            $json->hasAll('status', 'data')
+                 ->missingAll('message', 'code')
+        );
+
+To check if at least one of multiple attributes is present you may use the `hasAny` method:
+
+    $response
+        ->assertJson(fn (AssertableJson $json) =>
+            $json->has('status')
+                 ->hasAny('data', 'message', 'code')
+        );
+
 <a name="asserting-against-json-collections"></a>
 #### Asserting Against JSON Collections
 


### PR DESCRIPTION
Companion PR to laravel/framework#39265, documenting the new `hasAny` method.

I noticed that `hasAll` and `missingAll` were undocumented as well. And the `has(string $key)` was used in an example but not explicitly documented. Thus I decided to add a section for all of these attribute presence/absence methods. I included `missing` for completion, even though it is also described in the fluent assertion introduction.