### PR TITLE
fixed typo `broadcastsOn` @ LN:885

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -882,7 +882,7 @@ It is common to broadcast events when your application's [Eloquent models](/docs
 
 However, if you are not using these events for any other purposes in your application, it can be cumbersome to create event classes for the sole purpose of broadcasting them. To remedy this, Laravel allows you to indicate that an Eloquent model should automatically broadcast its state changes.
 
-To get started, your Eloquent model should use the `Illuminate\Database\Eloquent\BroadcastsEvents` trait. In addition, the model should define a `broadcastsOn` method, which will return an array of channels that the model's events should broadcast on:
+To get started, your Eloquent model should use the `Illuminate\Database\Eloquent\BroadcastsEvents` trait. In addition, the model should define a `broadcastOn` method, which will return an array of channels that the model's events should broadcast on:
 
 ```php
 <?php


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39241212/154796930-433e7b11-0101-4aef-b584-4717624de63b.png)
Fixed Typo for broadcastsOn instead of broadcastOn.