### PR TITLE
clarify csrf for SPA

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -296,15 +296,15 @@ Finally, you should ensure your application's session cookie domain configuratio
 <a name="csrf-protection"></a>
 #### CSRF Protection
 
-To authenticate your SPA, your SPA's "login" page should first make a request to the `/sanctum/csrf-cookie` endpoint to initialize CSRF protection for the application:
+Laravel [automatically sets](/docs/{{version}}/csrf#csrf-x-xsrf-token) an `XSRF-TOKEN` cookie containing the current CSRF token after a GET request. In the case that your your SPA is performing a POST request without having previously performed a GET, you should first make a request to the `/sanctum/csrf-cookie` endpoint to initialize CSRF protection for the application:
 
 ```js
 axios.get('/sanctum/csrf-cookie').then(response => {
-    // Login...
+    // POST...
 });
 ```
 
-During this request, Laravel will set an `XSRF-TOKEN` cookie containing the current CSRF token. This token should then be passed in an `X-XSRF-TOKEN` header on subsequent requests, which some HTTP client libraries like Axios and the Angular HttpClient will do automatically for you. If your JavaScript HTTP library does not set the value for you, you will need to manually set the `X-XSRF-TOKEN` header to match the value of the `XSRF-TOKEN` cookie that is set by this route.
+During this, or any other successful GET request, Laravel will set an `XSRF-TOKEN` cookie containing the current CSRF token. This token should then be passed in an `X-XSRF-TOKEN` header on subsequent requests, which some HTTP client libraries like Axios and the Angular HttpClient will do automatically for you. If your JavaScript HTTP library does not set the value for you, you will need to manually set the `X-XSRF-TOKEN` header to match the value of the `XSRF-TOKEN` cookie that is set by this route.
 
 <a name="logging-in"></a>
 #### Logging In


### PR DESCRIPTION
Related to this [PR](https://github.com/laravel/docs/pull/7932)

Current docs make it sound as if you are required to call the `/sanctum/csrf-cookie` endpoint in order to login. However this is not accurate as you just must have performed a successful GET request previously. There are many SPAs that initially perform a GET request to show public content and only later perform a login POST request.

There are quite a few question regarding this over the web such as:

https://stackoverflow.com/questions/61975282/laravel-sanctum-csrf-cookie-request-optional/64695186#64695186
https://stackoverflow.com/questions/72210505/should-we-make-a-request-to-sanctum-csrf-cookie-first-before-registration-that?noredirect=1#comment127597867_72210505
