### PR TITLE
[8.x] Fix skipWhile callback note

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1998,7 +1998,7 @@ The `skipWhile` method skips over items from the collection while the given call
 
     // [4]
 
-> {note} If the callback never returns `true`, the `skipWhile` method will return an empty collection.
+> {note} If the callback never returns `false`, the `skipWhile` method will return an empty collection.
 
 <a name="method-slice"></a>
 #### `slice()` {#collection-method}


### PR DESCRIPTION
If the callback given to `skipWhile` never returns `false`, then an empty collection would be returned. Currently the documentation states the opposite. If the callback never returns `true`, then the whole collection is returned unfiltered.

```
>>> $collection = collect([1, 2, 3, 4]);
=> Illuminate\Support\Collection {#4833
     all: [
       1,
       2,
       3,
       4,
     ],
   }
>>> $subset = $collection->skipWhile(function ($item) { return false; });
=> Illuminate\Support\Collection {#4835
     all: [
       1,
       2,
       3,
       4,
     ],
   }
>>> $subset = $collection->skipWhile(function ($item) { return true; });
=> Illuminate\Support\Collection {#4824
     all: [],
   }
```