### PR TITLE
[9.x] Suggest `public` job properties for `Bus::assertDispatched()` testing

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -183,7 +183,7 @@ Job classes are very simple, normally containing only a `handle` method that is 
          *
          * @var \App\Models\Podcast
          */
-        protected $podcast;
+        public $podcast;
 
         /**
          * Create a new job instance.
@@ -1711,7 +1711,7 @@ When a particular job fails, you may want to send an alert to your users or reve
          *
          * @var \App\Podcast
          */
-        protected $podcast;
+        public $podcast;
 
         /**
          * Create a new job instance.


### PR DESCRIPTION
This PR replaces the suggested `protected` properties on the example jobs for `public`.

This aligns the `Bus::assertDispatched()` documentation which suggests public properties for testing:

https://github.com/laravel/docs/blob/9.x/mocking.md#bus-fake

```php
Bus::assertDispatched(function (ShipOrder $job) use ($order) {
    return $job->order->id === $order->id;
});
```

This is a small hiccup for new Laravel users, since they may copy the example and go to test, puzzled that the test docs show accessing a `public` property but the example jobs show `protected`.