### PR TITLE
Replace Symfony API link

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -496,7 +496,7 @@ The `UploadedFile` class also contains methods for accessing the file's fully-qu
 <a name="other-file-methods"></a>
 #### Other File Methods
 
-There are a variety of other methods available on `UploadedFile` instances. Check out the [API documentation for the class](https://api.symfony.com/master/Symfony/Component/HttpFoundation/File/UploadedFile.html) for more information regarding these methods.
+There are a variety of other methods available on `UploadedFile` instances. Check out the [API documentation for the class](https://github.com/symfony/symfony/blob/6.0/src/Symfony/Component/HttpFoundation/File/UploadedFile.php) for more information regarding these methods.
 
 <a name="storing-uploaded-files"></a>
 ### Storing Uploaded Files


### PR DESCRIPTION
api.symfony.com no longer exists. It was redirecting to GitHub before they shut it down.

It should be changed for older versions, too.
ie. Laravel 8 --> [https://github.com/symfony/symfony/blob/**5.4**/src/Symfony/Component/HttpFoundation/File/UploadedFile.php](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpFoundation/File/UploadedFile.php)