### PR TITLE
Fix Log::withContext() middleware example

### DIFF
--- a/logging.md
+++ b/logging.md
@@ -233,7 +233,9 @@ Occasionally, you may wish to specify some contextual information that should be
                 'request-id' => $requestId
             ]);
 
-            return $next($request)->header('Request-Id', $requestId);
+            $request->headers->set('Request-Id', $requestId);
+
+            return $next($request);
         }
     }
 


### PR DESCRIPTION
`$request->header()` does not set any values. It only retrieves.

https://github.com/laravel/framework/blob/ff5c52b7556a41901b961d9ceee4fee55da27b3a/src/Illuminate/Http/Concerns/InteractsWithInput.php#L45-L48