### PR TITLE
Add more details on how to register RateLimiter

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -589,6 +589,23 @@ Rate limiters are defined using the `RateLimiter` facade's `for` method. The `fo
             return Limit::perMinute(1000);
         });
     }
+    
+Don't forget to register your RateLimiter by calling `configureRateLimiting()` in the `boot` function of your application's `App\Providers\RouteServiceProvider` class.
+
+    /**
+     * Define your route model bindings, pattern filters, etc.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+
+        parent::boot();
+
+        $this->configureRateLimiting();
+    }
+
 
 If the incoming request exceeds the specified rate limit, a response with a 429 HTTP status code will automatically be returned by Laravel. If you would like to define your own response that should be returned by a rate limit, you may use the `response` method:
 


### PR DESCRIPTION
Hi,

I have recently tried to use the RateLimiter and followed the documentation. Somehow, i could not pass my RateLimiter to the throttle middleware. After few trials, i found out that my RateLimiter is not recognized by the application since it is not registered

I am suggesting these changes to prevent others from facing the same issue

Regards 