### PR TITLE
[9.x] Add initialization example for building a Redis pipeline

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -299,11 +299,11 @@ Sometimes you may need to execute dozens of Redis commands. Instead of making a 
         }
     });
 
-It is also possible to initialize a pipeline and to bind methods to the Redis instance.
+It is also possible to initialize a pipeline which returns a Redis instance and can be used to chain Redis commands.
 
     use Illuminate\Support\Facades\Redis;
 
-    Redis::HMSET(
+    Redis::hmset(
         'myhash',
         [
             'field1' => 'Taylor Otwell',
@@ -313,8 +313,9 @@ It is also possible to initialize a pipeline and to bind methods to the Redis in
 
     $pipe = Redis::pipeline();
     $pipe->ping();
-    $pipe->hmget('myhash', ['field1', 'field2]);
-    $result = $pipe->exec();
+    $pipe->hmget('myhash', ['field1', 'field2']);
+
+    return $pipe->exec();
 
 <a name="pubsub"></a>
 ## Pub / Sub

--- a/redis.md
+++ b/redis.md
@@ -299,6 +299,23 @@ Sometimes you may need to execute dozens of Redis commands. Instead of making a 
         }
     });
 
+It is also possible to initialize a pipeline and to bind methods to the Redis instance.
+
+    use Illuminate\Support\Facades\Redis;
+
+    Redis::HMSET(
+        'myhash',
+        [
+            'field1' => 'Taylor Otwell',
+            'field2' => 'Laravel',
+        ]
+    );
+
+    $pipe = Redis::pipeline();
+    $pipe->ping();
+    $pipe->hmget('myhash', ['field1', 'field2]);
+    $result = $pipe->exec();
+
 <a name="pubsub"></a>
 ## Pub / Sub
 


### PR DESCRIPTION
When building a redis pipeline, a pipeline can also be initialized. This returns a Redis instance, this same instance then needs to be passed to whatever commands you want to use in order for it to return the expected results.

The documentation from Predis is somewhat hidden, which could cause confusion with how a Redis pipeline should be properly built. I therefore added this small part of documentation to avoid this confusion.

I explained this further in:

[laravel/framework#42375](https://github.com/laravel/framework/issues/42375)