### PR TITLE
Fix pluck example using dot notation

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1687,7 +1687,7 @@ The `pluck` method also supports retrieving nested values using "dot" notation:
 
     $plucked->all();
 
-    // ['Rosa', 'Judith']
+    // [['Rosa', 'Judith']]
 
 If duplicate keys exist, the last matching element will be inserted into the plucked collection:
 


### PR DESCRIPTION
It seems the current behavior isn't properly documented. This got documented here: https://github.com/laravel/docs/pull/6212.

But the current behavior is actually differently. I also didn't expect the current behavior but think we shouldn't change this as it could maybe lead to breaking changes? I think it's best to just properly document the current behavior instead. 

There also don't seem to be any tests about this behavior in the framework right now.

See https://github.com/laravel/framework/issues/42653