### PR TITLE
clarify how to define a logging channel for PHP deprecation warnings

### DIFF
--- a/logging.md
+++ b/logging.md
@@ -94,6 +94,19 @@ PHP, Laravel, and other libraries often notify their users that some of their fe
 
     'deprecations' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
 
+    'channels' => [
+        ...
+    ]
+
+or define a channel named `deprecations`:
+
+    'channels' => [
+        'deprecations' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/php-deprecation-warnings.log'),
+        ],
+    ],
+
 <a name="building-log-stacks"></a>
 ## Building Log Stacks
 

--- a/logging.md
+++ b/logging.md
@@ -98,7 +98,7 @@ PHP, Laravel, and other libraries often notify their users that some of their fe
         ...
     ]
 
-or define a channel named `deprecations`:
+Or, you may define a log channel named `deprecations`. If a log channel with this name exists, it will always be used to log deprecations:
 
     'channels' => [
         'deprecations' => [


### PR DESCRIPTION
I created a channel named `deprecations` so my config looked like:


```
return [

    'deprecations' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),

    'channels' => [
        ...
        'deprecations' => [
            'driver' => 'single',
            'path' => storage_path('logs/php-deprecation-warnings.log'),
        ],
    ],
]
```

But it was logging even if I didn't specify a LOG_DEPRECATIONS_CHANNEL in .env. I finally understood that the name I chose for my channel did overwrite and it made it log warnings anyway.

Not easy to write but I hope this PR make it a bit clearer...