### PR TITLE
Fix available validation rules section in v5.1

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -443,6 +443,7 @@ Below is a list of all available validation rules and their function:
 </style>
 
 <div class="collection-method-list" markdown="1">
+
 [Accepted](#rule-accepted)
 [Active URL](#rule-active-url)
 [After (Date)](#rule-after)


### PR DESCRIPTION
This PR is to fix the **available validation rules** section in v5.1, now on the website it shows like this 

![image](https://user-images.githubusercontent.com/29666390/178793412-85ec51c4-a2d6-484a-b24a-9877ce14cf52.png)

After fixing it shows like this

![image](https://user-images.githubusercontent.com/29666390/178793905-a864f986-b4ab-4f5c-8952-12841bd98ce1.png)
