### PR TITLE
Add instructions for `broadcastQueue` method

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -428,6 +428,18 @@ By default, each broadcast event is placed on the default queue for the default 
      */
     public $queue = 'default';
 
+Alternatively, you may customize the queue name by defining a `broadcastQueue` method on your event class:
+
+    /**
+     * The name of the queue on which to place the broadcasting job.
+     *
+     * @return string
+     */
+    public function broadcastQueue(): string
+    {
+        return 'default';
+    }
+
 If you want to broadcast your event using the `sync` queue instead of the default queue driver, you can implement the `ShouldBroadcastNow` interface instead of `ShouldBroadcast`:
 
     <?php


### PR DESCRIPTION
This is the method used in `\Illuminate\Broadcasting\BroadcastManager` before falling back to the `queue` property; useful if queue names are calculated, env-based or fetched from somewhere:

    if (method_exists($event, 'broadcastQueue')) {
        $queue = $event->broadcastQueue();
    } elseif (isset($event->broadcastQueue)) {
        $queue = $event->broadcastQueue;
    } elseif (isset($event->queue)) {
        $queue = $event->queue;
    }