### PR TITLE
[8.x] update documentation for event exclude and even exclude scope

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -393,12 +393,13 @@ If you only want to exclude event listeners from being faked for a portion of yo
         public function test_orders_can_be_processed()
         {
             $order = Event::fakeExceptFor(function () {
+                // Events are dispatched as normal and observers will run ...
                 $order = Order::factory()->create();
 
                 return $order;
             });
 
-            // Events are dispatched as normal and observers will run ...
+            // The Order Update Model Event will not be dispatched
             $order->update([...]);
         }
     }

--- a/mocking.md
+++ b/mocking.md
@@ -312,6 +312,27 @@ If you only want to fake event listeners for a specific set of events, you may p
         $order->update([...]);
     }
 
+<a name="excluding-event"></a>
+### Excluding Events From Fake
+
+If you want to fake everything but a given event, you may use the `fakeExcept` method:
+
+    /**
+     * Test order process.
+     */
+    public function test_orders_can_be_processed()
+    {
+        Event::fakeExcept([
+            OrderCreated::class,
+        ]);
+
+        ShippingLabel::factory()->create();
+
+        Order::factory()->create();
+    }
+
+This will fake all events except the OrderCreated event.
+
 <a name="scoped-event-fakes"></a>
 ### Scoped Event Fakes
 
@@ -336,6 +357,42 @@ If you only want to fake event listeners for a portion of your test, you may use
         public function test_orders_can_be_processed()
         {
             $order = Event::fakeFor(function () {
+                $order = Order::factory()->create();
+
+                Event::assertDispatched(OrderCreated::class);
+
+                return $order;
+            });
+
+            // Events are dispatched as normal and observers will run ...
+            $order->update([...]);
+        }
+    }
+
+<a name="excluding-scoped-event-fakes"></a>
+### Excluding Scoped Event Fakes
+
+If you only want to exclude event listeners from being faked for a portion of your test, you may use the `fakeExceptFor` method:
+
+    <?php
+
+    namespace Tests\Feature;
+
+    use App\Events\OrderCreated;
+    use App\Models\Order;
+    use Illuminate\Foundation\Testing\RefreshDatabase;
+    use Illuminate\Support\Facades\Event;
+    use Illuminate\Foundation\Testing\WithoutMiddleware;
+    use Tests\TestCase;
+
+    class ExampleTest extends TestCase
+    {
+        /**
+         * Test order process.
+         */
+        public function test_orders_can_be_processed()
+        {
+            $order = Event::fakeExceptFor(function () {
                 $order = Order::factory()->create();
 
                 Event::assertDispatched(OrderCreated::class);

--- a/mocking.md
+++ b/mocking.md
@@ -395,8 +395,6 @@ If you only want to exclude event listeners from being faked for a portion of yo
             $order = Event::fakeExceptFor(function () {
                 $order = Order::factory()->create();
 
-                Event::assertDispatched(OrderCreated::class);
-
                 return $order;
             });
 


### PR DESCRIPTION
This PR updated the Event mocking documentation that originally did not include the Event Fake Exclude Documentation