### PR TITLE
[9.x] Use Backed Enums For Enum Casting

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -412,7 +412,19 @@ If a custom format is applied to the `date` or `datetime` cast, such as `datetim
 
 > {note} Enum casting is only available for PHP 8.1+.
 
-Eloquent also allows you to cast your attribute values to PHP enums. To accomplish this, you may specify the attribute and enum you wish to cast in your model's `$casts` property array:
+Eloquent also allows you to cast your attribute values to PHP enums. To take advantage of enum casting, you must use [backed enums](https://www.php.net/manual/en/language.enumerations.backed.php);
+
+    <?php
+
+    namespace App\Enums;
+
+    enum ServerStatus: string
+    {
+        case Ready = 'ready';
+        case Provisioned = 'provisioned';
+    }
+
+To use your enum as a cast, you may specify the attribute and enum you wish to cast in your model's `$casts` property array:
 
     use App\Enums\ServerStatus;
 
@@ -427,8 +439,8 @@ Eloquent also allows you to cast your attribute values to PHP enums. To accompli
 
 Once you have defined the cast on your model, the specified attribute will be automatically cast to and from an enum when you interact with the attribute:
 
-    if ($server->status == ServerStatus::provisioned) {
-        $server->status = ServerStatus::ready;
+    if ($server->status == ServerStatus::Provisioned) {
+        $server->status = ServerStatus::Ready;
 
         $server->save();
     }

--- a/releases.md
+++ b/releases.md
@@ -135,7 +135,19 @@ public function address(): Attribute
 
 _Enum casting was contributed by [Mohamed Said](https://github.com/themsaid)_.
 
-Eloquent now allows you to cast your attribute values to PHP enums. To accomplish this, you may specify the attribute and enum you wish to cast in your model's `$casts` property array:
+Eloquent now allows you to cast your attribute values to PHP enums. To take advantage of enum casting, you must use [backed enums](https://www.php.net/manual/en/language.enumerations.backed.php);
+
+    <?php
+
+    namespace App\Enums;
+
+    enum ServerStatus: string
+    {
+        case Ready = 'ready';
+        case Provisioned = 'provisioned';
+    }
+
+To use your enum as a cast, you may specify the attribute and enum you wish to cast in your model's `$casts` property array:
 
     use App\Enums\ServerStatus;
 
@@ -150,8 +162,8 @@ Eloquent now allows you to cast your attribute values to PHP enums. To accomplis
 
 Once you have defined the cast on your model, the specified attribute will be automatically cast to and from an enum when you interact with the attribute:
 
-    if ($server->status == ServerStatus::provisioned) {
-        $server->status = ServerStatus::ready;
+    if ($server->status == ServerStatus::Provisioned) {
+        $server->status = ServerStatus::Ready;
 
         $server->save();
     }


### PR DESCRIPTION
The documentation does not state that backed enums must be used for enum casting.

When using a standard enum for casting (not a backed enum), the error message is `Undefined property: App\Enums\ServerStatus::$value` which may be confusing for those who are just starting to use enums and are just following the docs. 

This PR adds a backed enum example for enum casting (on both the releases page and the mutators page). The enum naming convention used matches the naming used in the [Implicit Enum Binding] section (https://laravel.com/docs/9.x/routing#implicit-enum-binding) in the docs. 