### PR TITLE
[8.x] Fix `waitForReload` example

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -818,7 +818,7 @@ If you need to make assertions after a page has been reloaded, use the `waitForR
     use Laravel\Dusk\Browser;
 
     $browser->waitForReload(function (Browser $browser) {
-        $browser->assertSee('something');
+        $browser->press('Submit');
     });
 
 Since the need to wait for the page to reload typically occurs after clicking a button, you may use the `clickAndWaitForReload` method for convenience:

--- a/dusk.md
+++ b/dusk.md
@@ -813,13 +813,14 @@ You may also wait for a [named route's](/docs/{{version}}/routing#named-routes) 
 <a name="waiting-for-page-reloads"></a>
 #### Waiting for Page Reloads
 
-If you need to make assertions after a page has been reloaded, use the `waitForReload` method:
+If you need to wait for a page to reload after performing an action, use the `waitForReload` method:
 
     use Laravel\Dusk\Browser;
 
     $browser->waitForReload(function (Browser $browser) {
         $browser->press('Submit');
-    });
+    })
+    ->assertSee('Success!');
 
 Since the need to wait for the page to reload typically occurs after clicking a button, you may use the `clickAndWaitForReload` method for convenience:
 


### PR DESCRIPTION
I noticed that the old description wasn't accurate. I've updated it.

I've also changed `assertSee` to `press`. An assertion won't cause a page reload, pressing a button will.