### PR TITLE
onlyInput() method pass values as single array

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -251,7 +251,7 @@ We will access Laravel's authentication services via the `Auth` [facade](/docs/{
 
             return back()->withErrors([
                 'email' => 'The provided credentials do not match our records.',
-            ])->onlyInput(['email']);
+            ])->onlyInput('email');
         }
     }
 


### PR DESCRIPTION
onlyInput() uses PHP func_get_args() which receives value as ARRAY and converts to ARRAY.

onlyInput(['email']) - converts to multi-dimensional array. (latter in framework Arr::set() breaks code to TypeError)
onlyInput('email') - converts to simple array.