### PR TITLE
[8.x] Added declined and declined_if validation rule documentation

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -769,6 +769,8 @@ Below is a list of all available validation rules and their function:
 [Date](#rule-date)
 [Date Equals](#rule-date-equals)
 [Date Format](#rule-date-format)
+[Declined](#rule-declined)
+[Declined If](#rule-declined-if)
 [Different](#rule-different)
 [Digits](#rule-digits)
 [Digits Between](#rule-digits-between)
@@ -971,6 +973,16 @@ The field under validation must be equal to the given date. The dates will be pa
 #### date_format:_format_
 
 The field under validation must match the given _format_. You should use **either** `date` or `date_format` when validating a field, not both. This validation rule supports all formats supported by PHP's [DateTime](https://www.php.net/manual/en/class.datetime.php) class.
+
+<a name="rule-declined"></a>
+#### declined
+
+The field under validation must be `"no"`, `"off"`, `0`, or `false`.
+
+<a name="rule-declined-if"></a>
+#### declined_if:anotherfield,value,...
+
+The field under validation must be `"no"`, `"off"`, `0`, or `false` if another field under validation is equal to a specified value.
 
 <a name="rule-different"></a>
 #### different:_field_


### PR DESCRIPTION
Adds declined and declined_at validation rules to the documentation

Should only be merged if feature PR (https://github.com/laravel/framework/pull/39579) is merged.

Laravel PR: https://github.com/laravel/laravel/pull/5723
Framework PR: https://github.com/laravel/framework/pull/39579

> We are running a financial application where users answer yes, and no selectors, such as are you registered as a bad payer or if do you have existing debt. We could solve our issue by reversing the question's phrasing, e.g. "not_registered_as_a_bad_payer", and using accepted but this reduces intent.
> 
> At the same time, we allow financial instances to select their configurations of what they allow or disallow. This rule could help us align validation closer to the original intent and limit developer or interpretation errors when used to compare each input to each business's configuration; simply by avoiding a "semi-double negative".