### PR TITLE
[8.x] Add MariaDB to list of official supported databases

### DIFF
--- a/database.md
+++ b/database.md
@@ -12,10 +12,11 @@
 <a name="introduction"></a>
 ## Introduction
 
-Almost every modern web application interacts with a database. Laravel makes interacting with databases extremely simple across a variety of supported databases using raw SQL, a [fluent query builder](/docs/{{version}}/queries), and the [Eloquent ORM](/docs/{{version}}/eloquent). Currently, Laravel provides first-party support for four databases:
+Almost every modern web application interacts with a database. Laravel makes interacting with databases extremely simple across a variety of supported databases using raw SQL, a [fluent query builder](/docs/{{version}}/queries), and the [Eloquent ORM](/docs/{{version}}/eloquent). Currently, Laravel provides first-party support for five databases:
 
 <div class="content-list" markdown="1">
 
+- MariaDB 10.2+ ([Version Policy](https://mariadb.org/about/#maintenance-policy))
 - MySQL 5.7+ ([Version Policy](https://en.wikipedia.org/wiki/MySQL#Release_history))
 - PostgreSQL 9.6+ ([Version Policy](https://www.postgresql.org/support/versioning/))
 - SQLite 3.8.8+


### PR DESCRIPTION
Now that we have a MariaDB build on framework it'll be easier for us to add tests that verify the behavior of MariaDB.