### PR TITLE
[9.x] Add note about custom tld's

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -97,8 +97,6 @@ Once Valet is installed, try pinging any `*.test` domain on your terminal using 
 
 Valet will automatically start its required services each time your machine boots.
 
-> {note}: even though it's possible to configure a different tld than `.test`, we only offer support for `.test` tld usage. Using a custom tld can lead to unexpected results with your Valet installation and should be used at your own risk.
-
 <a name="php-versions"></a>
 #### PHP Versions
 

--- a/valet.md
+++ b/valet.md
@@ -97,6 +97,8 @@ Once Valet is installed, try pinging any `*.test` domain on your terminal using 
 
 Valet will automatically start its required services each time your machine boots.
 
+> {note}: even though it's possible to configure a different tld than `.test`, we only offer support for `.test` tld usage. Using a custom tld can lead to unexpected results with your Valet installation and should be used at your own risk.
+
 <a name="php-versions"></a>
 #### PHP Versions
 
@@ -485,7 +487,7 @@ This directory contains custom Valet extensions / commands.
 
 #### `~/.config/valet/Nginx/`
 
-This directory contains all of Valet's Nginx site configurations. These files are rebuilt when running the `install`, `secure`, and `tld` commands.
+This directory contains all of Valet's Nginx site configurations. These files are rebuilt when running the `install` and `secure` commands.
 
 #### `~/.config/valet/Sites/`
 


### PR DESCRIPTION
After discussing with @mattstauffer we decided to add an explicit note about custom tld usage. Even though Valet ships with a `tld` command to set a custom one we don't document this. This is because it can potentially lead to unexpected results (see https://github.com/laravel/valet/issues/1231). We believe Valet was intended to be used with the shipped `.test` tld and using a custom tld should only be done as a last resort. However, if you do so we can't offer support because there's too much unknowns that can lead to broken usage.