### PR TITLE
[9.x] Moves documentation from Flysystem v2 to v3

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -72,8 +72,8 @@ You may configure additional symbolic links in your `filesystems` configuration 
 
 Before using the S3 or SFTP drivers, you will need to install the appropriate package via the Composer package manager:
 
-- Amazon S3: `composer require --with-all-dependencies league/flysystem-aws-s3-v3 "^2.0"`
-- SFTP: `composer require league/flysystem-sftp-v3 "^2.4"`
+- Amazon S3: `composer require --with-all-dependencies league/flysystem-aws-s3-v3 "^3.0"`
+- SFTP: `composer require league/flysystem-sftp-v3 "^3.0"`
 
 <a name="s3-driver-configuration"></a>
 #### S3 Driver Configuration

--- a/releases.md
+++ b/releases.md
@@ -61,14 +61,14 @@ Previous releases of Laravel utilized the [Swift Mailer](https://swiftmailer.sym
 
 Please review the [upgrade guide](/docs/{{version}}/upgrade#symfony-mailer) to learn more about ensuring your application is compatible with Symfony Mailer.
 
-<a name="flysystem-2"></a>
-### Flysystem 2.0
+<a name="flysystem-3"></a>
+### Flysystem 3.x
 
-_Flysystem 2.0 support was contributed by [Dries Vints](https://github.com/driesvints)_.
+_Flysystem 3.x support was contributed by [Dries Vints](https://github.com/driesvints)_.
 
-Laravel 9.x upgrades our upstream Flysystem dependency to Flysystem 2.x. Flysystem powers all of filesystem interactions offered by the `Storage` facade.
+Laravel 9.x upgrades our upstream Flysystem dependency to Flysystem 3.x. Flysystem powers all of filesystem interactions offered by the `Storage` facade.
 
-Please review the [upgrade guide](/docs/{{version}}/upgrade#flysystem-2) to learn more about ensuring your application is compatible with Flysystem 2.0.
+Please review the [upgrade guide](/docs/{{version}}/upgrade#flysystem-3) to learn more about ensuring your application is compatible with Flysystem 3.x.
 
 <a name="eloquent-accessors-and-mutators"></a>
 ### Improved Eloquent Accessors / Mutators

--- a/upgrade.md
+++ b/upgrade.md
@@ -6,7 +6,7 @@
 ## High Impact Changes
 
 <div class="content-list" markdown="1">
-- [Flysystem 2.0](#flysystem-2)
+- [Flysystem 3.x](#flysystem-3)
 - [Symfony Mailer](#symfony-mailer)
 </div>
 
@@ -197,19 +197,19 @@ protected static function getFacadeAccessor()
 
 The `FILESYSTEM_DRIVER` environment variable has been renamed to `FILESYSTEM_DISK` to more accurately reflect its usage. This change only affects the application skeleton; however, you are welcome to update your own application's environment variables to reflect this change if you wish.
 
-<a name="flysystem-2"></a>
-### Flysystem 2.0
+<a name="flysystem-3"></a>
+### Flysystem 3.x
 
 **Likelihood Of Impact: High**
 
-Laravel 9.x has migrated from [Flysystem](https://flysystem.thephpleague.com/v2/docs/) 1.x to 2.x. Under the hood, Flysystem powers all of the file manipulation methods provided by the `Storage` facade. In light of this, some changes may be required within your application; however, we have tried to make this transition as seamless as possible.
+Laravel 9.x has migrated from [Flysystem](https://flysystem.thephpleague.com/v2/docs/) 1.x to 3.x. Under the hood, Flysystem powers all of the file manipulation methods provided by the `Storage` facade. In light of this, some changes may be required within your application; however, we have tried to make this transition as seamless as possible.
 
 #### Driver Prerequisites
 
 Before using the S3 or SFTP drivers, you will need to install the appropriate package via the Composer package manager:
 
-- Amazon S3: `composer require --with-all-dependencies league/flysystem-aws-s3-v3 "^2.0"`
-- SFTP: `composer require league/flysystem-sftp-v3 "^2.4"`
+- Amazon S3: `composer require --with-all-dependencies league/flysystem-aws-s3-v3 "^3.0"`
+- SFTP: `composer require league/flysystem-sftp-v3 "^3.0"`
 
 #### Overwriting Existing Files
 


### PR DESCRIPTION
Following https://github.com/laravel/framework/pull/40411, this pull request moves the docs from Flysystem v2 to v3. 👍🏻