### PR TITLE
Documents whenContains method for Stringable

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -2628,10 +2628,9 @@ The `when` method invokes the given closure if a given condition is `true`. The 
 
     use Illuminate\Support\Str;
 
-    $string = Str::of('Taylor')
-                    ->when(true, function ($string) {
-                        return $string->append(' Otwell');
-                    });
+    $string = Str::of('Taylor')->when(true, function ($string) {
+        return $string->append(' Otwell');
+    });
 
     // 'Taylor Otwell'
 
@@ -2644,10 +2643,9 @@ The `whenContains` method invokes the given closure if the string contains the g
 
     use Illuminate\Support\Str;
 
-    $string = Str::of('tony stark')
-                    ->whenContains('tony', function ($string) {
-                        return $string->title();
-                    });
+    $string = Str::of('tony stark')->whenContains('tony', function ($string) {
+        return $string->title();
+    });
 
     // 'Tony Stark'
 
@@ -2657,12 +2655,11 @@ You may also pass an array of values to determine if the given string contains a
 
     use Illuminate\Support\Str;
 
-    $string = Str::of('this is my name')
-                    ->whenContains(['is', 'name'], function ($string) {
-                        return $string->title();
-                    });
+    $string = Str::of('tony stark')->whenContains(['tony', 'hulk'], function ($string) {
+        return $string->title();
+    });
 
-    // This Is My Name
+    // Tony Stark
 
 <a name="method-fluent-str-when-contains-all"></a>
 #### `whenContainsAll` {.collection-method}
@@ -2671,10 +2668,9 @@ The `whenContainsAll` method invokes the given closure if the string contains al
 
     use Illuminate\Support\Str;
 
-    $string = Str::of('tony stark')
-                    ->whenContainsAll(['tony', 'stark'], function ($string) {
-                        return $string->title();
-                    });
+    $string = Str::of('tony stark')->whenContainsAll(['tony', 'stark'], function ($string) {
+        return $string->title();
+    });
 
     // 'Tony Stark'
 

--- a/helpers.md
+++ b/helpers.md
@@ -2637,6 +2637,33 @@ The `when` method invokes the given closure if a given condition is `true`. The 
 
 If necessary, you may pass another closure as the third parameter to the `when` method. This closure will execute if the condition parameter evaluates to `false`.
 
+<a name="method-fluent-str-when-contains"></a>
+#### `whenContains` {.collection-method}
+
+The `whenContains` method invokes the given closure if the string contains the given value. The closure will receive the fluent string instance:
+
+    use Illuminate\Support\Str;
+
+    $string = Str::of('tony stark')
+                    ->whenContains('tony', function ($string) {
+                        return $string->title();
+                    });
+
+    // 'Tony Stark'
+
+If necessary, you may pass another closure as the third parameter to the `when` method. This closure will execute if the condition parameter evaluates to `false`.
+
+You may also pass an array of values to determine if the given string contains any of the values in the array:
+
+    use Illuminate\Support\Str;
+
+    $string = Str::of('this is my name')
+                    ->whenContains(['is', 'name'], function ($string) {
+                        return $string->title();
+                    });
+
+    // This Is My Name
+
 <a name="method-fluent-str-when-contains-all"></a>
 #### `whenContainsAll` {.collection-method}
 


### PR DESCRIPTION
New `when...` string helpers were documented in [this commit](https://github.com/laravel/docs/commit/9406cb60ddca3e322118a47442f48c4e89d7f95f).

`whenContains` was added to the index but not documented.

Also fixes indentation (other `when...` examples are all on one line).