### PR TITLE
[8.x] Add note about xdebug browser requirements

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -401,7 +401,7 @@ To debug your application while interacting with the application via a web brows
 
 If you're using PhpStorm, please review JetBrain's documentation regarding [zero-configuration debugging](https://www.jetbrains.com/help/phpstorm/zero-configuration-debugging.html).
 
-> {note} Laravel Sail relies on `artisan serve` under the hood to serve up the application. `artisan serve` only accepts the `XDEBUG_CONFIG` and `XDEBUG_MODE` variables as of Laravel version 8.53.0. Older versions of Laravel (8.52.0 and below) will not properly pass these variables through properly, preventing debug connections. You will need to upgrade to at least 8.53.0 to debug this way.
+> {note} Laravel Sail relies on `artisan serve` to serve your application. The `artisan serve` command only accepts the `XDEBUG_CONFIG` and `XDEBUG_MODE` variables as of Laravel version 8.53.0. Older versions of Laravel (8.52.0 and below) do not support these variables and will not accept debug connections.
 
 <a name="sail-customization"></a>
 ## Customization

--- a/sail.md
+++ b/sail.md
@@ -401,6 +401,8 @@ To debug your application while interacting with the application via a web brows
 
 If you're using PhpStorm, please review JetBrain's documentation regarding [zero-configuration debugging](https://www.jetbrains.com/help/phpstorm/zero-configuration-debugging.html).
 
+> {note} Laravel sail relies on the ServeCommand under the hood. The ServeCommand only accepts the `XDEBUG_CONFIG` and `XDEBUG_MODE` variables as of Laravel version 8.53.0. If you are on a version of Laravel older than 8.53.0, you will need to upgrade in order to use this configuration for browser debugging.
+
 <a name="sail-customization"></a>
 ## Customization
 

--- a/sail.md
+++ b/sail.md
@@ -401,7 +401,7 @@ To debug your application while interacting with the application via a web brows
 
 If you're using PhpStorm, please review JetBrain's documentation regarding [zero-configuration debugging](https://www.jetbrains.com/help/phpstorm/zero-configuration-debugging.html).
 
-> {note} Laravel sail relies on the ServeCommand under the hood. The ServeCommand only accepts the `XDEBUG_CONFIG` and `XDEBUG_MODE` variables as of Laravel version 8.53.0. If you are on a version of Laravel older than 8.53.0, you will need to upgrade in order to use this configuration for browser debugging.
+> {note} Laravel Sail relies on `artisan serve` under the hood to serve up the application. `artisan serve` only accepts the `XDEBUG_CONFIG` and `XDEBUG_MODE` variables as of Laravel version 8.53.0. Older versions of Laravel (8.52.0 and below) will not properly pass these variables through properly, preventing debug connections. You will need to upgrade to at least 8.53.0 to debug this way.
 
 <a name="sail-customization"></a>
 ## Customization


### PR DESCRIPTION
The [sail documentation](https://laravel.com/docs/8.x/sail) mentions xdebug support, but does not mention that Laravel 8.53.0 is the first version that supports the passing through of the `XDEBUG_MODE` and `XDEBUG_CONFIG` variables to the underlying server process. I ended up spending a chunk of time this afternoon troubleshooting my local xdebug configuration, only to realize I was on too old of a version of the framework.

I added a note in the xdebug section that spells this out much more clearly - it clearly states that you need at least version 8.53.0 in order to support browser debugging. I reworked the wording several times (pre and post commits), but still feel the wording could use a bit of work, so super receptive to rewordings. Likewise, I placed this as a note within the `Xdebug Browser Usage` because I felt it was the most appropriate place for it, but if anybody feels another place is more receptive, definitely open to suggestions.