### PR TITLE
[8.x] Mention package for custom claims

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -16,6 +16,7 @@
     - [Refreshing Tokens](#refreshing-tokens)
     - [Revoking Tokens](#revoking-tokens)
     - [Purging Tokens](#purging-tokens)
+    - [Custom Token Claims](#custom-token-claims)
 - [Authorization Code Grant with PKCE](#code-grant-pkce)
     - [Creating The Client](#creating-a-auth-pkce-grant-client)
     - [Requesting Tokens](#requesting-auth-pkce-grant-tokens)
@@ -538,6 +539,11 @@ You may also configure a [scheduled job](/docs/{{version}}/scheduling) in your a
     {
         $schedule->command('passport:purge')->hourly();
     }
+
+<a name="custom-token-claims"></a>
+### Custom Token Claims
+
+Sometimes, you may want to add your own custom claims to the issued access tokens. For this, we recommend using the [laravel-passport-claims](https://github.com/corbosman/laravel-passport-claims) package. 
 
 <a name="code-grant-pkce"></a>
 ## Authorization Code Grant with PKCE


### PR DESCRIPTION
A long outstanding issue on the Passport repo [is the ability to add custom claims to issued tokens](https://github.com/laravel/passport/issues/94). However, atm league/oauth2-server currently does not provide an easy way to do this. 

Until an easy way has been provided so we can add this natively to Passport, I recommend mentioning the l[aravel-passport-claims](https://github.com/corbosman/laravel-passport-claims) package. This will allow people to add their custom claims while we don't need to perform any changes right now in Passport.

The reason why I don't want to go down the path of adding these changes to Passport is because I don't want to diverge too far from the way league/oauth2-server works. It's best to wait until they provide the functionality for us to implement this easily.