### PR TITLE
fix: clarified breeze version

### DIFF
--- a/starter-kits.md
+++ b/starter-kits.md
@@ -37,7 +37,7 @@ php artisan migrate
 Once you have created a new Laravel application, you may install Laravel Breeze using Composer:
 
 ```bash
-composer require laravel/breeze --dev
+composer require laravel/breeze:1.9.2 
 ```
 
 After Composer has installed the Laravel Breeze package, you may run the `breeze:install` Artisan command. This command publishes the authentication views, routes, controllers, and other resources to your application. Laravel Breeze publishes all of its code to your application so that you have full control and visibility over its features and implementation. After Breeze is installed, you should also compile your assets so that your application's CSS file is available:


### PR DESCRIPTION
When installing version 8 of the laravel/framework, we need to install a specific version of the breeze package.