### PR TITLE
[9.x] Adds Laravel Pint documentation

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -38,6 +38,7 @@ The Laravel source code is managed on GitHub, and there are repositories for eac
 - [Laravel Horizon](https://github.com/laravel/horizon)
 - [Laravel Jetstream](https://github.com/laravel/jetstream)
 - [Laravel Passport](https://github.com/laravel/passport)
+- [Laravel Pint](https://github.com/laravel/pint)
 - [Laravel Sail](https://github.com/laravel/sail)
 - [Laravel Sanctum](https://github.com/laravel/sanctum)
 - [Laravel Scout](https://github.com/laravel/scout)

--- a/documentation.md
+++ b/documentation.md
@@ -87,6 +87,7 @@
     - [Mix](/docs/{{version}}/mix)
     - [Octane](/docs/{{version}}/octane)
     - [Passport](/docs/{{version}}/passport)
+    - [Pint](/docs/{{version}}/pint)
     - [Sail](/docs/{{version}}/sail)
     - [Sanctum](/docs/{{version}}/sanctum)
     - [Scout](/docs/{{version}}/scout)

--- a/pint.md
+++ b/pint.md
@@ -1,0 +1,132 @@
+# Laravel Pint
+
+- [Introduction](#introduction)
+- [Running Pint](#running-pint)
+- [Configuring Pint](#configuring-pint)
+    - [Presets](#presets)
+    - [Rules](#rules)
+    - [Excluding Files or Folders](#excluding-files-or-folders)
+
+<a name="introduction"></a>
+## Introduction
+
+[Laravel Pint](https://github.com/laravel/pint) is an opinionated PHP code style fixer for minimalists. Pint is built on top of PHP-CS-Fixer and makes it simple to ensure that your code style stays clean and consistent.
+
+Pint is automatically installed with all new Laravel applications so you may start using it immediately.
+
+By default, Pint does not require any configuration and will fix code style issues in your code by following an opinionated coding style of Laravel.
+
+<a name="running-pint"></a>
+## Running Pint
+
+You may start fixing code style issues by running the `pint` binary that is available in your project's `vendor/bin` directory:
+
+```shell
+./vendor/bin/pint
+```
+
+When running Pint, it will output a list of files that have been fixed. It is possible to see the changes made in more detail using the `-v` option:
+
+```shell
+./vendor/bin/pint -v
+```
+
+In addition, if you would like Pint to simply inspect your code for style errors without actually changing the files, you may use the `--test` option:
+
+```shell
+./vendor/bin/pint --test
+```
+
+<a name="configuring-pint"></a>
+## Configuring Pint
+
+As previously mentioned, Pint does not require any configuration. However, if you wish to customize the presets, rules, or inspected folders, you may do so by creating a `pint.json` file in your project's root directory:
+
+```json
+{
+    "preset": "laravel"
+}
+```
+
+In addition, if you wish to use a `pint.json` from a specific directory, you may use the `--config` option:
+
+```shell
+pint --config vendor/my-company/coding-style/pint.json
+```
+
+<a name="presets"></a>
+### Presets
+
+Presets defines a set of rules that can be used to fix code style issues in your code. By default, Pint uses the `laravel` preset, which fixes issues by following an opinionated coding style of Laravel.
+
+However, you can use a different preset by passing the `--preset` option:
+
+```shell
+pint --preset psr12
+```
+
+If you wish, you may also set the preset in your project's `pint.json` file:
+
+```json
+{
+    "preset": "psr12"
+}
+```
+
+The currently supported presets are: `laravel`, `psr12`, and `symfony`.
+
+<a name="rules"></a>
+### Rules
+
+Rules are style guidelines that Pint will use to fix code style issues in your code. As mentioned above, presets are predefined groups of rules that should be perfect for most PHP projects, so you typically will not need to worry about the individual rules they contain.
+
+However, if you wish, you may enable or disable specific rules in your `pint.json` file:
+
+```json
+{
+    "preset": "laravel",
+    "rules": {
+        "simplified_null_return": true,
+        "braces": false,
+        "new_with_braces": {
+            "anonymous_class": false,
+            "named_class": false
+        }
+    }
+}
+```
+
+Pint is built on top of [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer). Therefore, you may use any of its rules to fix code style issues in your project: [PHP-CS-Fixer Configurator](https://mlocati.github.io/php-cs-fixer-configurator).
+
+<a name="excluding-files-or-folders"></a>
+### Excluding Files or Folders
+
+By default, Pint will inspect all `.php` files in your project except those in the vendor folder. If you wish to exclude more folders, you may do so by using the `exclude` configuration option:
+
+```json
+{
+    "exclude": [
+        "my-specific/folder"
+    ]
+}
+```
+
+If you wish to exclude a file with a specific name, you may do so by using the `notName` configuration option:
+
+```json
+{
+    "notName": [
+        "*-my-file.php"
+    ]
+}
+```
+
+If you want to exclude a file from an exact path, you may do so by using the `notPath` configuration option:
+
+```json
+{
+    "notPath": [
+        "path/to/excluded-file.php"
+    ]
+}
+```

--- a/pint.md
+++ b/pint.md
@@ -5,21 +5,19 @@
 - [Configuring Pint](#configuring-pint)
     - [Presets](#presets)
     - [Rules](#rules)
-    - [Excluding Files or Folders](#excluding-files-or-folders)
+    - [Excluding Files / Folders](#excluding-files-or-folders)
 
 <a name="introduction"></a>
 ## Introduction
 
 [Laravel Pint](https://github.com/laravel/pint) is an opinionated PHP code style fixer for minimalists. Pint is built on top of PHP-CS-Fixer and makes it simple to ensure that your code style stays clean and consistent.
 
-Pint is automatically installed with all new Laravel applications so you may start using it immediately.
-
-By default, Pint does not require any configuration and will fix code style issues in your code by following an opinionated coding style of Laravel.
+Pint is automatically installed with all new Laravel applications so you may start using it immediately. By default, Pint does not require any configuration and will fix code style issues in your code by following the opinionated coding style of Laravel.
 
 <a name="running-pint"></a>
 ## Running Pint
 
-You may start fixing code style issues by running the `pint` binary that is available in your project's `vendor/bin` directory:
+You instruct Pint to fix code style issues by running the `pint` binary that is available in your project's `vendor/bin` directory:
 
 ```shell
 ./vendor/bin/pint
@@ -31,7 +29,7 @@ When running Pint, it will output a list of files that have been fixed. It is po
 ./vendor/bin/pint -v
 ```
 
-In addition, if you would like Pint to simply inspect your code for style errors without actually changing the files, you may use the `--test` option:
+If you would like Pint to simply inspect your code for style errors without actually changing the files, you may use the `--test` option:
 
 ```shell
 ./vendor/bin/pint --test
@@ -48,7 +46,7 @@ As previously mentioned, Pint does not require any configuration. However, if yo
 }
 ```
 
-In addition, if you wish to use a `pint.json` from a specific directory, you may use the `--config` option:
+In addition, if you wish to use a `pint.json` from a specific directory, you may provide the `--config` option when invoking Pint:
 
 ```shell
 pint --config vendor/my-company/coding-style/pint.json
@@ -57,9 +55,7 @@ pint --config vendor/my-company/coding-style/pint.json
 <a name="presets"></a>
 ### Presets
 
-Presets defines a set of rules that can be used to fix code style issues in your code. By default, Pint uses the `laravel` preset, which fixes issues by following an opinionated coding style of Laravel.
-
-However, you can use a different preset by passing the `--preset` option:
+Presets defines a set of rules that can be used to fix code style issues in your code. By default, Pint uses the `laravel` preset, which fixes issues by following the opinionated coding style of Laravel. However, you may specify a different preset by providing the `--preset` option to Pint:
 
 ```shell
 pint --preset psr12
@@ -73,7 +69,7 @@ If you wish, you may also set the preset in your project's `pint.json` file:
 }
 ```
 
-The currently supported presets are: `laravel`, `psr12`, and `symfony`.
+Pint's currently supported presets are: `laravel`, `psr12`, and `symfony`.
 
 <a name="rules"></a>
 ### Rules
@@ -99,9 +95,9 @@ However, if you wish, you may enable or disable specific rules in your `pint.jso
 Pint is built on top of [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer). Therefore, you may use any of its rules to fix code style issues in your project: [PHP-CS-Fixer Configurator](https://mlocati.github.io/php-cs-fixer-configurator).
 
 <a name="excluding-files-or-folders"></a>
-### Excluding Files or Folders
+### Excluding Files / Folders
 
-By default, Pint will inspect all `.php` files in your project except those in the vendor folder. If you wish to exclude more folders, you may do so by using the `exclude` configuration option:
+By default, Pint will inspect all `.php` files in your project except those in the `vendor` directory. If you wish to exclude more folders, you may do so using the `exclude` configuration option:
 
 ```json
 {
@@ -111,7 +107,7 @@ By default, Pint will inspect all `.php` files in your project except those in t
 }
 ```
 
-If you wish to exclude a file with a specific name, you may do so by using the `notName` configuration option:
+If you wish to exclude all files that contain a given name pattern, you may do so using the `notName` configuration option:
 
 ```json
 {
@@ -121,7 +117,7 @@ If you wish to exclude a file with a specific name, you may do so by using the `
 }
 ```
 
-If you want to exclude a file from an exact path, you may do so by using the `notPath` configuration option:
+If you would like to exclude a file by providing an exact path to the file, you may do so using the `notPath` configuration option:
 
 ```json
 {


### PR DESCRIPTION
This pull request adds Laravel Pint documentation. Note that, this pull request its on draft, as it should be only merged on the day we tag the next version of `laravel/laravel`.

Related to: https://github.com/laravel/laravel/pull/5945, https://github.com/laravel/docs/pull/8043.