### PR TITLE
Remove reference to --view option

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -597,14 +597,6 @@ php artisan make:component Forms/Input
 
 The command above will create an `Input` component in the `app/View/Components/Forms` directory and the view will be placed in the `resources/views/components/forms` directory.
 
-If you would like to create an anonymous component (a component with only a Blade template and no class), you may use the `--view` flag when invoking the `make:component` command:
-
-```shell
-php artisan make:component forms.input --view
-```
-
-The command above will create a Blade file at `resources/views/components/forms/input.blade.php` which can be rendered as a component via `<x-forms.input />`.
-
 <a name="manually-registering-package-components"></a>
 #### Manually Registering Package Components
 


### PR DESCRIPTION
`--view` option does not seem to exist on the ComponentMakeCommand so reference to this option should be remove from the docs.

Calling

> php artisan make:component Alert --view

raises an error 

>   The "--view" option does not exist.  