### PR TITLE
[8.x] Update Slack Prerequisites

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -1004,7 +1004,7 @@ Before you can send notifications via Slack, you must install the Slack notifica
 
     composer require laravel/slack-notification-channel
 
-You will also need to create a ["Slack App"](https://api.slack.com/apps?new_app=1) for your team. Once created, you must then configure an "Incoming Webhook" for the workspace. Slack will then provide you with a URL you may use when [routing Slack notifications](#routing-slack-notifications).
+You will also need to create a [Slack App](https://api.slack.com/apps?new_app=1) for your team. After creating the App, you should configure an "Incoming Webhook" for the workspace. Slack will then provide you with a webhook URL that you may use when [routing Slack notifications](#routing-slack-notifications).
 
 <a name="formatting-slack-notifications"></a>
 ### Formatting Slack Notifications

--- a/notifications.md
+++ b/notifications.md
@@ -1004,7 +1004,7 @@ Before you can send notifications via Slack, you must install the Slack notifica
 
     composer require laravel/slack-notification-channel
 
-You will also need to configure an ["Incoming Webhook"](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks) integration for your Slack team. This integration will provide you with a URL you may use when [routing Slack notifications](#routing-slack-notifications).
+You will also need to create a ["Slack Application"](https://api.slack.com/apps?new_app=1) for your team. Once created, you must then configure an "Incoming Webhook" for the workspace. Slack will then provide you with a URL you may use when [routing Slack notifications](#routing-slack-notifications).
 
 <a name="formatting-slack-notifications"></a>
 ### Formatting Slack Notifications

--- a/notifications.md
+++ b/notifications.md
@@ -1004,7 +1004,7 @@ Before you can send notifications via Slack, you must install the Slack notifica
 
     composer require laravel/slack-notification-channel
 
-You will also need to create a ["Slack Application"](https://api.slack.com/apps?new_app=1) for your team. Once created, you must then configure an "Incoming Webhook" for the workspace. Slack will then provide you with a URL you may use when [routing Slack notifications](#routing-slack-notifications).
+You will also need to create a ["Slack App"](https://api.slack.com/apps?new_app=1) for your team. Once created, you must then configure an "Incoming Webhook" for the workspace. Slack will then provide you with a URL you may use when [routing Slack notifications](#routing-slack-notifications).
 
 <a name="formatting-slack-notifications"></a>
 ### Formatting Slack Notifications


### PR DESCRIPTION
Slack's Incoming Webhooks are being deprecated (and possibly removed):

> Please note, this is a legacy custom integration - an outdated way for teams to integrate with Slack. These integrations lack newer features and they will be deprecated and possibly removed in the future. We do not recommend their use. Instead, we suggest that you check out their replacement: Slack apps.

I've updated the documentation to explain how to create a Slack App, then configure Incoming Webhooks.