### PR TITLE
[8.x] Revert "[8.x] Update Slack Prerequisites"

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -1018,7 +1018,7 @@ Before you can send notifications via Slack, you must install the Slack notifica
 
     composer require laravel/slack-notification-channel
 
-You will also need to create a [Slack App](https://api.slack.com/apps?new_app=1) for your team. After creating the App, you should configure an "Incoming Webhook" for the workspace. Slack will then provide you with a webhook URL that you may use when [routing Slack notifications](#routing-slack-notifications).
+You will also need to configure an ["Incoming Webhook"](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks) integration for your Slack team. This integration will provide you with a URL you may use when [routing Slack notifications](#routing-slack-notifications).
 
 <a name="formatting-slack-notifications"></a>
 ### Formatting Slack Notifications


### PR DESCRIPTION
Reverts laravel/docs#7430

Atm Slack Notification Channel only works with the now legacy Incoming Webhooks and the current docs can lead to confusion for people: https://github.com/laravel/slack-notification-channel/issues/54#issuecomment-1029420526. I'll be checking into modernising the package soon so Slack apps are fully supported.