### PR TITLE
Order of arguments inconsistent

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -619,7 +619,7 @@ However, if you are building a package that utilizes Blade components, you will 
      */
     public function boot()
     {
-        Blade::component('package-alert', Alert::class);
+        Blade::component(Alert::class, 'package-alert');
     }
 
 Once your component has been registered, it may be rendered using its tag alias:
@@ -1189,7 +1189,7 @@ However, if you are building a package that utilizes Blade components or placing
      */
     public function boot()
     {
-        Blade::component('package-alert', AlertComponent::class);
+        Blade::component(AlertComponent::class, 'package-alert');
     }
 
 Once your component has been registered, it may be rendered using its tag alias:

--- a/packages.md
+++ b/packages.md
@@ -264,7 +264,7 @@ If you are building a package that utilizes Blade components or placing componen
      */
     public function boot()
     {
-        Blade::component('package-alert', AlertComponent::class);
+        Blade::component(AlertComponent::class, 'package-alert');
     }
 
 Once your component has been registered, it may be rendered using its tag alias:


### PR DESCRIPTION
It seems like the example in the docs isn't inconsistent with the method signature. See: Illuminate/View/Compilers/BladeCompiler.php:633

I already noticed that Laravel swaps the arguments when they are in the wrong order, but it might be confusing because an IDE suggests `$class, $alias`. Whereas the docs say `$alias, $class`.