### PR TITLE
[9.x] Adds `ignition` to release notes

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -327,3 +327,12 @@ Laravel now includes pagination views built using [Bootstrap 5](https://getboots
     {
         Paginator::useBootstrapFive();
     }
+
+<a name="exception-page"></a>
+### Improved Exception Page
+
+Ignition, the open source exception page created by Spatie, has been redesigned from the ground up. The new version ships on Laravel 9.x, and it brings light / dark themes, customizable "open in editor", and more.
+
+<p align="center">
+<img width="100%" src="https://user-images.githubusercontent.com/483853/149235404-f7caba56-ebdf-499e-9883-cac5d5610369.png"/>
+</p>

--- a/releases.md
+++ b/releases.md
@@ -329,7 +329,7 @@ Laravel now includes pagination views built using [Bootstrap 5](https://getboots
     }
 
 <a name="exception-page"></a>
-### Improved Exception Page
+### Improved Ignition Exception Page
 
 Ignition, the open source exception debug page created by Spatie, has been redesigned from the ground up. The new, improved Ignition ships with Laravel 9.x and includes light / dark themes, customizable "open in editor" functionality, and more.
 

--- a/releases.md
+++ b/releases.md
@@ -331,7 +331,7 @@ Laravel now includes pagination views built using [Bootstrap 5](https://getboots
 <a name="exception-page"></a>
 ### Improved Exception Page
 
-Ignition, the open source exception page created by Spatie, has been redesigned from the ground up. The new version ships on Laravel 9.x, and it brings light / dark themes, customizable "open in editor", and more.
+Ignition, the open source exception debug page created by Spatie, has been redesigned from the ground up. The new, improved Ignition ships with Laravel 9.x and includes light / dark themes, customizable "open in editor" functionality, and more.
 
 <p align="center">
 <img width="100%" src="https://user-images.githubusercontent.com/483853/149235404-f7caba56-ebdf-499e-9883-cac5d5610369.png"/>


### PR DESCRIPTION
This pull request adds `ignition` to release notes.

<p align="center">
<img width="100%" src="https://user-images.githubusercontent.com/483853/149235404-f7caba56-ebdf-499e-9883-cac5d5610369.png"/>
</p>