### PR TITLE
[8.x] add details about environment-specific .env files

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -28,6 +28,8 @@ Laravel's default `.env` file contains some common configuration values that may
 
 If you are developing with a team, you may wish to continue including a `.env.example` file with your application. By putting placeholder values in the example configuration file, other developers on your team can clearly see which environment variables are needed to run your application.
 
+Before loading the environment variables, Laravel checks to see if either the `APP_ENV` environment variable is externally set, or the `--env` argument has been specified. If either one of those are set, Laravel will instead attempt to use a `.env.[APP_ENV]` file, if one exists. If it does not exist, or the argument/variable is not set, the fallback of `.env` is used instead.
+
 > {tip} Any variable in your `.env` file can be overridden by external environment variables such as server-level or system-level environment variables.
 
 <a name="environment-file-security"></a>

--- a/configuration.md
+++ b/configuration.md
@@ -28,14 +28,17 @@ Laravel's default `.env` file contains some common configuration values that may
 
 If you are developing with a team, you may wish to continue including a `.env.example` file with your application. By putting placeholder values in the example configuration file, other developers on your team can clearly see which environment variables are needed to run your application.
 
-Before loading the environment variables, Laravel checks to see if either the `APP_ENV` environment variable is externally set, or the `--env` argument has been specified. If either one of those are set, Laravel will instead attempt to use a `.env.[APP_ENV]` file, if one exists. If it does not exist, or the argument/variable is not set, the fallback of `.env` is used instead.
-
 > {tip} Any variable in your `.env` file can be overridden by external environment variables such as server-level or system-level environment variables.
 
 <a name="environment-file-security"></a>
 #### Environment File Security
 
 Your `.env` file should not be committed to your application's source control, since each developer / server using your application could require a different environment configuration. Furthermore, this would be a security risk in the event an intruder gains access to your source control repository, since any sensitive credentials would get exposed.
+
+<a name="additional-environment-files"></a>
+#### Additional Environment Files
+
+Before loading your application's environment variables, Laravel determines if either the `APP_ENV` environment variable has been externally provided or if the `--env` CLI argument has been specified. If so, Laravel will attempt to load an `.env.[APP_ENV]` file if it exists. If it does not exist, the default `.env` file will be loaded.
 
 <a name="environment-variable-types"></a>
 ### Environment Variable Types


### PR DESCRIPTION
Our project stores a bunch of .env files for particular environments as `.env.[environment]`. We didn't realise that Laravel auto-loads from these if an `APP_ENV` is specified.

This just adds some details documenting the feature, in the hopes that it doesn't catch someone else out like it did to me 🙂 