### PR TITLE
Vite - Add leading slash on aliases

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -185,7 +185,7 @@ By default, The Laravel plugin provides a common alias to help you hit the groun
 
 ```js
 {
-    '@' => 'resources/js'
+    '@' => '/resources/js'
 }
 ```
 
@@ -201,7 +201,7 @@ export default defineConfig({
     ],
     resolve: {
         alias: {
-            '@': 'resources/ts',
+            '@': '/resources/ts',
         },
     },
 });


### PR DESCRIPTION
Without the leading slash on the aliases, Vite fails to find the import correctly. Typically I've adjusted Vite aliases by calculating a path. I've given an example of this at the bottom of this PR. I think it could be justified to adjust the docs to the commonplace `path.resolve` version, but didn't want to create an overly complex PR when just adding the leading slash seems to work.

```typescript
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';
import path from 'path';

export default defineConfig({
    plugins: [
        laravel(['resources/ts/app.tsx']),
    ],
    resolve: {
        alias: {
            '@': path.resolve(__dirname, './resources/ts'),
        },
    },
});
```