### PR TITLE
Be specific what to add to components constructor

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -677,7 +677,7 @@ You may pass data to Blade components using HTML attributes. Hard-coded, primiti
 <x-alert type="error" :message="$message"/>
 ```
 
-You should define all component's data attributes in its class constructor. All public properties on a component will automatically be made available to the component's view. It is not necessary to pass the data to the view from the component's `render` method:
+You should define all of the component's data attributes in its class constructor. All public properties on a component will automatically be made available to the component's view. It is not necessary to pass the data to the view from the component's `render` method:
 
     <?php
 

--- a/blade.md
+++ b/blade.md
@@ -677,7 +677,7 @@ You may pass data to Blade components using HTML attributes. Hard-coded, primiti
 <x-alert type="error" :message="$message"/>
 ```
 
-You should define the component's required data in its class constructor. All public properties on a component will automatically be made available to the component's view. It is not necessary to pass the data to the view from the component's `render` method:
+You should define all component's data attributes in its class constructor. All public properties on a component will automatically be made available to the component's view. It is not necessary to pass the data to the view from the component's `render` method:
 
     <?php
 


### PR DESCRIPTION
The old sentence "You should define required component's data in its class constructor." could be read as that optional parameters for the component do not need to be specified in the constructor. I think other may have read it in the same way: https://github.com/laravel/framework/issues/36256