### PR TITLE
Document `clickAndWaitForReload()`

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -813,10 +813,9 @@ You may also wait for a [named route's](/docs/{{version}}/routing#named-routes) 
 <a name="waiting-for-page-reloads"></a>
 #### Waiting for Page Reloads
 
-If you need to make assertions after a page has been reloaded, use the `waitForReload` method:
+If you need to make assertions after a page has been reloaded, use the `clickAndWaitForReload` method:
 
-    $browser->click('.some-action')
-            ->waitForReload()
+    $browser->clickAndWaitForReload('.some-action')
             ->assertSee('something');
 
 <a name="waiting-on-javascript-expressions"></a>

--- a/dusk.md
+++ b/dusk.md
@@ -813,9 +813,17 @@ You may also wait for a [named route's](/docs/{{version}}/routing#named-routes) 
 <a name="waiting-for-page-reloads"></a>
 #### Waiting for Page Reloads
 
-If you need to make assertions after a page has been reloaded, use the `clickAndWaitForReload` method:
+If you need to make assertions after a page has been reloaded, use the `waitForReload` method:
 
-    $browser->clickAndWaitForReload('.some-action')
+    use Laravel\Dusk\Browser;
+
+    $browser->waitForReload(function (Browser $browser) {
+        $browser->assertSee('something');
+    });
+
+Since the need to wait for the page to reload typically occurs after clicking a button, you may use the `clickAndWaitForReload` method for convenience:
+
+    $browser->clickAndWaitForReload('.selector')
             ->assertSee('something');
 
 <a name="waiting-on-javascript-expressions"></a>


### PR DESCRIPTION
Document [`clickAndWaitForReload()`](https://github.com/laravel/dusk/pull/953)

I chose not to keep the `waitForReload()` example as I couldn't think of a scenario where it wouldn't be combined with a preceding click event.