### PR TITLE
[8.x] Remove queueable trait from example

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -206,14 +206,11 @@ If your queue connection's `after_commit` configuration option is set to `false`
 
     namespace App\Notifications;
 
-    use Illuminate\Bus\Queueable;
     use Illuminate\Contracts\Queue\ShouldQueue;
     use Illuminate\Notifications\Notification;
 
     class InvoicePaid extends Notification implements ShouldQueue
     {
-        use Queueable;
-
         public $afterCommit = true;
     }
 


### PR DESCRIPTION
Remove queue able trait from this example because it'll conflict with the `afterCommit` property.

See https://github.com/laravel/framework/issues/39888