### PR TITLE
Remove support for php 8.0 for Laravel 10

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -27,7 +27,7 @@ For all Laravel releases, bug fixes are provided for 18 months and security fixe
 | 7 | 7.2 - 8.0 | March 3rd, 2020 | October 6th, 2020 | March 3rd, 2021 |
 | 8 | 7.3 - 8.1 | September 8th, 2020 | July 26th, 2022 | January 24th, 2023 |
 | 9 | 8.0 - 8.1 | February 8th, 2022 | August 8th, 2023 | February 8th, 2024 |
-| 10 | 8.0 - 8.1 | February 7th, 2023 | August 7th, 2024 | February 7th, 2025 |
+| 10 | 8.1 | February 7th, 2023 | August 7th, 2024 | February 7th, 2025 |
 
 <div class="version-colors">
     <div class="end-of-life">


### PR DESCRIPTION
Laravel 10 will not support php 8.0 according to the composer.json file of the master branch.

https://github.com/laravel/framework/pull/41250