### PR TITLE
Remove type-hint to clarify the idea behind the Explicit Bindings

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -559,7 +559,7 @@ Next, define a route that contains a `{user}` parameter:
 
     use App\Models\User;
 
-    Route::get('/users/{user}', function (User $user) {
+    Route::get('/users/{user}', function ($user) {
         //
     });
 


### PR DESCRIPTION
I think in this case not type hinting to User clarifies what Explicit Binding does. It kinda emphasize that you no longer have to type-hint, in this case to User. Not in the Route closures, neither to UserController methods. Otherwise first thought would be: why bother to do something like Route::model('user', \App\Models\user::class); into the RouteServideProvider? If not using this way, looks a lot like we kinda repeating what laravel implicitly does, right? Maybe just changing the name within the closure from $user to something else clarifies that the param name to Route closures or Controller methods it's no longer required to match the one we specify to the URI. 