### PR TITLE
Correcting backup paths for database backups

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -597,7 +597,7 @@ Homestead can automatically backup your database when your Homestead virtual mac
 
     backup: true
 
-Once configured, Homestead will export your databases to `mysql_backup` and `postgres_backup` directories when the `vagrant destroy` command is executed. These directories can be found in the folder where you installed Homestead or in the root of your project if you are using the [per project installation](#per-project-installation) method.
+Once configured, Homestead will export your databases to `.backup/mysql_backup` and `.backup/postgres_backup` directories when the `vagrant destroy` command is executed. These directories can be found in the folder where you installed Homestead or in the root of your project if you are using the [per project installation](#per-project-installation) method.
 
 <a name="configuring-cron-schedules"></a>
 ### Configuring Cron Schedules


### PR DESCRIPTION
Updated the paths that were missing `.backup` in them.