### PR TITLE
[9.x] Add how to add React Vite plugin

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -247,6 +247,21 @@ export default defineConfig({
 <a name="react"></a>
 ### React
 
+First you will need to include the React plugin in the `vite.config.js` configuration file:
+
+```js
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+    plugins: [
+        laravel(['resources/js/app.jsx']),
+        react(),
+    ],
+});
+```
+
 When using Vite with React, you will need to ensure that any files containing JSX have a `.jsx` or `.tsx` extension, remembering to update your entry point, if required, as [shown above](#configuring-vite). You will also need to include the additional `@viteReactRefresh` Blade directive alongside your existing `@vite` directive.
 
 ```blade


### PR DESCRIPTION
In order to use the `@viteReactRefresh` blade directive you need to add
the React Vite plugin in the vite configuration. This is not especified
on the documentation.