### PR TITLE
[9.x] Document retry still throws connection exception even if `throw` argument is set to `false`

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -189,6 +189,8 @@ If all of the requests fail, an instance of `Illuminate\Http\Client\RequestExcep
 
     $response = Http::retry(3, 100, throw: false)->post(...);
 
+> {note} If all of the requests fail because of a connection issue, a `Illuminate\Http\Client\ConnectionException` will still be thrown even when the `throw` argument is set to `false`.
+
 <a name="error-handling"></a>
 ### Error Handling
 


### PR DESCRIPTION
This document that the `throw` argument does not work in case of a connection exception as there is no response object.