### PR TITLE
Correct note upsert

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -748,8 +748,6 @@ If you would like to perform multiple "upserts" in a single query, then you shou
         ['departure' => 'Chicago', 'destination' => 'New York', 'price' => 150]
     ], ['departure', 'destination'], ['price']);
 
-> {note} All databases systems except MySQL require the columns in the second argument provided to the `upsert` method to have a "primary" or "unique" index.
-
 <a name="deleting-models"></a>
 ## Deleting Models
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -748,7 +748,7 @@ If you would like to perform multiple "upserts" in a single query, then you shou
         ['departure' => 'Chicago', 'destination' => 'New York', 'price' => 150]
     ], ['departure', 'destination'], ['price']);
 
-> {note} All databases systems except SQL Server require the columns in the second argument provided to the `upsert` method to have a "primary" or "unique" index.
+> {note} All databases systems except MySQL require the columns in the second argument provided to the `upsert` method to have a "primary" or "unique" index.
 
 <a name="deleting-models"></a>
 ## Deleting Models


### PR DESCRIPTION
When digging deeper to `upsert` func, I find that `MySqlGrammar` has no use with params `uniqueBy`, but `SqlServerGrammar` do, as image below. After some investigate around google, I think this is a mistake in the documentation, not the source code.

![image](https://user-images.githubusercontent.com/25253808/139638544-c284d0e5-c21c-4658-93d2-5a7ea0ba7fe3.png)
![image](https://user-images.githubusercontent.com/25253808/139638587-1b1521c8-7a9a-446e-bab6-f11e9b63ae8c.png)
