### PR TITLE
[9.x] Remove unnecessary use statement from Redis example

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -181,8 +181,6 @@ In addition to the default `scheme`, `host`, `port`, `database`, and `password` 
 
 The phpredis extension may also be configured to use a variety serialization and compression algorithms. These algorithms can be configured via the `options` array of your Redis configuration:
 
-    use Redis;
-
     'redis' => [
 
         'client' => env('REDIS_CLIENT', 'phpredis'),


### PR DESCRIPTION
Since we're in a config file there is no current namespace and `use Redis` will generate a PHP warning. (Applies to 8.x docs as well)