### PR TITLE
[9.x] Noted about explicit base-url generation for MinIO in Sail

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -241,10 +241,10 @@ AWS_ENDPOINT=http://minio:9000
 AWS_USE_PATH_STYLE_ENDPOINT=true
 ```
 
-In order to generate proper URLs by the Filesystem in a development environment, the base URL must explicitely be defined as well:
+In order for Laravel's Flysystem integration to generate proper URLs when using MinIO, you should define the `AWS_URL` environment variable so that it matches your application's local URL and includes the bucket name in the URL path:
 
 ```ini
-AWS_URL=http://localhost:9000/local # APP_URL:9000/AWS_BUCKET
+AWS_URL=http://localhost:9000/local
 ```
 
 <a name="running-tests"></a>

--- a/sail.md
+++ b/sail.md
@@ -241,6 +241,12 @@ AWS_ENDPOINT=http://minio:9000
 AWS_USE_PATH_STYLE_ENDPOINT=true
 ```
 
+In order to generate proper URLs by the Filesystem in a development environment, the base URL must explicitely be defined as well:
+
+```ini
+AWS_URL=http://localhost:9000/local # APP_URL:9000/AWS_BUCKET
+```
+
 <a name="running-tests"></a>
 ## Running Tests
 


### PR DESCRIPTION
I'd love to convey 2 messages here:

1. Base URL has to be explicitly defined in order to be generated well by the [Filesystem](https://github.com/laravel/framework/blob/15b45877b2e8928635bfd3ebe28b536f8b5e7aec/src/Illuminate/Filesystem/AwsS3V3Adapter.php#L46) in Sail.
2. When updating the base-URL, old files need to be re-uploaded to have the correct URL.

So with the default settings shown in the [docs](https://laravel.com/docs/9.x/sail#file-storage), a file will have `http://minio:9000/example.file` URL which will cause a `GET net::ERR_NAME_NOT_RESOLVED` error.

But if we add an `AWS_URL=http://localhost:9000/local` environment variable, and **upload the file again**, then the Filesystem will generate the correct URL for it. ( `http://localhost:9000/local/example.file` )

Note: I haven't documented point 2 yet, until I get confirmation that any of this is worth it! 😋