### PR TITLE
[8.x] Prevent this tag to be closed by the markdown parser

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -127,7 +127,7 @@ The `$casts` property should be an array where the key is the name of the attrib
 - `datetime`
 - `immutable_date`
 - `immutable_datetime`
-- `decimal:<digits>`
+- `decimal:`<code>&lt;digits&gt;</code>
 - `double`
 - `encrypted`
 - `encrypted:array`


### PR DESCRIPTION
The markdown parser closed the "\<digits\>" tag in the current (view-source:https://laravel.com/docs/8.x/eloquent-mutators)

This commit fixes this behaviour.