### PR TITLE
Add a hint to also add an amount of $tries when using the backoff array in queues

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1684,6 +1684,8 @@ You may easily configure "exponential" backoffs by returning an array of backoff
     {
         return [1, 5, 10];
     }
+    
+When using an array of backoff values, remember to also set an amount of `$tries` equal to or more than the amount of number of seconds values in that array.
 
 <a name="cleaning-up-after-failed-jobs"></a>
 ### Cleaning Up After Failed Jobs


### PR DESCRIPTION
I tripped over this when trying to set an array of 5 backoff values in my project. I think when you set an array with 5 backoff values, Laravel should just default to a `$tries` amount of 5. But even if not, it should at least be mentioned in the docs, imho.

Keep on the great work, I love the framework even though I much disliked PHP before :)