### PR TITLE
Update APP_SERVICE on image name change

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -396,7 +396,13 @@ Since Sail is just Docker, you are free to customize nearly everything about it.
 sail artisan sail:publish
 ```
 
-After running this command, the Dockerfiles and other configuration files used by Laravel Sail will be placed within a `docker` directory in your application's root directory. After customizing your Sail installation, you may wish to change the image name for the `laravel.test` service in your application's `docker-compose.yml` file. After doing so, rebuild your application's containers using the `build` command. Assigning a unique name to the `laravel.test` service image is particularly important if you are using Sail to develop multiple Laravel applications on a single machine:
+After running this command, the Dockerfiles and other configuration files used by Laravel Sail will be placed within a `docker` directory in your application's root directory. After customizing your Sail installation, you may wish to change the image name for the `laravel.test` service in your application's `docker-compose.yml` file. Make sure to update this value in your `.env` file, so that sail commands will still work:
+
+```ini
+APP_SERVICE=laravel.test.your-image-name
+```
+
+After doing so, rebuild your application's containers using the `build` command. Assigning a unique name to the `laravel.test` service image is particularly important if you are using Sail to develop multiple Laravel applications on a single machine:
 
 ```bash
 sail build --no-cache


### PR DESCRIPTION
This is important, because if APP_SERVICE is not changed accordingly, 
then any sail command will throw `ERROR: No such service: laravel.test'`.

This has been mentioned also in forums like https://stackoverflow.com/questions/65982603/laravel-cli-sail-artisan-returns-no-such-service-after-updating-service-nam or https://laracasts.com/discuss/channels/laravel/sail-error-no-such-service-laraveldottest