### PR TITLE
[9.x] add Eloquent relationship cheat sheet

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -38,6 +38,7 @@
     - [Belongs To Relationships](#updating-belongs-to-relationships)
     - [Many To Many Relationships](#updating-many-to-many-relationships)
 - [Touching Parent Timestamps](#touching-parent-timestamps)
+- [Cheat Sheet](#cheat-sheet)
 
 <a name="introduction"></a>
 ## Introduction
@@ -1931,3 +1932,26 @@ For example, when a `Comment` model is updated, you may want to automatically "t
     }
 
 > {note} Parent model timestamps will only be updated if the child model is updated using Eloquent's `save` method.
+
+<a name="cheat-sheet"></a>
+## Cheat Sheet
+
+### Relationships
+
+| Relationship     | Primary          | Inverse         | Attach     | Detach     |
+|------------------|------------------|-----------------|------------|------------|
+| One To One       | `hasOne`         | `belongsTo`     | `save()`   | `delete()` |
+| One To Many      | `hasMany`        | `belongsTo`     | `save()`   | `delete()` |
+| Has One Of Many  | `hasOne`         | `belongsTo`     | `save()`   | `delete()` |
+| Has One Through  | `hasOneThrough`  | `belongsTo`     | `save()`   | `delete()` |
+| Has Many Through | `hasManyThrough` | `belongsTo`     | `attach()` | `detach()` |
+| Belongs To Many  | `belongsToMany`  | `belongsToMany` | `attach()` | `detach()` |
+
+### Polymorphic Relationships
+
+| Relationship     | Primary       | Inverse         | Attach     | Detach     |
+|------------------|---------------|-----------------|------------|------------|
+| One To One       | `morphOne`    | `morphTo`       | `save()`   | `delete()` |
+| One To Many      | `morphMany`   | `morphTo`       | `attach()` | `detach()` |
+| One Of Many      | `morphOne`    | `morphTo`       | `save()`   | `delete()` |
+| Many To Many     | `morphToMany` | `morphedByMany` | `attach()` | `detach()` |


### PR DESCRIPTION
the current docs are a spectacular resource for people newer to Eloquent relationships and how they work in depth.

however, for more experienced users, it can become a little difficult/annoying to dig through all this text to try and remember exactly what the relationship methods are, or what the methods are to attach or detach models in certain relationships.

having this at-a-glance table would be helpful to grok exactly what we're looking for.

I left out how you would call the attaching and detaching from the inverse method not because I wanted to, but more so because I was a little worried how wide this would display, and if it'd be easy to read.

If someone could confirm I actually wrote the correct methods down that would be appreciated, because honestly I went through this a little quick.