### PR TITLE
Updated container 'extend' method description

### DIFF
--- a/container.md
+++ b/container.md
@@ -339,7 +339,7 @@ Once the services have been tagged, you may easily resolve them all via the cont
 <a name="extending-bindings"></a>
 ### Extending Bindings
 
-The `extend` method allows the modification of resolved services. For example, when a service is resolved, you may run additional code to decorate or configure the service. The `extend` method accepts a closure, which should return the modified service, as its only argument. The closure receives the service being resolved and the container instance:
+The `extend` method allows the modification of resolved services. For example, when a service is resolved, you may run additional code to decorate or configure the service. The `extend` method accepts two arguments, the service class you're extending and a closure that should return the modified service. The closure receives the service being resolved and the container instance:
 
     $this->app->extend(Service::class, function ($service, $app) {
         return new DecoratedService($service);


### PR DESCRIPTION
The method was described as only having one argument, the closure. This is not true as its first argument is the service class that is being extended.

I believe the complex sentence might be why it has been overlooked for so long, so I simplified it and corrected the description to provide details on both arguments required by the method.