### PR TITLE
fix duplicated ids when rendering, missing style definitions

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -228,17 +228,17 @@ For the majority of the remaining collection documentation, we'll discuss each m
 ## Method Listing
 
 <style>
-    #collection-method code {
+    .collection-method code {
         font-size: 14px;
     }
 
-    #collection-method:not(.first-collection-method) {
+    .collection-method:not(.first-collection-method) {
         margin-top: 50px;
     }
 </style>
 
 <a name="method-all"></a>
-#### `all()` {#collection-method .first-collection-method}
+#### `all()` {.collection-method .first-collection-method}
 
 The `all` method returns the underlying array represented by the collection:
 
@@ -247,12 +247,12 @@ The `all` method returns the underlying array represented by the collection:
     // [1, 2, 3]
 
 <a name="method-average"></a>
-#### `average()` {#collection-method}
+#### `average()` {.collection-method}
 
 Alias for the [`avg`](#method-avg) method.
 
 <a name="method-avg"></a>
-#### `avg()` {#collection-method}
+#### `avg()` {.collection-method}
 
 The `avg` method returns the [average value](https://en.wikipedia.org/wiki/Average) of a given key:
 
@@ -270,7 +270,7 @@ The `avg` method returns the [average value](https://en.wikipedia.org/wiki/Avera
     // 2
 
 <a name="method-chunk"></a>
-#### `chunk()` {#collection-method}
+#### `chunk()` {.collection-method}
 
 The `chunk` method breaks the collection into multiple, smaller collections of a given size:
 
@@ -293,7 +293,7 @@ This method is especially useful in [views](/docs/{{version}}/views) when workin
     @endforeach
 
 <a name="method-chunkwhile"></a>
-#### `chunkWhile()` {#collection-method}
+#### `chunkWhile()` {.collection-method}
 
 The `chunkWhile` method breaks the collection into multiple, smaller collections based on the evaluation of the given callback. The `$chunk` variable passed to the closure may be used to inspect the previous element:
 
@@ -308,7 +308,7 @@ The `chunkWhile` method breaks the collection into multiple, smaller collections
     // [['A', 'A'], ['B', 'B'], ['C', 'C', 'C'], ['D']]
 
 <a name="method-collapse"></a>
-#### `collapse()` {#collection-method}
+#### `collapse()` {.collection-method}
 
 The `collapse` method collapses a collection of arrays into a single, flat collection:
 
@@ -325,7 +325,7 @@ The `collapse` method collapses a collection of arrays into a single, flat colle
     // [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 <a name="method-collect"></a>
-#### `collect()` {#collection-method}
+#### `collect()` {.collection-method}
 
 The `collect` method returns a new `Collection` instance with the items currently in the collection:
 
@@ -358,7 +358,7 @@ The `collect` method is primarily useful for converting [lazy collections](#lazy
 > {tip} The `collect` method is especially useful when you have an instance of `Enumerable` and need a non-lazy collection instance. Since `collect()` is part of the `Enumerable` contract, you can safely use it to get a `Collection` instance.
 
 <a name="method-combine"></a>
-#### `combine()` {#collection-method}
+#### `combine()` {.collection-method}
 
 The `combine` method combines the values of the collection, as keys, with the values of another array or collection:
 
@@ -371,7 +371,7 @@ The `combine` method combines the values of the collection, as keys, with the va
     // ['name' => 'George', 'age' => 29]
 
 <a name="method-concat"></a>
-#### `concat()` {#collection-method}
+#### `concat()` {.collection-method}
 
 The `concat` method appends the given `array` or collection's values onto the end of another collection:
 
@@ -384,7 +384,7 @@ The `concat` method appends the given `array` or collection's values onto the en
     // ['John Doe', 'Jane Doe', 'Johnny Doe']
 
 <a name="method-contains"></a>
-#### `contains()` {#collection-method}
+#### `contains()` {.collection-method}
 
 The `contains` method determines whether the collection contains a given item. You may pass a closure to the `contains` method to determine if an element exists in the collection matching a given truth test:
 
@@ -422,14 +422,14 @@ You may also pass a key / value pair to the `contains` method, which will determ
 The `contains` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`containsStrict`](#method-containsstrict) method to filter using "strict" comparisons.
 
 <a name="method-containsstrict"></a>
-#### `containsStrict()` {#collection-method}
+#### `containsStrict()` {.collection-method}
 
 This method has the same signature as the [`contains`](#method-contains) method; however, all values are compared using "strict" comparisons.
 
 > {tip} This method's behavior is modified when using [Eloquent Collections](/docs/{{version}}/eloquent-collections#method-contains).
 
 <a name="method-count"></a>
-#### `count()` {#collection-method}
+#### `count()` {.collection-method}
 
 The `count` method returns the total number of items in the collection:
 
@@ -440,7 +440,7 @@ The `count` method returns the total number of items in the collection:
     // 4
 
 <a name="method-countBy"></a>
-#### `countBy()` {#collection-method}
+#### `countBy()` {.collection-method}
 
 The `countBy` method counts the occurrences of values in the collection. By default, the method counts the occurrences of every element, allowing you to count certain "types" of elements in the collection:
 
@@ -465,7 +465,7 @@ You pass a closure to the `countBy` method to count all items by a custom value:
     // ['gmail.com' => 2, 'yahoo.com' => 1]
 
 <a name="method-crossjoin"></a>
-#### `crossJoin()` {#collection-method}
+#### `crossJoin()` {.collection-method}
 
 The `crossJoin` method cross joins the collection's values among the given arrays or collections, returning a Cartesian product with all possible permutations:
 
@@ -504,7 +504,7 @@ The `crossJoin` method cross joins the collection's values among the given array
     */
 
 <a name="method-dd"></a>
-#### `dd()` {#collection-method}
+#### `dd()` {.collection-method}
 
 The `dd` method dumps the collection's items and ends execution of the script:
 
@@ -524,7 +524,7 @@ The `dd` method dumps the collection's items and ends execution of the script:
 If you do not want to stop executing the script, use the [`dump`](#method-dump) method instead.
 
 <a name="method-diff"></a>
-#### `diff()` {#collection-method}
+#### `diff()` {.collection-method}
 
 The `diff` method compares the collection against another collection or a plain PHP `array` based on its values. This method will return the values in the original collection that are not present in the given collection:
 
@@ -539,7 +539,7 @@ The `diff` method compares the collection against another collection or a plain 
 > {tip} This method's behavior is modified when using [Eloquent Collections](/docs/{{version}}/eloquent-collections#method-diff).
 
 <a name="method-diffassoc"></a>
-#### `diffAssoc()` {#collection-method}
+#### `diffAssoc()` {.collection-method}
 
 The `diffAssoc` method compares the collection against another collection or a plain PHP `array` based on its keys and values. This method will return the key / value pairs in the original collection that are not present in the given collection:
 
@@ -561,7 +561,7 @@ The `diffAssoc` method compares the collection against another collection or a p
     // ['color' => 'orange', 'remain' => 6]
 
 <a name="method-diffkeys"></a>
-#### `diffKeys()` {#collection-method}
+#### `diffKeys()` {.collection-method}
 
 The `diffKeys` method compares the collection against another collection or a plain PHP `array` based on its keys. This method will return the key / value pairs in the original collection that are not present in the given collection:
 
@@ -585,7 +585,7 @@ The `diffKeys` method compares the collection against another collection or a pl
     // ['one' => 10, 'three' => 30, 'five' => 50]
 
 <a name="method-dump"></a>
-#### `dump()` {#collection-method}
+#### `dump()` {.collection-method}
 
 The `dump` method dumps the collection's items:
 
@@ -605,7 +605,7 @@ The `dump` method dumps the collection's items:
 If you want to stop executing the script after dumping the collection, use the [`dd`](#method-dd) method instead.
 
 <a name="method-duplicates"></a>
-#### `duplicates()` {#collection-method}
+#### `duplicates()` {.collection-method}
 
 The `duplicates` method retrieves and returns duplicate values from the collection:
 
@@ -628,12 +628,12 @@ If the collection contains arrays or objects, you can pass the key of the attrib
     // [2 => 'Developer']
 
 <a name="method-duplicatesstrict"></a>
-#### `duplicatesStrict()` {#collection-method}
+#### `duplicatesStrict()` {.collection-method}
 
 This method has the same signature as the [`duplicates`](#method-duplicates) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-each"></a>
-#### `each()` {#collection-method}
+#### `each()` {.collection-method}
 
 The `each` method iterates over the items in the collection and passes each item to a closure:
 
@@ -650,7 +650,7 @@ If you would like to stop iterating through the items, you may return `false` fr
     });
 
 <a name="method-eachspread"></a>
-#### `eachSpread()` {#collection-method}
+#### `eachSpread()` {.collection-method}
 
 The `eachSpread` method iterates over the collection's items, passing each nested item value into the given callback:
 
@@ -667,7 +667,7 @@ You may stop iterating through the items by returning `false` from the callback:
     });
 
 <a name="method-every"></a>
-#### `every()` {#collection-method}
+#### `every()` {.collection-method}
 
 The `every` method may be used to verify that all elements of a collection pass a given truth test:
 
@@ -688,7 +688,7 @@ If the collection is empty, the `every` method will return true:
     // true
 
 <a name="method-except"></a>
-#### `except()` {#collection-method}
+#### `except()` {.collection-method}
 
 The `except` method returns all items in the collection except for those with the specified keys:
 
@@ -705,7 +705,7 @@ For the inverse of `except`, see the [only](#method-only) method.
 > {tip} This method's behavior is modified when using [Eloquent Collections](/docs/{{version}}/eloquent-collections#method-except).
 
 <a name="method-filter"></a>
-#### `filter()` {#collection-method}
+#### `filter()` {.collection-method}
 
 The `filter` method filters the collection using the given callback, keeping only those items that pass a given truth test:
 
@@ -730,7 +730,7 @@ If no callback is supplied, all entries of the collection that are equivalent to
 For the inverse of `filter`, see the [reject](#method-reject) method.
 
 <a name="method-first"></a>
-#### `first()` {#collection-method}
+#### `first()` {.collection-method}
 
 The `first` method returns the first element in the collection that passes a given truth test:
 
@@ -747,7 +747,7 @@ You may also call the `first` method with no arguments to get the first element 
     // 1
 
 <a name="method-first-where"></a>
-#### `firstWhere()` {#collection-method}
+#### `firstWhere()` {.collection-method}
 
 The `firstWhere` method returns the first element in the collection with the given key / value pair:
 
@@ -775,7 +775,7 @@ Like the [where](#method-where) method, you may pass one argument to the `firstW
     // ['name' => 'Linda', 'age' => 14]
 
 <a name="method-flatmap"></a>
-#### `flatMap()` {#collection-method}
+#### `flatMap()` {.collection-method}
 
 The `flatMap` method iterates through the collection and passes each value to the given closure. The closure is free to modify the item and return it, thus forming a new collection of modified items. Then, the array is flattened by one level:
 
@@ -794,7 +794,7 @@ The `flatMap` method iterates through the collection and passes each value to th
     // ['name' => 'SALLY', 'school' => 'ARKANSAS', 'age' => '28'];
 
 <a name="method-flatten"></a>
-#### `flatten()` {#collection-method}
+#### `flatten()` {.collection-method}
 
 The `flatten` method flattens a multi-dimensional collection into a single dimension:
 
@@ -842,7 +842,7 @@ If necessary, you may pass the `flatten` method a "depth" argument:
 In this example, calling `flatten` without providing the depth would have also flattened the nested arrays, resulting in `['iPhone 6S', 'Apple', 'Galaxy S7', 'Samsung']`. Providing a depth allows you to specify the number of levels nested arrays will be flattened.
 
 <a name="method-flip"></a>
-#### `flip()` {#collection-method}
+#### `flip()` {.collection-method}
 
 The `flip` method swaps the collection's keys with their corresponding values:
 
@@ -855,7 +855,7 @@ The `flip` method swaps the collection's keys with their corresponding values:
     // ['taylor' => 'name', 'laravel' => 'framework']
 
 <a name="method-forget"></a>
-#### `forget()` {#collection-method}
+#### `forget()` {.collection-method}
 
 The `forget` method removes an item from the collection by its key:
 
@@ -870,7 +870,7 @@ The `forget` method removes an item from the collection by its key:
 > {note} Unlike most other collection methods, `forget` does not return a new modified collection; it modifies the collection it is called on.
 
 <a name="method-forpage"></a>
-#### `forPage()` {#collection-method}
+#### `forPage()` {.collection-method}
 
 The `forPage` method returns a new collection containing the items that would be present on a given page number. The method accepts the page number as its first argument and the number of items to show per page as its second argument:
 
@@ -883,7 +883,7 @@ The `forPage` method returns a new collection containing the items that would be
     // [4, 5, 6]
 
 <a name="method-get"></a>
-#### `get()` {#collection-method}
+#### `get()` {.collection-method}
 
 The `get` method returns the item at a given key. If the key does not exist, `null` is returned:
 
@@ -910,7 +910,7 @@ You may even pass a callback as the method's default value. The result of the ca
     // taylor@example.com
 
 <a name="method-groupby"></a>
-#### `groupBy()` {#collection-method}
+#### `groupBy()` {.collection-method}
 
 The `groupBy` method groups the collection's items by a given key:
 
@@ -995,7 +995,7 @@ Multiple grouping criteria may be passed as an array. Each array element will be
     */
 
 <a name="method-has"></a>
-#### `has()` {#collection-method}
+#### `has()` {.collection-method}
 
 The `has` method determines if a given key exists in the collection:
 
@@ -1014,7 +1014,7 @@ The `has` method determines if a given key exists in the collection:
     // false
 
 <a name="method-implode"></a>
-#### `implode()` {#collection-method}
+#### `implode()` {.collection-method}
 
 The `implode` method joins items in a collection. Its arguments depend on the type of items in the collection. If the collection contains arrays or objects, you should pass the key of the attributes you wish to join, and the "glue" string you wish to place between the values:
 
@@ -1034,7 +1034,7 @@ If the collection contains simple strings or numeric values, you should pass the
     // '1-2-3-4-5'
 
 <a name="method-intersect"></a>
-#### `intersect()` {#collection-method}
+#### `intersect()` {.collection-method}
 
 The `intersect` method removes any values from the original collection that are not present in the given `array` or collection. The resulting collection will preserve the original collection's keys:
 
@@ -1049,7 +1049,7 @@ The `intersect` method removes any values from the original collection that are 
 > {tip} This method's behavior is modified when using [Eloquent Collections](/docs/{{version}}/eloquent-collections#method-intersect).
 
 <a name="method-intersectbykeys"></a>
-#### `intersectByKeys()` {#collection-method}
+#### `intersectByKeys()` {.collection-method}
 
 The `intersectByKeys` method removes any keys and their corresponding values from the original collection that are not present in the given `array` or collection:
 
@@ -1066,7 +1066,7 @@ The `intersectByKeys` method removes any keys and their corresponding values fro
     // ['type' => 'screen', 'year' => 2009]
 
 <a name="method-isempty"></a>
-#### `isEmpty()` {#collection-method}
+#### `isEmpty()` {.collection-method}
 
 The `isEmpty` method returns `true` if the collection is empty; otherwise, `false` is returned:
 
@@ -1075,7 +1075,7 @@ The `isEmpty` method returns `true` if the collection is empty; otherwise, `fals
     // true
 
 <a name="method-isnotempty"></a>
-#### `isNotEmpty()` {#collection-method}
+#### `isNotEmpty()` {.collection-method}
 
 The `isNotEmpty` method returns `true` if the collection is not empty; otherwise, `false` is returned:
 
@@ -1084,7 +1084,7 @@ The `isNotEmpty` method returns `true` if the collection is not empty; otherwise
     // false
 
 <a name="method-join"></a>
-#### `join()` {#collection-method}
+#### `join()` {.collection-method}
 
 The `join` method joins the collection's values with a string. Using this method's second argument, you may also specify how the final element should be appended to the string:
 
@@ -1095,7 +1095,7 @@ The `join` method joins the collection's values with a string. Using this method
     collect([])->join(', ', ' and '); // ''
 
 <a name="method-keyby"></a>
-#### `keyBy()` {#collection-method}
+#### `keyBy()` {.collection-method}
 
 The `keyBy` method keys the collection by the given key. If multiple items have the same key, only the last one will appear in the new collection:
 
@@ -1131,7 +1131,7 @@ You may also pass a callback to the method. The callback should return the value
     */
 
 <a name="method-keys"></a>
-#### `keys()` {#collection-method}
+#### `keys()` {.collection-method}
 
 The `keys` method returns all of the collection's keys:
 
@@ -1147,7 +1147,7 @@ The `keys` method returns all of the collection's keys:
     // ['prod-100', 'prod-200']
 
 <a name="method-last"></a>
-#### `last()` {#collection-method}
+#### `last()` {.collection-method}
 
 The `last` method returns the last element in the collection that passes a given truth test:
 
@@ -1164,17 +1164,17 @@ You may also call the `last` method with no arguments to get the last element in
     // 4
 
 <a name="method-macro"></a>
-#### `macro()` {#collection-method}
+#### `macro()` {.collection-method}
 
 The static `macro` method allows you to add methods to the `Collection` class at run time. Refer to the documentation on [extending collections](#extending-collections) for more information.
 
 <a name="method-make"></a>
-#### `make()` {#collection-method}
+#### `make()` {.collection-method}
 
 The static `make` method creates a new collection instance. See the [Creating Collections](#creating-collections) section.
 
 <a name="method-map"></a>
-#### `map()` {#collection-method}
+#### `map()` {.collection-method}
 
 The `map` method iterates through the collection and passes each value to the given callback. The callback is free to modify the item and return it, thus forming a new collection of modified items:
 
@@ -1191,7 +1191,7 @@ The `map` method iterates through the collection and passes each value to the gi
 > {note} Like most other collection methods, `map` returns a new collection instance; it does not modify the collection it is called on. If you want to transform the original collection, use the [`transform`](#method-transform) method.
 
 <a name="method-mapinto"></a>
-#### `mapInto()` {#collection-method}
+#### `mapInto()` {.collection-method}
 
 The `mapInto()` method iterates over the collection, creating a new instance of the given class by passing the value into the constructor:
 
@@ -1218,7 +1218,7 @@ The `mapInto()` method iterates over the collection, creating a new instance of 
     // [Currency('USD'), Currency('EUR'), Currency('GBP')]
 
 <a name="method-mapspread"></a>
-#### `mapSpread()` {#collection-method}
+#### `mapSpread()` {.collection-method}
 
 The `mapSpread` method iterates over the collection's items, passing each nested item value into the given closure. The closure is free to modify the item and return it, thus forming a new collection of modified items:
 
@@ -1235,7 +1235,7 @@ The `mapSpread` method iterates over the collection's items, passing each nested
     // [1, 5, 9, 13, 17]
 
 <a name="method-maptogroups"></a>
-#### `mapToGroups()` {#collection-method}
+#### `mapToGroups()` {.collection-method}
 
 The `mapToGroups` method groups the collection's items by the given closure. The closure should return an associative array containing a single key / value pair, thus forming a new collection of grouped values:
 
@@ -1272,7 +1272,7 @@ The `mapToGroups` method groups the collection's items by the given closure. The
     // ['John Doe', 'Jane Doe']
 
 <a name="method-mapwithkeys"></a>
-#### `mapWithKeys()` {#collection-method}
+#### `mapWithKeys()` {.collection-method}
 
 The `mapWithKeys` method iterates through the collection and passes each value to the given callback. The callback should return an associative array containing a single key / value pair:
 
@@ -1303,7 +1303,7 @@ The `mapWithKeys` method iterates through the collection and passes each value t
     */
 
 <a name="method-max"></a>
-#### `max()` {#collection-method}
+#### `max()` {.collection-method}
 
 The `max` method returns the maximum value of a given key:
 
@@ -1319,7 +1319,7 @@ The `max` method returns the maximum value of a given key:
     // 5
 
 <a name="method-median"></a>
-#### `median()` {#collection-method}
+#### `median()` {.collection-method}
 
 The `median` method returns the [median value](https://en.wikipedia.org/wiki/Median) of a given key:
 
@@ -1337,7 +1337,7 @@ The `median` method returns the [median value](https://en.wikipedia.org/wiki/Med
     // 1.5
 
 <a name="method-merge"></a>
-#### `merge()` {#collection-method}
+#### `merge()` {.collection-method}
 
 The `merge` method merges the given array or collection with the original collection. If a string key in the given items matches a string key in the original collection, the given items's value will overwrite the value in the original collection:
 
@@ -1360,7 +1360,7 @@ If the given items's keys are numeric, the values will be appended to the end of
     // ['Desk', 'Chair', 'Bookcase', 'Door']
 
 <a name="method-mergerecursive"></a>
-#### `mergeRecursive()` {#collection-method}
+#### `mergeRecursive()` {.collection-method}
 
 The `mergeRecursive` method merges the given array or collection recursively with the original collection. If a string key in the given items matches a string key in the original collection, then the values for these keys are merged together into an array, and this is done recursively:
 
@@ -1377,7 +1377,7 @@ The `mergeRecursive` method merges the given array or collection recursively wit
     // ['product_id' => [1, 2], 'price' => [100, 200], 'discount' => false]
 
 <a name="method-min"></a>
-#### `min()` {#collection-method}
+#### `min()` {.collection-method}
 
 The `min` method returns the minimum value of a given key:
 
@@ -1390,7 +1390,7 @@ The `min` method returns the minimum value of a given key:
     // 1
 
 <a name="method-mode"></a>
-#### `mode()` {#collection-method}
+#### `mode()` {.collection-method}
 
 The `mode` method returns the [mode value](https://en.wikipedia.org/wiki/Mode_(statistics)) of a given key:
 
@@ -1412,7 +1412,7 @@ The `mode` method returns the [mode value](https://en.wikipedia.org/wiki/Mode_(s
     // [1, 2]
 
 <a name="method-nth"></a>
-#### `nth()` {#collection-method}
+#### `nth()` {.collection-method}
 
 The `nth` method creates a new collection consisting of every n-th element:
 
@@ -1429,7 +1429,7 @@ You may optionally pass a starting offset as the second argument:
     // ['b', 'f']
 
 <a name="method-only"></a>
-#### `only()` {#collection-method}
+#### `only()` {.collection-method}
 
 The `only` method returns the items in the collection with the specified keys:
 
@@ -1451,7 +1451,7 @@ For the inverse of `only`, see the [except](#method-except) method.
 > {tip} This method's behavior is modified when using [Eloquent Collections](/docs/{{version}}/eloquent-collections#method-only).
 
 <a name="method-pad"></a>
-#### `pad()` {#collection-method}
+#### `pad()` {.collection-method}
 
 The `pad` method will fill the array with the given value until the array reaches the specified size. This method behaves like the [array_pad](https://secure.php.net/manual/en/function.array-pad.php) PHP function.
 
@@ -1472,7 +1472,7 @@ To pad to the left, you should specify a negative size. No padding will take pla
     // [0, 0, 'A', 'B', 'C']
 
 <a name="method-partition"></a>
-#### `partition()` {#collection-method}
+#### `partition()` {.collection-method}
 
 The `partition` method may be combined with PHP array destructuring to separate elements that pass a given truth test from those that do not:
 
@@ -1491,7 +1491,7 @@ The `partition` method may be combined with PHP array destructuring to separate 
     // [3, 4, 5, 6]
 
 <a name="method-pipe"></a>
-#### `pipe()` {#collection-method}
+#### `pipe()` {.collection-method}
 
 The `pipe` method passes the collection to the given closure and returns the result of the executed closure:
 
@@ -1504,7 +1504,7 @@ The `pipe` method passes the collection to the given closure and returns the res
     // 6
 
 <a name="method-pipeinto"></a>
-#### `pipeInto()` {#collection-method}
+#### `pipeInto()` {.collection-method}
 
 The `pipeInto` method creates a new instance of the given class and passes the collection into the constructor:
 
@@ -1536,7 +1536,7 @@ The `pipeInto` method creates a new instance of the given class and passes the c
     // [1, 2, 3]
 
 <a name="method-pluck"></a>
-#### `pluck()` {#collection-method}
+#### `pluck()` {.collection-method}
 
 The `pluck` method retrieves all of the values for a given key:
 
@@ -1592,7 +1592,7 @@ If duplicate keys exist, the last matching element will be inserted into the plu
     // ['Tesla' => 'black', 'Pagani' => 'orange']
 
 <a name="method-pop"></a>
-#### `pop()` {#collection-method}
+#### `pop()` {.collection-method}
 
 The `pop` method removes and returns the last item from the collection:
 
@@ -1619,7 +1619,7 @@ You may pass an integer to the `pop` method to remove and return multiple items 
     // [1, 2]
 
 <a name="method-prepend"></a>
-#### `prepend()` {#collection-method}
+#### `prepend()` {.collection-method}
 
 The `prepend` method adds an item to the beginning of the collection:
 
@@ -1642,7 +1642,7 @@ You may also pass a second argument to specify the key of the prepended item:
     // ['zero' => 0, 'one' => 1, 'two' => 2]
 
 <a name="method-pull"></a>
-#### `pull()` {#collection-method}
+#### `pull()` {.collection-method}
 
 The `pull` method removes and returns an item from the collection by its key:
 
@@ -1657,7 +1657,7 @@ The `pull` method removes and returns an item from the collection by its key:
     // ['product_id' => 'prod-100']
 
 <a name="method-push"></a>
-#### `push()` {#collection-method}
+#### `push()` {.collection-method}
 
 The `push` method appends an item to the end of the collection:
 
@@ -1670,7 +1670,7 @@ The `push` method appends an item to the end of the collection:
     // [1, 2, 3, 4, 5]
 
 <a name="method-put"></a>
-#### `put()` {#collection-method}
+#### `put()` {.collection-method}
 
 The `put` method sets the given key and value in the collection:
 
@@ -1683,7 +1683,7 @@ The `put` method sets the given key and value in the collection:
     // ['product_id' => 1, 'name' => 'Desk', 'price' => 100]
 
 <a name="method-random"></a>
-#### `random()` {#collection-method}
+#### `random()` {.collection-method}
 
 The `random` method returns a random item from the collection:
 
@@ -1704,7 +1704,7 @@ You may pass an integer to `random` to specify how many items you would like to 
 If the collection instance has fewer items than requested, the `random` method will throw an `InvalidArgumentException`.
 
 <a name="method-range"></a>
-#### `range()` {#collection-method}
+#### `range()` {.collection-method}
 
 The `range` method returns a collection containing integers between the specified range:
 
@@ -1715,7 +1715,7 @@ The `range` method returns a collection containing integers between the specifie
     // [3, 4, 5, 6]
 
 <a name="method-reduce"></a>
-#### `reduce()` {#collection-method}
+#### `reduce()` {.collection-method}
 
 The `reduce` method reduces the collection to a single value, passing the result of each iteration into the subsequent iteration:
 
@@ -1756,7 +1756,7 @@ The `reduce` method also passes array keys in associative collections to the giv
     // 4264
 
 <a name="method-reduce-spread"></a>
-#### `reduceSpread()` {#collection-method}
+#### `reduceSpread()` {.collection-method}
 
 The `reduceSpread` method reduces the collection to an array of values, passing the results of each iteration into the subsequent iteration. This method is similar to the `reduce` method; however, it can accept multiple initial values:
 
@@ -1775,7 +1775,7 @@ The `reduceSpread` method reduces the collection to an array of values, passing 
 ```
 
 <a name="method-reject"></a>
-#### `reject()` {#collection-method}
+#### `reject()` {.collection-method}
 
 The `reject` method filters the collection using the given closure. The closure should return `true` if the item should be removed from the resulting collection:
 
@@ -1792,7 +1792,7 @@ The `reject` method filters the collection using the given closure. The closure 
 For the inverse of the `reject` method, see the [`filter`](#method-filter) method.
 
 <a name="method-replace"></a>
-#### `replace()` {#collection-method}
+#### `replace()` {.collection-method}
 
 The `replace` method behaves similarly to `merge`; however, in addition to overwriting matching items that have string keys, the `replace` method will also overwrite items in the collection that have matching numeric keys:
 
@@ -1805,7 +1805,7 @@ The `replace` method behaves similarly to `merge`; however, in addition to overw
     // ['Taylor', 'Victoria', 'James', 'Finn']
 
 <a name="method-replacerecursive"></a>
-#### `replaceRecursive()` {#collection-method}
+#### `replaceRecursive()` {.collection-method}
 
 This method works like `replace`, but it will recur into arrays and apply the same replacement process to the inner values:
 
@@ -1829,7 +1829,7 @@ This method works like `replace`, but it will recur into arrays and apply the sa
     // ['Charlie', 'Abigail', ['James', 'King', 'Finn']]
 
 <a name="method-reverse"></a>
-#### `reverse()` {#collection-method}
+#### `reverse()` {.collection-method}
 
 The `reverse` method reverses the order of the collection's items, preserving the original keys:
 
@@ -1850,7 +1850,7 @@ The `reverse` method reverses the order of the collection's items, preserving th
     */
 
 <a name="method-search"></a>
-#### `search()` {#collection-method}
+#### `search()` {.collection-method}
 
 The `search` method searches the collection for the given value and returns its key if found. If the item is not found, `false` is returned:
 
@@ -1875,7 +1875,7 @@ Alternatively, you may provide your own closure to search for the first item tha
     // 2
 
 <a name="method-shift"></a>
-#### `shift()` {#collection-method}
+#### `shift()` {.collection-method}
 
 The `shift` method removes and returns the first item from the collection:
 
@@ -1902,7 +1902,7 @@ You may pass an integer to the `shift` method to remove and return multiple item
     // [4, 5]
 
 <a name="method-shuffle"></a>
-#### `shuffle()` {#collection-method}
+#### `shuffle()` {.collection-method}
 
 The `shuffle` method randomly shuffles the items in the collection:
 
@@ -1915,7 +1915,7 @@ The `shuffle` method randomly shuffles the items in the collection:
     // [3, 2, 5, 1, 4] - (generated randomly)
 
 <a name="method-sliding"></a>
-#### `sliding()` {#collection-method}
+#### `sliding()` {.collection-method}
 
 The `sliding` method returns a new collection of chunks representing a "sliding window" view of the items in the collection:
 
@@ -1944,7 +1944,7 @@ You may optionally pass a second "step" value, which determines the distance bet
     // [[1, 2, 3], [3, 4, 5]]
 
 <a name="method-skip"></a>
-#### `skip()` {#collection-method}
+#### `skip()` {.collection-method}
 
 The `skip` method returns a new collection, with the given number of elements removed from the beginning of the collection:
 
@@ -1957,7 +1957,7 @@ The `skip` method returns a new collection, with the given number of elements re
     // [5, 6, 7, 8, 9, 10]
 
 <a name="method-skipuntil"></a>
-#### `skipUntil()` {#collection-method}
+#### `skipUntil()` {.collection-method}
 
 The `skipUntil` method skips over items from the collection until the given callback returns `true` and then returns the remaining items in the collection as a new collection instance:
 
@@ -1984,7 +1984,7 @@ You may also pass a simple value to the `skipUntil` method to skip all items unt
 > {note} If the given value is not found or the callback never returns `true`, the `skipUntil` method will return an empty collection.
 
 <a name="method-skipwhile"></a>
-#### `skipWhile()` {#collection-method}
+#### `skipWhile()` {.collection-method}
 
 The `skipWhile` method skips over items from the collection while the given callback returns `true` and then returns the remaining items in the collection as a new collection:
 
@@ -2001,7 +2001,7 @@ The `skipWhile` method skips over items from the collection while the given call
 > {note} If the callback never returns `false`, the `skipWhile` method will return an empty collection.
 
 <a name="method-slice"></a>
-#### `slice()` {#collection-method}
+#### `slice()` {.collection-method}
 
 The `slice` method returns a slice of the collection starting at the given index:
 
@@ -2024,7 +2024,7 @@ If you would like to limit the size of the returned slice, pass the desired size
 The returned slice will preserve keys by default. If you do not wish to preserve the original keys, you can use the [`values`](#method-values) method to reindex them.
 
 <a name="method-sole"></a>
-#### `sole()` {#collection-method}
+#### `sole()` {.collection-method}
 
 The `sole` method returns the first element in the collection that passes a given truth test, but only if the truth test matches exactly one element:
 
@@ -2058,12 +2058,12 @@ Alternatively, you may also call the `sole` method with no argument to get the f
 If there are no elements in the collection that should be returned by the `sole` method, an `\Illuminate\Collections\ItemNotFoundException` exception will be thrown. If there is more than one element that should be returned, an `\Illuminate\Collections\MultipleItemsFoundException` will be thrown. 
 
 <a name="method-some"></a>
-#### `some()` {#collection-method}
+#### `some()` {.collection-method}
 
 Alias for the [`contains`](#method-contains) method.
 
 <a name="method-sort"></a>
-#### `sort()` {#collection-method}
+#### `sort()` {.collection-method}
 
 The `sort` method sorts the collection. The sorted collection keeps the original array keys, so in the following example we will use the [`values`](#method-values) method to reset the keys to consecutively numbered indexes:
 
@@ -2080,7 +2080,7 @@ If your sorting needs are more advanced, you may pass a callback to `sort` with 
 > {tip} If you need to sort a collection of nested arrays or objects, see the [`sortBy`](#method-sortby) and [`sortByDesc`](#method-sortbydesc) methods.
 
 <a name="method-sortby"></a>
-#### `sortBy()` {#collection-method}
+#### `sortBy()` {.collection-method}
 
 The `sortBy` method sorts the collection by the given key. The sorted collection keeps the original array keys, so in the following example we will use the [`values`](#method-values) method to reset the keys to consecutively numbered indexes:
 
@@ -2195,12 +2195,12 @@ When sorting a collection by multiple attributes, you may also provide closures 
     */
 
 <a name="method-sortbydesc"></a>
-#### `sortByDesc()` {#collection-method}
+#### `sortByDesc()` {.collection-method}
 
 This method has the same signature as the [`sortBy`](#method-sortby) method, but will sort the collection in the opposite order.
 
 <a name="method-sortdesc"></a>
-#### `sortDesc()` {#collection-method}
+#### `sortDesc()` {.collection-method}
 
 This method will sort the collection in the opposite order as the [`sort`](#method-sort) method:
 
@@ -2215,7 +2215,7 @@ This method will sort the collection in the opposite order as the [`sort`](#meth
 Unlike `sort`, you may not pass a closure to `sortDesc`. Instead, you should use the [`sort`](#method-sort) method and invert your comparison.
 
 <a name="method-sortkeys"></a>
-#### `sortKeys()` {#collection-method}
+#### `sortKeys()` {.collection-method}
 
 The `sortKeys` method sorts the collection by the keys of the underlying associative array:
 
@@ -2238,12 +2238,12 @@ The `sortKeys` method sorts the collection by the keys of the underlying associa
     */
 
 <a name="method-sortkeysdesc"></a>
-#### `sortKeysDesc()` {#collection-method}
+#### `sortKeysDesc()` {.collection-method}
 
 This method has the same signature as the [`sortKeys`](#method-sortkeys) method, but will sort the collection in the opposite order.
 
 <a name="method-splice"></a>
-#### `splice()` {#collection-method}
+#### `splice()` {.collection-method}
 
 The `splice` method removes and returns a slice of items starting at the specified index:
 
@@ -2288,7 +2288,7 @@ In addition, you may pass a third argument containing the new items to replace t
     // [1, 2, 10, 11, 4, 5]
 
 <a name="method-split"></a>
-#### `split()` {#collection-method}
+#### `split()` {.collection-method}
 
 The `split` method breaks a collection into the given number of groups:
 
@@ -2301,7 +2301,7 @@ The `split` method breaks a collection into the given number of groups:
     // [[1, 2], [3, 4], [5]]
 
 <a name="method-splitin"></a>
-#### `splitIn()` {#collection-method}
+#### `splitIn()` {.collection-method}
 
 The `splitIn` method breaks a collection into the given number of groups, filling non-terminal groups completely before allocating the remainder to the final group:
 
@@ -2314,7 +2314,7 @@ The `splitIn` method breaks a collection into the given number of groups, fillin
     // [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10]]
 
 <a name="method-sum"></a>
-#### `sum()` {#collection-method}
+#### `sum()` {.collection-method}
 
 The `sum` method returns the sum of all items in the collection:
 
@@ -2348,7 +2348,7 @@ In addition, you may pass your own closure to determine which values of the coll
     // 6
 
 <a name="method-take"></a>
-#### `take()` {#collection-method}
+#### `take()` {.collection-method}
 
 The `take` method returns a new collection with the specified number of items:
 
@@ -2371,7 +2371,7 @@ You may also pass a negative integer to take the specified number of items from 
     // [4, 5]
 
 <a name="method-takeuntil"></a>
-#### `takeUntil()` {#collection-method}
+#### `takeUntil()` {.collection-method}
 
 The `takeUntil` method returns items in the collection until the given callback returns `true`:
 
@@ -2398,7 +2398,7 @@ You may also pass a simple value to the `takeUntil` method to get the items unti
 > {note} If the given value is not found or the callback never returns `true`, the `takeUntil` method will return all items in the collection.
 
 <a name="method-takewhile"></a>
-#### `takeWhile()` {#collection-method}
+#### `takeWhile()` {.collection-method}
 
 The `takeWhile` method returns items in the collection until the given callback returns `false`:
 
@@ -2415,7 +2415,7 @@ The `takeWhile` method returns items in the collection until the given callback 
 > {note} If the callback never returns `false`, the `takeWhile` method will return all items in the collection.
 
 <a name="method-tap"></a>
-#### `tap()` {#collection-method}
+#### `tap()` {.collection-method}
 
 The `tap` method passes the collection to the given callback, allowing you to "tap" into the collection at a specific point and do something with the items while not affecting the collection itself. The collection is then returned by the `tap` method:
 
@@ -2429,7 +2429,7 @@ The `tap` method passes the collection to the given callback, allowing you to "t
     // 1
 
 <a name="method-times"></a>
-#### `times()` {#collection-method}
+#### `times()` {.collection-method}
 
 The static `times` method creates a new collection by invoking the given closure a specified number of times:
 
@@ -2442,7 +2442,7 @@ The static `times` method creates a new collection by invoking the given closure
     // [9, 18, 27, 36, 45, 54, 63, 72, 81, 90]
 
 <a name="method-toarray"></a>
-#### `toArray()` {#collection-method}
+#### `toArray()` {.collection-method}
 
 The `toArray` method converts the collection into a plain PHP `array`. If the collection's values are [Eloquent](/docs/{{version}}/eloquent) models, the models will also be converted to arrays:
 
@@ -2459,7 +2459,7 @@ The `toArray` method converts the collection into a plain PHP `array`. If the co
 > {note} `toArray` also converts all of the collection's nested objects that are an instance of `Arrayable` to an array. If you want to get the raw array underlying the collection, use the [`all`](#method-all) method instead.
 
 <a name="method-tojson"></a>
-#### `toJson()` {#collection-method}
+#### `toJson()` {.collection-method}
 
 The `toJson` method converts the collection into a JSON serialized string:
 
@@ -2470,7 +2470,7 @@ The `toJson` method converts the collection into a JSON serialized string:
     // '{"name":"Desk", "price":200}'
 
 <a name="method-transform"></a>
-#### `transform()` {#collection-method}
+#### `transform()` {.collection-method}
 
 The `transform` method iterates over the collection and calls the given callback with each item in the collection. The items in the collection will be replaced by the values returned by the callback:
 
@@ -2487,7 +2487,7 @@ The `transform` method iterates over the collection and calls the given callback
 > {note} Unlike most other collection methods, `transform` modifies the collection itself. If you wish to create a new collection instead, use the [`map`](#method-map) method.
 
 <a name="method-union"></a>
-#### `union()` {#collection-method}
+#### `union()` {.collection-method}
 
 The `union` method adds the given array to the collection. If the given array contains keys that are already in the original collection, the original collection's values will be preferred:
 
@@ -2500,7 +2500,7 @@ The `union` method adds the given array to the collection. If the given array co
     // [1 => ['a'], 2 => ['b'], 3 => ['c']]
 
 <a name="method-unique"></a>
-#### `unique()` {#collection-method}
+#### `unique()` {.collection-method}
 
 The `unique` method returns all of the unique items in the collection. The returned collection keeps the original array keys, so in the following example we will use the [`values`](#method-values) method to reset the keys to consecutively numbered indexes:
 
@@ -2555,12 +2555,12 @@ The `unique` method uses "loose" comparisons when checking item values, meaning 
 > {tip} This method's behavior is modified when using [Eloquent Collections](/docs/{{version}}/eloquent-collections#method-unique).
 
 <a name="method-uniquestrict"></a>
-#### `uniqueStrict()` {#collection-method}
+#### `uniqueStrict()` {.collection-method}
 
 This method has the same signature as the [`unique`](#method-unique) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-unless"></a>
-#### `unless()` {#collection-method}
+#### `unless()` {.collection-method}
 
 The `unless` method will execute the given callback unless the first argument given to the method evaluates to `true`:
 
@@ -2595,17 +2595,17 @@ A second callback may be passed to the `unless` method. The second callback will
 For the inverse of `unless`, see the [`when`](#method-when) method.
 
 <a name="method-unlessempty"></a>
-#### `unlessEmpty()` {#collection-method}
+#### `unlessEmpty()` {.collection-method}
 
 Alias for the [`whenNotEmpty`](#method-whennotempty) method.
 
 <a name="method-unlessnotempty"></a>
-#### `unlessNotEmpty()` {#collection-method}
+#### `unlessNotEmpty()` {.collection-method}
 
 Alias for the [`whenEmpty`](#method-whenempty) method.
 
 <a name="method-unwrap"></a>
-#### `unwrap()` {#collection-method}
+#### `unwrap()` {.collection-method}
 
 The static `unwrap` method returns the collection's underlying items from the given value when applicable:
 
@@ -2622,7 +2622,7 @@ The static `unwrap` method returns the collection's underlying items from the gi
     // 'John Doe'
 
 <a name="method-values"></a>
-#### `values()` {#collection-method}
+#### `values()` {.collection-method}
 
 The `values` method returns a new collection with the keys reset to consecutive integers:
 
@@ -2643,7 +2643,7 @@ The `values` method returns a new collection with the keys reset to consecutive 
     */
 
 <a name="method-when"></a>
-#### `when()` {#collection-method}
+#### `when()` {.collection-method}
 
 The `when` method will execute the given callback when the first argument given to the method evaluates to `true`:
 
@@ -2678,7 +2678,7 @@ A second callback may be passed to the `when` method. The second callback will b
 For the inverse of `when`, see the [`unless`](#method-unless) method.
 
 <a name="method-whenempty"></a>
-#### `whenEmpty()` {#collection-method}
+#### `whenEmpty()` {.collection-method}
 
 The `whenEmpty` method will execute the given callback when the collection is empty:
 
@@ -2720,7 +2720,7 @@ A second closure may be passed to the `whenEmpty` method that will be executed w
 For the inverse of `whenEmpty`, see the [`whenNotEmpty`](#method-whennotempty) method.
 
 <a name="method-whennotempty"></a>
-#### `whenNotEmpty()` {#collection-method}
+#### `whenNotEmpty()` {.collection-method}
 
 The `whenNotEmpty` method will execute the given callback when the collection is not empty:
 
@@ -2762,7 +2762,7 @@ A second closure may be passed to the `whenNotEmpty` method that will be execute
 For the inverse of `whenNotEmpty`, see the [`whenEmpty`](#method-whenempty) method.
 
 <a name="method-where"></a>
-#### `where()` {#collection-method}
+#### `where()` {.collection-method}
 
 The `where` method filters the collection by a given key / value pair:
 
@@ -2806,12 +2806,12 @@ Optionally, you may pass a comparison operator as the second parameter.
     */
 
 <a name="method-wherestrict"></a>
-#### `whereStrict()` {#collection-method}
+#### `whereStrict()` {.collection-method}
 
 This method has the same signature as the [`where`](#method-where) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-wherebetween"></a>
-#### `whereBetween()` {#collection-method}
+#### `whereBetween()` {.collection-method}
 
 The `whereBetween` method filters the collection by determining if a specified item value is within a given range:
 
@@ -2836,7 +2836,7 @@ The `whereBetween` method filters the collection by determining if a specified i
     */
 
 <a name="method-wherein"></a>
-#### `whereIn()` {#collection-method}
+#### `whereIn()` {.collection-method}
 
 The `whereIn` method removes elements from the collection that do not have a specified item value that is contained within the given array:
 
@@ -2861,12 +2861,12 @@ The `whereIn` method removes elements from the collection that do not have a spe
 The `whereIn` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`whereInStrict`](#method-whereinstrict) method to filter using "strict" comparisons.
 
 <a name="method-whereinstrict"></a>
-#### `whereInStrict()` {#collection-method}
+#### `whereInStrict()` {.collection-method}
 
 This method has the same signature as the [`whereIn`](#method-wherein) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-whereinstanceof"></a>
-#### `whereInstanceOf()` {#collection-method}
+#### `whereInstanceOf()` {.collection-method}
 
 The `whereInstanceOf` method filters the collection by a given class type:
 
@@ -2886,7 +2886,7 @@ The `whereInstanceOf` method filters the collection by a given class type:
     // [App\Models\User, App\Models\User]
 
 <a name="method-wherenotbetween"></a>
-#### `whereNotBetween()` {#collection-method}
+#### `whereNotBetween()` {.collection-method}
 
 The `whereNotBetween` method filters the collection by determining if a specified item value is outside of a given range:
 
@@ -2910,7 +2910,7 @@ The `whereNotBetween` method filters the collection by determining if a specifie
     */
 
 <a name="method-wherenotin"></a>
-#### `whereNotIn()` {#collection-method}
+#### `whereNotIn()` {.collection-method}
 
 The `whereNotIn` method removes elements from the collection that have a specified item value that is contained within the given array:
 
@@ -2935,12 +2935,12 @@ The `whereNotIn` method removes elements from the collection that have a specifi
 The `whereNotIn` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`whereNotInStrict`](#method-wherenotinstrict) method to filter using "strict" comparisons.
 
 <a name="method-wherenotinstrict"></a>
-#### `whereNotInStrict()` {#collection-method}
+#### `whereNotInStrict()` {.collection-method}
 
 This method has the same signature as the [`whereNotIn`](#method-wherenotin) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-wherenotnull"></a>
-#### `whereNotNull()` {#collection-method}
+#### `whereNotNull()` {.collection-method}
 
 The `whereNotNull` method returns items from the collection where the given key is not `null`:
 
@@ -2962,7 +2962,7 @@ The `whereNotNull` method returns items from the collection where the given key 
     */
 
 <a name="method-wherenull"></a>
-#### `whereNull()` {#collection-method}
+#### `whereNull()` {.collection-method}
 
 The `whereNull` method returns items from the collection where the given key is `null`:
 
@@ -2984,7 +2984,7 @@ The `whereNull` method returns items from the collection where the given key is 
 
 
 <a name="method-wrap"></a>
-#### `wrap()` {#collection-method}
+#### `wrap()` {.collection-method}
 
 The static `wrap` method wraps the given value in a collection when applicable:
 
@@ -3009,7 +3009,7 @@ The static `wrap` method wraps the given value in a collection when applicable:
     // ['John Doe']
 
 <a name="method-zip"></a>
-#### `zip()` {#collection-method}
+#### `zip()` {.collection-method}
 
 The `zip` method merges together the values of the given array with the values of the original collection at their corresponding index:
 
@@ -3228,7 +3228,7 @@ Almost all methods available on the `Collection` class are also available on the
 In addition to the methods defined in the `Enumerable` contract, the `LazyCollection` class contains the following methods:
 
 <a name="method-takeUntilTimeout"></a>
-#### `takeUntilTimeout()` {#collection-method}
+#### `takeUntilTimeout()` {.collection-method}
 
 The `takeUntilTimeout` method returns a new lazy collection that will enumerate values until the specified time. After that time, the collection will then stop enumerating:
 
@@ -3259,7 +3259,7 @@ To illustrate the usage of this method, imagine an application that submits invo
         ->each(fn ($invoice) => $invoice->submit());
 
 <a name="method-tapEach"></a>
-#### `tapEach()` {#collection-method}
+#### `tapEach()` {.collection-method}
 
 While the `each` method calls the given callback for each item in the collection right away, the `tapEach` method only calls the given callback as the items are being pulled out of the list one by one:
 
@@ -3276,7 +3276,7 @@ While the `each` method calls the given callback for each item in the collection
     // 3
 
 <a name="method-remember"></a>
-#### `remember()` {#collection-method}
+#### `remember()` {.collection-method}
 
 The `remember` method returns a new lazy collection that will remember any values that have already been enumerated and will not retrieve them again on subsequent collection enumerations:
 

--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -48,6 +48,14 @@ In addition, the `Illuminate\Database\Eloquent\Collection` class provides a supe
     #collection-method-list a {
         display: block;
     }
+
+    .collection-method code {
+        font-size: 14px;
+    }
+
+    .collection-method:not(.first-collection-method) {
+        margin-top: 50px;
+    }
 </style>
 
 <div id="collection-method-list" markdown="1">
@@ -70,7 +78,7 @@ In addition, the `Illuminate\Database\Eloquent\Collection` class provides a supe
 </div>
 
 <a name="method-contains"></a>
-#### `contains($key, $operator = null, $value = null)`
+#### `contains($key, $operator = null, $value = null)` {.collection-method .first-collection-method}
 
 The `contains` method may be used to determine if a given model instance is contained by the collection. This method accepts a primary key or a model instance:
 
@@ -79,7 +87,7 @@ The `contains` method may be used to determine if a given model instance is cont
     $users->contains(User::find(1));
 
 <a name="method-diff"></a>
-#### `diff($items)`
+#### `diff($items)` {.collection-method}
 
 The `diff` method returns all of the models that are not present in the given collection:
 
@@ -88,14 +96,14 @@ The `diff` method returns all of the models that are not present in the given co
     $users = $users->diff(User::whereIn('id', [1, 2, 3])->get());
 
 <a name="method-except"></a>
-#### `except($keys)`
+#### `except($keys)` {.collection-method}
 
 The `except` method returns all of the models that do not have the given primary keys:
 
     $users = $users->except([1, 2, 3]);
 
 <a name="method-find"></a>
-#### `find($key)` {#collection-method .first-collection-method}
+#### `find($key)` {.collection-method}
 
 The `find` method returns the model that has a primary key matching the given key. If `$key` is a model instance, `find` will attempt to return a model matching the primary key. If `$key` is an array of keys, `find` will return all models which have a primary key in the given array:
 
@@ -104,7 +112,7 @@ The `find` method returns the model that has a primary key matching the given ke
     $user = $users->find(1);
 
 <a name="method-fresh"></a>
-#### `fresh($with = [])`
+#### `fresh($with = [])` {.collection-method}
 
 The `fresh` method retrieves a fresh instance of each model in the collection from the database. In addition, any specified relationships will be eager loaded:
 
@@ -113,7 +121,7 @@ The `fresh` method retrieves a fresh instance of each model in the collection fr
     $users = $users->fresh('comments');
 
 <a name="method-intersect"></a>
-#### `intersect($items)`
+#### `intersect($items)` {.collection-method}
 
 The `intersect` method returns all of the models that are also present in the given collection:
 
@@ -122,7 +130,7 @@ The `intersect` method returns all of the models that are also present in the gi
     $users = $users->intersect(User::whereIn('id', [1, 2, 3])->get());
 
 <a name="method-load"></a>
-#### `load($relations)`
+#### `load($relations)` {.collection-method}
 
 The `load` method eager loads the given relationships for all models in the collection:
 
@@ -131,7 +139,7 @@ The `load` method eager loads the given relationships for all models in the coll
     $users->load('comments.author');
 
 <a name="method-loadMissing"></a>
-#### `loadMissing($relations)`
+#### `loadMissing($relations)` {.collection-method}
 
 The `loadMissing` method eager loads the given relationships for all models in the collection if the relationships are not already loaded:
 
@@ -140,7 +148,7 @@ The `loadMissing` method eager loads the given relationships for all models in t
     $users->loadMissing('comments.author');
 
 <a name="method-modelKeys"></a>
-#### `modelKeys()`
+#### `modelKeys()` {.collection-method}
 
 The `modelKeys` method returns the primary keys for all models in the collection:
 
@@ -149,28 +157,28 @@ The `modelKeys` method returns the primary keys for all models in the collection
     // [1, 2, 3, 4, 5]
 
 <a name="method-makeVisible"></a>
-#### `makeVisible($attributes)`
+#### `makeVisible($attributes)` {.collection-method}
 
 The `makeVisible` method [makes attributes visible](/docs/{{version}}/eloquent-serialization#hiding-attributes-from-json) that are typically "hidden" on each model in the collection:
 
     $users = $users->makeVisible(['address', 'phone_number']);
 
 <a name="method-makeHidden"></a>
-#### `makeHidden($attributes)`
+#### `makeHidden($attributes)` {.collection-method}
 
 The `makeHidden` method [hides attributes](/docs/{{version}}/eloquent-serialization#hiding-attributes-from-json) that are typically "visible" on each model in the collection:
 
     $users = $users->makeHidden(['address', 'phone_number']);
 
 <a name="method-only"></a>
-#### `only($keys)`
+#### `only($keys)` {.collection-method}
 
 The `only` method returns all of the models that have the given primary keys:
 
     $users = $users->only([1, 2, 3]);
 
 <a name="method-toquery"></a>
-#### `toQuery()`
+#### `toQuery()` {.collection-method}
 
 The `toQuery` method returns an Eloquent query builder instance containing a `whereIn` constraint on the collection model's primary keys:
 
@@ -183,7 +191,7 @@ The `toQuery` method returns an Eloquent query builder instance containing a `wh
     ]);
 
 <a name="method-unique"></a>
-#### `unique($key = null, $strict = false)`
+#### `unique($key = null, $strict = false)` {.collection-method}
 
 The `unique` method returns all of the unique models in the collection. Any models of the same type with the same primary key as another model in the collection are removed:
 

--- a/helpers.md
+++ b/helpers.md
@@ -283,11 +283,11 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 ## Method Listing
 
 <style>
-    #collection-method code {
+    .collection-method code {
         font-size: 14px;
     }
 
-    #collection-method:not(.first-collection-method) {
+    .collection-method:not(.first-collection-method) {
         margin-top: 50px;
     }
 </style>
@@ -296,7 +296,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 ## Arrays & Objects
 
 <a name="method-array-accessible"></a>
-#### `Arr::accessible()` {#collection-method .first-collection-method}
+#### `Arr::accessible()` {.collection-method .first-collection-method}
 
 The `Arr::accessible` method determines if the given value is array accessible:
 
@@ -320,7 +320,7 @@ The `Arr::accessible` method determines if the given value is array accessible:
     // false
 
 <a name="method-array-add"></a>
-#### `Arr::add()` {#collection-method}
+#### `Arr::add()` {.collection-method}
 
 The `Arr::add` method adds a given key / value pair to an array if the given key doesn't already exist in the array or is set to `null`:
 
@@ -336,7 +336,7 @@ The `Arr::add` method adds a given key / value pair to an array if the given key
 
 
 <a name="method-array-collapse"></a>
-#### `Arr::collapse()` {#collection-method}
+#### `Arr::collapse()` {.collection-method}
 
 The `Arr::collapse` method collapses an array of arrays into a single array:
 
@@ -347,7 +347,7 @@ The `Arr::collapse` method collapses an array of arrays into a single array:
     // [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 <a name="method-array-crossjoin"></a>
-#### `Arr::crossJoin()` {#collection-method}
+#### `Arr::crossJoin()` {.collection-method}
 
 The `Arr::crossJoin` method cross joins the given arrays, returning a Cartesian product with all possible permutations:
 
@@ -380,7 +380,7 @@ The `Arr::crossJoin` method cross joins the given arrays, returning a Cartesian 
     */
 
 <a name="method-array-divide"></a>
-#### `Arr::divide()` {#collection-method}
+#### `Arr::divide()` {.collection-method}
 
 The `Arr::divide` method returns two arrays: one containing the keys and the other containing the values of the given array:
 
@@ -393,7 +393,7 @@ The `Arr::divide` method returns two arrays: one containing the keys and the oth
     // $values: ['Desk']
 
 <a name="method-array-dot"></a>
-#### `Arr::dot()` {#collection-method}
+#### `Arr::dot()` {.collection-method}
 
 The `Arr::dot` method flattens a multi-dimensional array into a single level array that uses "dot" notation to indicate depth:
 
@@ -406,7 +406,7 @@ The `Arr::dot` method flattens a multi-dimensional array into a single level arr
     // ['products.desk.price' => 100]
 
 <a name="method-array-except"></a>
-#### `Arr::except()` {#collection-method}
+#### `Arr::except()` {.collection-method}
 
 The `Arr::except` method removes the given key / value pairs from an array:
 
@@ -419,7 +419,7 @@ The `Arr::except` method removes the given key / value pairs from an array:
     // ['name' => 'Desk']
 
 <a name="method-array-exists"></a>
-#### `Arr::exists()` {#collection-method}
+#### `Arr::exists()` {.collection-method}
 
 The `Arr::exists` method checks that the given key exists in the provided array:
 
@@ -436,7 +436,7 @@ The `Arr::exists` method checks that the given key exists in the provided array:
     // false
 
 <a name="method-array-first"></a>
-#### `Arr::first()` {#collection-method}
+#### `Arr::first()` {.collection-method}
 
 The `Arr::first` method returns the first element of an array passing a given truth test:
 
@@ -457,7 +457,7 @@ A default value may also be passed as the third parameter to the method. This va
     $first = Arr::first($array, $callback, $default);
 
 <a name="method-array-flatten"></a>
-#### `Arr::flatten()` {#collection-method}
+#### `Arr::flatten()` {.collection-method}
 
 The `Arr::flatten` method flattens a multi-dimensional array into a single level array:
 
@@ -470,7 +470,7 @@ The `Arr::flatten` method flattens a multi-dimensional array into a single level
     // ['Joe', 'PHP', 'Ruby']
 
 <a name="method-array-forget"></a>
-#### `Arr::forget()` {#collection-method}
+#### `Arr::forget()` {.collection-method}
 
 The `Arr::forget` method removes a given key / value pair from a deeply nested array using "dot" notation:
 
@@ -483,7 +483,7 @@ The `Arr::forget` method removes a given key / value pair from a deeply nested a
     // ['products' => []]
 
 <a name="method-array-get"></a>
-#### `Arr::get()` {#collection-method}
+#### `Arr::get()` {.collection-method}
 
 The `Arr::get` method retrieves a value from a deeply nested array using "dot" notation:
 
@@ -504,7 +504,7 @@ The `Arr::get` method also accepts a default value, which will be returned if th
     // 0
 
 <a name="method-array-has"></a>
-#### `Arr::has()` {#collection-method}
+#### `Arr::has()` {.collection-method}
 
 The `Arr::has` method checks whether a given item or items exists in an array using "dot" notation:
 
@@ -521,7 +521,7 @@ The `Arr::has` method checks whether a given item or items exists in an array us
     // false
 
 <a name="method-array-hasany"></a>
-#### `Arr::hasAny()` {#collection-method}
+#### `Arr::hasAny()` {.collection-method}
 
 The `Arr::hasAny` method checks whether any item in a given set exists in an array using "dot" notation:
 
@@ -542,7 +542,7 @@ The `Arr::hasAny` method checks whether any item in a given set exists in an arr
     // false
 
 <a name="method-array-isassoc"></a>
-#### `Arr::isAssoc()` {#collection-method}
+#### `Arr::isAssoc()` {.collection-method}
 
 The `Arr::isAssoc` returns `true` if the given array is an associative array. An array is considered "associative" if it doesn't have sequential numerical keys beginning with zero:
 
@@ -557,7 +557,7 @@ The `Arr::isAssoc` returns `true` if the given array is an associative array. An
     // false
 
 <a name="method-array-last"></a>
-#### `Arr::last()` {#collection-method}
+#### `Arr::last()` {.collection-method}
 
 The `Arr::last` method returns the last element of an array passing a given truth test:
 
@@ -578,7 +578,7 @@ A default value may be passed as the third argument to the method. This value wi
     $last = Arr::last($array, $callback, $default);
 
 <a name="method-array-only"></a>
-#### `Arr::only()` {#collection-method}
+#### `Arr::only()` {.collection-method}
 
 The `Arr::only` method returns only the specified key / value pairs from the given array:
 
@@ -591,7 +591,7 @@ The `Arr::only` method returns only the specified key / value pairs from the giv
     // ['name' => 'Desk', 'price' => 100]
 
 <a name="method-array-pluck"></a>
-#### `Arr::pluck()` {#collection-method}
+#### `Arr::pluck()` {.collection-method}
 
 The `Arr::pluck` method retrieves all of the values for a given key from an array:
 
@@ -615,7 +615,7 @@ You may also specify how you wish the resulting list to be keyed:
     // [1 => 'Taylor', 2 => 'Abigail']
 
 <a name="method-array-prepend"></a>
-#### `Arr::prepend()` {#collection-method}
+#### `Arr::prepend()` {.collection-method}
 
 The `Arr::prepend` method will push an item onto the beginning of an array:
 
@@ -638,7 +638,7 @@ If needed, you may specify the key that should be used for the value:
     // ['name' => 'Desk', 'price' => 100]
 
 <a name="method-array-pull"></a>
-#### `Arr::pull()` {#collection-method}
+#### `Arr::pull()` {.collection-method}
 
 The `Arr::pull` method returns and removes a key / value pair from an array:
 
@@ -659,7 +659,7 @@ A default value may be passed as the third argument to the method. This value wi
     $value = Arr::pull($array, $key, $default);
 
 <a name="method-array-query"></a>
-#### `Arr::query()` {#collection-method}
+#### `Arr::query()` {.collection-method}
 
 The `Arr::query` method converts the array into a query string:
 
@@ -678,7 +678,7 @@ The `Arr::query` method converts the array into a query string:
     // name=Taylor&order[column]=created_at&order[direction]=desc
 
 <a name="method-array-random"></a>
-#### `Arr::random()` {#collection-method}
+#### `Arr::random()` {.collection-method}
 
 The `Arr::random` method returns a random value from an array:
 
@@ -699,7 +699,7 @@ You may also specify the number of items to return as an optional second argumen
     // [2, 5] - (retrieved randomly)
 
 <a name="method-array-set"></a>
-#### `Arr::set()` {#collection-method}
+#### `Arr::set()` {.collection-method}
 
 The `Arr::set` method sets a value within a deeply nested array using "dot" notation:
 
@@ -712,7 +712,7 @@ The `Arr::set` method sets a value within a deeply nested array using "dot" nota
     // ['products' => ['desk' => ['price' => 200]]]
 
 <a name="method-array-shuffle"></a>
-#### `Arr::shuffle()` {#collection-method}
+#### `Arr::shuffle()` {.collection-method}
 
 The `Arr::shuffle` method randomly shuffles the items in the array:
 
@@ -723,7 +723,7 @@ The `Arr::shuffle` method randomly shuffles the items in the array:
     // [3, 2, 5, 1, 4] - (generated randomly)
 
 <a name="method-array-sort"></a>
-#### `Arr::sort()` {#collection-method}
+#### `Arr::sort()` {.collection-method}
 
 The `Arr::sort` method sorts an array by its values:
 
@@ -758,7 +758,7 @@ You may also sort the array by the results of a given closure:
     */
 
 <a name="method-array-sort-recursive"></a>
-#### `Arr::sortRecursive()` {#collection-method}
+#### `Arr::sortRecursive()` {.collection-method}
 
 The `Arr::sortRecursive` method recursively sorts an array using the `sort` function for numerically indexed sub-arrays and the `ksort` function for associative sub-arrays:
 
@@ -781,7 +781,7 @@ The `Arr::sortRecursive` method recursively sorts an array using the `sort` func
     */
 
 <a name="method-array-to-css-classes"></a>
-#### `Arr::toCssClasses()` {#collection-method}
+#### `Arr::toCssClasses()` {.collection-method}
 
 The `Arr::toCssClasses` conditionally compiles a CSS class string. The method accepts an array of classes where the array key contains the class or classes you wish to add, while the value is a boolean expression. If the array element has a numeric key, it will always be included in the rendered class list:
 
@@ -801,7 +801,7 @@ The `Arr::toCssClasses` conditionally compiles a CSS class string. The method ac
 This method powers Laravel's functionality allowing [merging classes with a Blade component's attribute bag](/docs/{{version}}/blade#conditionally-merge-classes) as well as the `@class` [Blade directive](/docs/{{version}}/blade#conditional-classes).
 
 <a name="method-array-undot"></a>
-#### `Arr::undot()` {#collection-method}
+#### `Arr::undot()` {.collection-method}
 
 The `Arr::undot` method expands a single-dimensional array that uses "dot" notation into a multi-dimensional array:
 
@@ -817,7 +817,7 @@ The `Arr::undot` method expands a single-dimensional array that uses "dot" notat
     // ['user' => ['name' => 'Kevin Malone', 'occupation' => 'Accountant']]
 
 <a name="method-array-where"></a>
-#### `Arr::where()` {#collection-method}
+#### `Arr::where()` {.collection-method}
 
 The `Arr::where` method filters an array using the given closure:
 
@@ -832,7 +832,7 @@ The `Arr::where` method filters an array using the given closure:
     // [1 => '200', 3 => '400']
 
 <a name="method-array-where-not-null"></a>
-#### `Arr::whereNotNull()` {#collection-method}
+#### `Arr::whereNotNull()` {.collection-method}
 
 The `Arr::whereNotNull` method removes all `null` values from the given array:
 
@@ -845,7 +845,7 @@ The `Arr::whereNotNull` method removes all `null` values from the given array:
     // [0 => 0]
 
 <a name="method-array-wrap"></a>
-#### `Arr::wrap()` {#collection-method}
+#### `Arr::wrap()` {.collection-method}
 
 The `Arr::wrap` method wraps the given value in an array. If the given value is already an array it will be returned without modification:
 
@@ -866,7 +866,7 @@ If the given value is `null`, an empty array will be returned:
     // []
 
 <a name="method-data-fill"></a>
-#### `data_fill()` {#collection-method}
+#### `data_fill()` {.collection-method}
 
 The `data_fill` function sets a missing value within a nested array or object using "dot" notation:
 
@@ -901,7 +901,7 @@ This function also accepts asterisks as wildcards and will fill the target accor
     */
 
 <a name="method-data-get"></a>
-#### `data_get()` {#collection-method}
+#### `data_get()` {.collection-method}
 
 The `data_get` function retrieves a value from a nested array or object using "dot" notation:
 
@@ -929,7 +929,7 @@ The function also accepts wildcards using asterisks, which may target any key of
     // ['Desk 1', 'Desk 2'];
 
 <a name="method-data-set"></a>
-#### `data_set()` {#collection-method}
+#### `data_set()` {.collection-method}
 
 The `data_set` function sets a value within a nested array or object using "dot" notation:
 
@@ -968,7 +968,7 @@ By default, any existing values are overwritten. If you wish to only set a value
     // ['products' => ['desk' => ['price' => 100]]]
 
 <a name="method-head"></a>
-#### `head()` {#collection-method}
+#### `head()` {.collection-method}
 
 The `head` function returns the first element in the given array:
 
@@ -979,7 +979,7 @@ The `head` function returns the first element in the given array:
     // 100
 
 <a name="method-last"></a>
-#### `last()` {#collection-method}
+#### `last()` {.collection-method}
 
 The `last` function returns the last element in the given array:
 
@@ -993,7 +993,7 @@ The `last` function returns the last element in the given array:
 ## Paths
 
 <a name="method-app-path"></a>
-#### `app_path()` {#collection-method}
+#### `app_path()` {.collection-method}
 
 The `app_path` function returns the fully qualified path to your application's `app` directory. You may also use the `app_path` function to generate a fully qualified path to a file relative to the application directory:
 
@@ -1002,7 +1002,7 @@ The `app_path` function returns the fully qualified path to your application's `
     $path = app_path('Http/Controllers/Controller.php');
 
 <a name="method-base-path"></a>
-#### `base_path()` {#collection-method}
+#### `base_path()` {.collection-method}
 
 The `base_path` function returns the fully qualified path to your application's root directory. You may also use the `base_path` function to generate a fully qualified path to a given file relative to the project root directory:
 
@@ -1011,7 +1011,7 @@ The `base_path` function returns the fully qualified path to your application's 
     $path = base_path('vendor/bin');
 
 <a name="method-config-path"></a>
-#### `config_path()` {#collection-method}
+#### `config_path()` {.collection-method}
 
 The `config_path` function returns the fully qualified path to your application's `config` directory. You may also use the `config_path` function to generate a fully qualified path to a given file within the application's configuration directory:
 
@@ -1020,7 +1020,7 @@ The `config_path` function returns the fully qualified path to your application'
     $path = config_path('app.php');
 
 <a name="method-database-path"></a>
-#### `database_path()` {#collection-method}
+#### `database_path()` {.collection-method}
 
 The `database_path` function returns the fully qualified path to your application's `database` directory. You may also use the `database_path` function to generate a fully qualified path to a given file within the database directory:
 
@@ -1029,14 +1029,14 @@ The `database_path` function returns the fully qualified path to your applicatio
     $path = database_path('factories/UserFactory.php');
 
 <a name="method-mix"></a>
-#### `mix()` {#collection-method}
+#### `mix()` {.collection-method}
 
 The `mix` function returns the path to a [versioned Mix file](/docs/{{version}}/mix):
 
     $path = mix('css/app.css');
 
 <a name="method-public-path"></a>
-#### `public_path()` {#collection-method}
+#### `public_path()` {.collection-method}
 
 The `public_path` function returns the fully qualified path to your application's `public` directory. You may also use the `public_path` function to generate a fully qualified path to a given file within the public directory:
 
@@ -1045,7 +1045,7 @@ The `public_path` function returns the fully qualified path to your application'
     $path = public_path('css/app.css');
 
 <a name="method-resource-path"></a>
-#### `resource_path()` {#collection-method}
+#### `resource_path()` {.collection-method}
 
 The `resource_path` function returns the fully qualified path to your application's `resources` directory. You may also use the `resource_path` function to generate a fully qualified path to a given file within the resources directory:
 
@@ -1054,7 +1054,7 @@ The `resource_path` function returns the fully qualified path to your applicatio
     $path = resource_path('sass/app.scss');
 
 <a name="method-storage-path"></a>
-#### `storage_path()` {#collection-method}
+#### `storage_path()` {.collection-method}
 
 The `storage_path` function returns the fully qualified path to your application's `storage` directory. You may also use the `storage_path` function to generate a fully qualified path to a given file within the storage directory:
 
@@ -1066,7 +1066,7 @@ The `storage_path` function returns the fully qualified path to your application
 ## Strings
 
 <a name="method-__"></a>
-#### `__()` {#collection-method}
+#### `__()` {.collection-method}
 
 The `__` function translates the given translation string or translation key using your [localization files](/docs/{{version}}/localization):
 
@@ -1077,7 +1077,7 @@ The `__` function translates the given translation string or translation key usi
 If the specified translation string or key does not exist, the `__` function will return the given value. So, using the example above, the `__` function would return `messages.welcome` if that translation key does not exist.
 
 <a name="method-class-basename"></a>
-#### `class_basename()` {#collection-method}
+#### `class_basename()` {.collection-method}
 
 The `class_basename` function returns the class name of the given class with the class's namespace removed:
 
@@ -1086,7 +1086,7 @@ The `class_basename` function returns the class name of the given class with the
     // Baz
 
 <a name="method-e"></a>
-#### `e()` {#collection-method}
+#### `e()` {.collection-method}
 
 The `e` function runs PHP's `htmlspecialchars` function with the `double_encode` option set to `true` by default:
 
@@ -1095,7 +1095,7 @@ The `e` function runs PHP's `htmlspecialchars` function with the `double_encode`
     // &lt;html&gt;foo&lt;/html&gt;
 
 <a name="method-preg-replace-array"></a>
-#### `preg_replace_array()` {#collection-method}
+#### `preg_replace_array()` {.collection-method}
 
 The `preg_replace_array` function replaces a given pattern in the string sequentially using an array:
 
@@ -1106,7 +1106,7 @@ The `preg_replace_array` function replaces a given pattern in the string sequent
     // The event will take place between 8:30 and 9:00
 
 <a name="method-str-after"></a>
-#### `Str::after()` {#collection-method}
+#### `Str::after()` {.collection-method}
 
 The `Str::after` method returns everything after the given value in a string. The entire string will be returned if the value does not exist within the string:
 
@@ -1117,7 +1117,7 @@ The `Str::after` method returns everything after the given value in a string. Th
     // ' my name'
 
 <a name="method-str-after-last"></a>
-#### `Str::afterLast()` {#collection-method}
+#### `Str::afterLast()` {.collection-method}
 
 The `Str::afterLast` method returns everything after the last occurrence of the given value in a string. The entire string will be returned if the value does not exist within the string:
 
@@ -1128,7 +1128,7 @@ The `Str::afterLast` method returns everything after the last occurrence of the 
     // 'Controller'
 
 <a name="method-str-ascii"></a>
-#### `Str::ascii()` {#collection-method}
+#### `Str::ascii()` {.collection-method}
 
 The `Str::ascii` method will attempt to transliterate the string into an ASCII value:
 
@@ -1139,7 +1139,7 @@ The `Str::ascii` method will attempt to transliterate the string into an ASCII v
     // 'u'
 
 <a name="method-str-before"></a>
-#### `Str::before()` {#collection-method}
+#### `Str::before()` {.collection-method}
 
 The `Str::before` method returns everything before the given value in a string:
 
@@ -1150,7 +1150,7 @@ The `Str::before` method returns everything before the given value in a string:
     // 'This is '
 
 <a name="method-str-before-last"></a>
-#### `Str::beforeLast()` {#collection-method}
+#### `Str::beforeLast()` {.collection-method}
 
 The `Str::beforeLast` method returns everything before the last occurrence of the given value in a string:
 
@@ -1161,7 +1161,7 @@ The `Str::beforeLast` method returns everything before the last occurrence of th
     // 'This '
 
 <a name="method-str-between"></a>
-#### `Str::between()` {#collection-method}
+#### `Str::between()` {.collection-method}
 
 The `Str::between` method returns the portion of a string between two values:
 
@@ -1172,7 +1172,7 @@ The `Str::between` method returns the portion of a string between two values:
     // ' is my '
 
 <a name="method-camel-case"></a>
-#### `Str::camel()` {#collection-method}
+#### `Str::camel()` {.collection-method}
 
 The `Str::camel` method converts the given string to `camelCase`:
 
@@ -1183,7 +1183,7 @@ The `Str::camel` method converts the given string to `camelCase`:
     // fooBar
 
 <a name="method-str-contains"></a>
-#### `Str::contains()` {#collection-method}
+#### `Str::contains()` {.collection-method}
 
 The `Str::contains` method determines if the given string contains the given value. This method is case sensitive:
 
@@ -1202,7 +1202,7 @@ You may also pass an array of values to determine if the given string contains a
     // true
 
 <a name="method-str-contains-all"></a>
-#### `Str::containsAll()` {#collection-method}
+#### `Str::containsAll()` {.collection-method}
 
 The `Str::containsAll` method determines if the given string contains all of the values in a given array:
 
@@ -1213,7 +1213,7 @@ The `Str::containsAll` method determines if the given string contains all of the
     // true
 
 <a name="method-ends-with"></a>
-#### `Str::endsWith()` {#collection-method}
+#### `Str::endsWith()` {.collection-method}
 
 The `Str::endsWith` method determines if the given string ends with the given value:
 
@@ -1237,7 +1237,7 @@ You may also pass an array of values to determine if the given string ends with 
     // false
 
 <a name="method-str-finish"></a>
-#### `Str::finish()` {#collection-method}
+#### `Str::finish()` {.collection-method}
 
 The `Str::finish` method adds a single instance of the given value to a string if it does not already end with that value:
 
@@ -1252,7 +1252,7 @@ The `Str::finish` method adds a single instance of the given value to a string i
     // this/string/
 
 <a name="method-str-headline"></a>
-#### `Str::headline()` {#collection-method}
+#### `Str::headline()` {.collection-method}
 
 The `Str::headline` method will convert strings delimited by casing, hyphens, or underscores into a space delimited string with each word's first letter capitalized:
 
@@ -1267,7 +1267,7 @@ The `Str::headline` method will convert strings delimited by casing, hyphens, or
     // Email Notification Sent
 
 <a name="method-str-is"></a>
-#### `Str::is()` {#collection-method}
+#### `Str::is()` {.collection-method}
 
 The `Str::is` method determines if a given string matches a given pattern. Asterisks may be used as wildcard values:
 
@@ -1282,7 +1282,7 @@ The `Str::is` method determines if a given string matches a given pattern. Aster
     // false
 
 <a name="method-str-is-ascii"></a>
-#### `Str::isAscii()` {#collection-method}
+#### `Str::isAscii()` {.collection-method}
 
 The `Str::isAscii` method determines if a given string is 7 bit ASCII:
 
@@ -1297,7 +1297,7 @@ The `Str::isAscii` method determines if a given string is 7 bit ASCII:
     // false
 
 <a name="method-str-is-uuid"></a>
-#### `Str::isUuid()` {#collection-method}
+#### `Str::isUuid()` {.collection-method}
 
 The `Str::isUuid` method determines if the given string is a valid UUID:
 
@@ -1312,7 +1312,7 @@ The `Str::isUuid` method determines if the given string is a valid UUID:
     // false
 
 <a name="method-kebab-case"></a>
-#### `Str::kebab()` {#collection-method}
+#### `Str::kebab()` {.collection-method}
 
 The `Str::kebab` method converts the given string to `kebab-case`:
 
@@ -1323,7 +1323,7 @@ The `Str::kebab` method converts the given string to `kebab-case`:
     // foo-bar
 
 <a name="method-str-length"></a>
-#### `Str::length()` {#collection-method}
+#### `Str::length()` {.collection-method}
 
 The `Str::length` method returns the length of the given string:
 
@@ -1334,7 +1334,7 @@ The `Str::length` method returns the length of the given string:
     // 7
 
 <a name="method-str-limit"></a>
-#### `Str::limit()` {#collection-method}
+#### `Str::limit()` {.collection-method}
 
 The `Str::limit` method truncates the given string to the specified length:
 
@@ -1353,7 +1353,7 @@ You may pass a third argument to the method to change the string that will be ap
     // The quick brown fox (...)
 
 <a name="method-str-lower"></a>
-#### `Str::lower()` {#collection-method}
+#### `Str::lower()` {.collection-method}
 
 The `Str::lower` method converts the given string to lowercase:
 
@@ -1364,7 +1364,7 @@ The `Str::lower` method converts the given string to lowercase:
     // laravel
 
 <a name="method-str-markdown"></a>
-#### `Str::markdown()` {#collection-method}
+#### `Str::markdown()` {.collection-method}
 
 The `Str::markdown` method converts GitHub flavored Markdown into HTML:
 
@@ -1381,7 +1381,7 @@ The `Str::markdown` method converts GitHub flavored Markdown into HTML:
     // <h1>Taylor Otwell</h1>
 
 <a name="method-str-mask"></a>
-#### `Str::mask()` {#collection-method}
+#### `Str::mask()` {.collection-method}
 
 The `Str::mask` method masks a portion of a string with a repeated character, and may be used to obfuscate segments of strings such as email addresses and phone numbers:
 
@@ -1398,7 +1398,7 @@ If needed, you provide a negative number as the third argument to the `mask` met
     // tay***@example.com
 
 <a name="method-str-ordered-uuid"></a>
-#### `Str::orderedUuid()` {#collection-method}
+#### `Str::orderedUuid()` {.collection-method}
 
 The `Str::orderedUuid` method generates a "timestamp first" UUID that may be efficiently stored in an indexed database column. Each UUID that is generated using this method will be sorted after UUIDs previously generated using the method:
 
@@ -1407,7 +1407,7 @@ The `Str::orderedUuid` method generates a "timestamp first" UUID that may be eff
     return (string) Str::orderedUuid();
 
 <a name="method-str-padboth"></a>
-#### `Str::padBoth()` {#collection-method}
+#### `Str::padBoth()` {.collection-method}
 
 The `Str::padBoth` method wraps PHP's `str_pad` function, padding both sides of a string with another string until the final string reaches a desired length:
 
@@ -1422,7 +1422,7 @@ The `Str::padBoth` method wraps PHP's `str_pad` function, padding both sides of 
     // '  James   '
 
 <a name="method-str-padleft"></a>
-#### `Str::padLeft()` {#collection-method}
+#### `Str::padLeft()` {.collection-method}
 
 The `Str::padLeft` method wraps PHP's `str_pad` function, padding the left side of a string with another string until the final string reaches a desired length:
 
@@ -1437,7 +1437,7 @@ The `Str::padLeft` method wraps PHP's `str_pad` function, padding the left side 
     // '     James'
 
 <a name="method-str-padright"></a>
-#### `Str::padRight()` {#collection-method}
+#### `Str::padRight()` {.collection-method}
 
 The `Str::padRight` method wraps PHP's `str_pad` function, padding the right side of a string with another string until the final string reaches a desired length:
 
@@ -1452,7 +1452,7 @@ The `Str::padRight` method wraps PHP's `str_pad` function, padding the right sid
     // 'James     '
 
 <a name="method-str-plural"></a>
-#### `Str::plural()` {#collection-method}
+#### `Str::plural()` {.collection-method}
 
 The `Str::plural` method converts a singular word string to its plural form. This function currently only supports the English language:
 
@@ -1479,7 +1479,7 @@ You may provide an integer as a second argument to the function to retrieve the 
     // child
 
 <a name="method-str-plural-studly"></a>
-#### `Str::pluralStudly()` {#collection-method}
+#### `Str::pluralStudly()` {.collection-method}
 
 The `Str::pluralStudly` method converts a singular word string formatted in studly caps case to its plural form. This function currently only supports the English language:
 
@@ -1506,7 +1506,7 @@ You may provide an integer as a second argument to the function to retrieve the 
     // VerifiedHuman
 
 <a name="method-str-random"></a>
-#### `Str::random()` {#collection-method}
+#### `Str::random()` {.collection-method}
 
 The `Str::random` method generates a random string of the specified length. This function uses PHP's `random_bytes` function:
 
@@ -1515,7 +1515,7 @@ The `Str::random` method generates a random string of the specified length. This
     $random = Str::random(40);
 
 <a name="method-str-remove"></a>
-#### `Str::remove()` {#collection-method}
+#### `Str::remove()` {.collection-method}
 
 The `Str::remove` method removes the given value or array of values from the string:
 
@@ -1530,7 +1530,7 @@ The `Str::remove` method removes the given value or array of values from the str
 You may also pass `false` as a third argument to the `remove` method to ignore case when removing strings.
 
 <a name="method-str-replace"></a>
-#### `Str::replace()` {#collection-method}
+#### `Str::replace()` {.collection-method}
 
 The `Str::replace` method replaces a given string within the string:
 
@@ -1543,7 +1543,7 @@ The `Str::replace` method replaces a given string within the string:
     // Laravel 9.x
 
 <a name="method-str-replace-array"></a>
-#### `Str::replaceArray()` {#collection-method}
+#### `Str::replaceArray()` {.collection-method}
 
 The `Str::replaceArray` method replaces a given value in the string sequentially using an array:
 
@@ -1556,7 +1556,7 @@ The `Str::replaceArray` method replaces a given value in the string sequentially
     // The event will take place between 8:30 and 9:00
 
 <a name="method-str-replace-first"></a>
-#### `Str::replaceFirst()` {#collection-method}
+#### `Str::replaceFirst()` {.collection-method}
 
 The `Str::replaceFirst` method replaces the first occurrence of a given value in a string:
 
@@ -1567,7 +1567,7 @@ The `Str::replaceFirst` method replaces the first occurrence of a given value in
     // a quick brown fox jumps over the lazy dog
 
 <a name="method-str-replace-last"></a>
-#### `Str::replaceLast()` {#collection-method}
+#### `Str::replaceLast()` {.collection-method}
 
 The `Str::replaceLast` method replaces the last occurrence of a given value in a string:
 
@@ -1578,7 +1578,7 @@ The `Str::replaceLast` method replaces the last occurrence of a given value in a
     // the quick brown fox jumps over a lazy dog
 
 <a name="method-str-singular"></a>
-#### `Str::singular()` {#collection-method}
+#### `Str::singular()` {.collection-method}
 
 The `Str::singular` method converts a string to its singular form. This function currently only supports the English language:
 
@@ -1593,7 +1593,7 @@ The `Str::singular` method converts a string to its singular form. This function
     // child
 
 <a name="method-str-slug"></a>
-#### `Str::slug()` {#collection-method}
+#### `Str::slug()` {.collection-method}
 
 The `Str::slug` method generates a URL friendly "slug" from the given string:
 
@@ -1604,7 +1604,7 @@ The `Str::slug` method generates a URL friendly "slug" from the given string:
     // laravel-5-framework
 
 <a name="method-snake-case"></a>
-#### `Str::snake()` {#collection-method}
+#### `Str::snake()` {.collection-method}
 
 The `Str::snake` method converts the given string to `snake_case`:
 
@@ -1619,7 +1619,7 @@ The `Str::snake` method converts the given string to `snake_case`:
     // foo-bar
 
 <a name="method-str-start"></a>
-#### `Str::start()` {#collection-method}
+#### `Str::start()` {.collection-method}
 
 The `Str::start` method adds a single instance of the given value to a string if it does not already start with that value:
 
@@ -1634,7 +1634,7 @@ The `Str::start` method adds a single instance of the given value to a string if
     // /this/string
 
 <a name="method-starts-with"></a>
-#### `Str::startsWith()` {#collection-method}
+#### `Str::startsWith()` {.collection-method}
 
 The `Str::startsWith` method determines if the given string begins with the given value:
 
@@ -1651,7 +1651,7 @@ If an array of possible values is passed, the `startsWith` method will return `t
     // true
 
 <a name="method-studly-case"></a>
-#### `Str::studly()` {#collection-method}
+#### `Str::studly()` {.collection-method}
 
 The `Str::studly` method converts the given string to `StudlyCase`:
 
@@ -1662,7 +1662,7 @@ The `Str::studly` method converts the given string to `StudlyCase`:
     // FooBar
 
 <a name="method-str-substr"></a>
-#### `Str::substr()` {#collection-method}
+#### `Str::substr()` {.collection-method}
 
 The `Str::substr` method returns the portion of string specified by the start and length parameters:
 
@@ -1673,7 +1673,7 @@ The `Str::substr` method returns the portion of string specified by the start an
     // Laravel
 
 <a name="method-str-substrcount"></a>
-#### `Str::substrCount()` {#collection-method}
+#### `Str::substrCount()` {.collection-method}
 
 The `Str::substrCount` method returns the number of occurrences of a given value in the given string:
 
@@ -1684,7 +1684,7 @@ The `Str::substrCount` method returns the number of occurrences of a given value
     // 2
 
 <a name="method-title-case"></a>
-#### `Str::title()` {#collection-method}
+#### `Str::title()` {.collection-method}
 
 The `Str::title` method converts the given string to `Title Case`:
 
@@ -1695,7 +1695,7 @@ The `Str::title` method converts the given string to `Title Case`:
     // A Nice Title Uses The Correct Case
 
 <a name="method-str-ucfirst"></a>
-#### `Str::ucfirst()` {#collection-method}
+#### `Str::ucfirst()` {.collection-method}
 
 The `Str::ucfirst` method returns the given string with the first character capitalized:
 
@@ -1706,7 +1706,7 @@ The `Str::ucfirst` method returns the given string with the first character capi
     // Foo bar
 
 <a name="method-str-upper"></a>
-#### `Str::upper()` {#collection-method}
+#### `Str::upper()` {.collection-method}
 
 The `Str::upper` method converts the given string to uppercase:
 
@@ -1717,7 +1717,7 @@ The `Str::upper` method converts the given string to uppercase:
     // LARAVEL
 
 <a name="method-str-uuid"></a>
-#### `Str::uuid()` {#collection-method}
+#### `Str::uuid()` {.collection-method}
 
 The `Str::uuid` method generates a UUID (version 4):
 
@@ -1726,7 +1726,7 @@ The `Str::uuid` method generates a UUID (version 4):
     return (string) Str::uuid();
 
 <a name="method-str-word-count"></a>
-#### `Str::wordCount()` {#collection-method}
+#### `Str::wordCount()` {.collection-method}
 
 The `Str::wordCount` method returns the number of words that a string contains:
 
@@ -1737,7 +1737,7 @@ Str::wordCount('Hello, world!'); // 2
 ```
 
 <a name="method-str-words"></a>
-#### `Str::words()` {#collection-method}
+#### `Str::words()` {.collection-method}
 
 The `Str::words` method limits the number of words in a string. An additional string may be passed to this method via its third argument to specify which string should be appended to the end of the truncated string:
 
@@ -1748,7 +1748,7 @@ The `Str::words` method limits the number of words in a string. An additional st
     // Perfectly balanced, as >>>
 
 <a name="method-trans"></a>
-#### `trans()` {#collection-method}
+#### `trans()` {.collection-method}
 
 The `trans` function translates the given translation key using your [localization files](/docs/{{version}}/localization):
 
@@ -1757,7 +1757,7 @@ The `trans` function translates the given translation key using your [localizati
 If the specified translation key does not exist, the `trans` function will return the given key. So, using the example above, the `trans` function would return `messages.welcome` if the translation key does not exist.
 
 <a name="method-trans-choice"></a>
-#### `trans_choice()` {#collection-method}
+#### `trans_choice()` {.collection-method}
 
 The `trans_choice` function translates the given translation key with inflection:
 
@@ -1771,7 +1771,7 @@ If the specified translation key does not exist, the `trans_choice` function wil
 Fluent strings provide a more fluent, object-oriented interface for working with string values, allowing you to chain multiple string operations together using a more readable syntax compared to traditional string operations.
 
 <a name="method-fluent-str-after"></a>
-#### `after` {#collection-method}
+#### `after` {.collection-method}
 
 The `after` method returns everything after the given value in a string. The entire string will be returned if the value does not exist within the string:
 
@@ -1782,7 +1782,7 @@ The `after` method returns everything after the given value in a string. The ent
     // ' my name'
 
 <a name="method-fluent-str-after-last"></a>
-#### `afterLast` {#collection-method}
+#### `afterLast` {.collection-method}
 
 The `afterLast` method returns everything after the last occurrence of the given value in a string. The entire string will be returned if the value does not exist within the string:
 
@@ -1793,7 +1793,7 @@ The `afterLast` method returns everything after the last occurrence of the given
     // 'Controller'
 
 <a name="method-fluent-str-append"></a>
-#### `append` {#collection-method}
+#### `append` {.collection-method}
 
 The `append` method appends the given values to the string:
 
@@ -1804,7 +1804,7 @@ The `append` method appends the given values to the string:
     // 'Taylor Otwell'
 
 <a name="method-fluent-str-ascii"></a>
-#### `ascii` {#collection-method}
+#### `ascii` {.collection-method}
 
 The `ascii` method will attempt to transliterate the string into an ASCII value:
 
@@ -1815,7 +1815,7 @@ The `ascii` method will attempt to transliterate the string into an ASCII value:
     // 'u'
 
 <a name="method-fluent-str-basename"></a>
-#### `basename` {#collection-method}
+#### `basename` {.collection-method}
 
 The `basename` method will return the trailing name component of the given string:
 
@@ -1834,7 +1834,7 @@ If needed, you may provide an "extension" that will be removed from the trailing
     // 'baz'
 
 <a name="method-fluent-str-before"></a>
-#### `before` {#collection-method}
+#### `before` {.collection-method}
 
 The `before` method returns everything before the given value in a string:
 
@@ -1845,7 +1845,7 @@ The `before` method returns everything before the given value in a string:
     // 'This is '
 
 <a name="method-fluent-str-before-last"></a>
-#### `beforeLast` {#collection-method}
+#### `beforeLast` {.collection-method}
 
 The `beforeLast` method returns everything before the last occurrence of the given value in a string:
 
@@ -1856,7 +1856,7 @@ The `beforeLast` method returns everything before the last occurrence of the giv
     // 'This '
 
 <a name="method-fluent-str-camel"></a>
-#### `camel` {#collection-method}
+#### `camel` {.collection-method}
 
 The `camel` method converts the given string to `camelCase`:
 
@@ -1867,7 +1867,7 @@ The `camel` method converts the given string to `camelCase`:
     // fooBar
 
 <a name="method-fluent-str-contains"></a>
-#### `contains` {#collection-method}
+#### `contains` {.collection-method}
 
 The `contains` method determines if the given string contains the given value. This method is case sensitive:
 
@@ -1886,7 +1886,7 @@ You may also pass an array of values to determine if the given string contains a
     // true
 
 <a name="method-fluent-str-contains-all"></a>
-#### `containsAll` {#collection-method}
+#### `containsAll` {.collection-method}
 
 The `containsAll` method determines if the given string contains all of the values in the given array:
 
@@ -1897,7 +1897,7 @@ The `containsAll` method determines if the given string contains all of the valu
     // true
 
 <a name="method-fluent-str-dirname"></a>
-#### `dirname` {#collection-method}
+#### `dirname` {.collection-method}
 
 The `dirname` method returns the parent directory portion of the given string:
 
@@ -1916,7 +1916,7 @@ If necessary, you may specify how many directory levels you wish to trim from th
     // '/foo'
 
 <a name="method-fluent-str-ends-with"></a>
-#### `endsWith` {#collection-method}
+#### `endsWith` {.collection-method}
 
 The `endsWith` method determines if the given string ends with the given value:
 
@@ -1939,7 +1939,7 @@ You may also pass an array of values to determine if the given string ends with 
     // false
 
 <a name="method-fluent-str-exactly"></a>
-#### `exactly` {#collection-method}
+#### `exactly` {.collection-method}
 
 The `exactly` method determines if the given string is an exact match with another string:
 
@@ -1950,7 +1950,7 @@ The `exactly` method determines if the given string is an exact match with anoth
     // true
 
 <a name="method-fluent-str-explode"></a>
-#### `explode` {#collection-method}
+#### `explode` {.collection-method}
 
 The `explode` method splits the string by the given delimiter and returns a collection containing each section of the split string:
 
@@ -1961,7 +1961,7 @@ The `explode` method splits the string by the given delimiter and returns a coll
     // collect(['foo', 'bar', 'baz'])
 
 <a name="method-fluent-str-finish"></a>
-#### `finish` {#collection-method}
+#### `finish` {.collection-method}
 
 The `finish` method adds a single instance of the given value to a string if it does not already end with that value:
 
@@ -1976,7 +1976,7 @@ The `finish` method adds a single instance of the given value to a string if it 
     // this/string/
 
 <a name="method-fluent-str-is"></a>
-#### `is` {#collection-method}
+#### `is` {.collection-method}
 
 The `is` method determines if a given string matches a given pattern. Asterisks may be used as wildcard values
 
@@ -1991,7 +1991,7 @@ The `is` method determines if a given string matches a given pattern. Asterisks 
     // false
 
 <a name="method-fluent-str-is-ascii"></a>
-#### `isAscii` {#collection-method}
+#### `isAscii` {.collection-method}
 
 The `isAscii` method determines if a given string is an ASCII string:
 
@@ -2006,7 +2006,7 @@ The `isAscii` method determines if a given string is an ASCII string:
     // false
 
 <a name="method-fluent-str-is-empty"></a>
-#### `isEmpty` {#collection-method}
+#### `isEmpty` {.collection-method}
 
 The `isEmpty` method determines if the given string is empty:
 
@@ -2021,7 +2021,7 @@ The `isEmpty` method determines if the given string is empty:
     // false
 
 <a name="method-fluent-str-is-not-empty"></a>
-#### `isNotEmpty` {#collection-method}
+#### `isNotEmpty` {.collection-method}
 
 The `isNotEmpty` method determines if the given string is not empty:
 
@@ -2037,7 +2037,7 @@ The `isNotEmpty` method determines if the given string is not empty:
     // true
 
 <a name="method-fluent-str-is-uuid"></a>
-#### `isUuid` {#collection-method}
+#### `isUuid` {.collection-method}
 
 The `isUuid` method determines if a given string is a UUID:
 
@@ -2052,7 +2052,7 @@ The `isUuid` method determines if a given string is a UUID:
     // false
 
 <a name="method-fluent-str-kebab"></a>
-#### `kebab` {#collection-method}
+#### `kebab` {.collection-method}
 
 The `kebab` method converts the given string to `kebab-case`:
 
@@ -2063,7 +2063,7 @@ The `kebab` method converts the given string to `kebab-case`:
     // foo-bar
 
 <a name="method-fluent-str-length"></a>
-#### `length` {#collection-method}
+#### `length` {.collection-method}
 
 The `length` method returns the length of the given string:
 
@@ -2074,7 +2074,7 @@ The `length` method returns the length of the given string:
     // 7
 
 <a name="method-fluent-str-limit"></a>
-#### `limit` {#collection-method}
+#### `limit` {.collection-method}
 
 The `limit` method truncates the given string to the specified length:
 
@@ -2093,7 +2093,7 @@ You may also pass a second argument to change the string that will be appended t
     // The quick brown fox (...)
 
 <a name="method-fluent-str-lower"></a>
-#### `lower` {#collection-method}
+#### `lower` {.collection-method}
 
 The `lower` method converts the given string to lowercase:
 
@@ -2104,7 +2104,7 @@ The `lower` method converts the given string to lowercase:
     // 'laravel'
 
 <a name="method-fluent-str-ltrim"></a>
-#### `ltrim` {#collection-method}
+#### `ltrim` {.collection-method}
 
 The `ltrim` method trims the left side of the string:
 
@@ -2119,7 +2119,7 @@ The `ltrim` method trims the left side of the string:
     // 'Laravel/'
 
 <a name="method-fluent-str-markdown"></a>
-#### `markdown` {#collection-method}
+#### `markdown` {.collection-method}
 
 The `markdown` method converts GitHub flavored Markdown into HTML:
 
@@ -2136,7 +2136,7 @@ The `markdown` method converts GitHub flavored Markdown into HTML:
     // <h1>Taylor Otwell</h1>
 
 <a name="method-fluent-str-mask"></a>
-#### `mask` {#collection-method}
+#### `mask` {.collection-method}
 
 The `mask` method masks a portion of a string with a repeated character, and may be used to obfuscate segments of strings such as email addresses and phone numbers:
 
@@ -2153,7 +2153,7 @@ If needed, you provide a negative number as the third argument to the `mask` met
     // tay***@example.com
 
 <a name="method-fluent-str-match"></a>
-#### `match` {#collection-method}
+#### `match` {.collection-method}
 
 The `match` method will return the portion of a string that matches a given regular expression pattern:
 
@@ -2168,7 +2168,7 @@ The `match` method will return the portion of a string that matches a given regu
     // 'bar'
 
 <a name="method-fluent-str-match-all"></a>
-#### `matchAll` {#collection-method}
+#### `matchAll` {.collection-method}
 
 The `matchAll` method will return a collection containing the portions of a string that match a given regular expression pattern:
 
@@ -2189,7 +2189,7 @@ If you specify a matching group within the expression, Laravel will return a col
 If no matches are found, an empty collection will be returned.
 
 <a name="method-fluent-str-padboth"></a>
-#### `padBoth` {#collection-method}
+#### `padBoth` {.collection-method}
 
 The `padBoth` method wraps PHP's `str_pad` function, padding both sides of a string with another string until the final string reaches the desired length:
 
@@ -2204,7 +2204,7 @@ The `padBoth` method wraps PHP's `str_pad` function, padding both sides of a str
     // '  James   '
 
 <a name="method-fluent-str-padleft"></a>
-#### `padLeft` {#collection-method}
+#### `padLeft` {.collection-method}
 
 The `padLeft` method wraps PHP's `str_pad` function, padding the left side of a string with another string until the final string reaches the desired length:
 
@@ -2219,7 +2219,7 @@ The `padLeft` method wraps PHP's `str_pad` function, padding the left side of a 
     // '     James'
 
 <a name="method-fluent-str-padright"></a>
-#### `padRight` {#collection-method}
+#### `padRight` {.collection-method}
 
 The `padRight` method wraps PHP's `str_pad` function, padding the right side of a string with another string until the final string reaches the desired length:
 
@@ -2234,7 +2234,7 @@ The `padRight` method wraps PHP's `str_pad` function, padding the right side of 
     // 'James     '
 
 <a name="method-fluent-str-pipe"></a>
-#### `pipe` {#collection-method}
+#### `pipe` {.collection-method}
 
 The `pipe` method allows you to transform the string by passing its current value to the given callable:
 
@@ -2251,7 +2251,7 @@ The `pipe` method allows you to transform the string by passing its current valu
     // 'bar'
 
 <a name="method-fluent-str-plural"></a>
-#### `plural` {#collection-method}
+#### `plural` {.collection-method}
 
 The `plural` method converts a singular word string to its plural form. This function currently only supports the English language:
 
@@ -2278,7 +2278,7 @@ You may provide an integer as a second argument to the function to retrieve the 
     // child
 
 <a name="method-fluent-str-prepend"></a>
-#### `prepend` {#collection-method}
+#### `prepend` {.collection-method}
 
 The `prepend` method prepends the given values onto the string:
 
@@ -2289,7 +2289,7 @@ The `prepend` method prepends the given values onto the string:
     // Laravel Framework
 
 <a name="method-fluent-str-remove"></a>
-#### `remove` {#collection-method}
+#### `remove` {.collection-method}
 
 The `remove` method removes the given value or array of values from the string:
 
@@ -2302,7 +2302,7 @@ The `remove` method removes the given value or array of values from the string:
 You may also pass `false` as a second parameter to ignore case when removing.
 
 <a name="method-fluent-str-replace"></a>
-#### `replace` {#collection-method}
+#### `replace` {.collection-method}
 
 The `replace` method replaces a given string within the string:
 
@@ -2313,7 +2313,7 @@ The `replace` method replaces a given string within the string:
     // Laravel 7.x
 
 <a name="method-fluent-str-replace-array"></a>
-#### `replaceArray` {#collection-method}
+#### `replaceArray` {.collection-method}
 
 The `replaceArray` method replaces a given value in the string sequentially using an array:
 
@@ -2326,7 +2326,7 @@ The `replaceArray` method replaces a given value in the string sequentially usin
     // The event will take place between 8:30 and 9:00
 
 <a name="method-fluent-str-replace-first"></a>
-#### `replaceFirst` {#collection-method}
+#### `replaceFirst` {.collection-method}
 
 The `replaceFirst` method replaces the first occurrence of a given value in a string:
 
@@ -2337,7 +2337,7 @@ The `replaceFirst` method replaces the first occurrence of a given value in a st
     // a quick brown fox jumps over the lazy dog
 
 <a name="method-fluent-str-replace-last"></a>
-#### `replaceLast` {#collection-method}
+#### `replaceLast` {.collection-method}
 
 The `replaceLast` method replaces the last occurrence of a given value in a string:
 
@@ -2348,7 +2348,7 @@ The `replaceLast` method replaces the last occurrence of a given value in a stri
     // the quick brown fox jumps over a lazy dog
 
 <a name="method-fluent-str-replace-matches"></a>
-#### `replaceMatches` {#collection-method}
+#### `replaceMatches` {.collection-method}
 
 The `replaceMatches` method replaces all portions of a string matching a pattern with the given replacement string:
 
@@ -2369,7 +2369,7 @@ The `replaceMatches` method also accepts a closure that will be invoked with eac
     // '[1][2][3]'
 
 <a name="method-fluent-str-rtrim"></a>
-#### `rtrim` {#collection-method}
+#### `rtrim` {.collection-method}
 
 The `rtrim` method trims the right side of the given string:
 
@@ -2384,7 +2384,7 @@ The `rtrim` method trims the right side of the given string:
     // '/Laravel'
 
 <a name="method-fluent-str-singular"></a>
-#### `singular` {#collection-method}
+#### `singular` {.collection-method}
 
 The `singular` method converts a string to its singular form. This function currently only supports the English language:
 
@@ -2399,7 +2399,7 @@ The `singular` method converts a string to its singular form. This function curr
     // child
 
 <a name="method-fluent-str-slug"></a>
-#### `slug` {#collection-method}
+#### `slug` {.collection-method}
 
 The `slug` method generates a URL friendly "slug" from the given string:
 
@@ -2410,7 +2410,7 @@ The `slug` method generates a URL friendly "slug" from the given string:
     // laravel-framework
 
 <a name="method-fluent-str-snake"></a>
-#### `snake` {#collection-method}
+#### `snake` {.collection-method}
 
 The `snake` method converts the given string to `snake_case`:
 
@@ -2421,7 +2421,7 @@ The `snake` method converts the given string to `snake_case`:
     // foo_bar
 
 <a name="method-fluent-str-split"></a>
-#### `split` {#collection-method}
+#### `split` {.collection-method}
 
 The `split` method splits a string into a collection using a regular expression:
 
@@ -2432,7 +2432,7 @@ The `split` method splits a string into a collection using a regular expression:
     // collect(["one", "two", "three"])
 
 <a name="method-fluent-str-start"></a>
-#### `start` {#collection-method}
+#### `start` {.collection-method}
 
 The `start` method adds a single instance of the given value to a string if it does not already start with that value:
 
@@ -2447,7 +2447,7 @@ The `start` method adds a single instance of the given value to a string if it d
     // /this/string
 
 <a name="method-fluent-str-starts-with"></a>
-#### `startsWith` {#collection-method}
+#### `startsWith` {.collection-method}
 
 The `startsWith` method determines if the given string begins with the given value:
 
@@ -2458,7 +2458,7 @@ The `startsWith` method determines if the given string begins with the given val
     // true
 
 <a name="method-fluent-str-studly"></a>
-#### `studly` {#collection-method}
+#### `studly` {.collection-method}
 
 The `studly` method converts the given string to `StudlyCase`:
 
@@ -2469,7 +2469,7 @@ The `studly` method converts the given string to `StudlyCase`:
     // FooBar
 
 <a name="method-fluent-str-substr"></a>
-#### `substr` {#collection-method}
+#### `substr` {.collection-method}
 
 The `substr` method returns the portion of the string specified by the given start and length parameters:
 
@@ -2484,7 +2484,7 @@ The `substr` method returns the portion of the string specified by the given sta
     // Frame
 
 <a name="method-fluent-str-tap"></a>
-#### `tap` {#collection-method}
+#### `tap` {.collection-method}
 
 The `tap` method passes the string to the given closure, allowing you to examine and interact with the string while not affecting the string itself. The original string is returned by the `tap` method regardless of what is returned by the closure:
 
@@ -2500,7 +2500,7 @@ The `tap` method passes the string to the given closure, allowing you to examine
     // LARAVEL FRAMEWORK
 
 <a name="method-fluent-str-test"></a>
-#### `test` {#collection-method}
+#### `test` {.collection-method}
 
 The `test` method determines if a string matches the given regular expression pattern:
 
@@ -2511,7 +2511,7 @@ The `test` method determines if a string matches the given regular expression pa
     // true
 
 <a name="method-fluent-str-title"></a>
-#### `title` {#collection-method}
+#### `title` {.collection-method}
 
 The `title` method converts the given string to `Title Case`:
 
@@ -2522,7 +2522,7 @@ The `title` method converts the given string to `Title Case`:
     // A Nice Title Uses The Correct Case
 
 <a name="method-fluent-str-trim"></a>
-#### `trim` {#collection-method}
+#### `trim` {.collection-method}
 
 The `trim` method trims the given string:
 
@@ -2537,7 +2537,7 @@ The `trim` method trims the given string:
     // 'Laravel'
 
 <a name="method-fluent-str-ucfirst"></a>
-#### `ucfirst` {#collection-method}
+#### `ucfirst` {.collection-method}
 
 The `ucfirst` method returns the given string with the first character capitalized:
 
@@ -2548,7 +2548,7 @@ The `ucfirst` method returns the given string with the first character capitaliz
     // Foo bar
 
 <a name="method-fluent-str-upper"></a>
-#### `upper` {#collection-method}
+#### `upper` {.collection-method}
 
 The `upper` method converts the given string to uppercase:
 
@@ -2559,7 +2559,7 @@ The `upper` method converts the given string to uppercase:
     // LARAVEL
 
 <a name="method-fluent-str-when"></a>
-#### `when` {#collection-method}
+#### `when` {.collection-method}
 
 The `when` method invokes the given closure if a given condition is `true`. The closure will receive the fluent string instance:
 
@@ -2575,7 +2575,7 @@ The `when` method invokes the given closure if a given condition is `true`. The 
 If necessary, you may pass another closure as the third parameter to the `when` method. This closure will execute if the condition parameter evaluates to `false`.
 
 <a name="method-fluent-str-when-empty"></a>
-#### `whenEmpty` {#collection-method}
+#### `whenEmpty` {.collection-method}
 
 The `whenEmpty` method invokes the given closure if the string is empty. If the closure returns a value, that value will also be returned by the `whenEmpty` method. If the closure does not return a value, the fluent string instance will be returned:
 
@@ -2588,7 +2588,7 @@ The `whenEmpty` method invokes the given closure if the string is empty. If the 
     // 'Laravel'
 
 <a name="method-fluent-str-word-count"></a>
-#### `wordCount` {#collection-method}
+#### `wordCount` {.collection-method}
 
 The `wordCount` method returns the number of words that a string contains:
 
@@ -2599,7 +2599,7 @@ Str::of('Hello, world!')->wordCount(); // 2
 ```
 
 <a name="method-fluent-str-words"></a>
-#### `words` {#collection-method}
+#### `words` {.collection-method}
 
 The `words` method limits the number of words in a string. If necessary, you may specify an additional string that will be appended to the truncated string:
 
@@ -2613,7 +2613,7 @@ The `words` method limits the number of words in a string. If necessary, you may
 ## URLs
 
 <a name="method-action"></a>
-#### `action()` {#collection-method}
+#### `action()` {.collection-method}
 
 The `action` function generates a URL for the given controller action:
 
@@ -2626,7 +2626,7 @@ If the method accepts route parameters, you may pass them as the second argument
     $url = action([UserController::class, 'profile'], ['id' => 1]);
 
 <a name="method-asset"></a>
-#### `asset()` {#collection-method}
+#### `asset()` {.collection-method}
 
 The `asset` function generates a URL for an asset using the current scheme of the request (HTTP or HTTPS):
 
@@ -2639,7 +2639,7 @@ You can configure the asset URL host by setting the `ASSET_URL` variable in your
     $url = asset('img/photo.jpg'); // http://example.com/assets/img/photo.jpg
 
 <a name="method-route"></a>
-#### `route()` {#collection-method}
+#### `route()` {.collection-method}
 
 The `route` function generates a URL for a given [named route](/docs/{{version}}/routing#named-routes):
 
@@ -2654,14 +2654,14 @@ By default, the `route` function generates an absolute URL. If you wish to gener
     $url = route('route.name', ['id' => 1], false);
 
 <a name="method-secure-asset"></a>
-#### `secure_asset()` {#collection-method}
+#### `secure_asset()` {.collection-method}
 
 The `secure_asset` function generates a URL for an asset using HTTPS:
 
     $url = secure_asset('img/photo.jpg');
 
 <a name="method-secure-url"></a>
-#### `secure_url()` {#collection-method}
+#### `secure_url()` {.collection-method}
 
 The `secure_url` function generates a fully qualified HTTPS URL to the given path. Additional URL segments may be passed in the function's second argument:
 
@@ -2670,7 +2670,7 @@ The `secure_url` function generates a fully qualified HTTPS URL to the given pat
     $url = secure_url('user/profile', [1]);
 
 <a name="method-url"></a>
-#### `url()` {#collection-method}
+#### `url()` {.collection-method}
 
 The `url` function generates a fully qualified URL to the given path:
 
@@ -2690,7 +2690,7 @@ If no path is provided, an `Illuminate\Routing\UrlGenerator` instance is returne
 ## Miscellaneous
 
 <a name="method-abort"></a>
-#### `abort()` {#collection-method}
+#### `abort()` {.collection-method}
 
 The `abort` function throws [an HTTP exception](/docs/{{version}}/errors#http-exceptions) which will be rendered by the [exception handler](/docs/{{version}}/errors#the-exception-handler):
 
@@ -2701,7 +2701,7 @@ You may also provide the exception's message and custom HTTP response headers th
     abort(403, 'Unauthorized.', $headers);
 
 <a name="method-abort-if"></a>
-#### `abort_if()` {#collection-method}
+#### `abort_if()` {.collection-method}
 
 The `abort_if` function throws an HTTP exception if a given boolean expression evaluates to `true`:
 
@@ -2710,7 +2710,7 @@ The `abort_if` function throws an HTTP exception if a given boolean expression e
 Like the `abort` method, you may also provide the exception's response text as the third argument and an array of custom response headers as the fourth argument to the function.
 
 <a name="method-abort-unless"></a>
-#### `abort_unless()` {#collection-method}
+#### `abort_unless()` {.collection-method}
 
 The `abort_unless` function throws an HTTP exception if a given boolean expression evaluates to `false`:
 
@@ -2719,7 +2719,7 @@ The `abort_unless` function throws an HTTP exception if a given boolean expressi
 Like the `abort` method, you may also provide the exception's response text as the third argument and an array of custom response headers as the fourth argument to the function.
 
 <a name="method-app"></a>
-#### `app()` {#collection-method}
+#### `app()` {.collection-method}
 
 The `app` function returns the [service container](/docs/{{version}}/container) instance:
 
@@ -2730,7 +2730,7 @@ You may pass a class or interface name to resolve it from the container:
     $api = app('HelpSpot\API');
 
 <a name="method-auth"></a>
-#### `auth()` {#collection-method}
+#### `auth()` {.collection-method}
 
 The `auth` function returns an [authenticator](/docs/{{version}}/authentication) instance. You may use it as an alternative to the `Auth` facade:
 
@@ -2741,7 +2741,7 @@ If needed, you may specify which guard instance you would like to access:
     $user = auth('admin')->user();
 
 <a name="method-back"></a>
-#### `back()` {#collection-method}
+#### `back()` {.collection-method}
 
 The `back` function generates a [redirect HTTP response](/docs/{{version}}/responses#redirects) to the user's previous location:
 
@@ -2750,14 +2750,14 @@ The `back` function generates a [redirect HTTP response](/docs/{{version}}/respo
     return back();
 
 <a name="method-bcrypt"></a>
-#### `bcrypt()` {#collection-method}
+#### `bcrypt()` {.collection-method}
 
 The `bcrypt` function [hashes](/docs/{{version}}/hashing) the given value using Bcrypt. You may use this function as an alternative to the `Hash` facade:
 
     $password = bcrypt('my-secret-password');
 
 <a name="method-blank"></a>
-#### `blank()` {#collection-method}
+#### `blank()` {.collection-method}
 
 The `blank` function determines whether the given value is "blank":
 
@@ -2777,7 +2777,7 @@ The `blank` function determines whether the given value is "blank":
 For the inverse of `blank`, see the [`filled`](#method-filled) method.
 
 <a name="method-broadcast"></a>
-#### `broadcast()` {#collection-method}
+#### `broadcast()` {.collection-method}
 
 The `broadcast` function [broadcasts](/docs/{{version}}/broadcasting) the given [event](/docs/{{version}}/events) to its listeners:
 
@@ -2786,7 +2786,7 @@ The `broadcast` function [broadcasts](/docs/{{version}}/broadcasting) the given 
     broadcast(new UserRegistered($user))->toOthers();
 
 <a name="method-cache"></a>
-#### `cache()` {#collection-method}
+#### `cache()` {.collection-method}
 
 The `cache` function may be used to get values from the [cache](/docs/{{version}}/cache). If the given key does not exist in the cache, an optional default value will be returned:
 
@@ -2801,21 +2801,21 @@ You may add items to the cache by passing an array of key / value pairs to the f
     cache(['key' => 'value'], now()->addSeconds(10));
 
 <a name="method-class-uses-recursive"></a>
-#### `class_uses_recursive()` {#collection-method}
+#### `class_uses_recursive()` {.collection-method}
 
 The `class_uses_recursive` function returns all traits used by a class, including traits used by all of its parent classes:
 
     $traits = class_uses_recursive(App\Models\User::class);
 
 <a name="method-collect"></a>
-#### `collect()` {#collection-method}
+#### `collect()` {.collection-method}
 
 The `collect` function creates a [collection](/docs/{{version}}/collections) instance from the given value:
 
     $collection = collect(['taylor', 'abigail']);
 
 <a name="method-config"></a>
-#### `config()` {#collection-method}
+#### `config()` {.collection-method}
 
 The `config` function gets the value of a [configuration](/docs/{{version}}/configuration) variable. The configuration values may be accessed using "dot" syntax, which includes the name of the file and the option you wish to access. A default value may be specified and is returned if the configuration option does not exist:
 
@@ -2828,28 +2828,28 @@ You may set configuration variables at runtime by passing an array of key / valu
     config(['app.debug' => true]);
 
 <a name="method-cookie"></a>
-#### `cookie()` {#collection-method}
+#### `cookie()` {.collection-method}
 
 The `cookie` function creates a new [cookie](/docs/{{version}}/requests#cookies) instance:
 
     $cookie = cookie('name', 'value', $minutes);
 
 <a name="method-csrf-field"></a>
-#### `csrf_field()` {#collection-method}
+#### `csrf_field()` {.collection-method}
 
 The `csrf_field` function generates an HTML `hidden` input field containing the value of the CSRF token. For example, using [Blade syntax](/docs/{{version}}/blade):
 
     {{ csrf_field() }}
 
 <a name="method-csrf-token"></a>
-#### `csrf_token()` {#collection-method}
+#### `csrf_token()` {.collection-method}
 
 The `csrf_token` function retrieves the value of the current CSRF token:
 
     $token = csrf_token();
 
 <a name="method-dd"></a>
-#### `dd()` {#collection-method}
+#### `dd()` {.collection-method}
 
 The `dd` function dumps the given variables and ends execution of the script:
 
@@ -2860,14 +2860,14 @@ The `dd` function dumps the given variables and ends execution of the script:
 If you do not want to halt the execution of your script, use the [`dump`](#method-dump) function instead.
 
 <a name="method-dispatch"></a>
-#### `dispatch()` {#collection-method}
+#### `dispatch()` {.collection-method}
 
 The `dispatch` function pushes the given [job](/docs/{{version}}/queues#creating-jobs) onto the Laravel [job queue](/docs/{{version}}/queues):
 
     dispatch(new App\Jobs\SendEmails);
 
 <a name="method-dump"></a>
-#### `dump()` {#collection-method}
+#### `dump()` {.collection-method}
 
 The `dump` function dumps the given variables:
 
@@ -2878,7 +2878,7 @@ The `dump` function dumps the given variables:
 If you want to stop executing the script after dumping the variables, use the [`dd`](#method-dd) function instead.
 
 <a name="method-env"></a>
-#### `env()` {#collection-method}
+#### `env()` {.collection-method}
 
 The `env` function retrieves the value of an [environment variable](/docs/{{version}}/configuration#environment-configuration) or returns a default value:
 
@@ -2889,14 +2889,14 @@ The `env` function retrieves the value of an [environment variable](/docs/{{vers
 > {note} If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded and all calls to the `env` function will return `null`.
 
 <a name="method-event"></a>
-#### `event()` {#collection-method}
+#### `event()` {.collection-method}
 
 The `event` function dispatches the given [event](/docs/{{version}}/events) to its listeners:
 
     event(new UserRegistered($user));
 
 <a name="method-filled"></a>
-#### `filled()` {#collection-method}
+#### `filled()` {.collection-method}
 
 The `filled` function determines whether the given value is not "blank":
 
@@ -2916,7 +2916,7 @@ The `filled` function determines whether the given value is not "blank":
 For the inverse of `filled`, see the [`blank`](#method-blank) method.
 
 <a name="method-info"></a>
-#### `info()` {#collection-method}
+#### `info()` {.collection-method}
 
 The `info` function will write information to your application's [log](/docs/{{version}}/logging):
 
@@ -2927,7 +2927,7 @@ An array of contextual data may also be passed to the function:
     info('User login attempt failed.', ['id' => $user->id]);
 
 <a name="method-logger"></a>
-#### `logger()` {#collection-method}
+#### `logger()` {.collection-method}
 
 The `logger` function can be used to write a `debug` level message to the [log](/docs/{{version}}/logging):
 
@@ -2942,7 +2942,7 @@ A [logger](/docs/{{version}}/errors#logging) instance will be returned if no val
     logger()->error('You are not allowed here.');
 
 <a name="method-method-field"></a>
-#### `method_field()` {#collection-method}
+#### `method_field()` {.collection-method}
 
 The `method_field` function generates an HTML `hidden` input field containing the spoofed value of the form's HTTP verb. For example, using [Blade syntax](/docs/{{version}}/blade):
 
@@ -2951,14 +2951,14 @@ The `method_field` function generates an HTML `hidden` input field containing th
     </form>
 
 <a name="method-now"></a>
-#### `now()` {#collection-method}
+#### `now()` {.collection-method}
 
 The `now` function creates a new `Illuminate\Support\Carbon` instance for the current time:
 
     $now = now();
 
 <a name="method-old"></a>
-#### `old()` {#collection-method}
+#### `old()` {.collection-method}
 
 The `old` function [retrieves](/docs/{{version}}/requests#retrieving-input) an [old input](/docs/{{version}}/requests#old-input) value flashed into the session:
 
@@ -2967,7 +2967,7 @@ The `old` function [retrieves](/docs/{{version}}/requests#retrieving-input) an [
     $value = old('value', 'default');
 
 <a name="method-optional"></a>
-#### `optional()` {#collection-method}
+#### `optional()` {.collection-method}
 
 The `optional` function accepts any argument and allows you to access properties or call methods on that object. If the given object is `null`, properties and methods will return `null` instead of causing an error:
 
@@ -2982,14 +2982,14 @@ The `optional` function also accepts a closure as its second argument. The closu
     });
 
 <a name="method-policy"></a>
-#### `policy()` {#collection-method}
+#### `policy()` {.collection-method}
 
 The `policy` method retrieves a [policy](/docs/{{version}}/authorization#creating-policies) instance for a given class:
 
     $policy = policy(App\Models\User::class);
 
 <a name="method-redirect"></a>
-#### `redirect()` {#collection-method}
+#### `redirect()` {.collection-method}
 
 The `redirect` function returns a [redirect HTTP response](/docs/{{version}}/responses#redirects), or returns the redirector instance if called with no arguments:
 
@@ -3000,7 +3000,7 @@ The `redirect` function returns a [redirect HTTP response](/docs/{{version}}/res
     return redirect()->route('route.name');
 
 <a name="method-report"></a>
-#### `report()` {#collection-method}
+#### `report()` {.collection-method}
 
 The `report` function will report an exception using your [exception handler](/docs/{{version}}/errors#the-exception-handler):
 
@@ -3011,7 +3011,7 @@ The `report` function also accepts a string as an argument. When a string is giv
     report('Something went wrong.');
 
 <a name="method-request"></a>
-#### `request()` {#collection-method}
+#### `request()` {.collection-method}
 
 The `request` function returns the current [request](/docs/{{version}}/requests) instance or obtains an input field's value from the current request:
 
@@ -3020,7 +3020,7 @@ The `request` function returns the current [request](/docs/{{version}}/requests)
     $value = request('key', $default);
 
 <a name="method-rescue"></a>
-#### `rescue()` {#collection-method}
+#### `rescue()` {.collection-method}
 
 The `rescue` function executes the given closure and catches any exceptions that occur during its execution. All exceptions that are caught will be sent to your [exception handler](/docs/{{version}}/errors#the-exception-handler); however, the request will continue processing:
 
@@ -3041,14 +3041,14 @@ You may also pass a second argument to the `rescue` function. This argument will
     });
 
 <a name="method-resolve"></a>
-#### `resolve()` {#collection-method}
+#### `resolve()` {.collection-method}
 
 The `resolve` function resolves a given class or interface name to an instance using the [service container](/docs/{{version}}/container):
 
     $api = resolve('HelpSpot\API');
 
 <a name="method-response"></a>
-#### `response()` {#collection-method}
+#### `response()` {.collection-method}
 
 The `response` function creates a [response](/docs/{{version}}/responses) instance or obtains an instance of the response factory:
 
@@ -3057,7 +3057,7 @@ The `response` function creates a [response](/docs/{{version}}/responses) instan
     return response()->json(['foo' => 'bar'], 200, $headers);
 
 <a name="method-retry"></a>
-#### `retry()` {#collection-method}
+#### `retry()` {.collection-method}
 
 The `retry` function attempts to execute the given callback until the given maximum attempt threshold is met. If the callback does not throw an exception, its return value will be returned. If the callback throws an exception, it will automatically be retried. If the maximum attempt count is exceeded, the exception will be thrown:
 
@@ -3083,7 +3083,7 @@ To only retry under specific conditions, you may pass a closure as the fourth ar
     });
 
 <a name="method-session"></a>
-#### `session()` {#collection-method}
+#### `session()` {.collection-method}
 
 The `session` function may be used to get or set [session](/docs/{{version}}/session) values:
 
@@ -3100,7 +3100,7 @@ The session store will be returned if no value is passed to the function:
     session()->put('key', $value);
 
 <a name="method-tap"></a>
-#### `tap()` {#collection-method}
+#### `tap()` {.collection-method}
 
 The `tap` function accepts two arguments: an arbitrary `$value` and a closure. The `$value` will be passed to the closure and then be returned by the `tap` function. The return value of the closure is irrelevant:
 
@@ -3124,7 +3124,7 @@ To add a `tap` method to a class, you may add the `Illuminate\Support\Traits\Tap
     });
 
 <a name="method-throw-if"></a>
-#### `throw_if()` {#collection-method}
+#### `throw_if()` {.collection-method}
 
 The `throw_if` function throws the given exception if a given boolean expression evaluates to `true`:
 
@@ -3137,7 +3137,7 @@ The `throw_if` function throws the given exception if a given boolean expression
     );
 
 <a name="method-throw-unless"></a>
-#### `throw_unless()` {#collection-method}
+#### `throw_unless()` {.collection-method}
 
 The `throw_unless` function throws the given exception if a given boolean expression evaluates to `false`:
 
@@ -3150,21 +3150,21 @@ The `throw_unless` function throws the given exception if a given boolean expres
     );
 
 <a name="method-today"></a>
-#### `today()` {#collection-method}
+#### `today()` {.collection-method}
 
 The `today` function creates a new `Illuminate\Support\Carbon` instance for the current date:
 
     $today = today();
 
 <a name="method-trait-uses-recursive"></a>
-#### `trait_uses_recursive()` {#collection-method}
+#### `trait_uses_recursive()` {.collection-method}
 
 The `trait_uses_recursive` function returns all traits used by a trait:
 
     $traits = trait_uses_recursive(\Illuminate\Notifications\Notifiable::class);
 
 <a name="method-transform"></a>
-#### `transform()` {#collection-method}
+#### `transform()` {.collection-method}
 
 The `transform` function executes a closure on a given value if the value is not [blank](#method-blank) and then returns the return value of the closure:
 
@@ -3183,14 +3183,14 @@ A default value or closure may be passed as the third argument to the function. 
     // The value is blank
 
 <a name="method-validator"></a>
-#### `validator()` {#collection-method}
+#### `validator()` {.collection-method}
 
 The `validator` function creates a new [validator](/docs/{{version}}/validation) instance with the given arguments. You may use it as an alternative to the `Validator` facade:
 
     $validator = validator($data, $rules, $messages);
 
 <a name="method-value"></a>
-#### `value()` {#collection-method}
+#### `value()` {.collection-method}
 
 The `value` function returns the value it is given. However, if you pass a closure to the function, the closure will be executed and its returned value will be returned:
 
@@ -3205,14 +3205,14 @@ The `value` function returns the value it is given. However, if you pass a closu
     // false
 
 <a name="method-view"></a>
-#### `view()` {#collection-method}
+#### `view()` {.collection-method}
 
 The `view` function retrieves a [view](/docs/{{version}}/views) instance:
 
     return view('auth.login');
 
 <a name="method-with"></a>
-#### `with()` {#collection-method}
+#### `with()` {.collection-method}
 
 The `with` function returns the value it is given. If a closure is passed as the second argument to the function, the closure will be executed and its returned value will be returned:
 

--- a/migrations.md
+++ b/migrations.md
@@ -322,6 +322,15 @@ The schema builder blueprint offers a variety of methods that correspond to the 
     #collection-method-list a {
         display: block;
     }
+
+    .collection-method code {
+        font-size: 14px;
+    }
+
+    .collection-method:not(.first-collection-method) {
+        margin-top: 50px;
+    }
+</style>
 </style>
 
 <div id="collection-method-list" markdown="1">
@@ -392,210 +401,210 @@ The schema builder blueprint offers a variety of methods that correspond to the 
 </div>
 
 <a name="column-method-bigIncrements"></a>
-#### `bigIncrements()` {#collection-method}
+#### `bigIncrements()` {.collection-method .first-collection-method}
 
 The `bigIncrements` method creates an auto-incrementing `UNSIGNED BIGINT` (primary key) equivalent column:
 
     $table->bigIncrements('id');
 
 <a name="column-method-bigInteger"></a>
-#### `bigInteger()` {#collection-method}
+#### `bigInteger()` {.collection-method}
 
 The `bigInteger` method creates a `BIGINT` equivalent column:
 
     $table->bigInteger('votes');
 
 <a name="column-method-binary"></a>
-#### `binary()` {#collection-method}
+#### `binary()` {.collection-method}
 
 The `binary` method creates a `BLOB` equivalent column:
 
     $table->binary('photo');
 
 <a name="column-method-boolean"></a>
-#### `boolean()` {#collection-method}
+#### `boolean()` {.collection-method}
 
 The `boolean` method creates a `BOOLEAN` equivalent column:
 
     $table->boolean('confirmed');
 
 <a name="column-method-char"></a>
-#### `char()` {#collection-method}
+#### `char()` {.collection-method}
 
 The `char` method creates a `CHAR` equivalent column with of a given length:
 
     $table->char('name', 100);
 
 <a name="column-method-dateTimeTz"></a>
-#### `dateTimeTz()` {#collection-method}
+#### `dateTimeTz()` {.collection-method}
 
 The `dateTimeTz` method creates a `DATETIME` (with timezone) equivalent column with an optional precision (total digits):
 
     $table->dateTimeTz('created_at', $precision = 0);
 
 <a name="column-method-dateTime"></a>
-#### `dateTime()` {#collection-method}
+#### `dateTime()` {.collection-method}
 
 The `dateTime` method creates a `DATETIME` equivalent column with an optional precision (total digits):
 
     $table->dateTime('created_at', $precision = 0);
 
 <a name="column-method-date"></a>
-#### `date()` {#collection-method}
+#### `date()` {.collection-method}
 
 The `date` method creates a `DATE` equivalent column:
 
     $table->date('created_at');
 
 <a name="column-method-decimal"></a>
-#### `decimal()` {#collection-method}
+#### `decimal()` {.collection-method}
 
 The `decimal` method creates a `DECIMAL` equivalent column with the given precision (total digits) and scale (decimal digits):
 
     $table->decimal('amount', $precision = 8, $scale = 2);
 
 <a name="column-method-double"></a>
-#### `double()` {#collection-method}
+#### `double()` {.collection-method}
 
 The `double` method creates a `DOUBLE` equivalent column with the given precision (total digits) and scale (decimal digits):
 
     $table->double('amount', 8, 2);
 
 <a name="column-method-enum"></a>
-#### `enum()` {#collection-method}
+#### `enum()` {.collection-method}
 
 The `enum` method creates a `ENUM` equivalent column with the given valid values:
 
     $table->enum('difficulty', ['easy', 'hard']);
 
 <a name="column-method-float"></a>
-#### `float()` {#collection-method}
+#### `float()` {.collection-method}
 
 The `float` method creates a `FLOAT` equivalent column with the given precision (total digits) and scale (decimal digits):
 
     $table->float('amount', 8, 2);
 
 <a name="column-method-foreignId"></a>
-#### `foreignId()` {#collection-method}
+#### `foreignId()` {.collection-method}
 
 The `foreignId` method creates an `UNSIGNED BIGINT` equivalent column:
 
     $table->foreignId('user_id');
 
 <a name="column-method-foreignIdFor"></a>
-#### `foreignIdFor()` {#collection-method}
+#### `foreignIdFor()` {.collection-method}
 
 The `foreignIdFor` method adds a `{column}_id UNSIGNED BIGINT` equivalent column for a given model class:
 
     $table->foreignIdFor(User::class);
 
 <a name="column-method-foreignUuid"></a>
-#### `foreignUuid()` {#collection-method}
+#### `foreignUuid()` {.collection-method}
 
 The `foreignUuid` method creates a `UUID` equivalent column:
 
     $table->foreignUuid('user_id');
 
 <a name="column-method-geometryCollection"></a>
-#### `geometryCollection()` {#collection-method}
+#### `geometryCollection()` {.collection-method}
 
 The `geometryCollection` method creates a `GEOMETRYCOLLECTION` equivalent column:
 
     $table->geometryCollection('positions');
 
 <a name="column-method-geometry"></a>
-#### `geometry()` {#collection-method}
+#### `geometry()` {.collection-method}
 
 The `geometry` method creates a `GEOMETRY` equivalent column:
 
     $table->geometry('positions');
 
 <a name="column-method-id"></a>
-#### `id()` {#collection-method}
+#### `id()` {.collection-method}
 
 The `id` method is an alias of the `bigIncrements` method. By default, the method will create an `id` column; however, you may pass a column name if you would like to assign a different name to the column:
 
     $table->id();
 
 <a name="column-method-increments"></a>
-#### `increments()` {#collection-method}
+#### `increments()` {.collection-method}
 
 The `increments` method creates an auto-incrementing `UNSIGNED INTEGER` equivalent column as a primary key:
 
     $table->increments('id');
 
 <a name="column-method-integer"></a>
-#### `integer()` {#collection-method}
+#### `integer()` {.collection-method}
 
 The `integer` method creates an `INTEGER` equivalent column:
 
     $table->integer('votes');
 
 <a name="column-method-ipAddress"></a>
-#### `ipAddress()` {#collection-method}
+#### `ipAddress()` {.collection-method}
 
 The `ipAddress` method creates a `VARCHAR` equivalent column:
 
     $table->ipAddress('visitor');
 
 <a name="column-method-json"></a>
-#### `json()` {#collection-method}
+#### `json()` {.collection-method}
 
 The `json` method creates a `JSON` equivalent column:
 
     $table->json('options');
 
 <a name="column-method-jsonb"></a>
-#### `jsonb()` {#collection-method}
+#### `jsonb()` {.collection-method}
 
 The `jsonb` method creates a `JSONB` equivalent column:
 
     $table->jsonb('options');
 
 <a name="column-method-lineString"></a>
-#### `lineString()` {#collection-method}
+#### `lineString()` {.collection-method}
 
 The `lineString` method creates a `LINESTRING` equivalent column:
 
     $table->lineString('positions');
 
 <a name="column-method-longText"></a>
-#### `longText()` {#collection-method}
+#### `longText()` {.collection-method}
 
 The `longText` method creates a `LONGTEXT` equivalent column:
 
     $table->longText('description');
 
 <a name="column-method-macAddress"></a>
-#### `macAddress()` {#collection-method}
+#### `macAddress()` {.collection-method}
 
 The `macAddress` method creates a column that is intended to hold a MAC address. Some database systems, such as PostgreSQL, have a dedicated column type for this type of data. Other database systems will use a string equivalent column:
 
     $table->macAddress('device');
 
 <a name="column-method-mediumIncrements"></a>
-#### `mediumIncrements()` {#collection-method}
+#### `mediumIncrements()` {.collection-method}
 
 The `mediumIncrements` method creates an auto-incrementing `UNSIGNED MEDIUMINT` equivalent column as a primary key:
 
     $table->mediumIncrements('id');
 
 <a name="column-method-mediumInteger"></a>
-#### `mediumInteger()` {#collection-method}
+#### `mediumInteger()` {.collection-method}
 
 The `mediumInteger` method creates a `MEDIUMINT` equivalent column:
 
     $table->mediumInteger('votes');
 
 <a name="column-method-mediumText"></a>
-#### `mediumText()` {#collection-method}
+#### `mediumText()` {.collection-method}
 
 The `mediumText` method creates a `MEDIUMTEXT` equivalent column:
 
     $table->mediumText('description');
 
 <a name="column-method-morphs"></a>
-#### `morphs()` {#collection-method}
+#### `morphs()` {.collection-method}
 
 The `morphs` method is a convenience method that adds a `{column}_id` `UNSIGNED BIGINT` equivalent column and a `{column}_type` `VARCHAR` equivalent column.
 
@@ -604,224 +613,224 @@ This method is intended to be used when defining the columns necessary for a pol
     $table->morphs('taggable');
 
 <a name="column-method-multiLineString"></a>
-#### `multiLineString()` {#collection-method}
+#### `multiLineString()` {.collection-method}
 
 The `multiLineString` method creates a `MULTILINESTRING` equivalent column:
 
     $table->multiLineString('positions');
 
 <a name="column-method-multiPoint"></a>
-#### `multiPoint()` {#collection-method}
+#### `multiPoint()` {.collection-method}
 
 The `multiPoint` method creates a `MULTIPOINT` equivalent column:
 
     $table->multiPoint('positions');
 
 <a name="column-method-multiPolygon"></a>
-#### `multiPolygon()` {#collection-method}
+#### `multiPolygon()` {.collection-method}
 
 The `multiPolygon` method creates a `MULTIPOLYGON` equivalent column:
 
     $table->multiPolygon('positions');
 
 <a name="column-method-nullableTimestamps"></a>
-#### `nullableTimestamps()` {#collection-method}
+#### `nullableTimestamps()` {.collection-method}
 
 The `nullableTimestamps` method is an alias of the [timestamps](#column-method-timestamps) method:
 
     $table->nullableTimestamps(0);
 
 <a name="column-method-nullableMorphs"></a>
-#### `nullableMorphs()` {#collection-method}
+#### `nullableMorphs()` {.collection-method}
 
 The method is similar to the [morphs](#column-method-morphs) method; however, the columns that are created will be "nullable":
 
     $table->nullableMorphs('taggable');
 
 <a name="column-method-nullableUuidMorphs"></a>
-#### `nullableUuidMorphs()` {#collection-method}
+#### `nullableUuidMorphs()` {.collection-method}
 
 The method is similar to the [uuidMorphs](#column-method-uuidMorphs) method; however, the columns that are created will be "nullable":
 
     $table->nullableUuidMorphs('taggable');
 
 <a name="column-method-point"></a>
-#### `point()` {#collection-method}
+#### `point()` {.collection-method}
 
 The `point` method creates a `POINT` equivalent column:
 
     $table->point('position');
 
 <a name="column-method-polygon"></a>
-#### `polygon()` {#collection-method}
+#### `polygon()` {.collection-method}
 
 The `polygon` method creates a `POLYGON` equivalent column:
 
     $table->polygon('position');
 
 <a name="column-method-rememberToken"></a>
-#### `rememberToken()` {#collection-method}
+#### `rememberToken()` {.collection-method}
 
 The `rememberToken` method creates a nullable, `VARCHAR(100)` equivalent column that is intended to store the current "remember me" [authentication token](/docs/{{version}}/authentication#remembering-users):
 
     $table->rememberToken();
 
 <a name="column-method-set"></a>
-#### `set()` {#collection-method}
+#### `set()` {.collection-method}
 
 The `set` method creates a `SET` equivalent column with the given list of valid values:
 
     $table->set('flavors', ['strawberry', 'vanilla']);
 
 <a name="column-method-smallIncrements"></a>
-#### `smallIncrements()` {#collection-method}
+#### `smallIncrements()` {.collection-method}
 
 The `smallIncrements` method creates an auto-incrementing `UNSIGNED SMALLINT` equivalent column as a primary key:
 
     $table->smallIncrements('id');
 
 <a name="column-method-smallInteger"></a>
-#### `smallInteger()` {#collection-method}
+#### `smallInteger()` {.collection-method}
 
 The `smallInteger` method creates a `SMALLINT` equivalent column:
 
     $table->smallInteger('votes');
 
 <a name="column-method-softDeletesTz"></a>
-#### `softDeletesTz()` {#collection-method}
+#### `softDeletesTz()` {.collection-method}
 
 The `softDeletesTz` method adds a nullable `deleted_at` `TIMESTAMP` (with timezone) equivalent column with an optional precision (total digits). This column is intended to store the `deleted_at` timestamp needed for Eloquent's "soft delete" functionality:
 
     $table->softDeletesTz($column = 'deleted_at', $precision = 0);
 
 <a name="column-method-softDeletes"></a>
-#### `softDeletes()` {#collection-method}
+#### `softDeletes()` {.collection-method}
 
 The `softDeletes` method adds a nullable `deleted_at` `TIMESTAMP` equivalent column with an optional precision (total digits). This column is intended to store the `deleted_at` timestamp needed for Eloquent's "soft delete" functionality:
 
     $table->softDeletes($column = 'deleted_at', $precision = 0);
 
 <a name="column-method-string"></a>
-#### `string()` {#collection-method}
+#### `string()` {.collection-method}
 
 The `string` method creates a `VARCHAR` equivalent column of the given length:
 
     $table->string('name', 100);
 
 <a name="column-method-text"></a>
-#### `text()` {#collection-method}
+#### `text()` {.collection-method}
 
 The `text` method creates a `TEXT` equivalent column:
 
     $table->text('description');
 
 <a name="column-method-timeTz"></a>
-#### `timeTz()` {#collection-method}
+#### `timeTz()` {.collection-method}
 
 The `timeTz` method creates a `TIME` (with timezone) equivalent column with an optional precision (total digits):
 
     $table->timeTz('sunrise', $precision = 0);
 
 <a name="column-method-time"></a>
-#### `time()` {#collection-method}
+#### `time()` {.collection-method}
 
 The `time` method creates a `TIME` equivalent column with an optional precision (total digits):
 
     $table->time('sunrise', $precision = 0);
 
 <a name="column-method-timestampTz"></a>
-#### `timestampTz()` {#collection-method}
+#### `timestampTz()` {.collection-method}
 
 The `timestampTz` method creates a `TIMESTAMP` (with timezone) equivalent column with an optional precision (total digits):
 
     $table->timestampTz('added_at', $precision = 0);
 
 <a name="column-method-timestamp"></a>
-#### `timestamp()` {#collection-method}
+#### `timestamp()` {.collection-method}
 
 The `timestamp` method creates a `TIMESTAMP` equivalent column with an optional precision (total digits):
 
     $table->timestamp('added_at', $precision = 0);
 
 <a name="column-method-timestampsTz"></a>
-#### `timestampsTz()` {#collection-method}
+#### `timestampsTz()` {.collection-method}
 
 The `timestampsTz` method creates `created_at` and `updated_at` `TIMESTAMP` (with timezone) equivalent columns with an optional precision (total digits):
 
     $table->timestampsTz($precision = 0);
 
 <a name="column-method-timestamps"></a>
-#### `timestamps()` {#collection-method}
+#### `timestamps()` {.collection-method}
 
 The `timestamps` method creates `created_at` and `updated_at` `TIMESTAMP` equivalent columns with an optional precision (total digits):
 
     $table->timestamps($precision = 0);
 
 <a name="column-method-tinyIncrements"></a>
-#### `tinyIncrements()` {#collection-method}
+#### `tinyIncrements()` {.collection-method}
 
 The `tinyIncrements` method creates an auto-incrementing `UNSIGNED TINYINT` equivalent column as a primary key:
 
     $table->tinyIncrements('id');
 
 <a name="column-method-tinyInteger"></a>
-#### `tinyInteger()` {#collection-method}
+#### `tinyInteger()` {.collection-method}
 
 The `tinyInteger` method creates a `TINYINT` equivalent column:
 
     $table->tinyInteger('votes');
     
 <a name="column-method-tinyText"></a>
-#### `tinyText()` {#collection-method}
+#### `tinyText()` {.collection-method}
 
 The `tinyText` method creates a `TINYTEXT` equivalent column:
 
     $table->tinyText('notes');
 
 <a name="column-method-unsignedBigInteger"></a>
-#### `unsignedBigInteger()` {#collection-method}
+#### `unsignedBigInteger()` {.collection-method}
 
 The `unsignedBigInteger` method creates an `UNSIGNED BIGINT` equivalent column:
 
     $table->unsignedBigInteger('votes');
 
 <a name="column-method-unsignedDecimal"></a>
-#### `unsignedDecimal()` {#collection-method}
+#### `unsignedDecimal()` {.collection-method}
 
 The `unsignedDecimal` method creates an `UNSIGNED DECIMAL` equivalent column with an optional precision (total digits) and scale (decimal digits):
 
     $table->unsignedDecimal('amount', $precision = 8, $scale = 2);
 
 <a name="column-method-unsignedInteger"></a>
-#### `unsignedInteger()` {#collection-method}
+#### `unsignedInteger()` {.collection-method}
 
 The `unsignedInteger` method creates an `UNSIGNED INTEGER` equivalent column:
 
     $table->unsignedInteger('votes');
 
 <a name="column-method-unsignedMediumInteger"></a>
-#### `unsignedMediumInteger()` {#collection-method}
+#### `unsignedMediumInteger()` {.collection-method}
 
 The `unsignedMediumInteger` method creates an `UNSIGNED MEDIUMINT` equivalent column:
 
     $table->unsignedMediumInteger('votes');
 
 <a name="column-method-unsignedSmallInteger"></a>
-#### `unsignedSmallInteger()` {#collection-method}
+#### `unsignedSmallInteger()` {.collection-method}
 
 The `unsignedSmallInteger` method creates an `UNSIGNED SMALLINT` equivalent column:
 
     $table->unsignedSmallInteger('votes');
 
 <a name="column-method-unsignedTinyInteger"></a>
-#### `unsignedTinyInteger()` {#collection-method}
+#### `unsignedTinyInteger()` {.collection-method}
 
 The `unsignedTinyInteger` method creates an `UNSIGNED TINYINT` equivalent column:
 
     $table->unsignedTinyInteger('votes');
 
 <a name="column-method-uuidMorphs"></a>
-#### `uuidMorphs()` {#collection-method}
+#### `uuidMorphs()` {.collection-method}
 
 The `uuidMorphs` method is a convenience method that adds a `{column}_id` `CHAR(36)` equivalent column and a `{column}_type` `VARCHAR` equivalent column.
 
@@ -830,14 +839,14 @@ This method is intended to be used when defining the columns necessary for a pol
     $table->uuidMorphs('taggable');
 
 <a name="column-method-uuid"></a>
-#### `uuid()` {#collection-method}
+#### `uuid()` {.collection-method}
 
 The `uuid` method creates a `UUID` equivalent column:
 
     $table->uuid('id');
 
 <a name="column-method-year"></a>
-#### `year()` {#collection-method}
+#### `year()` {.collection-method}
 
 The `year` method creates a `YEAR` equivalent column:
 


### PR DESCRIPTION
This pull requests tries to fix some errors found when rendering the docs with Parsedown.

- First, using #collection-method and Parsedown (https://github.com/laravel/laravel.com-next/blob/master/app/Parsedown.php) at laravel.com-next, renders a duplicated id

```html
<h4 id="method-all" id="collection-method" class="first-collection-method"><code>all()</code></h4>
```

which causes and invalid html. It's not a very big issue unless you're trying to make an epub out it (please see the screenshot) 

- Second, trying to follow the idea behind collections.md, where the methods have a class to make the "code" tag render with 14px, and having the first element also the class ".first-collection-method", I've checked a few files where the css style was missing or the class was not correctly added to the code.

If accepted this pull requests should be backported.

Thanks.

<img width="1109" alt="Captura de pantalla 2021-12-12 a las 12 24 22" src="https://user-images.githubusercontent.com/5692232/145710386-524c57c1-4a80-467e-92ae-70f615e27dd1.png">
