### PR TITLE
[8.x] Bump Sail to PHP 8.1 container

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -159,6 +159,8 @@ docker run --rm \
     composer install --ignore-platform-reqs
 ```
 
+Please note that you'll need to use the same PHP version for `laravelsail/phpXX-composer` that your app uses: `74`, `80` or `81`.
+
 <a name="executing-artisan-commands"></a>
 ### Executing Artisan Commands
 

--- a/sail.md
+++ b/sail.md
@@ -159,7 +159,7 @@ docker run --rm \
     composer install --ignore-platform-reqs
 ```
 
-Please note that you'll need to use the same PHP version for `laravelsail/phpXX-composer` that your app uses: `74`, `80` or `81`.
+When using the `laravelsail/phpXX-composer` image, you should use the same version of PHP that you plan to use for your application (`74`, `80`, or `81`).
 
 <a name="executing-artisan-commands"></a>
 ### Executing Artisan Commands

--- a/sail.md
+++ b/sail.md
@@ -155,7 +155,7 @@ docker run --rm \
     -u "$(id -u):$(id -g)" \
     -v $(pwd):/var/www/html \
     -w /var/www/html \
-    laravelsail/php80-composer:latest \
+    laravelsail/php81-composer:latest \
     composer install --ignore-platform-reqs
 ```
 


### PR DESCRIPTION
Now that 8.1 is the default. I also added a note about the correct PHP version to use.