### PR TITLE
Updating custom throttle response.

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -644,6 +644,7 @@ Laravel includes powerful and customizable rate limiting services that you may u
 Rate limiters are defined using the `RateLimiter` facade's `for` method. The `for` method accepts a rate limiter name and a closure that returns the limit configuration that should apply to routes that are assigned to the rate limiter. Limit configuration are instances of the `Illuminate\Cache\RateLimiting\Limit` class. This class contains helpful "builder" methods so that you can quickly define your limit. The rate limiter name may be any string you wish:
 
     use Illuminate\Cache\RateLimiting\Limit;
+    use Illuminate\Http\Request;
     use Illuminate\Support\Facades\RateLimiter;
 
     /**

--- a/routing.md
+++ b/routing.md
@@ -661,8 +661,8 @@ Rate limiters are defined using the `RateLimiter` facade's `for` method. The `fo
 If the incoming request exceeds the specified rate limit, a response with a 429 HTTP status code will automatically be returned by Laravel. If you would like to define your own response that should be returned by a rate limit, you may use the `response` method:
 
     RateLimiter::for('global', function (Request $request) {
-        return Limit::perMinute(1000)->response(function () {
-            return response('Custom response...', 429);
+        return Limit::perMinute(1000)->response(function (Request $request, array $headers) {
+            return response('Custom response...', 429, $headers);
         });
     });
 


### PR DESCRIPTION
Added the 2 parameters that the custom response callback is called with in the ThrottleRequests::buildException method. I tried to implement my own custom response and lost the throttle headers (X-RateLimit-Limit, etc). It was not obvious to me how to get the header info into my response. I tried to dig through the code, but missed the spot where the callback is called. Got a response to my problem on Laracasts, through I'd help put it in the docs for others.