### PR TITLE
Added version number when install via Composer

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -157,7 +157,7 @@ If you do not specify which services you would like configured, a default stack 
 
 If your computer already has PHP and Composer installed, you may create a new Laravel project by using Composer directly. After the application has been created, you may start Laravel's local development server using the Artisan CLI's `serve` command:
 
-    composer create-project laravel/laravel example-app
+    composer create-project laravel/laravel:^8.0 example-app
 
     cd example-app
 


### PR DESCRIPTION
Since Laravel 9.0 has released, older installation commands should "downgrade" to 8.0.

Not sure what other command need to specify version, just started with this one.