### PR TITLE
[8.x] Correcting the Billing canceled method name

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -744,7 +744,7 @@ The `recurring` method may be used to determine if the user is currently subscri
 
 To determine if the user was once an active subscriber but has canceled their subscription, you may use the `canceled` method:
 
-    if ($user->subscription('default')->canceled()) {
+    if ($user->subscription('default')->cancelled()) {
         //
     }
 
@@ -808,12 +808,12 @@ Most subscription states are also available as query scopes so that you may easi
     $subscriptions = Subscription::query()->active()->get();
 
     // Get all of the canceled subscriptions for a user...
-    $subscriptions = $user->subscriptions()->canceled()->get();
+    $subscriptions = $user->subscriptions()->cancelled()->get();
 
 A complete list of available scopes is available below:
 
     Subscription::query()->active();
-    Subscription::query()->canceled();
+    Subscription::query()->cancelled();
     Subscription::query()->ended();
     Subscription::query()->incomplete();
     Subscription::query()->notCanceled();

--- a/billing.md
+++ b/billing.md
@@ -816,7 +816,7 @@ A complete list of available scopes is available below:
     Subscription::query()->cancelled();
     Subscription::query()->ended();
     Subscription::query()->incomplete();
-    Subscription::query()->notCanceled();
+    Subscription::query()->notCancelled();
     Subscription::query()->notOnGracePeriod();
     Subscription::query()->notOnTrial();
     Subscription::query()->onGracePeriod();


### PR DESCRIPTION
The method name to check if the subscription is canceled is incorrect, the correct one must be `cancelled()` according to the file `Laravel\Cashier\Subscription` line 296 and 307.

->notCanceled() to ->notCancelled() `Laravel\Cashier\Subscription` line 318.