### PR TITLE
[8.x] Added `Rule::when` (recent 8.x addition)

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1600,6 +1600,8 @@ If you need to use a validation rule that already exists but you need to do add 
         'value' => Rule::when($request->type === 'numeric', ['required|numeric'], ['required|string']),
     ]);
 
+The `Rule::when` method can be used inside a Form Request's `rule` method.
+
 <a name="complex-conditional-array-validation"></a>
 #### Complex Conditional Array Validation
 

--- a/validation.md
+++ b/validation.md
@@ -1587,6 +1587,19 @@ The first argument passed to the `sometimes` method is the name of the field we 
 
 > {tip} The `$input` parameter passed to your closure will be an instance of `Illuminate\Support\Fluent` and may be used to access your input and files under validation.
 
+<a name="complex-conditional-validation-using-rule-object"></a>
+#### Complex Conditional Validation Using `when`
+
+If you need to use a validation rule that already exists but you need to do add it or not based on a complex conditional, you can take advantage of `Rule::when()`. For example, you may wish to require and check the value type when a field passed a truth test:
+
+    use Illuminate\Support\Facades\Validator;
+    use Illuminate\Validation\Rule;
+
+    $validator = Validator::make($request->all(), [
+        'type' => 'required|string|in:numeric,string',
+        'value' => Rule::when($request->type === 'numeric', ['required|numeric'], ['required|string']),
+    ]);
+
 <a name="complex-conditional-array-validation"></a>
 #### Complex Conditional Array Validation
 


### PR DESCRIPTION
I just saw a post on [StackOverflow](https://stackoverflow.com/questions/70822355/different-validation-rules-for-input-based-on-another-input-value-from-formreque) and someone answered it using `Rule::when` (I was totally unaware of it) and I think adding it to the documentation would be an awesome addition as it is a really simple way of adding or not rules based on a complex conditional (either on a `Validator` or inside a `FormRequest` but I just used the `Validator` example).

I am not 100% happy with the example I added to the documentation, so please, feel free to correct me and add a better example if you have one 👍