### PR TITLE
Add column modifiers docs for PostgreSQL spatial column type

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -875,6 +875,7 @@ Modifier  |  Description
 `->virtualAs($expression)`  |  Create a virtual generated column (MySQL).
 `->generatedAs($expression)`  |  Create an identity column with specified sequence options (PostgreSQL).
 `->always()`  |  Defines the precedence of sequence values over input for an identity column (PostgreSQL).
+`->isGeometry()`  |  Set spatial column type to geometry, the default type is geography (PostgreSQL).
 
 <a name="default-expressions"></a>
 #### Default Expressions

--- a/migrations.md
+++ b/migrations.md
@@ -875,7 +875,7 @@ Modifier  |  Description
 `->virtualAs($expression)`  |  Create a virtual generated column (MySQL).
 `->generatedAs($expression)`  |  Create an identity column with specified sequence options (PostgreSQL).
 `->always()`  |  Defines the precedence of sequence values over input for an identity column (PostgreSQL).
-`->isGeometry()`  |  Set spatial column type to geometry, the default type is geography (PostgreSQL).
+`->isGeometry()`  |  Set spatial column type to `geometry` - the default type is `geography` (PostgreSQL).
 
 <a name="default-expressions"></a>
 #### Default Expressions


### PR DESCRIPTION
It's possible to change spatial column type (PostgreSQL) between the default `geography` become `geometry` by adding column modifiers `isGeometry()`.
In one of my project I was having trouble how to create database migration of spatial column type `geometry`, but fortunately solved my problem after reading this code [Illuminate/Database/Schema/Grammars/PostgresGrammar.php#L943](https://github.com/laravel/framework/blob/b2be94b68aec532c90d878497748dcc837b95d25/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php#L943)  

Example of migrations code:
```php
Schema::create('some_table', function (Blueprint $table) {
    //....
    $table->geometry('geometry_column')->nullable()->isGeometry(); // this generate spatial column type geometry
    $table->geometry('geography_column')->nullable(); // this generate spatial column type geography
    //....
});
```
By submitting this PR I hope that anyone can solve this same problem by reading the Laravel documentation. Thanks.