### PR TITLE
[9.x] Clarify instance of billable user

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -483,7 +483,7 @@ These defaults will be used for every action in Cashier that generates a [pay li
 <a name="creating-subscriptions"></a>
 ### Creating Subscriptions
 
-To create a subscription, first retrieve an instance of your billable model, which typically will be an instance of `App\Models\User`. Once you have retrieved the model instance, you may use the `newSubscription` method to create the model's subscription pay link:
+To create a subscription, first retrieve an instance of your billable model from the database, which typically will be an instance of `App\Models\User`. Once you have retrieved the model instance, you may use the `newSubscription` method to create the model's subscription pay link:
 
     use Illuminate\Http\Request;
 

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -488,7 +488,7 @@ To create a subscription, first retrieve an instance of your billable model, whi
     use Illuminate\Http\Request;
 
     Route::get('/user/subscribe', function (Request $request) {
-        $payLink = $user->newSubscription('default', $premium = 12345)
+        $payLink = $request->user()->newSubscription('default', $premium = 12345)
             ->returnTo(route('home'))
             ->create();
 

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -483,7 +483,7 @@ These defaults will be used for every action in Cashier that generates a [pay li
 <a name="creating-subscriptions"></a>
 ### Creating Subscriptions
 
-To create a subscription, first retrieve an instance of your billable model from the database, which typically will be an instance of `App\Models\User`. Once you have retrieved the model instance, you may use the `newSubscription` method to create the model's subscription pay link:
+To create a subscription, first retrieve an instance of your billable model from your database, which typically will be an instance of `App\Models\User`. Once you have retrieved the model instance, you may use the `newSubscription` method to create the model's subscription pay link:
 
     use Illuminate\Http\Request;
 


### PR DESCRIPTION
Clarifies that the instance of a billable user needs to be an existing instance from the database. This wasn't always clear it seems.