### PR TITLE
Add documentation for CheckAbilities and CheckForAnyAbility Middleware in Sanctum

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -151,16 +151,16 @@ Sanctum allows you to assign "abilities" to tokens. Abilities serve a similar pu
 
     return $user->createToken('token-name', ['server:update'])->plainTextToken;
 
-<a name="checking-abilities"></a>
-#### Checking Abilities
-
 When handling an incoming request authenticated by Sanctum, you may determine if the token has a given ability using the `tokenCan` method:
 
     if ($user->tokenCan('server:update')) {
         //
     }
 
-Sanctum also includes two middleware that may be used to verify that an incoming request is authenticated with a token that has been granted a given ability. To get started, add the following middleware to the `$routeMiddleware` property of your `app/Http/Kernel.php` file:
+<a name="token-ability-middleware"></a>
+#### Token Ability Middleware
+
+Sanctum also includes two middleware that may be used to verify that an incoming request is authenticated with a token that has been granted a given ability. To get started, add the following middleware to the `$routeMiddleware` property of your application's `app/Http/Kernel.php` file:
 
     'abilities' => \Laravel\Sanctum\Http\Middleware\CheckAbilities::class,
     'ability' => \Laravel\Sanctum\Http\Middleware\CheckForAnyAbility::class,
@@ -174,7 +174,7 @@ The `abilities` middleware may be assigned to a route to verify that the incomin
 The `ability` middleware may be assigned to a route to verify that the incoming request's token has *at least one* of the listed abilities:
 
     Route::get('/orders', function () {
-        // Token has either "check-status" or "place-orders" ability...
+        // Token has the "check-status" or "place-orders" ability...
     })->middleware(['auth:sanctum', 'ability:check-status,place-orders']);
 
 <a name="first-party-ui-initiated-requests"></a>


### PR DESCRIPTION
This PR adds documentation for the CheckAbilities and CheckForAnyAbility middleware added to Sanctum (laravel/sanctum#310 and laravel/sanctum#312).

~~I've marked this PR as draft because although the feature has already been released in Sanctum [v2.12.0](https://github.com/laravel/sanctum/releases/tag/v2.12.0), the middleware were later renamed and those changes are yet to be released.~~