### PR TITLE
SFTP driver configuration remove duplicate key

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -125,8 +125,6 @@ Laravel's Flysystem integrations work great with SFTP; however, a sample configu
         
         // Settings for basic authentication...
         'username' => env('SFTP_USERNAME'),
-        'password' => env('SFTP_PASSWORD'),
-
         // Settings for SSH key based authentication with encryption password...
         'privateKey' => env('SFTP_PRIVATE_KEY'),
         'password' => env('SFTP_PASSWORD'),


### PR DESCRIPTION
PHP array automatically removes the duplicate key, we have two 'password' => env('SFTP_PASSWORD') in SFTP driver file system configuration Example. So there is no need to define two similar keys.