### PR TITLE
[9.x] Fix code sample showing incorrect usage

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -188,7 +188,7 @@ If needed, you may pass a third argument to the `retry` method. The third argume
 If a request attempt fails, you may wish to make a change to the request before a new attempt is made. You can achieve this by modifying request argument provided to the callable you provided to the `retry` method. For example, you might want to retry the request with a new authorization token if the first attempt returned an authentication error:
 
     $response = Http::withToken($this->getToken())->retry(2, 0, function ($exception, $request) {
-        if (! $exception instanceof RequestException || $request->response->status() !== 401) {
+        if (! $exception instanceof RequestException || $exception->response->status() !== 401) {
             return false;
         }
 


### PR DESCRIPTION
Sample was showing `response` as a property on the recently added `$request` parameter when it is actually a property on `$exception` (when exception is an instance of `RequestException`).