### PR TITLE
Clarify using toSearchableArray with the Scout database engine

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -171,6 +171,8 @@ By default, the entire `toArray` form of a given model will be persisted to its 
             return $array;
         }
     }
+    
+> {note} When using a database engine, don't use `toArray` to define `toSearchableArray`, or implement `toArray` with the specific columns for your table. `toArray` will return an empty result as it is called before the table data is loaded.
 
 <a name="configuring-the-model-id"></a>
 ### Configuring The Model ID


### PR DESCRIPTION
Using `toArray` when using the Scout database engine will return an empty array if it's not specifically defined on the model, and this empty array will mean that no columns are filtered.

This should be clarified in the documentation.