### PR TITLE
How eloquent determines the foreign key?

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -90,7 +90,7 @@ The first argument passed to the `hasOne` method is the name of the related mode
 
     $phone = User::find(1)->phone;
 
-Eloquent determines the foreign key of the relationship based on the parent model name. In this case, the `Phone` model is automatically assumed to have a `user_id` foreign key. If you wish to override this convention, you may pass a second argument to the `hasOne` method:
+Eloquent determines the default foreign key name by examining the name of the relationship method and suffixing the method name with a `_` followed by the name of the parent model's primary key column. In this case, the `Phone` model is automatically assumed to have a `user_id` foreign key. If you wish to override this convention, you may pass a second argument to the `hasOne` method:
 
     return $this->hasOne(Phone::class, 'foreign_key');
 


### PR DESCRIPTION
How eloquent determines the foreign key is mentioned in three different ways under the following headings. I was wondering if all three of them are correct.

## One To One
Eloquent determines the foreign key of the relationship **based on the parent model name**. In this case, the `Phone` model is automatically assumed to have a `user_id` foreign key.

### Defining The Inverse Of The Relationship
Eloquent determines the foreign key name **by examining the name of the relationship method** and suffixing the method name with `_id`.

## One To Many (Inverse) / Belongs To
Eloquent determines the default foreign key name by examining the name of the relationship method and suffixing the method name with a `_` **followed by the name of the parent model's primary key column**.