### PR TITLE
[8.x]: Fix potentially risky behavior about prepareForValidation example

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -451,7 +451,7 @@ If you need to prepare or sanitize any data from the request before you apply yo
     protected function prepareForValidation()
     {
         $this->merge([
-            'slug' => Str::slug($this->slug),
+            'slug' => Str::slug($this->get('slug')),
         ]);
     }
 


### PR DESCRIPTION
Hi,

The documentation example about `prepareForValidation`  can potentially cause a tricky situation

```php
protected function prepareForValidation()
{
    $this->merge([
        'languages' => Str::slug($this->languages),
    ]);
```

If the key you are targeting is also the name of a property of the `Request` class, you will get the property and not the argument.

![image](https://user-images.githubusercontent.com/11473997/152842751-c461028a-8254-468d-903c-1576b3bf3214.png)


