### PR TITLE
[8.x] NGINX example IPv6 support

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -47,6 +47,7 @@ Please ensure, like the configuration below, your web server directs all request
 
     server {
         listen 80;
+        listen [::]:80;
         server_name example.com;
         root /srv/example.com/public;
 


### PR DESCRIPTION
The NGINX configuration example on the deployment page only has an IPv4 listener. I suggest adding an IPv6 listener to the example as well.

http://nginx.org/en/docs/http/ngx_http_core_module.html#listen