### PR TITLE
Remove reference to 'purge' option from Tailwind configuration

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -94,7 +94,7 @@ Your application's `webpack.mix.js` file is your entry point for all asset compi
 
     npx tailwindcss init
 
-The `init` command will generate a `tailwind.config.js` file. The content section of this file is where you configure the paths to all of your HTML templates, JavaScript components, and any other source files that contain Tailwind class names.
+The `init` command will generate a `tailwind.config.js` file. The `content` section of this file allows you to configure the paths to all of your HTML templates, JavaScript components, and any other source files that contain Tailwind class names:
 
 ```js
 content: [

--- a/mix.md
+++ b/mix.md
@@ -94,7 +94,7 @@ Your application's `webpack.mix.js` file is your entry point for all asset compi
 
     npx tailwindcss init
 
-The `init` command will generate a `tailwind.config.js` file. The `content` section of this file allows you to configure the paths to all of your HTML templates, JavaScript components, and any other source files that contain Tailwind class names:
+The `init` command will generate a `tailwind.config.js` file. The `content` section of this file allows you to configure the paths to all of your HTML templates, JavaScript components, and any other source files that contain Tailwind class names so that they may be purged:
 
 ```js
 content: [

--- a/mix.md
+++ b/mix.md
@@ -94,10 +94,10 @@ Your application's `webpack.mix.js` file is your entry point for all asset compi
 
     npx tailwindcss init
 
-The `init` command will generate a `tailwind.config.js` file. Within this file, you may configure the paths to all of your application's templates and JavaScript so that Tailwind can tree-shake unused styles when optimizing your CSS for production:
+The `init` command will generate a `tailwind.config.js` file. The content section of this file is where you configure the paths to all of your HTML templates, JavaScript components, and any other source files that contain Tailwind class names.
 
 ```js
-purge: [
+content: [
     './storage/framework/views/*.php',
     './resources/**/*.blade.php',
     './resources/**/*.js',


### PR DESCRIPTION
The 'purge' option in the Tailwind configuration has been renamed to 'content'. The 'purge' option generates warnings when running npm.

Reference: https://tailwindcss.com/docs/upgrade-guide#configure-content-sources
Reference to wording: https://tailwindcss.com/docs/content-configuration