### PR TITLE
[9.x] fix sail binary references

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -43,7 +43,7 @@ php artisan help migrate
 If you are using [Laravel Sail](/docs/{{version}}/sail) as your local development environment, remember to use the `sail` command line to invoke Artisan commands. Sail will execute your Artisan commands within your application's Docker containers:
 
 ```shell
-./sail artisan list
+./vendor/bin/sail artisan list
 ```
 
 <a name="tinker"></a>

--- a/mix.md
+++ b/mix.md
@@ -51,8 +51,8 @@ npm -v
 You can easily install the latest version of Node and NPM using simple graphical installers from [the official Node website](https://nodejs.org/en/download/). Or, if you are using [Laravel Sail](/docs/{{version}}/sail), you may invoke Node and NPM through Sail:
 
 ```shell
-./sail node -v
-./sail npm -v
+./vendor/bin/sail node -v
+./vendor/bin/sail npm -v
 ```
 
 <a name="installing-laravel-mix"></a>


### PR DESCRIPTION
The sail binary is referenced as `./vendor/bin/sail` across all the docs pages, except for the sail docs page (where the alias is referenced).

This is however neither the alias or the vendor bin path and this is a left over from O.G. sail when it was copied into the root.