### PR TITLE
[POC] Example with dot notation in groupBy with enum

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -985,6 +985,49 @@ The `groupBy` method groups the collection's items by a given key:
         ]
     */
 
+Additionally, you may use "dot" notation to access public property of objects in the collection, which is useful when working with `enums`:
+
+    $collection = collect([
+        ['department' => App\Enums\Department::Development, 'name' => 'John'],
+        ['department' => App\Enums\Department::Sales, 'name' => 'Jane'],
+        ['department' => App\Enums\Department::Development, 'name' => 'Sally'],
+    ]);
+
+    $grouped = $collection->groupBy('department.value');
+
+    $grouped->all();
+
+    /*
+        [
+            "development" => Illuminate\Support\Collection {#1439
+                all: [
+                    [
+                        "department" => App\Enums\Department {#1443
+                            +name: "Development",
+                            +value: "development",
+                        },
+                        "name" => "John",
+                    ],
+                    [
+                        "department" => App\Enums\Department {#1443},
+                        "name" => "Sally",
+                    ],
+                ],
+            },
+            "sales" => Illuminate\Support\Collection {#1438
+                all: [
+                    [
+                        "department" => App\Enums\Department {#1442
+                            +name: "Sales",
+                            +value: "sales",
+                        },
+                        "name" => "Jane",
+                    ],
+                ],
+            },
+        ]
+    */
+
 Instead of passing a string `key`, you may pass a callback. The callback should return the value you wish to key the group by:
 
     $grouped = $collection->groupBy(function ($item, $key) {


### PR DESCRIPTION
With the ability to casts Eloquent properties to `enums`, there are some situations like `groupBy` on collections that behave differently now that a property maybe an object.

I was using a closure in the `groupBy` to do `->groupBy(fn($model) => $model->enum->value)`, but after digging into code, I see that [`data_get`](https://github.com/laravel/framework/blob/b9203fca96960ef9cd8860cb4ec99d1279353a8d/src/Illuminate/Collections/helpers.php#L37) will treat dot notated keys as a public property on an object, so you can actually do `->groupBy('enum.value')`.

I feel that this should be documented.  I am not sure if this is the right place, but I thought that I would start the discussion.