### PR TITLE
Add Sail yarn documentation

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -181,6 +181,12 @@ sail node --version
 sail npm run prod
 ```
 
+Yarn can also be used instead of NPM.
+
+```nothing
+sail yarn
+```
+
 <a name="interacting-with-sail-databases"></a>
 ## Interacting With Databases
 

--- a/sail.md
+++ b/sail.md
@@ -181,7 +181,7 @@ sail node --version
 sail npm run prod
 ```
 
-Yarn can also be used instead of NPM.
+If you wish, you may use Yarn instead of NPM:
 
 ```nothing
 sail yarn


### PR DESCRIPTION
Yarn support was added in [laravel/sail#29](https://github.com/laravel/sail/pull/29) but was not documented.