### PR TITLE
[9.x] Fix description of Mailer return types

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -486,7 +486,7 @@ composer require symfony/postmark-mailer symfony/http-client
 
 #### Updated Return Types
 
-The `send`, `html`, `text`, and `plain` methods no longer return the number of recipients that received the message. Instead, an instance of `Illuminate\Mail\SentMessage` is returned. This object contains an instance of `Symfony\Component\Mailer\SentMessage` that is accessible via the `getSymfonySentMessage` method or by dynamically invoking methods on the object.
+The `send`, `html`, `raw`, and `plain` methods on `Illuminate\Mail\Mailer` no longer return `void`. Instead, an instance of `Illuminate\Mail\SentMessage` is returned. This object contains an instance of `Symfony\Component\Mailer\SentMessage` that is accessible via the `getSymfonySentMessage` method or by dynamically invoking methods on the object.
 
 #### Renamed "Swift" Methods
 


### PR DESCRIPTION
It seems this was mistakenly referencing "number of recipients" which wasn't returned in the first place. That happened on transport level, not mail level. It's of more interest to document the Mailer return types of the most common methods.

Related: https://github.com/laravel/framework/pull/42035