### PR TITLE
Small clarification database transaction exceptions

### DIFF
--- a/database.md
+++ b/database.md
@@ -263,7 +263,7 @@ If you would like to specify a closure that is invoked for each SQL query execut
 <a name="database-transactions"></a>
 ## Database Transactions
 
-You may use the `transaction` method provided by the `DB` facade to run a set of operations within a database transaction. If an exception is thrown within the transaction closure, the transaction will automatically be rolled back. If the closure executes successfully, the transaction will automatically be committed. You don't need to worry about manually rolling back or committing while using the `transaction` method:
+You may use the `transaction` method provided by the `DB` facade to run a set of operations within a database transaction. If an exception is thrown within the transaction closure, the transaction will automatically be rolled back and the exception is re-thrown. If the closure executes successfully, the transaction will automatically be committed. You don't need to worry about manually rolling back or committing while using the `transaction` method:
 
     use Illuminate\Support\Facades\DB;
 


### PR DESCRIPTION
I was looking for the (re) throw behaviour of exceptions in a `DB::transaction()` call. Looked it up in the code and thought it'd be good to mention in the docs.