### PR TITLE
[8.x] Add PHP versions to release notes

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -31,7 +31,7 @@ For LTS releases, such as Laravel 9, bug fixes are provided for 2 years and secu
 | 7 | 7.2 - 8.0 | March 3rd, 2020 | October 6th, 2020 | March 3rd, 2021 |
 | 8 | 7.3 - 8.1 | September 8th, 2020 | July 26th, 2022 | January 24th, 2023 |
 | 9 (LTS) | 8.0 - 8.1 | January 25th, 2022 | January 30th, 2024 | January 28th, 2025 |
-| 10 | 8.0 - 8.2 | January 24th, 2023 | July 30th, 2024 | January 28th, 2025 |
+| 10 | 8.0 - 8.1 | January 24th, 2023 | July 30th, 2024 | January 28th, 2025 |
 
 (*) Supported PHP versions
 

--- a/releases.md
+++ b/releases.md
@@ -25,13 +25,15 @@ At this time, PHP's [named arguments](https://www.php.net/manual/en/functions.ar
 
 For LTS releases, such as Laravel 9, bug fixes are provided for 2 years and security fixes are provided for 3 years. These releases provide the longest window of support and maintenance. For general releases, bug fixes are provided for 18 months and security fixes are provided for 2 years. For all additional libraries, including Lumen, only the latest release receives bug fixes. In addition, please review the database versions [supported by Laravel](/docs/{{version}}/database#introduction).
 
-| Version | Release | Bug Fixes Until | Security Fixes Until |
+| Version | PHP (*) | Release | Bug Fixes Until | Security Fixes Until |
 | --- | --- | --- | --- |
-| 6 (LTS) | September 3rd, 2019 | January 25th, 2022 | September 6th, 2022 |
-| 7 | March 3rd, 2020 | October 6th, 2020 | March 3rd, 2021 |
-| 8 | September 8th, 2020 | July 26th, 2022 | January 24th, 2023 |
-| 9 (LTS) | January 25th, 2022 | January 30th, 2024 | January 28th, 2025 |
-| 10 | January 24th, 2023 | July 30th, 2024 | January 28th, 2025 |
+| 6 (LTS) | 7.2 - 8.0 | September 3rd, 2019 | January 25th, 2022 | September 6th, 2022 |
+| 7 | 7.2 - 8.0 | March 3rd, 2020 | October 6th, 2020 | March 3rd, 2021 |
+| 8 | 7.3 - 8.1 | September 8th, 2020 | July 26th, 2022 | January 24th, 2023 |
+| 9 (LTS) | 8.0 - 8.1 | January 25th, 2022 | January 30th, 2024 | January 28th, 2025 |
+| 10 | 8.0 - 8.2 | January 24th, 2023 | July 30th, 2024 | January 28th, 2025 |
+
+(*) Supported PHP versions
 
 <a name="laravel-8"></a>
 ## Laravel 8


### PR DESCRIPTION
This PR adds the supported PHP versions to each Laravel version in the release notes. This should make it clear which PHP versions are supported on which Laravel major version.

(note that it says 8.2 for Laravel 10 in the screenshot, please ignore this, I've updated it to 8.1 again in the Markdown file).

![Screenshot 2021-11-28 at 21 56 35](https://user-images.githubusercontent.com/594614/143785950-5b6c2543-0751-4091-8380-7270140e2803.png)
