### PR TITLE
[8.x] Correct some link to monolog github repository

### DIFF
--- a/logging.md
+++ b/logging.md
@@ -280,7 +280,7 @@ Once you have configured the `tap` option on your channel, you're ready to defin
 <a name="creating-monolog-handler-channels"></a>
 ### Creating Monolog Handler Channels
 
-Monolog has a variety of [available handlers](https://github.com/Seldaek/monolog/tree/master/src/Monolog/Handler) and Laravel does not include a built-in channel for each one. In some cases, you may wish to create a custom channel that is merely an instance of a specific Monolog handler that does not have a corresponding Laravel log driver.  These channels can be easily created using the `monolog` driver.
+Monolog has a variety of [available handlers](https://github.com/Seldaek/monolog/tree/main/src/Monolog/Handler) and Laravel does not include a built-in channel for each one. In some cases, you may wish to create a custom channel that is merely an instance of a specific Monolog handler that does not have a corresponding Laravel log driver.  These channels can be easily created using the `monolog` driver.
 
 When using the `monolog` driver, the `handler` configuration option is used to specify which handler will be instantiated. Optionally, any constructor parameters the handler needs may be specified using the `with` configuration option:
 


### PR DESCRIPTION
Just to get rid of the annoying message (Branch not found, redirected to default branch.)
![image](https://user-images.githubusercontent.com/731905/138533430-826857b8-a9b4-41b3-9a3f-f425c859dbff.png)
