### PR TITLE
[8.x] add stripe id check for automatic sync stripe customer details

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -330,7 +330,9 @@ To automate this, you may define an event listener on your billable model that r
     protected static function booted()
     {
         static::updated(queueable(function ($customer) {
-            $customer->syncStripeCustomerDetails();
+            if ($customer->hasStripeId()) {
+                $customer->syncStripeCustomerDetails();
+            }
         }));
     }
 


### PR DESCRIPTION
I've integrated cashier following the official doc, but when I tried to update a user without `stripe_id`, I get this error message:

```
Stripe\Exception\InvalidArgumentException: The resource ID cannot be null or whitespace. in /var/www/html/vendor/stripe/stripe-php/lib/Service/AbstractService.php:94
  Stack trace:
  #0 /var/www/html/vendor/stripe/stripe-php/lib/Service/CustomerService.php(319): Stripe\Service\AbstractService->buildPath()
  #1 /var/www/html/vendor/laravel/cashier/src/Concerns/ManagesCustomer.php(101): Stripe\Service\CustomerService->update()
  #2 /var/www/html/vendor/laravel/cashier/src/Concerns/ManagesCustomer.php(193): App\Models\User->updateStripeCustomer()
  #3 laravel-serializable-closure://function ($customer) {
              $customer->syncStripeCustomerDetails();
          }(3): App\Models\User->syncStripeCustomerDetails()
  #4 [internal function]: App\Models\User::{closure}()

```

The problem lies within the below snippet:

```
static::updated(queueable(function ($customer) {
    $customer->syncStripeCustomerDetails();
}));
```

I think we should remind readers to check `stripe_id` validity before call `syncStripeCustomerDetails`.

Because beginners like me don't know if `stripe_id` validity check is already handled in `syncStripeCustomerDetails` or should be handled manually by themselves.