### PR TITLE
Fix FlushFailedCommand method name and argument in upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -545,10 +545,10 @@ Laravel's dependency on `opis/closure` has been replaced by `laravel/serializabl
 
 **Likelihood Of Impact: Low**
 
-The `flush` method defined by the `Illuminate\Queue\Failed\FailedJobProviderInterface` interface now accepts an `$age` argument which determines how old a failed job must be (in days) before it is flushed by the `queue:flush` command. If you are manually implementing the `FailedJobProviderInterface` you should ensure that your implementation is updated to reflect this new argument:
+The `flush` method defined by the `Illuminate\Queue\Failed\FailedJobProviderInterface` interface now accepts an `$hours` argument which determines how old a failed job must be (in hours) before it is flushed by the `queue:flush` command. If you are manually implementing the `FailedJobProviderInterface` you should ensure that your implementation is updated to reflect this new argument:
 
 ```php
-public function flush($age = null);
+public function flush($hours = null);
 ```
 
 ### Session

--- a/upgrade.md
+++ b/upgrade.md
@@ -541,7 +541,7 @@ In new Laravel applications, the `resources/lang` directory is now located in th
 
 Laravel's dependency on `opis/closure` has been replaced by `laravel/serializable-closure`. This should not cause any breaking change in your application unless you are interacting with the `opis/closure` library directly. In addition, the previously deprecated `Illuminate\Queue\SerializableClosureFactory` and `Illuminate\Queue\SerializableClosure` classes have been removed. If you are interacting with `opis/closure` library directly or using any of the removed classes, you may use [Laravel Serializable Closure](https://github.com/laravel/serializable-closure) instead.
 
-#### The Failed Job Provider `failed` Method
+#### The Failed Job Provider `flush` Method
 
 **Likelihood Of Impact: Low**
 


### PR DESCRIPTION
### Changed

- The title says `failed`, but the rest of the section means `flush`, so I think that was a typo. Also, the argument changed from `$age` to `$hours` ([source](https://github.com/laravel/framework/commit/6daecf43dd931dc503e410645ff4a7d611e3371f#diff-e21923e2ff937000ffb1ecb58376f9868079ebf98a249a49e43160cb4f23c8f6)), so this needs to change as well, I think.