### PR TITLE
Replace locale for name

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -942,7 +942,7 @@ When additional values are provided to the `array` rule, each key in the input a
     ];
 
     Validator::make($input, [
-        'user' => 'array:username,locale',
+        'user' => 'array:name,username',
     ]);
 
 In general, you should always specify the array keys that are allowed to be present within your array.


### PR DESCRIPTION
Noticed the validation rules saying "locale" which is not used in the code example above. Replaced locale with "name" and re-ordered to match the array above