### PR TITLE
[9.x] Adds `str` helper documentation

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -1800,7 +1800,7 @@ The `Str::words` method limits the number of words in a string. An additional st
 <a name="method-str"></a>
 #### `str()` {.collection-method}
 
-The `str` function returns a new `Stringable` instance with the given string, similar to the `Str::of` method:
+The `str` function returns a new `Stringable` instance of the given string. This function is equivalent to the `Str::of` method:
 
     $string = str('Taylor')->append(' Otwell');
 

--- a/helpers.md
+++ b/helpers.md
@@ -140,6 +140,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [Str::uuid](#method-str-uuid)
 [Str::wordCount](#method-str-word-count)
 [Str::words](#method-str-words)
+[str](#method-str)
 [trans](#method-trans)
 [trans_choice](#method-trans-choice)
 
@@ -1795,6 +1796,15 @@ The `Str::words` method limits the number of words in a string. An additional st
     return Str::words('Perfectly balanced, as all things should be.', 3, ' >>>');
 
     // Perfectly balanced, as >>>
+
+<a name="method-str"></a>
+#### `str()` {.collection-method}
+
+The `str` function returns a new `Stringable` instance with the given string, similar to the `Str::of` method:
+
+    $string = str('Taylor')->append(' Otwell');
+
+    // 'Taylor Otwell'
 
 <a name="method-trans"></a>
 #### `trans()` {.collection-method}

--- a/helpers.md
+++ b/helpers.md
@@ -1800,7 +1800,7 @@ The `Str::words` method limits the number of words in a string. An additional st
 <a name="method-str"></a>
 #### `str()` {.collection-method}
 
-The `str` function returns a new `Stringable` instance of the given string. This function is equivalent to the `Str::of` method:
+The `str` function returns a new `Illuminate\Support\Stringable` instance of the given string. This function is equivalent to the `Str::of` method:
 
     $string = str('Taylor')->append(' Otwell');
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -347,7 +347,7 @@ Previously, the `data_get` helper could be used to retrieve nested data on array
 
 **Likelihood Of Impact: Very Low**
 
-Laravel 9.x now includes a global `str` helper function. If you are defining a global `str` helper in your application, you should rename or remove it so that it does not conflict with Laravel's own `str` helper.
+Laravel 9.x now includes a global `str` [helper function](/docs/{{version}}/helpers#method-str). If you are defining a global `str` helper in your application, you should rename or remove it so that it does not conflict with Laravel's own `str` helper.
 
 <a name="when-and-unless-methods"></a>
 #### The `when` / `unless` Methods

--- a/upgrade.md
+++ b/upgrade.md
@@ -335,11 +335,19 @@ Storage::extend('dropbox', function ($app, $config) {
 
 ### Helpers
 
+<a name="data-get-function"></a>
 #### The `data_get` Helper & Iterable Objects
 
 **Likelihood Of Impact: Very Low**
 
 Previously, the `data_get` helper could be used to retrieve nested data on arrays and `Collection` instances; however, this helper can now retrieve nested data on all iterable objects.
+
+<a name="str-function"></a>
+#### The `str` Helper
+
+**Likelihood Of Impact: Very Low**
+
+The `str` global helper was added in Laravel 9.x. If you are defining a global `str` function in your application, you should rename it or remove it, so it doesn't collide with Laravel's `str` helper.
 
 <a name="when-and-unless-methods"></a>
 #### The `when` / `unless` Methods

--- a/upgrade.md
+++ b/upgrade.md
@@ -347,7 +347,7 @@ Previously, the `data_get` helper could be used to retrieve nested data on array
 
 **Likelihood Of Impact: Very Low**
 
-The `str` global helper was added in Laravel 9.x. If you are defining a global `str` function in your application, you should rename it or remove it, so it doesn't collide with Laravel's `str` helper.
+Laravel 9.x now includes a global `str` helper. If you are defining a global `str` helper in your application, you should rename it or remove it, so it doesn't collide with Laravel's `str` helper.
 
 <a name="when-and-unless-methods"></a>
 #### The `when` / `unless` Methods

--- a/upgrade.md
+++ b/upgrade.md
@@ -347,7 +347,7 @@ Previously, the `data_get` helper could be used to retrieve nested data on array
 
 **Likelihood Of Impact: Very Low**
 
-Laravel 9.x now includes a global `str` helper. If you are defining a global `str` helper in your application, you should rename it or remove it, so it doesn't collide with Laravel's `str` helper.
+Laravel 9.x now includes a global `str` helper function. If you are defining a global `str` helper in your application, you should rename or remove it so that it does not conflict with Laravel's own `str` helper.
 
 <a name="when-and-unless-methods"></a>
 #### The `when` / `unless` Methods


### PR DESCRIPTION
This pull request adds documentation regarding the new `str` helper: https://github.com/laravel/framework/pull/40520.