### PR TITLE
[9.x] Added undocumented retention policy for daily log channel

### DIFF
--- a/logging.md
+++ b/logging.md
@@ -75,11 +75,11 @@ Name | Description | Default
 `locking` | Attempt to lock the log file before writing to it | `false`
 `permission` | The log file's permissions | `0644`
 
-Additionally, the retention policy for the `daily` channel can be configured with the `days` option:
+Additionally, the retention policy for the `daily` channel can be configured via the `days` option:
 
 Name | Description                                                       | Default
 ------------- |-------------------------------------------------------------------| -------------
-`days` | Sets the amount of maximum days of daily log files to be retained | `7`
+`days` | The number of days that daily log files should be retained | `7`
 
 <a name="configuring-the-papertrail-channel"></a>
 #### Configuring The Papertrail Channel

--- a/logging.md
+++ b/logging.md
@@ -75,6 +75,12 @@ Name | Description | Default
 `locking` | Attempt to lock the log file before writing to it | `false`
 `permission` | The log file's permissions | `0644`
 
+Additionally, the retention policy for the `daily` channel can be configured with the `days` option:
+
+Name | Description                                                       | Default
+------------- |-------------------------------------------------------------------| -------------
+`days` | Sets the amount of maximum days of daily log files to be retained | `7`
+
 <a name="configuring-the-papertrail-channel"></a>
 #### Configuring The Papertrail Channel
 


### PR DESCRIPTION
In `\Illuminate\Log\LogManager::createDailyDriver()` one can find usage of the config setting `days` which isn't documented yet.

It seems helpful to mention this setting along with its default in the documentation.