### PR TITLE
Change to make full theme tailwind config file.

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -92,7 +92,7 @@ Your application's `webpack.mix.js` file is your entry point for all asset compi
 
     npm install -D tailwindcss
 
-    npx tailwindcss init
+    npx tailwindcss init --full
 
 The `init` command will generate a `tailwind.config.js` file. The `content` section of this file allows you to configure the paths to all of your HTML templates, JavaScript components, and any other source files that contain Tailwind class names so that any CSS classes that are not used within these files will be purged from your production CSS build:
 


### PR DESCRIPTION
Mix used tailwind v3.
And `tailwind init` will generate an almost empty setting file. It will work well normally.
However, when `@apply` directive is used own CSS definition, it makes an "undefined" error for tailwind default classes. (Maybe it is a bug of tailwind.)
So, the full-defined-theme tailwind config file is safe to use. It is easy to generate.