### PR TITLE
Fix Server Requirements list 

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -17,11 +17,13 @@
 The Laravel framework has a few system requirements. Of course, all of these requirements are satisfied by the [Laravel Homestead](/docs/{{version}}/homestead) virtual machine:
 
 <div class="content-list" markdown="1">
+
 - PHP >= 5.5.9
 - OpenSSL PHP Extension
 - PDO PHP Extension
 - Mbstring PHP Extension
 - Tokenizer PHP Extension
+
 </div>
 
 <a name="install-laravel"></a>


### PR DESCRIPTION
This PR is to address the display on the list of server requirements. In dark mode the list of server requirements is not clearly legible. This problem exists in version 5.1 to 5.8

Light mode
![light mode](https://user-images.githubusercontent.com/27954794/160223420-184dde7c-7543-44c2-ac7e-648f2497ecd3.png)

Dark mode
![dark mode](https://user-images.githubusercontent.com/27954794/160223426-bad127fb-98b6-4792-9b47-abde07778602.png)

