### PR TITLE
Use collect()->times instead of full class name

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -2575,7 +2575,7 @@ The `tap` method passes the collection to the given callback, allowing you to "t
 
 The static `times` method creates a new collection by invoking the given closure a specified number of times:
 
-    $collection = Collection::times(10, function ($number) {
+    $collection = collect()->times(10, function ($number) {
         return $number * 9;
     });
 


### PR DESCRIPTION
Looks more like rest of the collect() examples instead of using the full Collection class name for `times()` only.