### PR TITLE
require php.ini set variables_order = "GPCS" not "EGPCS"

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -25,6 +25,7 @@ The Laravel framework has a few system requirements. You should ensure that your
 <div class="content-list" markdown="1">
 
 - PHP >= 8.0
+- variables_order = "GPCS"
 - BCMath PHP Extension
 - Ctype PHP Extension
 - cURL PHP Extension


### PR DESCRIPTION
the php.ini default variables_order = "EGPCS", when execute "php artisan serve "will cause this problem (the reason is only "?", cannot print useful debug info):

Starting Laravel development server: http://127.0.0.1:8000
[Wed Apr 20 12:41:32 2022] Failed to listen on 127.0.0.1:8000 (reason: ?)
Starting Laravel development server: http://127.0.0.1:8001
[Wed Apr 20 12:41:32 2022] Failed to listen on 127.0.0.1:8001 (reason: ?)
Starting Laravel development server: http://127.0.0.1:8002
[Wed Apr 20 12:41:33 2022] Failed to listen on 127.0.0.1:8002 (reason: ?)
Starting Laravel development server: http://127.0.0.1:8003
[Wed Apr 20 12:41:33 2022] Failed to listen on 127.0.0.1:8003 (reason: ?)
Starting Laravel development server: http://127.0.0.1:8004
[Wed Apr 20 12:41:34 2022] Failed to listen on 127.0.0.1:8004 (reason: ?)
Starting Laravel development server: http://127.0.0.1:8005
[Wed Apr 20 12:41:34 2022] Failed to listen on 127.0.0.1:8005 (reason: ?)
Starting Laravel development server: http://127.0.0.1:8006
[Wed Apr 20 12:41:35 2022] Failed to listen on 127.0.0.1:8006 (reason: ?)
Starting Laravel development server: http://127.0.0.1:8007
[Wed Apr 20 12:41:35 2022] Failed to listen on 127.0.0.1:8007 (reason: ?)
Starting Laravel development server: http://127.0.0.1:8008
[Wed Apr 20 12:41:36 2022] Failed to listen on 127.0.0.1:8008 (reason: ?)
Starting Laravel development server: http://127.0.0.1:8009
[Wed Apr 20 12:41:36 2022] Failed to listen on 127.0.0.1:8009 (reason: ?)
Starting Laravel development server: http://127.0.0.1:8010
[Wed Apr 20 12:41:37 2022] Failed to listen on 127.0.0.1:8010 (reason: ?)

so, must set variables_order = "GPCS" in php.ini file.