### PR TITLE
Reference updating/adding APP_SERVICE key in .env file

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -412,7 +412,7 @@ Since Sail is just Docker, you are free to customize nearly everything about it.
 sail artisan sail:publish
 ```
 
-After running this command, the Dockerfiles and other configuration files used by Laravel Sail will be placed within a `docker` directory in your application's root directory. After customizing your Sail installation, you may wish to change the image name for the `laravel.test` service in your application's `docker-compose.yml` file. After doing so, rebuild your application's containers using the `build` command. Assigning a unique name to the `laravel.test` service image is particularly important if you are using Sail to develop multiple Laravel applications on a single machine:
+After running this command, the Dockerfiles and other configuration files used by Laravel Sail will be placed within a `docker` directory in your application's root directory. After customizing your Sail installation, you may wish to change the image name for the `laravel.test` service in your application's `docker-compose.yml` file. After doing so, rebuild your application's containers using the `build` command. Assigning a unique name to the `laravel.test` service image is particularly important if you are using Sail to develop multiple Laravel applications on a single machine, remember to update your applications `.env` file to include an `APP_SERVICE` key with the customized service name from your `docker-compose.yml` file then:
 
 ```bash
 sail build --no-cache


### PR DESCRIPTION
If a user customises their docker-compose service name without an APP_SERVICE key set sail will fail to run commands on the correct service.