### PR TITLE
SFTP_ROOT needs to have default value

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -120,7 +120,7 @@ Laravel's Flysystem integrations work great with SFTP; however, a sample configu
 
         // Optional SFTP Settings...
         // 'port' => env('SFTP_PORT', 22),
-        // 'root' => env('SFTP_ROOT'),
+        // 'root' => env('SFTP_ROOT', ''),
         // 'timeout' => 30,
     ],
 


### PR DESCRIPTION
To make SFTP works env('SFTP_ROOT') needs to have a default value that's why i added env('SFTP_ROOT', '').
notice this on the developments