### PR TITLE
Add a note about querying morph relationships with WhereHasMorph 

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1311,6 +1311,8 @@ Instead of passing an array of possible polymorphic models, you may provide `*` 
         $query->where('title', 'like', 'foo%');
     })->get();
 
+> {note} WhereHasMorph() is only for MorphTo relationships. Use whereHas for all other relationships like for example MorphToMany
+
 <a name="aggregating-related-models"></a>
 ## Aggregating Related Models
 

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1311,7 +1311,7 @@ Instead of passing an array of possible polymorphic models, you may provide `*` 
         $query->where('title', 'like', 'foo%');
     })->get();
 
-> {note} WhereHasMorph() is only for MorphTo relationships. Use whereHas for all other relationships like for example MorphToMany
+> {note} WhereHasMorph() is only for MorphTo relationships. Use whereHas for all other relationships, like for example MorphToMany
 
 <a name="aggregating-related-models"></a>
 ## Aggregating Related Models


### PR DESCRIPTION
This adds a note to ["Querying Morph To Relationships"](https://laravel.com/docs/8.x/eloquent-relationships#querying-morph-to-relationships) to make it clear that `whereHasMorph` only works for `MorphTo` relationships. For `MorphToMany` relationships `whereHas`should be used.

This should  makes it more clear on when to use `whereHasMorph`and when not. I spend quite some time figuring out why `whereHasMorph` didn't work in my project only to conclude it wasn't meant to be used with a Many To Many polymorphic relationship.

**I'm not a native English speaker so a proper look at the note is very welcome!**