### PR TITLE
Update wording explaining after _commit

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -732,7 +732,7 @@ Thankfully, Laravel provides several methods of working around this problem. Fir
         'after_commit' => true,
     ],
 
-When the `after_commit` option is `true`, you may dispatch jobs within database transactions; however, Laravel will wait until the open parent database transactions has been committed before actually dispatching the job. Of course, if no database transactions are currently open, the job will be dispatched immediately.
+When the `after_commit` option is `true`, you may dispatch jobs within database transactions; however, Laravel will wait until the open parent database transactions have been committed before actually dispatching the job. Of course, if no database transactions are currently open, the job will be dispatched immediately.
 
 If a transaction is rolled back due to an exception that occurs during the transaction, the jobs that were dispatched during that transaction will be discarded.
 

--- a/queues.md
+++ b/queues.md
@@ -722,7 +722,7 @@ If you would like to dispatch a job immediately (synchronously), you may use the
 <a name="jobs-and-database-transactions"></a>
 ### Jobs & Database Transactions
 
-While it is perfectly fine to dispatch jobs within database transactions, you should take special care to ensure that your job will actually be able to execute successfully. When dispatching a job within a transaction, it is possible that the job will be processed by a worker before the transaction has committed. When this happens, any updates you have made to models or database records during the database transaction may not yet be reflected in the database. In addition, any models or database records created within the transaction may not exist in the database.
+While it is perfectly fine to dispatch jobs within database transactions, you should take special care to ensure that your job will actually be able to execute successfully. When dispatching a job within a transaction, it is possible that the job will be processed by a worker before the parent transaction has committed. When this happens, any updates you have made to models or database records during the database transaction(s) may not yet be reflected in the database. In addition, any models or database records created within the transaction(s) may not exist in the database.
 
 Thankfully, Laravel provides several methods of working around this problem. First, you may set the `after_commit` connection option in your queue connection's configuration array:
 
@@ -732,9 +732,9 @@ Thankfully, Laravel provides several methods of working around this problem. Fir
         'after_commit' => true,
     ],
 
-When the `after_commit` option is `true`, you may dispatch jobs within database transactions; however, Laravel will wait until all open database transactions have been committed before actually dispatching the job. Of course, if no database transactions are currently open, the job will be dispatched immediately.
+When the `after_commit` option is `true`, you may dispatch jobs within database transactions; however, Laravel will wait until the open parent database transactions has been committed before actually dispatching the job. Of course, if no database transactions are currently open, the job will be dispatched immediately.
 
-If a transaction is rolled back due to an exception that occurs during the transaction, the dispatched jobs that were dispatched during that transaction will be discarded.
+If a transaction is rolled back due to an exception that occurs during the transaction, the jobs that were dispatched during that transaction will be discarded.
 
 > {tip} Setting the `after_commit` configuration option to `true` will also cause any queued event listeners, mailables, notifications, and broadcast events to be dispatched after all open database transactions have been committed.
 


### PR DESCRIPTION
The section explaining the after_commit queue option was a bit unclear with regards to what transaction(s) Laravel waits for before dispatching a job within a database (see StackOverflow post asking this exact question - https://stackoverflow.com/questions/67943199/clarification-for-aftercommit-in-laravel-queues).

It is also a bit unclear what happens in cases where nested database transactions are used, for instance, a nested transaction where the parent transaction fails, but the child transaction succeeds eg:

![image](https://user-images.githubusercontent.com/62015001/153204914-9233dc52-6bb7-4c88-b07d-f1eb096975aa.png)

Sorry for the screenshot, but I couldn't get the formatting to work properly.

In the example above, the job should not be dispatched because the parent transaction failed, even though the child transaction completed successfully. The proposed changes would make this, in my opinion, a bit clearer for newcomers to Laravel.