### PR TITLE
[9.x] Added type to closure

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -382,7 +382,9 @@ If you would like to fake a sequence of responses but do not need to specify a s
 
 If you require more complicated logic to determine what responses to return for certain endpoints, you may pass a closure to the `fake` method. This closure will receive an instance of `Illuminate\Http\Client\Request` and should return a response instance. Within your closure, you may perform whatever logic is necessary to determine what type of response to return:
 
-    Http::fake(function ($request) {
+    use Illuminate\Http\Client\Request;
+
+    Http::fake(function (Request $request) {
         return Http::response('Hello World', 200);
     });
 


### PR DESCRIPTION
Hey! This PR is only a really small one and just adds a typehint and 'use statement' to a code example.

When I was writing some tests today I needed to use the `Http::fake()` that allows you to define the response in a closure. I wasn't 100% sure what type `$request` would be straight away, but managed to figure out what it'd be by looking at the other examples on the page.

So, I just thought I'd propose adding the typehint to this example to make it a bit easier to tell what type `$request` is :)