### PR TITLE
Route Model Binding: Warn patterns apply even for custom route keys

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -464,6 +464,8 @@ If you would like model binding to always use a database column other than `id` 
     {
         return 'slug';
     }
+    
+> {note} Even if you specify a custom key, any [pattern](#parameters-global-constraints) defined for the model will still apply.
 
 <a name="implicit-model-binding-scoping"></a>
 #### Custom Keys & Scoping


### PR DESCRIPTION
So this is something I spent a *lot* of time debugging. 

What went wrong is that the website I was working on had a pattern defined like `Route::pattern('post', '[0-9]+');` that I was unaware of. I changed the variable to explicitly specify the key `{post:slug}`, and without any helpful error message I kept getting a 404 for any slug, except, as I discovered later, numeric slugs.

Documenting that a pattern will still apply even if you specify a non-standard key will hopefully avoid others spending as much time.

----
Also applies to older Laravel versions (we're at 8.x), but I'm first waiting if this PR needs any changes before opening any for the other branches