### PR TITLE
[9.x] Fix Rule::foreEach typo

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1669,7 +1669,7 @@ Likewise, you may use the `*` character when specifying [custom validation messa
 <a name="accessing-nested-array-data"></a>
 #### Accessing Nested Array Data
 
-Sometimes you may need to access the value for a given nested array element when assigning validation rules to the attribute. You may accomplish this using the `Rule::foreEach` method. The `forEach` method accepts a closure that will be invoked for each iteration of the array attribute under validation and will receive the attribute's value and explicit, fully-expanded attribute name. The closure should return an array of rules to assign to the array element:
+Sometimes you may need to access the value for a given nested array element when assigning validation rules to the attribute. You may accomplish this using the `Rule::forEach` method. The `forEach` method accepts a closure that will be invoked for each iteration of the array attribute under validation and will receive the attribute's value and explicit, fully-expanded attribute name. The closure should return an array of rules to assign to the array element:
 
     use App\Rules\HasPermission;
     use Illuminate\Support\Facades\Validator;


### PR DESCRIPTION
Changed `Rule::foreEach` to `Rule::forEach` in the [Validation](https://laravel.com/docs/9.x/validation#accessing-nested-array-data) docs.