### PR TITLE
Added important environment variables for Sail Dusk testing

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -257,6 +257,15 @@ depends_on:
     - redis
     - selenium
 ```
+Then, the following lines should be added to the '.env' file.
+
+```yaml
+APP_SERVICE="laravel.test"
+APP_URL="http://laravel.test:80"
+DUSK_DRIVER_URL="http://selenium:4444"
+```
+
+>{tip} The service name can be modified after publishing Sail's Dockerfiles. Refer to the [Sail Customization] (#sail-customization) documetation for more info.
 
 Finally, you may run your Dusk test suite by starting Sail and running the `dusk` command:
 


### PR DESCRIPTION
The DUSK_DRIVER_URL must target the selenium docker image which starts on port 4444. The chromium browser will access the local webapp on port 80 for testing. These ports can be changed, however these are the default ports that they are started on. Without these environment variables Dusk testing on Sail returns errors. 

https://stackoverflow.com/questions/65569147/laravel-sail-dusk-selenium-connection-refused