### PR TITLE
[9.x] Review mocking - Clarify requirements for `image` method

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -608,6 +608,8 @@ For more information on testing file uploads, you may consult the [HTTP testing 
 
 > {tip} By default, the `fake` method will delete all files in its temporary directory. If you would like to keep these files, you may use the "persistentFake" method instead.
 
+> {tip} The `image` method requires the [GD extension](https://www.php.net/manual/en/book.image.php).
+
 <a name="interacting-with-time"></a>
 ## Interacting With Time
 

--- a/mocking.md
+++ b/mocking.md
@@ -604,11 +604,9 @@ The `Storage` facade's `fake` method allows you to easily generate a fake disk t
         }
     }
 
-For more information on testing file uploads, you may consult the [HTTP testing documentation's information on file uploads](/docs/{{version}}/http-tests#testing-file-uploads).
+By default, the `fake` method will delete all files in its temporary directory. If you would like to keep these files, you may use the "persistentFake" method instead. For more information on testing file uploads, you may consult the [HTTP testing documentation's information on file uploads](/docs/{{version}}/http-tests#testing-file-uploads).
 
-> {tip} By default, the `fake` method will delete all files in its temporary directory. If you would like to keep these files, you may use the "persistentFake" method instead.
-
-> {tip} The `image` method requires the [GD extension](https://www.php.net/manual/en/book.image.php).
+> {note} The `image` method requires the [GD extension](https://www.php.net/manual/en/book.image.php).
 
 <a name="interacting-with-time"></a>
 ## Interacting With Time


### PR DESCRIPTION
This page should clarify the requirements for calling `UploadedFile::fake()->image()`. This method  [calls functions like `imagecreatetruecolor`](https://github.com/laravel/framework/blob/89e43ae6be9f173233e89a2f452f8a0c43f0e857/src/Illuminate/Http/Testing/FileFactory.php#L77), which requires the [GD Library](https://www.php.net/manual/en/function.imagecreatetruecolor.php). This extension is not always present by default, such as when working with a [PHP base image from Docker](https://hub.docker.com/_/php).

I hope I added the tip correctly. I was not sure how to preview it properly.