### PR TITLE
[9.x] - Added a line that need to be changed in TrustProxied.php at upgrade.md

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -621,7 +621,7 @@ If you are upgrading your Laravel 8 project to Laravel 9 by importing your exist
 
 Within your `app/Http/Middleware/TrustProxies.php` file, update `use Fideloper\Proxy\TrustProxies as Middleware` to `use Illuminate\Http\Middleware\TrustProxies as Middleware`.
 
-Next, within `app/Http/Middleware/TrustProxies.php`, you should update the following `$headers` property definition:
+Next, within `app/Http/Middleware/TrustProxies.php`, you should update the `$headers` property definition:
 
 ```php
 // Before...

--- a/upgrade.md
+++ b/upgrade.md
@@ -621,15 +621,13 @@ If you are upgrading your Laravel 8 project to Laravel 9 by importing your exist
 
 Within your `app/Http/Middleware/TrustProxies.php` file, update `use Fideloper\Proxy\TrustProxies as Middleware` to `use Illuminate\Http\Middleware\TrustProxies as Middleware`.
 
-In case you have in `app/Http/Middleware/TrustProxies.php` the next line:
+Next, within `app/Http/Middleware/TrustProxies.php`, you should update the following `$headers` property definition:
 
 ```php
+// Before...
 protected $headers = Request::HEADER_X_FORWARDED_ALL;
-```
 
-You will need to change it to:
-
-```php
+// After...
 protected $headers =
     Request::HEADER_X_FORWARDED_FOR |
     Request::HEADER_X_FORWARDED_HOST |

--- a/upgrade.md
+++ b/upgrade.md
@@ -621,6 +621,23 @@ If you are upgrading your Laravel 8 project to Laravel 9 by importing your exist
 
 Within your `app/Http/Middleware/TrustProxies.php` file, update `use Fideloper\Proxy\TrustProxies as Middleware` to `use Illuminate\Http\Middleware\TrustProxies as Middleware`.
 
+In case you have in `app/Http/Middleware/TrustProxies.php` the next line:
+
+```php
+protected $headers = Request::HEADER_X_FORWARDED_ALL;
+```
+
+You will need to change it to:
+
+```php
+protected $headers =
+    Request::HEADER_X_FORWARDED_FOR |
+    Request::HEADER_X_FORWARDED_HOST |
+    Request::HEADER_X_FORWARDED_PORT |
+    Request::HEADER_X_FORWARDED_PROTO |
+    Request::HEADER_X_FORWARDED_AWS_ELB;
+```
+
 ### Validation
 
 #### Form Request `validated` Method


### PR DESCRIPTION
### What does this PR do?

- Adds a hint that may be helpful to the upgrade guide in **TrustProxies** section

### Why do we need this PR?

By following the actual Upgrade guide, I found the next issue:

![brave_wjOx8ynp4F](https://user-images.githubusercontent.com/22081875/153045687-4ee8d149-42e4-42a7-afc3-e2221c287c75.png)

This issue is caused because some Laravel projects that were started since 5.x can have the next line:

![Code_p6FqmFuACM](https://user-images.githubusercontent.com/22081875/153045957-9d33ee5e-cb53-4033-b390-8ae0baab1313.png)

Since the new 9.x upgrade doesn't use **Fideloper\Proxy** this can cause the previous mentioned issue. To fix this problem you can change that line with:

![Code_9evT6zrBSR](https://user-images.githubusercontent.com/22081875/153046218-96bcbfa3-0ec5-4cb6-9b16-1e8cfb535a21.png)

