### PR TITLE
Precision about Console option shortcuts requiring a single hyphen

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -264,6 +264,10 @@ To assign a shortcut when defining an option, you may specify it before the opti
 
     mail:send {user} {--Q|queue}
 
+Whereas the full version of an option or a switch requires two hyphens, as stated above (`--queue`), shortcuts require a single one when used in the console:
+
+    php artisan mail:send 1 -Q
+
 <a name="input-arrays"></a>
 ### Input Arrays
 


### PR DESCRIPTION
Artisan Console option shortcuts require a single hyphen, but the mention of {--Q|queue} in the doc can mislead slow thinkers like me :)

Cf. this closed issue from 2017 : https://github.com/laravel/framework/issues/19594, others ran into this ambiguity in the past.