### PR TITLE
Clarify the idea behind Explicit Binding

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -550,7 +550,7 @@ You are not required to use Laravel's implicit, convention based model resolutio
      */
     public function boot()
     {
-        Route::model('user', User::class);
+        Route::model('user_id', User::class);
 
         // ...
     }
@@ -559,7 +559,7 @@ Next, define a route that contains a `{user}` parameter:
 
     use App\Models\User;
 
-    Route::get('/users/{user}', function (User $user) {
+    Route::get('/users/{user_id}', function ($user) {
         //
     });
 


### PR DESCRIPTION
-Making URI param{user_id} look different from (Route closure | UserController methods) param ($user) clarifies that, compare to implicit binding, explicit binding no longer requires them to match.
-Removing type-hint, in this case User shows that it's not required after using Explicit binding and if you wish then only $user could be used.

Otherwise, well talking for myself. First thought was, why not just simply use implicit binding? It seemed at first we are only repeating what laravel does with implicit binding. And even worse, some extra work required with Route::model('user', User::class); Of course until I tried things out. 
Making these changes, I think clarifies for someone trying to figure it out for the first time. At least this is what I would wish to see, maybe an hour ago