### PR TITLE
[8.x] Add note about different DB connections with whereHasMorph

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1299,6 +1299,8 @@ You may occasionally need to add query constraints based on the "type" of the re
             $query->where($column, 'like', 'code%');
         }
     )->get();
+    
+> {note} Unfortunately, different database connections for models aren't compatible with the `whereHasMorph` call.
 
 <a name="querying-all-morph-to-related-models"></a>
 #### Querying All Related Models


### PR DESCRIPTION
`whereHasMorph` doesn't seems compatible with multiple database connections on models. I'm not entirely sure if this is a bug or a limitation. I tried to dig into the (Eloquent) query builder but couldn't figure out how to fix this.

It's around here where the constraints get applied: https://github.com/laravel/framework/blob/8eb1827d7290dba9c55e54fa296275eb6f4b491a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php#L229-L230

So I opted to put it in the documentation for now.