### PR TITLE
Correct FRONTEND_URL environment variable name

### DIFF
--- a/starter-kits.md
+++ b/starter-kits.md
@@ -82,7 +82,7 @@ php artisan breeze:install api
 php artisan migrate
 ```
 
-During installation, Breeze will add an `APP_FRONTEND_URL` environment variable to your application's `.env` file. This URL should be the URL of your JavaScript application. This will typically be `http://localhost:3000` during local development.
+During installation, Breeze will add a `FRONTEND_URL` environment variable to your application's `.env` file. This URL should be the URL of your JavaScript application. This will typically be `http://localhost:3000` during local development.
 
 <a name="next-reference-implementation"></a>
 #### Next.js Reference Implementation


### PR DESCRIPTION
The Breeze API scaffolding creates and references an environment variable named `FRONTEND_URL` (see, e.g., https://github.com/laravel/breeze/blob/9abe49ebe4ff941660b7af1df318344f728d8f3d/src/Console/InstallsApiStack.php#L50), but the existing docs prepend `APP_` to the name of this environment variable. This PR removes the prepended `APP_` to make the name in the docs consistent with the name in the code.