### PR TITLE
[9.x] Fix example for Rule::in

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1219,8 +1219,8 @@ When the `in` rule is combined with the `array` rule, each value in the input ar
         'airports' => [
             'required',
             'array',
-            Rule::in(['NYC', 'LIT']),
         ],
+        'airports.*' => Rule::in(['NYC', 'LIT']),
     ]);
 
 <a name="rule-in-array"></a>


### PR DESCRIPTION
Fixes the example of `Rule::in` to the correct usage.

See https://github.com/laravel/framework/issues/42399