### PR TITLE
update The Redis Facade Alias section of Redis docs

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -151,9 +151,7 @@ In addition to the default `host`, `port`, `database`, and `password` server con
 Laravel's `config/app.php` configuration file contains an `aliases` array which defines all of the class aliases that will be registered by the framework. By default, no `Redis` alias is included because it would conflict with the `Redis` class name provided by the phpredis extension. If you are using the Predis client and would like to add a `Redis` alias, you may add it to the `aliases` array in your application's `config/app.php` configuration file:
 
     'aliases' => Facade::defaultAliases()->merge([
-    
         'Redis' => Illuminate\Support\Facades\Redis::class,
-        
     ])->toArray(),
 
 <a name="phpredis"></a>

--- a/redis.md
+++ b/redis.md
@@ -148,7 +148,13 @@ In addition to the default `host`, `port`, `database`, and `password` server con
 <a name="the-redis-facade-alias"></a>
 #### The Redis Facade Alias
 
-Laravel's `config/app.php` configuration file contains an `aliases` array which defines all of the class aliases that will be registered by the framework. For convenience, an alias entry is included for each [facade](/docs/{{version}}/facades) offered by Laravel; however, the `Redis` alias is disabled because it conflicts with the `Redis` class name provided by the phpredis extension. If you are using the Predis client and would like to enable this alias, you may un-comment the alias in your application's `config/app.php` configuration file.
+Laravel's `config/app.php` configuration file contains an `aliases` array which defines all of the class aliases that will be registered by the framework. By default, no `Redis` alias is included because it would conflict with the `Redis` class name provided by the phpredis extension. If you are using the Predis client and would like to add a `Redis` alias, you may add it to the `aliases` array in your application's `config/app.php` configuration file:
+
+    'aliases' => Facade::defaultAliases()->merge([
+    
+        'Redis' => Illuminate\Support\Facades\Redis::class,
+        
+    ])->toArray(),
 
 <a name="phpredis"></a>
 ### phpredis


### PR DESCRIPTION
The current documentation re: using Predis for Redis suggests uncommenting the Redis alias in config/app.php.  However, that commented out alias was removed when Facade::defaultAliases() was added.  This commit instructs users who are using Predis and who want a Redis alias to insert the alias into config/app.php