### PR TITLE
Make columns responsive

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -79,17 +79,19 @@ If necessary, you may define macros that accept additional arguments:
 For the majority of the remaining collection documentation, we'll discuss each method available on the `Collection` class. Remember, all of these methods may be chained to fluently manipulate the underlying array. Furthermore, almost every method returns a new `Collection` instance, allowing you to preserve the original copy of the collection when necessary:
 
 <style>
-    #collection-method-list > p {
-        column-count: 3; -moz-column-count: 3; -webkit-column-count: 3;
-        column-gap: 2em; -moz-column-gap: 2em; -webkit-column-gap: 2em;
+    .collection-method-list > p {
+        columns: 10.8em 3; -moz-columns: 10.8em 3; -webkit-columns: 10.8em 3;
     }
 
-    #collection-method-list a {
+    .collection-method-list a {
         display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 </style>
 
-<div id="collection-method-list" markdown="1">
+<div class="collection-method-list" markdown="1">
 
 [all](#method-all)
 [average](#method-average)

--- a/dusk.md
+++ b/dusk.md
@@ -913,12 +913,14 @@ Dusk provides a variety of assertions that you may make against your application
 
 <style>
     .collection-method-list > p {
-        column-count: 3; -moz-column-count: 3; -webkit-column-count: 3;
-        column-gap: 2em; -moz-column-gap: 2em; -webkit-column-gap: 2em;
+        columns: 10.8em 3; -moz-columns: 10.8em 3; -webkit-columns: 10.8em 3;
     }
 
     .collection-method-list a {
         display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 </style>
 

--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -40,13 +40,15 @@ All Eloquent collections extend the base [Laravel collection](/docs/{{version}}/
 In addition, the `Illuminate\Database\Eloquent\Collection` class provides a superset of methods to aid with managing your model collections. Most methods return `Illuminate\Database\Eloquent\Collection` instances; however, some methods, like `modelKeys`, return an `Illuminate\Support\Collection` instance.
 
 <style>
-    #collection-method-list > p {
-        column-count: 1; -moz-column-count: 1; -webkit-column-count: 1;
-        column-gap: 2em; -moz-column-gap: 2em; -webkit-column-gap: 2em;
+    .collection-method-list > p {
+        columns: 14.4em 1; -moz-columns: 14.4em 1; -webkit-columns: 14.4em 1;
     }
 
-    #collection-method-list a {
+    .collection-method-list a {
         display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     .collection-method code {
@@ -58,7 +60,7 @@ In addition, the `Illuminate\Database\Eloquent\Collection` class provides a supe
     }
 </style>
 
-<div id="collection-method-list" markdown="1">
+<div class="collection-method-list" markdown="1">
 
 [contains](#method-contains)
 [diff](#method-diff)

--- a/helpers.md
+++ b/helpers.md
@@ -13,12 +13,14 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 
 <style>
     .collection-method-list > p {
-        column-count: 3; -moz-column-count: 3; -webkit-column-count: 3;
-        column-gap: 2em; -moz-column-gap: 2em; -webkit-column-gap: 2em;
+        columns: 10.8em 3; -moz-columns: 10.8em 3; -webkit-columns: 10.8em 3;
     }
 
     .collection-method-list a {
         display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 </style>
 

--- a/http-tests.md
+++ b/http-tests.md
@@ -602,12 +602,14 @@ Laravel's `Illuminate\Testing\TestResponse` class provides a variety of custom a
 
 <style>
     .collection-method-list > p {
-        column-count: 2; -moz-column-count: 2; -webkit-column-count: 2;
-        column-gap: 2em; -moz-column-gap: 2em; -webkit-column-gap: 2em;
+        columns: 14.4em 2; -moz-columns: 14.4em 2; -webkit-columns: 14.4em 2;
     }
 
     .collection-method-list a {
         display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 </style>
 

--- a/migrations.md
+++ b/migrations.md
@@ -322,13 +322,15 @@ The `table` method on the `Schema` facade may be used to update existing tables.
 The schema builder blueprint offers a variety of methods that correspond to the different types of columns you can add to your database tables. Each of the available methods are listed in the table below:
 
 <style>
-    #collection-method-list > p {
-        column-count: 3; -moz-column-count: 3; -webkit-column-count: 3;
-        column-gap: 2em; -moz-column-gap: 2em; -webkit-column-gap: 2em;
+    .collection-method-list > p {
+        columns: 10.8em 3; -moz-columns: 10.8em 3; -webkit-columns: 10.8em 3;
     }
 
-    #collection-method-list a {
+    .collection-method-list a {
         display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     .collection-method code {
@@ -340,7 +342,7 @@ The schema builder blueprint offers a variety of methods that correspond to the 
     }
 </style>
 
-<div id="collection-method-list" markdown="1">
+<div class="collection-method-list" markdown="1">
 
 [bigIncrements](#column-method-bigIncrements)
 [bigInteger](#column-method-bigInteger)

--- a/validation.md
+++ b/validation.md
@@ -752,12 +752,14 @@ Below is a list of all available validation rules and their function:
 
 <style>
     .collection-method-list > p {
-        column-count: 3; -moz-column-count: 3; -webkit-column-count: 3;
-        column-gap: 2em; -moz-column-gap: 2em; -webkit-column-gap: 2em;
+        columns: 10.8em 3; -moz-columns: 10.8em 3; -webkit-columns: 10.8em 3;
     }
 
     .collection-method-list a {
         display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 </style>
 


### PR DESCRIPTION
Some parts of the docs contain lists of methods in two or three different columns. They look good on larger screens, but for mobile, the links break:
![bad_1](https://user-images.githubusercontent.com/2665860/165639348-03c5f018-d74a-400e-ac42-81c28d2137b4.png)

This PR fixes this by making the columns responsive and makes sure the links don't take up more space than they should. For example, on mobile they might have one column:
![good_1](https://user-images.githubusercontent.com/2665860/165639517-7cd9518d-a315-48e5-9ec7-1146d692e176.png)

And then they get bigger on medium screens:
![good_2](https://user-images.githubusercontent.com/2665860/165639567-66d388db-7cd6-4d2b-9289-811c94e9231a.png)

And then back to three solumns on large screens:
![good_3](https://user-images.githubusercontent.com/2665860/165639621-c0c6a342-0318-4828-a7fa-5457938fd085.png)

Finally, in order to avoid having to create columns that are too wide, names that are too long will simply get cut off on smaller screens:
![good_4](https://user-images.githubusercontent.com/2665860/165639774-f016f8ac-5a81-48ab-bef3-d8656b3a3ccd.png)
