### PR TITLE
Add $entry->isSlowQuery() in documentation.

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -183,6 +183,7 @@ You may filter the data that is recorded by Telescope via the `filter` closure t
             return $entry->isReportableException() ||
                 $entry->isFailedJob() ||
                 $entry->isScheduledTask() ||
+                $entry->isSlowQuery() ||
                 $entry->hasMonitoredTag();
         });
     }


### PR DESCRIPTION
As this [PR](https://github.com/laravel/telescope/pull/1146) has been merged, I think it's better to add the method in documentation so it will be easier for developers to find it.

```
    Telescope::filter(function (IncomingEntry $entry) {
        if ($this->app->environment('local')) {
            return true;
        }

        return $entry->isReportableException() ||
            $entry->isFailedJob() ||
            $entry->isScheduledTask() ||
            $entry->isSlowQuery() ||
            $entry->hasMonitoredTag();
    });
```


