### PR TITLE
[9.x] Add 'sole' and missing header to upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -7,7 +7,6 @@
 
 <div class="content-list" markdown="1">
 - [Updating Dependencies](#updating-dependencies)
-- [Application](#application)
 - [Flysystem 3.x](#flysystem-3)
 - [Symfony Mailer](#symfony-mailer)
 </div>
@@ -87,6 +86,18 @@ public function ignore(string $class);
 
 When iterating over a `LazyCollection` instance within a Blade template, the `$loop` variable is no longer available, as accessing this variable causes the entire `LazyCollection` to be loaded into memory, thus rendering the usage of lazy collections pointless in this scenario.
 
+### Collections
+
+#### The `Enumerable` Contract
+
+**Likelihood Of Impact: Low**
+
+The `Illuminate\Support\Enumerable` contract now defines a `sole` method. If you are manually implementing this interface, you should update your implementation to reflect this new method:
+
+```php
+public function sole($key = null, $operator = null, $value = null);
+```
+
 ### Container
 
 #### The `Container` Contract
@@ -103,18 +114,6 @@ The `Illuminate\Contracts\Container\ContextualBindingBuilder` contract now defin
 
 ```php
 public function giveConfig($key, $default = null);
-```
-
-### Collections
-
-#### The `Enumerable` Contract
-
-**Likelihood Of Impact: Low**
-
-The `Illuminate\Support\Enumerable` contract now defines a `sole` method. If you are manually implementing this interface, you should update your implementation to reflect this new method:
-
-```php
-public function sole($key = null, $operator = null, $value = null);
 ```
 
 ### Database

--- a/upgrade.md
+++ b/upgrade.md
@@ -105,6 +105,18 @@ The `Illuminate\Contracts\Container\ContextualBindingBuilder` contract now defin
 public function giveConfig($key, $default = null);
 ```
 
+### Collections
+
+#### The `Enumerable` Contract
+
+**Likelihood Of Impact: Low**
+
+The `Illuminate\Support\Enumerable` contract now defines a `sole` method. If you are manually implementing this interface, you should update your implementation to reflect this new method:
+
+```php
+public function sole($key = null, $operator = null, $value = null);
+```
+
 ### Database
 
 <a name="postgres-schema-configuration"></a>

--- a/upgrade.md
+++ b/upgrade.md
@@ -7,6 +7,7 @@
 
 <div class="content-list" markdown="1">
 - [Updating Dependencies](#updating-dependencies)
+- [Application](#application)
 - [Flysystem 3.x](#flysystem-3)
 - [Symfony Mailer](#symfony-mailer)
 </div>


### PR DESCRIPTION
Hi! I was just looking through the upgrade guide and noticed that there wasn't any mention of the `sole` method being added to the `Illuminate\Support\Enumerable`. It might not be needed, but I just made this PR in case it was something that's slipped through accidentally and was missed off.

I also added a heading to the contents list at the top of the page too that I think was missing.

Apologies if none of these are needed though :)