### PR TITLE
[Fix][Installation] Sail up command should not be relative

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -72,7 +72,7 @@ After the project has been created, you can navigate to the application director
 ```shell
 cd example-app
 
-./vendor/bin/sail up
+vendor/bin/sail up
 ```
 
 The first time you run the Sail `up` command, Sail's application containers will be built on your local machine. This could take several minutes. **Don't worry, subsequent attempts to start Sail will be much faster.**
@@ -101,7 +101,7 @@ After the project has been created, you can navigate to the application director
 ```shell
 cd example-app
 
-./vendor/bin/sail up
+vendor/bin/sail up
 ```
 
 The first time you run the Sail `up` command, Sail's application containers will be built on your local machine. This could take several minutes. **Don't worry, subsequent attempts to start Sail will be much faster.**
@@ -132,7 +132,7 @@ After the project has been created, you can navigate to the application director
 ```shell
 cd example-app
 
-./vendor/bin/sail up
+vendor/bin/sail up
 ```
 
 The first time you run the Sail `up` command, Sail's application containers will be built on your local machine. This could take several minutes. **Don't worry, subsequent attempts to start Sail will be much faster.**


### PR DESCRIPTION
`./vendor/bin/sail up` fails with the error described here: https://laracasts.com/discuss/channels/code-review/laravel-sail-service-laraveltest-failed-to-build-build-failed

Sail runs perfectly when you start with `vendor/bin/sail up`