### PR TITLE
[8.x] Update Sail Default PHP Version to 8.1

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -295,7 +295,7 @@ sail tinker
 <a name="sail-php-versions"></a>
 ## PHP Versions
 
-Sail currently supports serving your application via PHP 8.1, PHP 8.0, or PHP 7.4. The default PHP version used by Sail is currently PHP 8.0. To change the PHP version that is used to serve your application, you should update the `build` definition of the `laravel.test` container in your application's `docker-compose.yml` file:
+Sail currently supports serving your application via PHP 8.1, PHP 8.0, or PHP 7.4. The default PHP version used by Sail is currently PHP 8.1. To change the PHP version that is used to serve your application, you should update the `build` definition of the `laravel.test` container in your application's `docker-compose.yml` file:
 
 ```yaml
 # PHP 8.1
@@ -311,7 +311,7 @@ context: ./vendor/laravel/sail/runtimes/7.4
 In addition, you may wish to update your `image` name to reflect the version of PHP being used by your application. This option is also defined in your application's `docker-compose.yml` file:
 
 ```yaml
-image: sail-8.0/app
+image: sail-8.1/app
 ```
 
 After updating your application's `docker-compose.yml` file, you should rebuild your container images:


### PR DESCRIPTION
Update Sail Default PHP Version to 8.1

Ref:
https://github.com/laravel/sail/releases/tag/v1.12.9