### PR TITLE
doc: add info about used markdown parser

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -1492,7 +1492,7 @@ The `Str::lower` method converts the given string to lowercase:
 <a name="method-str-markdown"></a>
 #### `Str::markdown()` {.collection-method}
 
-The `Str::markdown` method converts GitHub flavored Markdown into HTML:
+The `Str::markdown` method converts GitHub flavored Markdown into HTML using the [CommonMark parser](https://commonmark.org/):
 
     use Illuminate\Support\Str;
 

--- a/helpers.md
+++ b/helpers.md
@@ -1492,7 +1492,7 @@ The `Str::lower` method converts the given string to lowercase:
 <a name="method-str-markdown"></a>
 #### `Str::markdown()` {.collection-method}
 
-The `Str::markdown` method converts GitHub flavored Markdown into HTML using the [CommonMark parser](https://commonmark.thephpleague.com/):
+The `Str::markdown` method converts GitHub flavored Markdown into HTML using [CommonMark](https://commonmark.thephpleague.com/):
 
     use Illuminate\Support\Str;
 

--- a/helpers.md
+++ b/helpers.md
@@ -1492,7 +1492,7 @@ The `Str::lower` method converts the given string to lowercase:
 <a name="method-str-markdown"></a>
 #### `Str::markdown()` {.collection-method}
 
-The `Str::markdown` method converts GitHub flavored Markdown into HTML using the [CommonMark parser](https://commonmark.org/):
+The `Str::markdown` method converts GitHub flavored Markdown into HTML using the [CommonMark parser](https://commonmark.thephpleague.com/):
 
     use Illuminate\Support\Str;
 


### PR DESCRIPTION
There are fine differences between different Markdown parsers. Without studying source code, it should be documented, which Markdown parser is being used.