### PR TITLE
[9.x] Correct docs for the observer boot method

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1421,7 +1421,7 @@ To register an observer, you need to call the `observe` method on the model you 
      *
      * @return void
      */
-    public function boot()
+    public static function boot()
     {
         User::observe(UserObserver::class);
     }


### PR DESCRIPTION
This is a small PR that fixes the missing `static` in the `boot()` method according to https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Eloquent/Model.php#L250