### PR TITLE
Clarified laravel_token cookie creation

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -1161,7 +1161,7 @@ Typically, if you want to consume your API from your JavaScript application, you
 
 > {note} You should ensure that the `CreateFreshApiToken` middleware is the last middleware listed in your middleware stack.
 
-This middleware will attach a `laravel_token` cookie to your outgoing responses. This cookie contains an encrypted JWT that Passport will use to authenticate API requests from your JavaScript application. The JWT has a lifetime equal to your `session.lifetime` configuration value. Now, since the browser will automatically send the cookie with all subsequent requests, you may make requests to your application's API without explicitly passing an access token:
+This middleware will attach a `laravel_token` cookie to your outgoing responses, but it will create cookie only for `web` routes, `GET` requests. This cookie contains an encrypted JWT that Passport will use to authenticate API requests from your JavaScript application. The JWT has a lifetime equal to your `session.lifetime` configuration value. Now, since the browser will automatically send the cookie with all subsequent requests, you may make requests to your application's API without explicitly passing an access token:
 
     axios.get('/api/user')
         .then(response => {


### PR DESCRIPTION
This small docs fix will help people to understand how it really works.

There is a lot of confusion about laravel_token cookie creation by CreateFreshApiToken  middleware, because people usually try to implement this as POST "login" route.

Inside CreateFreshApiToken [https://github.com/laravel/passport/blob/9.x/src/Http/Middleware/CreateFreshApiToken.php#L82](https://github.com/laravel/passport/blob/9.x/src/Http/Middleware/CreateFreshApiToken.php#L82) there is condition which checks if request method is equal to "GET", so in case of POST login route - it won't create cookie.