### PR TITLE
[9.x] For multiple arguments for hasAll and missingAll, it would be an array.

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -386,8 +386,8 @@ To assert that an attribute is present or absent, you may use the `has` and `mis
 In addition, the `hasAll` and `missingAll` methods allow asserting the presence or absence of multiple attributes simultaneously:
 
     $response->assertJson(fn (AssertableJson $json) =>
-        $json->hasAll('status', 'data')
-             ->missingAll('message', 'code')
+        $json->hasAll(['status', 'data'])
+             ->missingAll(['message', 'code'])
     );
 
 You may use the `hasAny` method to determine if at least one of a given list of attributes is present:


### PR DESCRIPTION
I'm currently writing some tests on a project, then I run the psalm tool that finds this issue related to 
`Too many arguments for method hasAll, and the same for missingAll`.

Illuminate\Testing\Fluent\Concerns\Has::hasAll
```php
    /**
     * Assert that all of the given props exist.
     *
     * @param  array|string  $key
     * @return $this
     */
    public function hasAll($key): self
    {
        $keys = is_array($key) ? $key : func_get_args();

        foreach ($keys as $prop => $count) {
            if (is_int($prop)) {
                $this->has($count);
            } else {
                $this->has($prop, $count);
            }
        }

        return $this;
    }
``` 
