### PR TITLE
[9.x] Migrations fixes

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -482,9 +482,9 @@ The `date` method creates a `DATE` equivalent column:
 <a name="column-method-decimal"></a>
 #### `decimal()` {.collection-method}
 
-The `decimal` method creates a `DECIMAL` equivalent column with the given precision (total digits) and scale (decimal digits):
+The `decimal` method creates a `DECIMAL` equivalent column with the given total (total digits) and places (decimal digits):
 
-    $table->decimal('amount', $precision = 8, $scale = 2);
+    $table->decimal('amount', $total = 8, $places = 2);
 
 <a name="column-method-double"></a>
 #### `double()` {.collection-method}

--- a/migrations.md
+++ b/migrations.md
@@ -454,9 +454,9 @@ The `boolean` method creates a `BOOLEAN` equivalent column:
 <a name="column-method-char"></a>
 #### `char()` {.collection-method}
 
-The `char` method creates a `CHAR` equivalent column with of a given length:
+The `char` method creates a `CHAR` equivalent column with an optional length:
 
-    $table->char('name', 100);
+    $table->char('name', $length = null);
 
 <a name="column-method-dateTimeTz"></a>
 #### `dateTimeTz()` {.collection-method}


### PR DESCRIPTION
Fixed a typo and stated that the length parameter for the char column type is optional