### PR TITLE
[8.x] Add upsert unique index note

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -754,6 +754,8 @@ If you would like to perform multiple "upserts" in a single query, then you shou
         ['departure' => 'Chicago', 'destination' => 'New York', 'price' => 150]
     ], ['departure', 'destination'], ['price']);
 
+> {note} When using `upsert` method make sure to create unique compound index on all columns passed as second argument for database table represented by given model.
+
 <a name="deleting-models"></a>
 ## Deleting Models
 


### PR DESCRIPTION
Upsert at leat in MySQL add code like:

```
on duplicate key update `value` = values(`value`), `updated_at` = values(`updated_at`)
```

 to the query so in case no unique index is created, then new records are created instead of updating existing ones and it's not mentioned in documentation that unique index should be created on those columns