### PR TITLE
[8.x] Mail - Document the global to address

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -832,7 +832,7 @@ If you are using [Laravel Sail](/docs/{{version}}/sail), you may preview your me
 
 Finally, you may specify a global "to" address in your `config/mail.php` configuration file. This address will always be used instead of the original recipient specified on the email message your application will be sending. This is another simple solution but don't forget to configure a real mailer so the messages can actually be sent to that one address:
 
-    'to' => ['address' => 'taylor@example.com', 'name' => 'Test User'],
+    'to' => ['address' => 'taylor@example.com', 'name' => 'App Name'],
 
 If you need more control and granularity, you could instead define it within a Service Provider, like your `AppServiceProvider.php` file for example:
 

--- a/mail.md
+++ b/mail.md
@@ -823,9 +823,22 @@ Instead of sending your emails, the `log` mail driver will write all email messa
 <a name="mailtrap"></a>
 #### HELO / Mailtrap / MailHog
 
-Finally, you may use a service like [HELO](https://usehelo.com) or [Mailtrap](https://mailtrap.io) and the `smtp` driver to send your email messages to a "dummy" mailbox where you may view them in a true email client. This approach has the benefit of allowing you to actually inspect the final emails in Mailtrap's message viewer.
+You may use a service like [HELO](https://usehelo.com) or [Mailtrap](https://mailtrap.io) and the `smtp` driver to send your email messages to a "dummy" mailbox where you may view them in a true email client. This approach has the benefit of allowing you to actually inspect the final emails in Mailtrap's message viewer.
 
 If you are using [Laravel Sail](/docs/{{version}}/sail), you may preview your messages using [MailHog](https://github.com/mailhog/MailHog). When Sail is running, you may access the MailHog interface at: `http://localhost:8025`.
+
+<a name="using-a-global-to-address"></a>
+#### Using A Global `to` Address
+
+Finally, you may specify a global "to" address in your `config/mail.php` configuration file. This address will always be used instead of the original recipient specified on the email message your application will be sending. This is another simple solution but don't forget to configure a real mailer so the messages can actually be sent to that one address:
+
+    'to' => ['address' => 'taylor@example.com', 'name' => 'Test User'],
+
+If you need more control and granularity, you could instead define it within a Service Provider, like your `AppServiceProvider.php` file for example:
+
+    if (app()->environment('local')) {
+        Mail::alwaysTo('taylor@example.com');
+    }
 
 <a name="events"></a>
 ## Events


### PR DESCRIPTION
For some reason, this was removed from the documentation [from 5.5+](https://laravel.com/docs/5.4/mail#mail-and-local-development) but it still seems to be useful to the community.

https://twitter.com/fideloper/status/1484263823074856961

Positive feedback:
- https://twitter.com/larstwolters_/status/1484480146803462145
- https://twitter.com/LanceRigdon/status/1484304192399417345
- https://twitter.com/iampoul/status/1484275012706185218
- https://twitter.com/JosueYenga/status/1484387580552613889
- https://twitter.com/yorkiebar16/status/1484276979574652934
- https://twitter.com/benjymancox/status/1484277136823402497
- https://twitter.com/davorminchorov/status/1484334016677380099
- https://twitter.com/8ivek/status/1484520620394446855