### PR TITLE
Validation exceptions

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -97,7 +97,7 @@ Next, let's take a look at a simple controller that handles incoming requests to
 <a name="quick-writing-the-validation-logic"></a>
 ### Writing The Validation Logic
 
-Now we are ready to fill in our `store` method with the logic to validate the new blog post. To do this, we will use the `validate` method provided by the `Illuminate\Http\Request` object. If the validation rules pass, your code will keep executing normally; however, if validation fails, an exception will be thrown and the proper error response will automatically be sent back to the user.
+Now we are ready to fill in our `store` method with the logic to validate the new blog post. To do this, we will use the `validate` method provided by the `Illuminate\Http\Request` object. If the validation rules pass, your code will keep executing normally; however, if validation fails, an exception, `Illuminate\Validation\ValidationException`, will be thrown and the proper error response will automatically be sent back to the user.
 
 If validation fails during a traditional HTTP request, a redirect response to the previous URL will be generated. If the incoming request is an XHR request, a JSON response containing the validation error messages will be returned.
 
@@ -528,6 +528,11 @@ You may use the `validateWithBag` method to store the error messages in a [named
         'title' => 'required|unique:posts|max:255',
         'body' => 'required',
     ])->validateWithBag('post');
+
+<a name="catching-validation-exceptions"></a>
+### Catching Validation Exceptions
+
+`validate()` throws an `Illuminate\Validation\ValidationException`.  If you want to handle an invalid validation manually then wrap your `validate()` call in a try-catch and catch this exception.  To override redirection and 422 return JSON in your entire application you may handle this exception in your `App\Exceptions\Handler`.
 
 <a name="named-error-bags"></a>
 ### Named Error Bags


### PR DESCRIPTION
It took some sleuthing to discover how to override default Validator failures.  I wanted the power of validators without a redirect or 422 JSON response.  A catch for the exception `Illuminate\Validation\ValidationException` was the right answer so I've documented that here.