### PR TITLE
fix/add missing "return"

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1163,7 +1163,7 @@ Scopes should always return the same query builder instance or `void`:
          */
         public function scopeActive($query)
         {
-            $query->where('active', 1);
+            return $query->where('active', 1);
         }
     }
 


### PR DESCRIPTION
- a `scope`-function should return an `\Illuminate\Database\Eloquent\Builder`-instance
- adds a missing `return` on the `scopeActive()`-function