### PR TITLE
Add tip about Octane development experience

### DIFF
--- a/octane.md
+++ b/octane.md
@@ -239,6 +239,8 @@ npm install --save-dev chokidar
 
 You may configure the directories and files that should be watched using the `watch` configuration option within your application's `config/octane.php` configuration file.
 
+> {tip} If you don't mind reloading twice to see changes, you can simply limit the [worker count](#specifying-the-worker-count) and [request count](#specifying-the-max-request-count) to 1 which will make the worker restart *after* every request.
+
 <a name="specifying-the-worker-count"></a>
 ### Specifying The Worker Count
 


### PR DESCRIPTION
I'm not sure if this optional is intentionally left out because it lacks a bit of elegance, but I had a great time with just

```php
php artisan octane:start --workers=1 --max-requests=1
```
taking care of code reloads while developing.

The only issue is that (at least on Swoole) the code gets loaded after the request and waits for the next incoming request as it is. So a code change requires one empty request to load the new code and then the real request to see the change. I just got used to double F5.