### PR TITLE
Add missing return value

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -789,7 +789,7 @@ In the example above, we are retrieving the model from the database before calli
 
 Of course, you may build an Eloquent query to delete all models matching your query's criteria. In this example, we will delete all flights that are marked as inactive. Like mass updates, mass deletes will not dispatch model events for the models that are deleted:
 
-    $deletedRows = Flight::where('active', 0)->delete();
+    $deleted = Flight::where('active', 0)->delete();
 
 > {note} When executing a mass delete statement via Eloquent, the `deleting` and `deleted` model events will not be dispatched for the deleted models. This is because the models are never actually retrieved when executing the delete statement.
 

--- a/queries.md
+++ b/queries.md
@@ -897,11 +897,11 @@ You may also specify additional columns to update during the operation:
 <a name="delete-statements"></a>
 ## Delete Statements
 
-The query builder's `delete` method may be used to delete records from the table. You may constrain `delete` statements by adding "where" clauses before calling the `delete` method:
+The query builder's `delete` method may be used to delete records from the table. The `delete` method returns the number of affected rows. You may constrain `delete` statements by adding "where" clauses before calling the `delete` method:
 
-    DB::table('users')->delete();
+    $deleted = DB::table('users')->delete();
 
-    DB::table('users')->where('votes', '>', 100)->delete();
+    $deleted = DB::table('users')->where('votes', '>', 100)->delete();
 
 If you wish to truncate an entire table, which will remove all records from the table and reset the auto-incrementing ID to zero, you may use the `truncate` method:
 


### PR DESCRIPTION
The return value from running a delete statement was missing in [`queries.md`](https://laravel.com/docs/8.x/queries#delete-statements).

In comparison, it is mentioned in [`database.md`](https://laravel.com/docs/8.x/database#running-a-delete-statement) and [`eloquent.md`](https://laravel.com/docs/8.x/eloquent#deleting-models-using-queries).

---

(Similar to PR #7552)