### PR TITLE
Fix description of Linux Host IP Configuration

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -416,7 +416,7 @@ SAIL_XDEBUG_MODE=develop,debug
 
 #### Linux Host IP Configuration
 
-Internally, the `XDEBUG_CONFIG` environment variable is defined as `client_host=host.docker.internal` so that Xdebug will be properly configured for Mac and Windows (WSL2). If your local machine is running Linux, you should ensure that you are running `Docker Engine 17.06.0+` and  `Compose 1.16.0+`. Otherwise, you will need to manually define this environment variable as shown below.
+Internally, the `XDEBUG_CONFIG` environment variable is defined as `client_host=host.docker.internal` so that Xdebug will be properly configured for Mac and Windows (WSL2). If your local machine is running Linux, you should ensure that you are running Docker Engine 17.06.0+ and Compose 1.16.0+. Otherwise, you will need to manually define this environment variable as shown below.
 
 First, you should determine the correct host IP address to add to the environment variable by running the following command. Typically, the `<container-name>` should be the name of the container that serves your application and often ends with `_laravel.test_1`:
 

--- a/sail.md
+++ b/sail.md
@@ -416,7 +416,7 @@ SAIL_XDEBUG_MODE=develop,debug
 
 #### Linux Host IP Configuration
 
-Internally, the `XDEBUG_CONFIG` environment variable is defined as `client_host=host.docker.internal` so that Xdebug will be properly configured for Mac and Windows (WSL2). If your local machine is running Linux, you will need to make sure that you are running `Docker Engine 17.06.0+` and  `Compose 1.16.0+`. Otherwise you will need to manually define this environment variable as shown below.
+Internally, the `XDEBUG_CONFIG` environment variable is defined as `client_host=host.docker.internal` so that Xdebug will be properly configured for Mac and Windows (WSL2). If your local machine is running Linux, you should ensure that you are running `Docker Engine 17.06.0+` and  `Compose 1.16.0+`. Otherwise, you will need to manually define this environment variable as shown below.
 
 First, you should determine the correct host IP address to add to the environment variable by running the following command. Typically, the `<container-name>` should be the name of the container that serves your application and often ends with `_laravel.test_1`:
 

--- a/sail.md
+++ b/sail.md
@@ -416,7 +416,7 @@ SAIL_XDEBUG_MODE=develop,debug
 
 #### Linux Host IP Configuration
 
-Internally, the `XDEBUG_CONFIG` environment variable is defined as `client_host=host.docker.internal` so that Xdebug will be properly configured for Mac and Windows (WSL2). If your local machine is running Linux, you will need to manually define this environment variable.
+Internally, the `XDEBUG_CONFIG` environment variable is defined as `client_host=host.docker.internal` so that Xdebug will be properly configured for Mac and Windows (WSL2). If your local machine is running Linux, you will need to make sure that you are running `Docker Engine 17.06.0+` and  `Compose 1.16.0+`. Otherwise you will need to manually define this environment variable as shown below.
 
 First, you should determine the correct host IP address to add to the environment variable by running the following command. Typically, the `<container-name>` should be the name of the container that serves your application and often ends with `_laravel.test_1`:
 


### PR DESCRIPTION
Since [sail v1.10.1](https://github.com/laravel/sail/releases/tag/v1.10.1) the `extra_hosts` option makes the definition of the `XDEBUG_CONFIG` environment variable unnecessary for Linux.

I think the only thing to consider will be the [Docker Engine and Compose versions.](https://docs.docker.com/compose/compose-file/compose-versioning/#version-23)

The main reason to change this is that it could be confusing for people that use `sail down` and `sail up` since the internal IP address of the container will change every time is created. Other than that, as stated above, since the incorporation of `extra_hosts` the steps of Linux Host IP Configuration are no longer needed in most cases.