### PR TITLE
[9.x] Improve `groupBy` preserveKeys argument syntax

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1034,7 +1034,7 @@ Multiple grouping criteria may be passed as an array. Each array element will be
 
     $result = $data->groupBy(['skill', function ($item) {
         return $item['roles'];
-    }], $preserveKeys = true);
+    }], preserveKeys: true);
 
     /*
     [


### PR DESCRIPTION
I *believe* this was the intended syntax here, using PHP 8.0 named arguments. Apologies if I am incorrect :p
Couldn't find any other places where this occurred.