### PR TITLE
Deployment - New server requirements

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -24,13 +24,15 @@ The Laravel framework has a few system requirements. You should ensure that your
 
 <div class="content-list" markdown="1">
 
-- PHP >= 7.3
+- PHP >= 8.0
 - BCMath PHP Extension
 - Ctype PHP Extension
+- DOM PHP Extension
 - Fileinfo PHP Extension
 - JSON PHP Extension
 - Mbstring PHP Extension
 - OpenSSL PHP Extension
+- PCRE PHP Extension
 - PDO PHP Extension
 - Tokenizer PHP Extension
 - XML PHP Extension


### PR DESCRIPTION
PHP >= 8.0
PCRE PHP Extension is required by vlucas/phpdotenv which is requried by laravel/framework v9.0.0
DOM PHP Extension is required by tijsverkoyen/css-to-inline-styles which is required by laravel/framework v9.0.0