### PR TITLE
Fix example in 'Using An Existing Client Instance'

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -189,13 +189,16 @@ If you already have a pre-configured Pusher Channels client instance that you wo
 
 ```js
 import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
 
-const client = require('pusher-js');
+const options = {
+    broadcaster: 'pusher',
+    key: 'your-pusher-channels-key'
+}
 
 window.Echo = new Echo({
-    broadcaster: 'pusher',
-    key: 'your-pusher-channels-key',
-    client: client
+    ...options,
+    client: new Pusher(options.key, options)
 });
 ```
 


### PR DESCRIPTION
Looking at the laravel-echo [source](https://github.com/laravel/echo/blob/cd608aac40f136b9a50da8b1785615cadf95b04c/src/connector/pusher-connector.ts#L29) it expects an instance (as the title suggests), not the class.