### PR TITLE
[9.x] Document new Cashier Paddle fake test methods

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -1249,7 +1249,7 @@ If you run into a situaton where you need to provide a specific response from Pa
             'name' => 'main',
             'paddle_id' => 23423,
             'paddle_plan' => 12345,
-            'paddle_status' => Subscription::STATUS_ACTIVE,
+            'paddle_status' => 'active',
             'quantity' => 1,
         ]);
 


### PR DESCRIPTION
Documents https://github.com/laravel/cashier-paddle/pull/165. I'm not sure I'm 100% happy with the examples as they don't demonstrate real-life app situations. Although giving specific app examples might make things too complicated.