### PR TITLE
[9.x] Added new env options for v3 sftp adaptor

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -129,13 +129,13 @@ Laravel's Flysystem integrations work great with SFTP; however, a sample configu
         'password' => env('SFTP_PASSWORD'),
 
         // Optional SFTP Settings...
+        // 'hostFingerprint' => env('SFTP_HOST_FINGERPRINT'),
+        // 'maxTries' => 4,
         // 'passphrase' => env('SFTP_PASSPHRASE'),
         // 'port' => env('SFTP_PORT', 22),
-        // 'useAgent' => true,
         // 'root' => env('SFTP_ROOT', ''),
         // 'timeout' => 30,
-        // 'maxTries' => 4,
-        // 'hostFingerprint' => env('SFTP_HOST_FINGERPRINT'),
+        // 'useAgent' => true,
     ],
 
 <a name="amazon-s3-compatible-filesystems"></a>

--- a/filesystem.md
+++ b/filesystem.md
@@ -129,9 +129,13 @@ Laravel's Flysystem integrations work great with SFTP; however, a sample configu
         'password' => env('SFTP_PASSWORD'),
 
         // Optional SFTP Settings...
+        // 'passphrase' => env('SFTP_PASSPHRASE'),
         // 'port' => env('SFTP_PORT', 22),
+        // 'useAgent' => true,
         // 'root' => env('SFTP_ROOT', ''),
         // 'timeout' => 30,
+        // 'maxTries' => 4,
+        // 'hostFingerprint' => env('SFTP_HOST_FINGERPRINT'),
     ],
 
 <a name="amazon-s3-compatible-filesystems"></a>


### PR DESCRIPTION
Added new possible values for the SFTP Driver Configuration example.

The new optional values were added to match the order of the arguments for: `League\Flysystem\PhpseclibV3\SftpConnectionProvider`.

```
return new SftpConnectionProvider(
    $options['host'],
    $options['username'],
    $options['password'] ?? null,
    $options['privateKey'] ?? null,
    $options['passphrase'] ?? null,
    $options['port'] ?? 22,
    $options['useAgent'] ?? false,
    $options['timeout'] ?? 10,
    $options['maxTries'] ?? 4,
    $options['hostFingerprint'] ?? null,
    $options['connectivityChecker'] ?? null
);
```