### PR TITLE
Reference updating/adding APP_SERVICE key in .env file

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -412,7 +412,7 @@ Since Sail is just Docker, you are free to customize nearly everything about it.
 sail artisan sail:publish
 ```
 
-After running this command, the Dockerfiles and other configuration files used by Laravel Sail will be placed within a `docker` directory in your application's root directory. After customizing your Sail installation, you may wish to change the image name for the `laravel.test` service in your application's `docker-compose.yml` file. After doing so, rebuild your application's containers using the `build` command. Assigning a unique name to the `laravel.test` service image is particularly important if you are using Sail to develop multiple Laravel applications on a single machine, remember to update your applications `.env` file to include an `APP_SERVICE` key with the customized service name from your `docker-compose.yml` file then:
+After running this command, the Dockerfiles and other configuration files used by Laravel Sail will be placed within a `docker` directory in your application's root directory. After customizing your Sail installation, you may wish to change the image name for the `laravel.test` service in your application's `docker-compose.yml` file. After doing so, rebuild your application's containers using the `build` command. Assigning a unique name to the `laravel.test` service image is particularly important if you are using Sail to develop multiple Laravel applications on a single machine, remember to update your applications `.env` file to include an `APP_SERVICE` key with the customized image name from your `docker-compose.yml` file then:
 
 ```bash
 sail build --no-cache

--- a/sail.md
+++ b/sail.md
@@ -412,7 +412,7 @@ Since Sail is just Docker, you are free to customize nearly everything about it.
 sail artisan sail:publish
 ```
 
-After running this command, the Dockerfiles and other configuration files used by Laravel Sail will be placed within a `docker` directory in your application's root directory. After customizing your Sail installation, you may wish to change the image name for the `laravel.test` service in your application's `docker-compose.yml` file. After doing so, rebuild your application's containers using the `build` command. Assigning a unique name to the `laravel.test` service image is particularly important if you are using Sail to develop multiple Laravel applications on a single machine:
+After running this command, the Dockerfiles and other configuration files used by Laravel Sail will be placed within a `docker` directory in your application's root directory. After customizing your Sail installation, you may wish to change the image name for the `laravel.test` service in your application's `docker-compose.yml` file. After doing so, rebuild your application's containers using the `build` command. Assigning a unique name to the `laravel.test` service image is particularly important if you are using Sail to develop multiple Laravel applications on a single machine, remember to update your applications `.env` file to include an `APP_SERVICE` key with the customized service name from your `docker-compose.yml` file then:
 
 ```bash
 sail build --no-cache


### PR DESCRIPTION
Reopens #7511
References: laravel/sail#256

Opening a new PR as my wording/understanding was off in #7511.

Add reference to adding/updating an APP_SERVICE key in a users .env file after changing the laravel.test service image name.

The scenario behind this addition to the docs is a developer wanting a custom domain for there Sail project so they change the service image name in the docker-compose.yml file but then commands like `sail artisan` etc aren't proxied through to the correct application container and fail silently.

Thanks for your time team, appreciate the work everyone does.