### PR TITLE
Remove extra spaces when merging two strings

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -1779,7 +1779,7 @@ When defining your `success_url` checkout option, you may instruct Stripe to add
 
     Route::get('/product-checkout', function (Request $request) {
         return $request->user()->checkout(['price_tshirt' => 1], [
-            'success_url' => route('checkout-success') . '?session_id={CHECKOUT_SESSION_ID}',
+            'success_url' => route('checkout-success').'?session_id={CHECKOUT_SESSION_ID}',
             'cancel_url' => route('checkout-cancel'),
         ]);
     });

--- a/helpers.md
+++ b/helpers.md
@@ -2942,7 +2942,7 @@ The `tap` method passes the string to the given closure, allowing you to examine
     $string = Str::of('Laravel')
         ->append(' Framework')
         ->tap(function ($string) {
-            dump('String after append: ' . $string);
+            dump('String after append: '.$string);
         })
         ->upper();
 


### PR DESCRIPTION
Remove extra spaces when merging two strings.
in laravel repository used this pattern for merge two strings:
[cache.php](https://github.com/laravel/laravel/blob/9.x/config/cache.php#L108)

