### PR TITLE
[9.x] Specify exception throwing for Filesystem in upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -322,6 +322,10 @@ Before using the S3, FTP, or SFTP drivers, you will need to install the appropri
 
 Write operations such as `put`, `write`, `writeStream` now overwrite existing files by default. If you do not want to overwrite existing files, you should manually check for the file's existence before performing the write operation.
 
+#### Exception Throwing
+
+Methods such as `put`, `write`, `writeStream` no longer throw a Flysystem exception and will return `false` when a write operation fails. This is because Flysystem now throws an non-specific `UnableToWriteFile` exception instead of the previous more specific `FileExistsException` exception.
+
 #### Reading Missing Files
 
 Attempting to read from a file that does not exist now returns `null`. In previous releases of Laravel, an `Illuminate\Contracts\Filesystem\FileNotFoundException` would have been thrown.


### PR DESCRIPTION
It seems this was forgotten from https://github.com/laravel/framework/pull/33612. Flysystem no longer throws a specific `FileExistsException` exception which makes it unclear why a file couldn't be written. Therefor we decided to catch all internal exception throwing by Flysystem and return `false` when a write operation fails. This also adheres more to the method signature of the `FilesystemAdapter` which only allowed a boolean to be returned.