### PR TITLE
Document the usage of DB::raw() within the default value as to not be…

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -927,7 +927,7 @@ The `default` modifier accepts a value or an `Illuminate\Database\Query\Expressi
         }
     };
 
-> {note} Support for default expressions depends on your database driver, database version, and the field type. Please refer to your database's documentation.
+> {note} Support for default expressions depends on your database driver, database version, and the field type. Please refer to your database's documentation. Be aware that is strongly recommended to not use `DB::raw()` for specifying the default value as Laravel utilizes doctrine/dbal to do migration changes and there is no guarantee for raw statements to be formatted correctly.
 
 <a name="column-order"></a>
 #### Column Order

--- a/migrations.md
+++ b/migrations.md
@@ -927,7 +927,7 @@ The `default` modifier accepts a value or an `Illuminate\Database\Query\Expressi
         }
     };
 
-> {note} Support for default expressions depends on your database driver, database version, and the field type. Please refer to your database's documentation. Be aware that is strongly recommended to not use `DB::raw()` for specifying the default value as Laravel utilizes doctrine/dbal to do migration changes and there is no guarantee for raw statements to be formatted correctly.
+> {note} Support for default expressions depends on your database driver, database version, and the field type. Please refer to your database's documentation. Be aware that it is strongly recommended to not use `DB::raw()` for specifying the default value as Laravel utilizes doctrine/dbal to do migration changes and there is no guarantee for raw statements to be formatted correctly.
 
 <a name="column-order"></a>
 #### Column Order


### PR DESCRIPTION
As discussed with @driesvints within issue [laravel/framework#42336](https://github.com/laravel/framework/issues/42336) a documentation change to recommend against using raw query statements within the default() method.