### PR TITLE
Hint in an example that querybuilder is clever about OR's in generated SQL

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -617,7 +617,7 @@ Sometimes you may need to group several "where" clauses within parentheses in or
     $users = DB::table('users')
                ->where('name', '=', 'John')
                ->where(function ($query) {
-                   $query->where('votes', '>', 100)
+                   $query->orWhere('votes', '>', 100)
                          ->orWhere('title', '=', 'Admin');
                })
                ->get();


### PR DESCRIPTION
I'm on a team where there was a reading of the docs that `orWhere` always needed to come _after_ a `where` (and couldn't be called first with a simple `orWhere`). This led to some overcomplex logic to ensure the first call in a loop was `where` and subsequents were `orWhere`.

It would be great if the docs showed some variation, so others wouldn't fall into this mistaken assumption that leads to more complex code paths :)

I thought this was the smallest change, but maybe it could be called out specifically in a Note too 🤷 

Anyhow, thanks for considering! Y'all are the best