### PR TITLE
revert anon class in first migration example

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -76,7 +76,7 @@ Within both of these methods, you may use the Laravel schema builder to expressi
     use Illuminate\Database\Schema\Blueprint;
     use Illuminate\Support\Facades\Schema;
 
-    return new class extends Migration
+    class CreateFlightsTable extends Migration
     {
         /**
          * Run the migrations.


### PR DESCRIPTION
the text after the first example migration states that the example should show the automatically assigned class name ie from running php artisan make:migration create_flights_table