### PR TITLE
Document `DisconnectFromDatabases` usage

### DIFF
--- a/octane.md
+++ b/octane.md
@@ -263,6 +263,8 @@ To help prevent stray memory leaks, Octane can gracefully restart a worker once 
 php artisan octane:start --max-requests=250
 ```
 
+The restarted workers abandon the database connection. If this leads to too many open connections on your database or you are bothered by aborted connection and `Connection reset by peer` warnings, you should uncomment `DisconnectFromDatabases::class` listener for `OperationTerminated::class` event in the `octane` configuration file.
+
 <a name="reloading-the-workers"></a>
 ### Reloading The Workers
 


### PR DESCRIPTION
When running into issues that require the `DisconnectFromDatabases` listener, it's quite hard to understand what's going on, what causes it and how to resolve it.

This PR tries to address that by describing the listener and adding the common errors/notices (`too many connections` in postgres and mysql, `connection reset by peer` in postgres, `aborted [...]` in mysql) so people in need could easily discover it in the Octane docs.