### PR TITLE
[8.x] Fix directory paths in Blade docs

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -471,7 +471,7 @@ Blade also allows you to define comments in your views. However, unlike HTML com
 
 Components and slots provide similar benefits to sections, layouts, and includes; however, some may find the mental model of components and slots easier to understand. There are two approaches to writing components: class based components and anonymous components.
 
-To create a class based component, you may use the `make:component` Artisan command. To illustrate how to use components, we will create a simple `Alert` component. The `make:component` command will place the component in the `App\View\Components` directory:
+To create a class based component, you may use the `make:component` Artisan command. To illustrate how to use components, we will create a simple `Alert` component. The `make:component` command will place the component in the `app/View/Components` directory:
 
     php artisan make:component Alert
 
@@ -481,7 +481,7 @@ You may also create components within subdirectories:
 
     php artisan make:component Forms/Input
 
-The command above will create an `Input` component in the `App\View\Components\Forms` directory and the view will be placed in the `resources/views/components/forms` directory.
+The command above will create an `Input` component in the `app/View/Components/Forms` directory and the view will be placed in the `resources/views/components/forms` directory.
 
 <a name="manually-registering-package-components"></a>
 #### Manually Registering Package Components
@@ -534,7 +534,7 @@ To display a component, you may use a Blade component tag within one of your Bla
 
     <x-user-profile/>
 
-If the component class is nested deeper within the `App\View\Components` directory, you may use the `.` character to indicate directory nesting. For example, if we assume a component is located at `App\View\Components\Inputs\Button.php`, we may render it like so:
+If the component class is nested deeper within the `app/View/Components` directory, you may use the `.` character to indicate directory nesting. For example, if we assume a component is located at `app/View/Components/Inputs/Button.php`, we may render it like so:
 
     <x-inputs.button/>
 


### PR DESCRIPTION
Fixes a few references to directories that were written using namespace syntax.