### PR TITLE
document callAfterResolving method

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -146,6 +146,28 @@ You may type-hint dependencies for your service provider's `boot` method. The [s
             //
         });
     }
+    
+
+<a name="call-after-resolving"></a>
+#### Call After Resolving
+
+You can use the `callAfterResolving()` method, when working with other packages that provide Blade directives or Blade components - especially if those packages use `app()->afterResolving()`. This will ensure that your callback gets run after the Blade compiler has been registered:
+
+    use Illuminate\View\Compilers\BladeCompiler;
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->callAfterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
+            $bladeCompiler->directive('asset', function ($parameter) {
+                //
+            });
+        });
+    }
 
 <a name="registering-providers"></a>
 ## Registering Providers


### PR DESCRIPTION
I was surprised to learn about `callAfterResolving()` from https://github.com/laravel/framework/pull/41397. And it looks like a lot of other popular package maintainers don't know about it either:
- https://github.com/spatie/laravel-permission
- https://github.com/tighten/ziggy
- https://github.com/404labfr/laravel-impersonate
- https://github.com/albertcht/invisible-recaptcha

Because some 3rd-party packages use `Blade::directive()` and others use `app()->afterResolving()`, a race condition is created. If we recommend all packages use `callAfterResolving()`, no more race condition.

So I think `callAfterResolving()` should be added to the docs. Not sure this is the proper form - let me know if it needs rephrasing or moving.