### PR TITLE
Fix return type of scopeActive example

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1185,7 +1185,7 @@ Scopes should always return the same query builder instance or `void`:
          * Scope a query to only include active users.
          *
          * @param  \Illuminate\Database\Eloquent\Builder  $query
-         * @return void
+         * @return \Illuminate\Database\Eloquent\Builder
          */
         public function scopeActive($query)
         {


### PR DESCRIPTION
Reviewing the documentation I've seen that a code block is nor right:
```
    /**
     * Scope a query to only include active users.
     *
     * @param  \Illuminate\Database\Eloquent\Builder  $query
     * @return void
     */
    public function scopeActive($query)
    {
        $query->where('active', 1);
    }
```
The method `scopeActive($query)` should return an instance of ` \Illuminate\Database\Eloquent\Builder` instead of a `void`.