### PR TITLE
Replaced misplaced sail with php binary in publishing command

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -458,7 +458,7 @@ If you're using PhpStorm, please review JetBrain's documentation regarding [zero
 Since Sail is just Docker, you are free to customize nearly everything about it. To publish Sail's own Dockerfiles, you may execute the `sail:publish` command:
 
 ```shell
-sail artisan sail:publish
+php artisan sail:publish
 ```
 
 After running this command, the Dockerfiles and other configuration files used by Laravel Sail will be placed within a `docker` directory in your application's root directory. After customizing your Sail installation, you may wish to change the image name for the application container in your application's `docker-compose.yml` file. After doing so, rebuild your application's containers using the `build` command. Assigning a unique name to the application image is particularly important if you are using Sail to develop multiple Laravel applications on a single machine:


### PR DESCRIPTION
Nothing special, only a small typo in the documentation of Laravel Sail.