### PR TITLE
[9.x] Clarify domain approval with Paddle

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -75,7 +75,7 @@ When using the Paddle Sandbox environment, you should set the `PADDLE_SANDBOX` e
 
 PADDLE_SANDBOX=true
 
-After you have finished developing your application you may [apply for a Paddle vendor account](https://paddle.com). Before going live, Paddle will need to approve the domain you'll be selling on.
+After you have finished developing your application you may [apply for a Paddle vendor account](https://paddle.com). Before your application is placed into production, Paddle will need to approve your application's domain.
 
 <a name="database-migrations"></a>
 ### Database Migrations


### PR DESCRIPTION
Explicitly note this in the docs so people are aware they can't use the widget right away on a vendor account.