### PR TITLE
Clarify octane max-requests defaults

### DIFF
--- a/octane.md
+++ b/octane.md
@@ -257,7 +257,7 @@ php artisan octane:start --workers=4 --task-workers=6
 <a name="specifying-the-max-request-count"></a>
 ### Specifying The Max Request Count
 
-To help prevent stray memory leaks, Octane can gracefully restart a worker once it has handled a given number of requests. To instruct Octane to do this, you may use the `--max-requests` option:
+To help prevent stray memory leaks, Octane gracefully restarts any worker once it has handled 500 requests. To adjust this number, you may use the `--max-requests` option:
 
 ```shell
 php artisan octane:start --max-requests=250


### PR DESCRIPTION
It appears that every start command has 500 as the default value for `max-requests`:

https://github.com/laravel/octane/blob/master/src/Commands/StartCommand.php#L23
https://github.com/laravel/octane/blob/master/src/Commands/StartRoadRunnerCommand.php#L29
https://github.com/laravel/octane/blob/master/src/Commands/StartSwooleCommand.php#L27

This change clarifies that the limit is already enabled.

I'm not sure, but maybe "specify `0` to disable reloading" is also worth specifying?