### PR TITLE
Update starter-kits.md to mention Fortify

### DIFF
--- a/starter-kits.md
+++ b/starter-kits.md
@@ -23,6 +23,8 @@ Breeze provides a wonderful starting point for beginning a fresh Laravel applica
 
 <img src="https://laravel.com/img/docs/breeze-register.png">
 
+> {tip} If you are adding authentication to an existing application or will be implementing your own frontend views and logic you find [Fortify](/docs/{{version}}/fortify) a better match. Fortify provides a complete serverside authentication setup without imposing a frontend on you.
+
 <a name="laravel-breeze-installation"></a>
 ### Installation
 


### PR DESCRIPTION
Fortify can sometimes get lost in the documentation. I’ve seen many articles and stories mentioning the starter-kits and forum posts with people asking how to customise or remove X from the frontend. I myself have used a starter-kit only to remove the frontend in the past. Like how the Fortify docs reference the starter-kits, to starter-kits should reference Fortify as an alternative.