### PR TITLE
Include notes on webhooks and local development

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -931,6 +931,11 @@ Since Paddle webhooks need to bypass Laravel's [CSRF protection](/docs/{{version
     protected $except = [
         'paddle/*',
     ];
+    
+<a name="webhooks-local-development"></a>
+#### Webhooks & Local Development
+
+For Paddle to be able to send your application webhooks during local development, you will need to expose your application via a site sharing service such as [Ngrok](https://ngrok.com/) or [Expose](https://expose.dev/docs/introduction). If you are developing your application locally using [Laravel Sail](https://laravel.com/docs/{{version}}/sail), you may use Sail's [site sharing command](https://laravel.com/docs/{{version}}/sail#sharing-your-site).
 
 <a name="defining-webhook-event-handlers"></a>
 ### Defining Webhook Event Handlers

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -935,7 +935,7 @@ Since Paddle webhooks need to bypass Laravel's [CSRF protection](/docs/{{version
 <a name="webhooks-local-development"></a>
 #### Webhooks & Local Development
 
-For Paddle to be able to send your application webhooks during local development, you will need to expose your application via a site sharing service such as [Ngrok](https://ngrok.com/) or [Expose](https://expose.dev/docs/introduction). If you are developing your application locally using [Laravel Sail](https://laravel.com/docs/{{version}}/sail), you may use Sail's [site sharing command](https://laravel.com/docs/{{version}}/sail#sharing-your-site).
+For Paddle to be able to send your application webhooks during local development, you will need to expose your application via a site sharing service such as [Ngrok](https://ngrok.com/) or [Expose](https://expose.dev/docs/introduction). If you are developing your application locally using [Laravel Sail](/docs/{{version}}/sail), you may use Sail's [site sharing command](/docs/{{version}}/sail#sharing-your-site).
 
 <a name="defining-webhook-event-handlers"></a>
 ### Defining Webhook Event Handlers


### PR DESCRIPTION
This borrows from the new [Spark documentation](https://spark.laravel.com/docs/1.x/spark-paddle/configuration.html) to let users know they'll need to expose their local URLs in order to test webhooks locally.