### PR TITLE
Replace request() with $request

### DIFF
--- a/fortify.md
+++ b/fortify.md
@@ -452,7 +452,7 @@ public function boot()
 
 Fortify will take care of defining the route to display this view. Your `reset-password` template should include a form that makes a POST request to `/reset-password`.
 
-The `/reset-password` endpoint expects a string `email` field, a `password` field, a `password_confirmation` field, and a hidden field named `token` that contains the value of `request()->route('token')`. The name of the "email" field / database column should match the `email` configuration value defined within your application's `fortify` configuration file.
+The `/reset-password` endpoint expects a string `email` field, a `password` field, a `password_confirmation` field, and a hidden field named `token` that contains the value of `$request->route('token')`. The name of the "email" field / database column should match the `email` configuration value defined within your application's `fortify` configuration file.
 
 <a name="handling-the-password-reset-response"></a>
 #### Handling The Password Reset Response


### PR DESCRIPTION
Hi, when the view for resetting the password is returned in the boot method, it is sending the
$request variable as parameter, so for consistency should be better use
it instead of the global helper request()