### PR TITLE
[8.x] Add docs for the `NotificationSending` event

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -1203,7 +1203,56 @@ Once you have implemented the interface, Laravel will automatically use the pref
 <a name="notification-events"></a>
 ## Notification Events
 
-When a notification is sent, the `Illuminate\Notifications\Events\NotificationSent` [event](/docs/{{version}}/events) is fired by the notification system. This contains the "notifiable" entity and the notification instance itself. You may register listeners for this event in your `EventServiceProvider`:
+<a name="notification-sending-event"></a>
+#### Notification Sending Event
+
+When a notification is sent, the `Illuminate\Notifications\Events\NotificationSending` [event](/docs/{{version}}/events) is dispatched by the notification system. This contains the "notifiable" entity and the notification instance itself. You may register listeners for this event in your application's `EventServiceProvider`:
+
+    /**
+     * The event listener mappings for the application.
+     *
+     * @var array
+     */
+    protected $listen = [
+        'Illuminate\Notifications\Events\NotificationSending' => [
+            'App\Listeners\CheckNotificationStatus',
+        ],
+    ];
+
+The notification will not be sent if an event listener for the `NotificationSending` event returns `false` from its `handle` method:
+
+    use Illuminate\Notifications\Events\NotificationSending;
+
+    /**
+     * Handle the event.
+     *
+     * @param  \Illuminate\Notifications\Events\NotificationSending  $event
+     * @return void
+     */
+    public function handle(NotificationSending $event)
+    {
+        return false;
+    }
+
+Within an event listener, you may access the `notifiable`, `notification`, and `channel` properties on the event to learn more about the notification recipient or the notification itself:
+
+    /**
+     * Handle the event.
+     *
+     * @param  \Illuminate\Notifications\Events\NotificationSending  $event
+     * @return void
+     */
+    public function handle(NotificationSending $event)
+    {
+        // $event->channel
+        // $event->notifiable
+        // $event->notification
+    }
+
+<a name="notification-sent-event"></a>
+#### Notification Sent Event
+
+When a notification is sent, the `Illuminate\Notifications\Events\NotificationSent` [event](/docs/{{version}}/events) is dispatched by the notification system. This contains the "notifiable" entity and the notification instance itself. You may register listeners for this event in your `EventServiceProvider`:
 
     /**
      * The event listener mappings for the application.
@@ -1233,48 +1282,6 @@ Within an event listener, you may access the `notifiable`, `notification`, `chan
         // $event->notification
         // $event->response
     }
-    
-When a notification is sending `Illuminate\Notifications\Events\NotificationSending` event will be fired, and You will be able to listen on it which contains a `notifiable` entity. You can set the listener in `EventServiceProvicer` for this event:
-
-    /**
-     * The event listener mappings for the application.
-     *
-     * @var array
-     */
-    protected $listen = [
-        'Illuminate\Notifications\Events\NotificationSending' => [
-            'App\Listeners\CheckNotificationStatus',
-        ],
-    ];
-
-When `Illuminate\Notifications\Events\NotificationSending`'s listener `handle` method returns `false` notification will not be sent and it will prevent from sending the notification:
-
-    /**
-     * Handle the event.
-     *
-     * @param  \Illuminate\Notifications\Events\NotificationSending  $event
-     * @return void
-     */
-    public function handle(NotificationSending $event)
-    {
-        return false;
-    }
-    
-Also, You access the `notifiable`, `notification` and `channel` properties on the event:
-
-    /**
-     * Handle the event.
-     *
-     * @param  \Illuminate\Notifications\Events\NotificationSending  $event
-     * @return void
-     */
-    public function handle(NotificationSending $event)
-    {
-        // $event->channel
-        // $event->notifiable
-        // $event->notification
-    }   
-
 
 <a name="custom-channels"></a>
 ## Custom Channels

--- a/notifications.md
+++ b/notifications.md
@@ -1247,7 +1247,7 @@ When a notification is sending `Illuminate\Notifications\Events\NotificationSend
         ],
     ];
 
-When `Illuminate\Notifications\Events\NotificationSending`'s listener handle method returns `false` notification will not be sent and it will prevent from sending the notification:
+When `Illuminate\Notifications\Events\NotificationSending`'s listener `handle` method returns `false` notification will not be sent and it will prevent from sending the notification:
 
     /**
      * Handle the event.

--- a/notifications.md
+++ b/notifications.md
@@ -1233,6 +1233,48 @@ Within an event listener, you may access the `notifiable`, `notification`, `chan
         // $event->notification
         // $event->response
     }
+    
+When a notification is sending `Illuminate\Notifications\Events\NotificationSending` event will be fired, and You will be able to listen on it which contains a `notifiable` entity. You can set the listener in `EventServiceProvicer` for this event:
+
+    /**
+     * The event listener mappings for the application.
+     *
+     * @var array
+     */
+    protected $listen = [
+        'Illuminate\Notifications\Events\NotificationSending' => [
+            'App\Listeners\CheckNotificationStatus',
+        ],
+    ];
+
+When `Illuminate\Notifications\Events\NotificationSending`'s listener handle method returns `false` notification will not be sent and it will prevent from sending the notification:
+
+    /**
+     * Handle the event.
+     *
+     * @param  \Illuminate\Notifications\Events\NotificationSending  $event
+     * @return void
+     */
+    public function handle(NotificationSending $event)
+    {
+        return false;
+    }
+    
+Also, You access the `notifiable`, `notification` and `channel` properties on the event:
+
+    /**
+     * Handle the event.
+     *
+     * @param  \Illuminate\Notifications\Events\NotificationSending  $event
+     * @return void
+     */
+    public function handle(NotificationSending $event)
+    {
+        // $event->channel
+        // $event->notifiable
+        // $event->notification
+    }   
+
 
 <a name="custom-channels"></a>
 ## Custom Channels

--- a/notifications.md
+++ b/notifications.md
@@ -1206,7 +1206,7 @@ Once you have implemented the interface, Laravel will automatically use the pref
 <a name="notification-sending-event"></a>
 #### Notification Sending Event
 
-When a notification is sent, the `Illuminate\Notifications\Events\NotificationSending` [event](/docs/{{version}}/events) is dispatched by the notification system. This contains the "notifiable" entity and the notification instance itself. You may register listeners for this event in your application's `EventServiceProvider`:
+When a notification is sending, the `Illuminate\Notifications\Events\NotificationSending` [event](/docs/{{version}}/events) is dispatched by the notification system. This contains the "notifiable" entity and the notification instance itself. You may register listeners for this event in your application's `EventServiceProvider`:
 
     /**
      * The event listener mappings for the application.


### PR DESCRIPTION
There was no documentation for `NotificationSending` event and its features like preventing from sending notifications by just returning a `false` value.