### PR TITLE
Update eloquent-resource toArray examples to use $request

### DIFF
--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -498,8 +498,6 @@ Paginated responses always contain `meta` and `links` keys with information abou
 
 Sometimes you may wish to only include an attribute in a resource response if a given condition is met. For example, you may wish to only include a value if the current user is an "administrator". Laravel provides a variety of helper methods to assist you in this situation. The `when` method may be used to conditionally add an attribute to a resource response:
 
-    use Illuminate\Support\Facades\Auth;
-
     /**
      * Transform the resource into an array.
      *
@@ -512,7 +510,7 @@ Sometimes you may wish to only include an attribute in a resource response if a 
             'id' => $this->id,
             'name' => $this->name,
             'email' => $this->email,
-            'secret' => $this->when(Auth::user()->isAdmin(), 'secret-value'),
+            'secret' => $this->when($request->user()->isAdmin(), 'secret-value'),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];
@@ -522,7 +520,7 @@ In this example, the `secret` key will only be returned in the final resource re
 
 The `when` method also accepts a closure as its second argument, allowing you to calculate the resulting value only if the given condition is `true`:
 
-    'secret' => $this->when(Auth::user()->isAdmin(), function () {
+    'secret' => $this->when($request->user()->isAdmin(), function () {
         return 'secret-value';
     }),
 
@@ -543,7 +541,7 @@ Sometimes you may have several attributes that should only be included in the re
             'id' => $this->id,
             'name' => $this->name,
             'email' => $this->email,
-            $this->mergeWhen(Auth::user()->isAdmin(), [
+            $this->mergeWhen($request->user()->isAdmin(), [
                 'first-secret' => 'value',
                 'second-secret' => 'value',
             ]),


### PR DESCRIPTION
Adjust the code examples to use the `$request` variable that is passed to the `toArray` method when possible. I thought it might be nice if there was examples that used the Request that is passed.