### PR TITLE
[9.x] Added Pluralizer::useLanguage documentation

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -326,7 +326,7 @@ When using a custom keyed implicit binding as a nested route parameter, Laravel 
 <a name="restful-localizing-resource-uris"></a>
 ### Localizing Resource URIs
 
-By default, `Route::resource` will create resource URIs using English verbs. If you need to localize the `create` and `edit` action verbs, you may use the `Route::resourceVerbs` method. This may be done at the beginning of the `boot` method within your application's `App\Providers\RouteServiceProvider`:
+By default, `Route::resource` will create resource URIs using English verbs and plural rules. If you need to localize the `create` and `edit` action verbs, you may use the `Route::resourceVerbs` method. This may be done at the beginning of the `boot` method within your application's `App\Providers\RouteServiceProvider`:
 
     /**
      * Define your route model bindings, pattern filters, etc.
@@ -343,11 +343,11 @@ By default, `Route::resource` will create resource URIs using English verbs. If 
         // ...
     }
 
-Once the verbs have been customized, a resource route registration such as `Route::resource('fotos', PhotoController::class)` will produce the following URIs:
+It's also possible to [change the pluralization rules](/docs/{{version}}/localization#changing-pluralization-rules) for better parameter names. Once the verbs and pluralization language have been customized, a resource route registration such as `Route::resource('publicacion', PublicacionController::class)` will produce the following URIs:
 
-    /fotos/crear
+    /publicacion/crear
 
-    /fotos/{foto}/editar
+    /publicacion/{publicaciones}/editar
 
 <a name="restful-supplementing-resource-controllers"></a>
 ### Supplementing Resource Controllers

--- a/helpers.md
+++ b/helpers.md
@@ -1583,7 +1583,7 @@ The `Str::padRight` method wraps PHP's `str_pad` function, padding the right sid
 <a name="method-str-plural"></a>
 #### `Str::plural()` {.collection-method}
 
-The `Str::plural` method converts a singular word string to its plural form. This function currently only supports the English language:
+The `Str::plural` method converts a singular word string to its plural form. This function supports [other languages](/docs/{{version}}/localization#changing-pluralization-rules):
 
     use Illuminate\Support\Str;
 
@@ -1610,7 +1610,7 @@ You may provide an integer as a second argument to the function to retrieve the 
 <a name="method-str-plural-studly"></a>
 #### `Str::pluralStudly()` {.collection-method}
 
-The `Str::pluralStudly` method converts a singular word string formatted in studly caps case to its plural form. This function currently only supports the English language:
+The `Str::pluralStudly` method converts a singular word string formatted in studly caps case to its plural form. This function supports [other languages](/docs/{{version}}/localization#changing-pluralization-rules):
 
     use Illuminate\Support\Str;
 
@@ -1721,7 +1721,7 @@ The `Str::reverse` method reverses the given string:
 <a name="method-str-singular"></a>
 #### `Str::singular()` {.collection-method}
 
-The `Str::singular` method converts a string to its singular form. This function currently only supports the English language:
+The `Str::singular` method converts a string to its singular form. This function supports [other languages](/docs/{{version}}/localization#changing-pluralization-rules):
 
     use Illuminate\Support\Str;
 
@@ -2539,7 +2539,7 @@ The `pipe` method allows you to transform the string by passing its current valu
 <a name="method-fluent-str-plural"></a>
 #### `plural` {.collection-method}
 
-The `plural` method converts a singular word string to its plural form. This function currently only supports the English language:
+The `plural` method converts a singular word string to its plural form. This function supports [other languages](/docs/{{version}}/localization#changing-pluralization-rules):
 
     use Illuminate\Support\Str;
 
@@ -2683,7 +2683,7 @@ The `scan` method parses input from a string into a collection according to a fo
 <a name="method-fluent-str-singular"></a>
 #### `singular` {.collection-method}
 
-The `singular` method converts a string to its singular form. This function currently only supports the English language:
+The `singular` method converts a string to its singular form. This function supports [other languages](/docs/{{version}}/localization#changing-pluralization-rules):
 
     use Illuminate\Support\Str;
 

--- a/localization.md
+++ b/localization.md
@@ -67,6 +67,29 @@ You may use the `currentLocale` and `isLocale` methods on the `App` facade to de
         //
     }
 
+<a name="changing-pluralization-rules"></a>
+### Changing Pluralization rules
+
+It's also possible to change Laravels's default pluralization rules from a set of available languages other than english: 'french', 'norwegian-bokmal', 'portuguese', 'spanish' and 'turkish', see [Doctrine/Inflector](https://www.doctrine-project.org/projects/inflector.html) for details. This can be done at the `boot` method within your application's `App\Providers\AppServiceProvider`:
+
+    use Illuminate\Support\Pluralizer;
+
+    // ...   
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        Pluralizer::useLanguage('spanish');     
+
+        // ...     
+    }
+
+> {note} When using a different language rule, the `User` model might need to have its [table name](/docs/{{version}}/eloquent#table-names) manually set to `users`, as the word "user" may have a different plural form in other languages.
+
 <a name="defining-translation-strings"></a>
 ## Defining Translation Strings
 


### PR DESCRIPTION
New documentation for https://github.com/laravel/framework/pull/41941

I also changed the Controller's `Localizing Resource URIs` example to a word (Publicacion) that would specifically have a wrong plural with English rules, _publicacions_ instead of _publicaciones_.