### PR TITLE
[9.x] HTTP middleware now runs when the client is faked

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -317,8 +317,6 @@ For example, to instruct the HTTP client to return empty, `200` status code resp
 
     $response = Http::post(...);
 
-> {note} When faking requests, HTTP client middleware are not executed. You should define expectations for faked responses as if these middleware have run correctly.
-
 <a name="faking-specific-urls"></a>
 #### Faking Specific URLs
 


### PR DESCRIPTION
This was fixed in https://github.com/laravel/framework/pull/40636. Related issue: https://github.com/laravel/framework/issues/34505 and original docs PR https://github.com/laravel/docs/pull/6457


