### PR TITLE
[8.x] add space to match expression

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -880,7 +880,7 @@ In addition, you may have noticed that the `broadcastOn` method receives a strin
  */
 public function broadcastOn($event)
 {
-    return match($event) {
+    return match ($event) {
         'deleted' => [],
         default => [$this, $this->user],
     };


### PR DESCRIPTION
Should there maybe also be a note that match expressions are available as of PHP 8.0.0?

Since Laravel 8.x's [server requirements](https://github.com/laravel/docs/blob/8.x/deployment.md#server-requirements) are PHP >= 7.3