### PR TITLE
[8.x] Document custom factory and model discovery

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -138,6 +138,33 @@ Next, define a `model` property on the corresponding factory:
         protected $model = Flight::class;
     }
 
+Alternatively, you can register your own logic of discovering model names from factories using the static `Factory::guessModelNamesUsing()` method, for example from within `AppServiceProvider`:
+
+    use Illuminate\Database\Eloquent\Factories\Factory;
+
+    class AppServiceProvider
+    {
+        public function boot()
+        {
+            Factory::guessModelNamesUsing(function (Factory $factory) {
+                $modelName = customModelDiscovery($factory);
+
+                return $modelName;
+            });
+        }
+    }
+
+Similarly, you can use `Factory::guessFactoryNamesUsing()` to instruct Laravel to return the corresponding factory from the model name following your own convention: 
+
+    public function boot()
+    {
+        Factory::guessFactoryNamesUsing(function (string $modelName) {
+            $factoryName = customFactoryDiscovery($modelName);
+
+            return $factoryName::new();
+        });
+    }
+
 <a name="factory-states"></a>
 ### Factory States
 


### PR DESCRIPTION
Just realized that the current documentation for model factories doesn't mention the ability to implement custom model and factory discovery logic with `Factory::guessModelNamesUsing()` and `Factory::guessFactoryNamesUsing()`. Unless there's a specific reason I'm not aware of, this ability is pretty powerful IMHO, especially if we're having a non-traditional app structure (for example, using [Laravel Modules](https://github.com/nWidart/laravel-modules)).

Let me know if there's anything I should fix, or if I should simply close this PR off 😄.