### PR TITLE
Link to reference Signed Routes in assertRedirectToSignedRoute

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -954,7 +954,7 @@ Assert whether the response is redirecting to a URI that contains the given stri
 <a name="assert-redirect-to-signed-route"></a>
 #### assertRedirectToSignedRoute
 
-Assert that the response is a redirect to the given signed route:
+Assert that the response is a redirect to the given [signed route](/docs/{{version}}/urls#signed-urls):
 
     $response->assertRedirectToSignedRoute($name = null, $parameters = []);
 


### PR DESCRIPTION
Was confused what was a signed route in the testing documentation for "assertRedirectToSignedRoute" so this is adding a reference to the "signed route" documentation for convenience.