### PR TITLE
[8.x] Note reserved Redis connection for Horizon

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -43,6 +43,8 @@ After installing Horizon, publish its assets using the `horizon:install` Artisan
 
 After publishing Horizon's assets, its primary configuration file will be located at `config/horizon.php`. This configuration file allows you to configure the queue worker options for your application. Each configuration option includes a description of its purpose, so be sure to thoroughly explore this file.
 
+> {note} Please note that the Redis connection `horizon` is reserved and cannot be used as a Redis connection in `database.php` or as the value of `use` in `horizon.php`.
+
 <a name="environments"></a>
 #### Environments
 

--- a/horizon.md
+++ b/horizon.md
@@ -43,7 +43,7 @@ After installing Horizon, publish its assets using the `horizon:install` Artisan
 
 After publishing Horizon's assets, its primary configuration file will be located at `config/horizon.php`. This configuration file allows you to configure the queue worker options for your application. Each configuration option includes a description of its purpose, so be sure to thoroughly explore this file.
 
-> {note} Please note that the Redis connection `horizon` is reserved and cannot be used as a Redis connection in `database.php` or as the value of `use` in `horizon.php`.
+> {note} Horizon uses a Redis connection named `horizon` internally. This Redis connection name is reserved and should not be assigned to another Redis connection in the `database.php` configuration file or as the value of the `use` option in the `horizon.php` configuration file.
 
 <a name="environments"></a>
 #### Environments


### PR DESCRIPTION
People keep trying to name this `horizon` while it's reserved. See https://github.com/laravel/framework/issues/40073