### PR TITLE
[8.x] Don't recommend legacy Passport grants anymore

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -633,7 +633,7 @@ If the state parameter matches, the consumer should issue a `POST` request to yo
 <a name="password-grant-tokens"></a>
 ## Password Grant Tokens
 
-> {note} It's no longer recommended to use the legacy password grant tokens. Instead, you should choose [a grant recommended by OAuth2 Server](https://oauth2.thephpleague.com/authorization-server/which-grant/).
+> {note} We no longer recommend using password grant tokens. Instead, you should choose [a grant type that is currently recommended by OAuth2 Server](https://oauth2.thephpleague.com/authorization-server/which-grant/).
 
 The OAuth2 password grant allows your other first-party clients, such as a mobile application, to obtain an access token using an email address / username and password. This allows you to issue access tokens securely to your first-party clients without requiring your users to go through the entire OAuth2 authorization code redirect flow.
 

--- a/passport.md
+++ b/passport.md
@@ -633,6 +633,8 @@ If the state parameter matches, the consumer should issue a `POST` request to yo
 <a name="password-grant-tokens"></a>
 ## Password Grant Tokens
 
+> {note} It's no longer recommended to use the legacy password grant tokens. Instead, you should choose [a grant recommended by OAuth2 Server](https://oauth2.thephpleague.com/authorization-server/which-grant/).
+
 The OAuth2 password grant allows your other first-party clients, such as a mobile application, to obtain an access token using an email address / username and password. This allows you to issue access tokens securely to your first-party clients without requiring your users to go through the entire OAuth2 authorization code redirect flow.
 
 <a name="creating-a-password-grant-client"></a>
@@ -744,6 +746,8 @@ When authenticating using the password grant, Passport will use the `password` a
 
 <a name="implicit-grant-tokens"></a>
 ## Implicit Grant Tokens
+
+> {note} It's no longer recommended to use the legacy implicit grant tokens. Instead, you should choose [a grant recommended by OAuth2 Server](https://oauth2.thephpleague.com/authorization-server/which-grant/).
 
 The implicit grant is similar to the authorization code grant; however, the token is returned to the client without exchanging an authorization code. This grant is most commonly used for JavaScript or mobile applications where the client credentials can't be securely stored. To enable the grant, call the `enableImplicitGrant` method in the `boot` method of your application's `App\Providers\AuthServiceProvider` class:
 

--- a/passport.md
+++ b/passport.md
@@ -747,7 +747,7 @@ When authenticating using the password grant, Passport will use the `password` a
 <a name="implicit-grant-tokens"></a>
 ## Implicit Grant Tokens
 
-> {note} It's no longer recommended to use the legacy implicit grant tokens. Instead, you should choose [a grant recommended by OAuth2 Server](https://oauth2.thephpleague.com/authorization-server/which-grant/).
+> {note} We no longer recommend using implicit grant tokens. Instead, you should choose [a grant type that is currently recommended by OAuth2 Server](https://oauth2.thephpleague.com/authorization-server/which-grant/).
 
 The implicit grant is similar to the authorization code grant; however, the token is returned to the client without exchanging an authorization code. This grant is most commonly used for JavaScript or mobile applications where the client credentials can't be securely stored. To enable the grant, call the `enableImplicitGrant` method in the `boot` method of your application's `App\Providers\AuthServiceProvider` class:
 


### PR DESCRIPTION
These aren't recommended anymore by OAuth2 Server and we should warn people who are using them: https://oauth2.thephpleague.com/authorization-server/which-grant/