### PR TITLE
Document `json` as a supported castable value.

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -199,6 +199,7 @@ The `$casts` property should be an array where the key is the name of the attrib
 <div class="content-list" markdown="1">
 
 - `array`
+- `json`
 - `AsStringable::class`
 - `boolean`
 - `collection`


### PR DESCRIPTION
`isJsonCastable@HasAttributes` has `json` in the list, but this isn't documented.