### PR TITLE
Fix example in sortKeysUsing method in the collection docs

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -2322,7 +2322,7 @@ The `sortKeysUsing` method sorts the collection by the keys of the underlying as
     /*
         [
             'first' => 'John',
-            'id' => 22345,
+            'ID' => 22345,
             'last' => 'Doe',
         ]
     */


### PR DESCRIPTION
Partly reverts e9e85ff since the capitals `ID` were intended to show how the `sortKeysUsing` method can sort the keys case insensitive (unlike the `sortKeys` method, which would place `ID` at the first position).

Also, the output in the example now does not match the input code.