### PR TITLE
Clarify that csrf endpoint is only required for 3rd party and mobile apps

### DIFF
--- a/csrf.md
+++ b/csrf.md
@@ -65,7 +65,7 @@ The `App\Http\Middleware\VerifyCsrfToken` [middleware](/docs/{{version}}/middlew
 <a name="csrf-tokens-and-spas"></a>
 ### CSRF Tokens & SPAs
 
-If you are building a SPA that is utilizing Laravel as an API backend, you should consult the [Laravel Sanctum documentation](/docs/{{version}}/sanctum) for information on authenticating with your API and protecting against CSRF vulnerabilities.
+If you are building a third-party SPA or mobile application that is utilizing Laravel as an API backend, you should consult the [Laravel Sanctum documentation](/docs/{{version}}/sanctum) for information on authenticating with your API and protecting against CSRF vulnerabilities.
 
 <a name="csrf-excluding-uris"></a>
 ### Excluding URIs From CSRF Protection

--- a/sanctum.md
+++ b/sanctum.md
@@ -296,7 +296,9 @@ Finally, you should ensure your application's session cookie domain configuratio
 <a name="csrf-protection"></a>
 #### CSRF Protection
 
-To authenticate your SPA, your SPA's "login" page should first make a request to the `/sanctum/csrf-cookie` endpoint to initialize CSRF protection for the application:
+> {tip} If your application is a first-party SPA there is no need to call the bellow endpoint, the App\Http\Middleware\VerifyCsrfToken middleware, which is included in the web middleware group by default, will automatically verify that the token in the request input matches the token stored in the session.
+
+If your application is a third-party SPA or a mobile application, your "login" page should first make a request to the `/sanctum/csrf-cookie` endpoint to initialize CSRF protection for the application:
 
 ```js
 axios.get('/sanctum/csrf-cookie').then(response => {


### PR DESCRIPTION
This section is causing confusion to many so it would be good to clarify this is only needed for 3rd party SPA's and mobile apps.