### PR TITLE
[8.x] Add ThrottleRequestsWithRedis to the default $middlewarePriority list

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -221,6 +221,7 @@ Rarely, you may need your middleware to execute in a specific order but not have
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
         \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        \Illuminate\Routing\Middleware\ThrottleRequestsWithRedis::class,
         \Illuminate\Session\Middleware\AuthenticateSession::class,
         \Illuminate\Routing\Middleware\SubstituteBindings::class,
         \Illuminate\Auth\Middleware\Authorize::class,


### PR DESCRIPTION
This PR reflects this change: https://github.com/laravel/framework/pull/39316

[As this block suggests copy-pasting the default definition](https://laravel.com/docs/8.x/middleware#sorting-middleware) out of the documentation, we should now also provide the **ThrottleRequestsWithRedis** middleware.