### PR TITLE
Add documentation for TrimStrings::skipWhen

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -462,9 +462,32 @@ All cookies created by the Laravel framework are encrypted and signed with an au
 
 By default, Laravel includes the `App\Http\Middleware\TrimStrings` and `App\Http\Middleware\ConvertEmptyStringsToNull` middleware in your application's global middleware stack. These middleware are listed in the global middleware stack by the `App\Http\Kernel` class. These middleware will automatically trim all incoming string fields on the request, as well as convert any empty string fields to `null`. This allows you to not have to worry about these normalization concerns in your routes and controllers.
 
-If you would like to disable this behavior, you may remove the two middleware from your application's middleware stack by removing them from the `$middleware` property of your `App\Http\Kernel` class.
+#### Disabling Input Normalization
 
-> {tip} If you only want to disable this behavior for part of your application, you can register the `TrimStrings::skipWhen` callback in the `boot` method of your application's `App\Providers\AppServiceProvider` class.
+If you would like to disable this behavior for all requests, you may remove the two middleware from your application's middleware stack by removing them from the `$middleware` property of your `App\Http\Kernel` class.
+
+If you would like to disable string trimming and empty string conversion for a subset of requests to your application, you may use the `skipWhen` method offered by both middleware. This method accepts a closure which should return `true` or `false` to indicate if input normalization should be skipped. Typically, the `skipWhen` method should be invoked in the `boot` method of your application's `AppServiceProvider`.
+
+```php
+use App\Http\Middleware\ConvertEmptyStringsToNull;
+use App\Http\Middleware\TrimStrings;
+
+/**
+ * Bootstrap any application services.
+ *
+ * @return void
+ */
+public function boot()
+{
+    TrimStrings::skipWhen(function ($request) {
+        return $request->is('admin/*');
+    });
+
+    ConvertEmptyStringsToNull::skipWhen(function ($request) {
+        // ...
+    });
+}
+```
 
 <a name="files"></a>
 ## Files

--- a/requests.md
+++ b/requests.md
@@ -464,6 +464,8 @@ By default, Laravel includes the `App\Http\Middleware\TrimStrings` and `App\Http
 
 If you would like to disable this behavior, you may remove the two middleware from your application's middleware stack by removing them from the `$middleware` property of your `App\Http\Kernel` class.
 
+> {tip} If you only want to disable this behavior for part of your application, you can register the `TrimStrings::skipWhen` callback in the `boot` method of your application's `App\Providers\AppServiceProvider` class.
+
 <a name="files"></a>
 ## Files
 


### PR DESCRIPTION
I needed to disable `TrimStrings` just for one webhook controller, and I discovered this method looking at the source code. I thought it would be useful to surface it in the docs.