### PR TITLE
Correct order model namespace

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -268,7 +268,7 @@ When a user is viewing one of their orders, we don't want them to have to refres
 
     namespace App\Events;
 
-    use App\Order;
+    use App\Models\Order;
     use Illuminate\Broadcasting\Channel;
     use Illuminate\Broadcasting\InteractsWithSockets;
     use Illuminate\Broadcasting\PresenceChannel;


### PR DESCRIPTION
Correct the namespace of Order model in broadcasting section

```https://laravel.com/docs/9.x/broadcasting#the-shouldbroadcast-interface```