### PR TITLE
Update SSR directory

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -389,7 +389,7 @@ Then, to build and start the SSR server, you may run the following commands:
 
 ```sh
 npm run build
-node storage/ssr/ssr.js
+node bootstrap/ssr/ssr.js
 ```
 
 > {tip} Laravel's [starter kits](/docs/{{version}}/starter-kits) already include the proper Laravel, Inertia SSR, and Vite configuration. Check out [Laravel Breeze](/docs/{{version}}/starter-kits#breeze-and-inertia) for the fastest way to get started with Laravel, Inertia SSR, and Vite.


### PR DESCRIPTION
This PR updates the SSR instructions to use the new build directory from https://github.com/laravel/vite-plugin/pull/70.

We should hold off releasing this until the new version of `laravel-vite-plugin` has also been released.