### PR TITLE
Update octane.md

### DIFF
--- a/octane.md
+++ b/octane.md
@@ -88,7 +88,7 @@ After installing the RoadRunner binary, you may exit your Sail shell session. Yo
 Next, update the `command` directive of your application's `docker/supervisord.conf` file so that Sail serves your application using Octane instead of the PHP development server:
 
 ```ini
-command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=8000
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=80
 ```
 
 Finally, ensure the `rr` binary is executable and build your Sail images:

--- a/octane.md
+++ b/octane.md
@@ -73,6 +73,12 @@ Next, you should start a Sail shell and use the `rr` executable to retrieve the 
 ./vendor/bin/rr get-binary
 ```
 
+ ```
+ # choose no as an answer
+ Do you want create default ".rr.yaml" configuration file? (yes/no) [yes]:
+ > no
+ ```
+
 After installing the RoadRunner binary, you may exit your Sail shell session. You will now need to adjust the `supervisor.conf` file used by Sail to keep your application running. To get started, execute the `sail:publish` Artisan command:
 
 ```shell


### PR DESCRIPTION
updated port to use `80` as by default as default sail `docker-compose.yml` internal port configured to `80` 
so for the sail users who is simply following the docs will be able to run as is.

You need to choose `no` as an answer otherwise it registers some grpc plugins and it will try to find the proto files thus resulting in error on startup.