### PR TITLE
A response to laravel/valet discussion #1207

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -18,7 +18,10 @@
 - [Custom Valet Drivers](#custom-valet-drivers)
     - [Local Drivers](#local-drivers)
 - [Other Valet Commands](#other-valet-commands)
-- [Valet Directories & Files](#valet-directories-and-files)
+- [Troubleshooting](#troubleshooting)
+    - [Recommendations](#recommendations)
+    - [Valet Directories & Files](#valet-directories-and-files)
+    - [Support](#support)
 
 <a name="introduction"></a>
 ## Introduction
@@ -462,8 +465,16 @@ Command  | Description
 `valet trust` | Add sudoers files for Brew and Valet to allow Valet commands to be run without prompting for your password.
 `valet uninstall` | Uninstall Valet: shows instructions for manual uninstall. Pass the `--force` option to aggressively delete all of Valet's resources.
 
+<a name="troubleshooting"></a>
+## Troubleshooting
+
+<a name="recommendations"></a>
+### Recommendations
+
+By default since version 10.14 [macOS restricts access to files and folders](https://manuals.info.apple.com/MANUALS/1000/MA1902/en_US/apple-platform-security-guide.pdf) including Desktop, Documents, Downloads, network volumes, and removable volumes. Therefore, Valet recommends your site folders are located outside of those protected folders. If you wish to serve sites from within one of those folders you will need to give Nginx 'Full Disk Acess', otherwise you may see 500 errors or other unpredictable behavior from Nginx, especially for static assets. To do so, go to `System Preferences` > `Security & Privacy` > `Privacy` and select `Full Disk Access` from the sidebar. Enable any `nginx` entries in the main window pane.
+
 <a name="valet-directories-and-files"></a>
-## Valet Directories & Files
+### Valet Directories & Files
 
 You may find the following directory and file information helpful while troubleshooting issues with your Valet environment:
 
@@ -526,3 +537,8 @@ This file is the PHP-FPM pool configuration file.
 #### `~/.composer/vendor/laravel/valet/cli/stubs/secure.valet.conf`
 
 This file is the default Nginx configuration used for building SSL certificates for your sites.
+
+<a name="support"</a>>
+### Support
+
+More support can be found at the project's [GitHub Discussions](https://github.com/laravel/valet/discussions) page.


### PR DESCRIPTION
This changeset is an attempt to more explicitly warn users away from
serving sites from within folders protected by macOS by default or give
them instructions on elevating Nginx's permissions to do so. I've
slightly reorganized the table of contents to create a 'Troubleshooting'
section and placed this information and the `Valet Directories & Files`
section is now an H3 and moved under the new Troubleshooting H2 section.