### PR TITLE
[8.x] Add client credentials grant note

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -924,7 +924,7 @@ Passport includes an [authentication guard](/docs/{{version}}/authentication#add
         //
     })->middleware('auth:api');
 
-> {note} If you are using the [client credentials grant](/docs/{{version}}/authentication#client-credentials-grant-tokens), you should use [the `client` middleware](/docs/{{version}}/passport#client-credentials-grant-tokens) to protect your routes instead of the `auth:api` middleware.
+> {note} If you are using the [client credentials grant](#client-credentials-grant-tokens), you should use [the `client` middleware](#client-credentials-grant-tokens) to protect your routes instead of the `auth:api` middleware.
 
 <a name="multiple-authentication-guards"></a>
 #### Multiple Authentication Guards

--- a/passport.md
+++ b/passport.md
@@ -924,6 +924,8 @@ Passport includes an [authentication guard](/docs/{{version}}/authentication#add
         //
     })->middleware('auth:api');
 
+> {note} If you are using the [client credentials grant](/docs/{{version}}/authentication#client-credentials-grant-tokens), see that section on using the `client` middleware instead of the `auth:api` middleware.
+
 <a name="multiple-authentication-guards"></a>
 #### Multiple Authentication Guards
 

--- a/passport.md
+++ b/passport.md
@@ -924,7 +924,7 @@ Passport includes an [authentication guard](/docs/{{version}}/authentication#add
         //
     })->middleware('auth:api');
 
-> {note} If you are using the [client credentials grant](/docs/{{version}}/authentication#client-credentials-grant-tokens), see that section on using the `client` middleware instead of the `auth:api` middleware.
+> {note} If you are using the [client credentials grant](/docs/{{version}}/authentication#client-credentials-grant-tokens), you should use [the `client` middleware](/docs/{{version}}/passport#client-credentials-grant-tokens) to protect your routes instead of the `auth:api` middleware.
 
 <a name="multiple-authentication-guards"></a>
 #### Multiple Authentication Guards


### PR DESCRIPTION
Someone on the Laracasts forums claimed protecting routes with the client credentials grant type was confusing because they had read the “Protecting Routes” section, so had erroneously added `auth:api` to their routes, instead of using the `client` middleware as instructed in the “Client Credentials Grant Tokens” section.

This attempts to mitigate that misunderstanding by adding a note highlighting if you _are_ using the client credentials grant type, to use the `client` middleware and not the `auth:api` middleware.