### PR TITLE
[9.x] Document the usage of expressions and raw statements within the default() modifier

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -927,7 +927,7 @@ The `default` modifier accepts a value or an `Illuminate\Database\Query\Expressi
         }
     };
 
-> {note} Support for default expressions depends on your database driver, database version, and the field type. Please refer to your database's documentation.
+> {note} Support for default expressions depends on your database driver, database version, and the field type. Please refer to your database's documentation. Be aware that it is currently not possible to chain the `change()` on to the default method combined with an raw statement or expression. `default(new Expression('(JSON_ARRAY())'))->change()` or `default(DB::raw('(JSON_ARRAY())')))->change()` are currently not supported due to the way Laravel utilizes doctrine/dbal under the hood.
 
 <a name="column-order"></a>
 #### Column Order

--- a/migrations.md
+++ b/migrations.md
@@ -927,7 +927,7 @@ The `default` modifier accepts a value or an `Illuminate\Database\Query\Expressi
         }
     };
 
-> {note} Support for default expressions depends on your database driver, database version, and the field type. Please refer to your database's documentation. Be aware that it is currently not possible to chain the `change()` on to the default method combined with an raw statement or expression. `default(new Expression('(JSON_ARRAY())'))->change()` or `default(DB::raw('(JSON_ARRAY())')))->change()` are currently not supported due to the way Laravel utilizes doctrine/dbal under the hood.
+> {note} Support for default expressions depends on your database driver, database version, and the field type. Please refer to your database's documentation. In addition, it is not possible to combine raw `default` expressions (using `DB::raw`) with column changes via the `change` method.
 
 <a name="column-order"></a>
 #### Column Order


### PR DESCRIPTION
Related to issue: https://github.com/laravel/framework/issues/42336

**The problem**

The documentation currently states the following:

`The default modifier accepts a value or an Illuminate\Database\Query\Expression instance. Using an Expression instance will prevent Laravel from wrapping the value in quotes and allow you to use database specific functions. One situation where this is particularly useful is when you need to assign default values to JSON columns:`

The problem is that the ChangeColumn is currently looking at the difference between two doctrine objects and utilizes the Doctrine DatabasePlatforms to generate sql to alter a table. The problem is that the SQL is generated by a database platform which does some validation but does not know about Laravel itself, so when DB::raw or an Expression is used when chaining the change(), thieAfter carefully looking at various options to make the change() compatible with the default(), this would require Laravel to maintain a custom database platform as suggested by doctrine 3.2 documentation, this is what Doctrine recommends:
https://github.com/laravel/framework/issues/42336

`If you want to overwrite parts of your platform you can do so when creating a connection. There is a platform option you can pass an instance of the platform you want the connection to use`

This would require us to create multiple platforms for all drivers and maintain them for all types to adjust the `getDefaultValueDeclarationSQL`.  

I have been looking for a way to rewrite the ChangeColumn class, but this has too much impact. Therefore, I decided to simply add a documentation note in order for this to be supported.

-----
**What is this referring to?**

This is referring to the usage of raw statements using the `DB::raw()` or the usage of Expressions within the default() within the migration scheme. When chaining the `change()` to the default, e.g:

```
Schema::table('example', function (Blueprint $table) {… used as this could cause issues with doctrine/dbal.
    $table->uuid('uuid')->default(DB::raw('(replace(uuid(),\'-\',\'\'))'))->change();
});
```

The ChangeColumn class utilizes the database platform which essentually calls `alterTableSql()` which then tries to populate this raw statement without validating what's given in Laravel.

This addition to the documentation would explain that it is recommended to not use raw statements within the default method.

The issue is linked under where @driesvints has recommended going for a documentation notation.

@taylorotwell Otherwise it is possible to actually fix this issue, but this would mean to follow up on doctrines way which means to actually customize the platform or look at a different way of generating SQL for table differences.. If this is preferred, I would be happy too.

https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/platforms.html

Otherwise this documentation change would be the easiest way of warning against using raw statements or Expressions. Let me know what is preferred and I will make sure to get it done properly.
