### PR TITLE
fix: missing "return" in code example

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1185,7 +1185,7 @@ Scopes should always return the same query builder instance or `void`:
          */
         public function scopeActive($query)
         {
-            $query->where('active', 1);
+            return $query->where('active', 1);
         }
     }
 


### PR DESCRIPTION
I guess this is missing (also for older versions)