### PR TITLE
[9.x] add hmr host config for vite to have hot reload for valet with ssl

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -128,6 +128,9 @@ export default defineConfig({
     server: { // [tl! add]
         https: true, // [tl! add]
         host: 'localhost', // [tl! add]
+        hmr: { // [tl! add]
+            host: 'localhost', // [tl! add]
+        }, // [tl! add]
     }, // [tl! add]
 });
 ```


### PR DESCRIPTION
HMR isn't working if the valet server is secured with ssl. 
<img width="379" alt="grafik" src="https://user-images.githubusercontent.com/28383494/179224497-bb552d90-6411-4560-bd89-4ba7dabf6113.png">

If the hmr host attribute is set to localhost, it works as expected



