### PR TITLE
[9.x] Add note about legacy Sources API

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -396,7 +396,7 @@ If you would like to generate the URL to the billing portal without generating a
 <a name="payment-methods"></a>
 ## Payment Methods
 
-> **Note:** as of Cashier v13, the legacy Source API by Stripe is no longer supported (including the `default_source` on a customer object). It's recommended that you only rely on the Payment Methods API.
+> **Note:** The legacy Sources API by Stripe is deprecated and should no longer be used (including the `default_source` on a customer object). It's recommended that you only rely on the Payment Methods API.
 
 <a name="storing-payment-methods"></a>
 ### Storing Payment Methods

--- a/billing.md
+++ b/billing.md
@@ -396,6 +396,8 @@ If you would like to generate the URL to the billing portal without generating a
 <a name="payment-methods"></a>
 ## Payment Methods
 
+> **Note:** as of Cashier v13, the legacy Source API by Stripe is no longer supported (including the `default_source` on a customer object). It's recommended that you only rely on the Payment Methods API.
+
 <a name="storing-payment-methods"></a>
 ### Storing Payment Methods
 


### PR DESCRIPTION
We did not explicitly note this yet in our own docs even though the Stripe docs note this. It's best that we explicitly mention that we don't support this API anymore and recommend people to only rely on the Payment Methods API.

Also see https://github.com/laravel/cashier-stripe/issues/1310