### PR TITLE
[9.x] Mention the update for TrustProxies middleware in upgrade guide if upgrading from Laravel <=8.5.23

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -389,6 +389,14 @@ If you wish to specify a longer timeout for a given request, you may do so using
 
     $response = Http::timeout(120)->get(...);
 
+### Trusted proxies Middleware
+
+**Likelihood Of Impact: High**
+
+If you are upgrading from Laravel <=8.5.23 then you will have to change the TrustProxies middleware in 'app/Http/Middleware/TrustProxies.php'.
+
+Change line 5 from `use Fideloper\Proxy\TrustProxies as Middleware;` to `use Illuminate\Http\Middleware\TrustProxies as Middleware;`. 
+
 <a name="symfony-mailer"></a>
 ### Symfony Mailer
 


### PR DESCRIPTION
When upgrading several apps from Laravel <=8.5.23 to L9 I needed to update the TrustProxies middleware from Fideloper trustproxies to the Illuminate version.  This is not mentioned in the docs. 