### PR TITLE
[9.x] Remove fideloper proxy from composer.json for Laravel 9

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -617,7 +617,7 @@ All calls to the `assertDeleted` method should be updated to `assertModelMissing
 
 **Likelihood Of Impact: Low**
 
-If you are upgrading your Laravel 8 project to Laravel 9 by importing your existing application code into a totally new Laravel 9 application skeleton, you may need to update your application's "trusted proxy" middleware.
+If you are upgrading your Laravel 8 project to Laravel 9 by importing your existing application code into a totally new Laravel 9 application skeleton, you may need to update your application's "trusted proxy" middleware, and remove the dependency on the `fideloper/proxy` package.
 
 Within your `app/Http/Middleware/TrustProxies.php` file, update `use Fideloper\Proxy\TrustProxies as Middleware` to `use Illuminate\Http\Middleware\TrustProxies as Middleware`.
 
@@ -635,6 +635,8 @@ protected $headers =
     Request::HEADER_X_FORWARDED_PROTO |
     Request::HEADER_X_FORWARDED_AWS_ELB;
 ```
+
+Finally, remove `fideloper/proxy` from the `composer.json` file and run `composer update`. Otherwise, you may run into the error "Undefined constant Illuminate\Http\Request::HEADER_X_FORWARDED_ALL" after the `composer update`.
 
 ### Validation
 


### PR DESCRIPTION
My suggestion probably needs to be rephrased in some other way, so please do so.

But I've encountered this error while running `composer update` on a Laravel 8.40 project.
Screenshots in my tweet: https://twitter.com/PovilasKorop/status/1491295158859669505

As one of the replies to that tweet pointed, the removal of `fideloper/proxy` has been actually done in v8.x, in August 2021, but I think a lot of people didn't upgrade their composer.json accordingly: https://github.com/laravel/laravel/pull/5662/commits/001e33dd2cd8a8b902fc8656a8858d7c18b30c96