### PR TITLE
[4.2] Envoy Task Runner's Notifications link fixed

### DIFF
--- a/ssh.md
+++ b/ssh.md
@@ -218,7 +218,6 @@ The `deploy` macro can now be run via a single, simple command:
 	envoy run deploy
 
 <a name="envoy-notifications"></a>
-<a name="envoy-hipchat-notifications"></a>
 ### Notifications
 
 #### HipChat


### PR DESCRIPTION
It does not work when you click on "Notifications". This PR will solve the problem.
![image](https://user-images.githubusercontent.com/54996800/169696774-0b0f706b-b646-45da-baec-d1e0ac20db84.png)
