### PR TITLE
[8.x] Add note to 'Dispatching Batches' chapter to not use $this in callbacks

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1182,6 +1182,8 @@ To dispatch a batch of jobs, you should use the `batch` method of the `Bus` faca
 
 The batch's ID, which may be accessed via the `$batch->id` property, may be used to [query the Laravel command bus](#inspecting-batches) for information about the batch after it has been dispatched.
 
+> {note} You cannot use `$this` in callbacks.
+
 <a name="naming-batches"></a>
 #### Naming Batches
 

--- a/queues.md
+++ b/queues.md
@@ -1182,7 +1182,7 @@ To dispatch a batch of jobs, you should use the `batch` method of the `Bus` faca
 
 The batch's ID, which may be accessed via the `$batch->id` property, may be used to [query the Laravel command bus](#inspecting-batches) for information about the batch after it has been dispatched.
 
-> {note} You cannot use `$this` in callbacks.
+> {note} Since batch callbacks are serialized and executed at a later time by the Laravel queue, you should not use the `$this` variable within the callbacks.
 
 <a name="naming-batches"></a>
 #### Naming Batches


### PR DESCRIPTION
Calling `$this` in callbacks of `Bus::batch` is not supported, as clarified here: https://github.com/laravel/framework/issues/38573
However, this was not documented yet. I've added a small note.