### PR TITLE
Fix anonymous component namespace example

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -1344,7 +1344,7 @@ The `anonymousComponentNamespace` method accepts the "path" to the anonymous com
      */
     public function boot()
     {
-        Blade::anonymousComponentNamespace('flights.bookings', 'flights');
+        Blade::anonymousComponentNamespace('flights.bookings.components', 'flights');
     }
 
 Given the example above, you may render a `panel` component that exists within the newly registered component directory like so:


### PR DESCRIPTION
Hey! Thanks for the accepting the PR for anonymous component namespaces. 

@adelf contacted me via Twitter to point out a small mistake in the docs for this feature, so this fixes that example in the docs.