### PR TITLE
Make requirement to run config:clear more prominent

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -23,7 +23,9 @@ An `ExampleTest.php` file is provided in both the `Feature` and `Unit` test dire
 
 When running tests, Laravel will automatically set the [configuration environment](/docs/{{version}}/configuration#environment-configuration) to `testing` because of the environment variables defined in the `phpunit.xml` file. Laravel also automatically configures the session and cache to the `array` driver while testing, meaning no session or cache data will be persisted while testing.
 
-You are free to define other testing environment configuration values as necessary. The `testing` environment variables may be configured in your application's `phpunit.xml` file, but make sure to clear your configuration cache using the `config:clear` Artisan command before running your tests!
+You are free to define other testing environment configuration values as necessary. The `testing` environment variables may be configured in your application's `phpunit.xml` file
+
+> {note} Make sure to clear your configuration cache using the `config:clear` Artisan command before running your tests!
 
 <a name="the-env-testing-environment-file"></a>
 #### The `.env.testing` Environment File

--- a/testing.md
+++ b/testing.md
@@ -23,7 +23,7 @@ An `ExampleTest.php` file is provided in both the `Feature` and `Unit` test dire
 
 When running tests, Laravel will automatically set the [configuration environment](/docs/{{version}}/configuration#environment-configuration) to `testing` because of the environment variables defined in the `phpunit.xml` file. Laravel also automatically configures the session and cache to the `array` driver while testing, meaning no session or cache data will be persisted while testing.
 
-You are free to define other testing environment configuration values as necessary. The `testing` environment variables may be configured in your application's `phpunit.xml` file
+You are free to define other testing environment configuration values as necessary. The `testing` environment variables may be configured in your application's `phpunit.xml` file.
 
 > {note} Make sure to clear your configuration cache using the `config:clear` Artisan command before running your tests!
 


### PR DESCRIPTION
Failing to do this can cause significant issues, so i feel this should be made more visible. It could possibly be reworded to explain the reason but i do not have the experience to write this up at this point.

I recently ran in to this when building just a small local app - fortunately i had backed up my database and was able to restore easily. I had run this command at some stage `php artisan config:cache` as described here https://laravel.com/docs/9.x/deployment#optimizing-configuration-loading

This article helped me understand exactly what was going on after running that command https://jasonmccreary.me/articles/laravel-testing-configuration-precedence/