### PR TITLE
[8.x] Document assertSimilarJson for http tests

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -1073,6 +1073,13 @@ Assert that the session does not contain the given key:
 
     $response->assertSessionMissing($key);
 
+<a name="assert-similar-json"></a>
+#### assertSimilarJson
+
+Assert that the response has the similar JSON as given.
+
+    $response->assertSimilarJson($data);
+
 <a name="assert-status"></a>
 #### assertStatus
 


### PR DESCRIPTION
Added missing `assertSimilarJson` description