### PR TITLE
Added a short note for the usage of name parameter

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -207,6 +207,8 @@ The `download` method may be used to generate a response that forces the user's 
 
     return Storage::download('file.jpg', $name, $headers);
 
+> {note} The `$name` should only contain the proposed file name excluding the extension otherwise the extension will be added twice in the complete file name.
+> 
 <a name="file-urls"></a>
 ### File URLs
 


### PR DESCRIPTION
Just added a small note to mention that the Storage::download() method automatically adds the concerned file's extension at the end of the file name and that the developer do not have to pass parameter including that file's extension.