### PR TITLE
[9.x] Remove Lumen from Valet's support list

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -38,7 +38,6 @@ Out of the box, Valet support includes, but is not limited to:
 <div id="valet-support" markdown="1">
 
 - [Laravel](https://laravel.com)
-- [Lumen](https://lumen.laravel.com)
 - [Bedrock](https://roots.io/bedrock/)
 - [CakePHP 3](https://cakephp.org)
 - [Concrete5](https://www.concrete5.org/)


### PR DESCRIPTION
I checked with @mattstauffer and he was okay with removing this. Lumen support is not explicitly removed from Valet.