### PR TITLE
[9.x] Document `about` command

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -92,28 +92,19 @@ You may also pass arguments to the `environment` method to determine if the envi
 
 > {tip} The current application environment detection can be overridden by defining a server-level `APP_ENV` environment variable.
 
-<a name="environment-information"></a>
-### Environment Information
+<a name="environment-overview"></a>
+## Environment Overview
 
-Laravel ships with a built-in `about` Artisan command that outputs information about your application, such as; configuration, environment, drivers and more.
+To get an overview of your application's configuration, drivers and environment, you may use the `about` Artisan commmand:
 
-Applications and packages may add their own information to the output of the command:
-
-```php
-<?php
-
-use Illuminate\Foundation\Console\AboutCommand;
-
-AboutCommand::add('My Package', 'Version', '1.0.0');
+```shell
+php artisan about
 ```
 
-You may also add multiple key / value pairs:
+In addition, you may filter by sections using the `--only` option:
 
-```php
-AboutCommand::add('My Package', [
-    'Version' => '1.0.0',
-    'Driver' => fn() => config('my-package.driver'),
-]);
+```shell
+php artisan about --only=environment
 ```
 
 <a name="accessing-configuration-values"></a>

--- a/configuration.md
+++ b/configuration.md
@@ -92,6 +92,30 @@ You may also pass arguments to the `environment` method to determine if the envi
 
 > {tip} The current application environment detection can be overridden by defining a server-level `APP_ENV` environment variable.
 
+<a name="environment-information"></a>
+### Environment Information
+
+Laravel ships with a built-in Artisan command that outputs information about your application, such as; configuration, environment, drivers and more.
+
+Applications and packages may add their own information to the output of the command:
+
+```php
+<?php
+
+use Illuminate\Foundation\Console\AboutCommand;
+
+AboutCommand::add('My Package', 'Version', '1.0.0');
+```
+
+You may also add multiple key / value pairs:
+
+```php
+AboutCommand::add('My Package', [
+    'Version' => '1.0.0',
+    'Driver' => fn() => config('my-package.driver'),
+]);
+```
+
 <a name="accessing-configuration-values"></a>
 ## Accessing Configuration Values
 

--- a/configuration.md
+++ b/configuration.md
@@ -5,6 +5,7 @@
     - [Environment Variable Types](#environment-variable-types)
     - [Retrieving Environment Configuration](#retrieving-environment-configuration)
     - [Determining The Current Environment](#determining-the-current-environment)
+- [Environment Overview](#environment-overview)
 - [Accessing Configuration Values](#accessing-configuration-values)
 - [Configuration Caching](#configuration-caching)
 - [Debug Mode](#debug-mode)

--- a/configuration.md
+++ b/configuration.md
@@ -95,7 +95,7 @@ You may also pass arguments to the `environment` method to determine if the envi
 <a name="environment-information"></a>
 ### Environment Information
 
-Laravel ships with a built-in Artisan command that outputs information about your application, such as; configuration, environment, drivers and more.
+Laravel ships with a built-in `about` Artisan command that outputs information about your application, such as; configuration, environment, drivers and more.
 
 Applications and packages may add their own information to the output of the command:
 

--- a/configuration.md
+++ b/configuration.md
@@ -18,6 +18,21 @@ All of the configuration files for the Laravel framework are stored in the `conf
 
 These configuration files allow you to configure things like your database connection information, your mail server information, as well as various other core configuration values such as your application timezone and encryption key.
 
+<a name="application-overview"></a>
+#### Application Overview
+
+In a hurry? You can get a quick overview of your application's configuration, drivers, and environment via the `about` Artisan command:
+
+```shell
+php artisan about
+```
+
+If you're only interested in a particular section of the application overview output, you may filter for that section using the `--only` option:
+
+```shell
+php artisan about --only=environment
+```
+
 <a name="environment-configuration"></a>
 ## Environment Configuration
 
@@ -92,21 +107,6 @@ You may also pass arguments to the `environment` method to determine if the envi
     }
 
 > {tip} The current application environment detection can be overridden by defining a server-level `APP_ENV` environment variable.
-
-<a name="environment-overview"></a>
-## Environment Overview
-
-To get an overview of your application's configuration, drivers and environment, you may use the `about` Artisan commmand:
-
-```shell
-php artisan about
-```
-
-In addition, you may filter by sections using the `--only` option:
-
-```shell
-php artisan about --only=environment
-```
 
 <a name="accessing-configuration-values"></a>
 ## Accessing Configuration Values

--- a/configuration.md
+++ b/configuration.md
@@ -5,7 +5,6 @@
     - [Environment Variable Types](#environment-variable-types)
     - [Retrieving Environment Configuration](#retrieving-environment-configuration)
     - [Determining The Current Environment](#determining-the-current-environment)
-- [Environment Overview](#environment-overview)
 - [Accessing Configuration Values](#accessing-configuration-values)
 - [Configuration Caching](#configuration-caching)
 - [Debug Mode](#debug-mode)

--- a/packages.md
+++ b/packages.md
@@ -5,13 +5,13 @@
 - [Package Discovery](#package-discovery)
 - [Service Providers](#service-providers)
 - [Resources](#resources)
-    - [About](#about)
     - [Configuration](#configuration)
     - [Migrations](#migrations)
     - [Routes](#routes)
     - [Translations](#translations)
     - [Views](#views)
     - [View Components](#view-components)
+    - ["About" Artisan Command](#about-artisan-command)
 - [Commands](#commands)
 - [Public Assets](#public-assets)
 - [Publishing File Groups](#publishing-file-groups)
@@ -86,24 +86,6 @@ A service provider extends the `Illuminate\Support\ServiceProvider` class and co
 
 <a name="resources"></a>
 ## Resources
-
-<a name="about"></a>
-### About
-
-Packages may push additional information to the output of the `about` Artisan command:
-
-    use Illuminate\Foundation\Console\AboutCommand;
-
-    AboutCommand::add('My Package', 'Version', '1.0.0');
-
-If certain data is expensive to compute, you may consider lazy-loading that information by passing a closure:
-
-    AboutCommand::add('My Package', [
-        'Version' => '1.0.0',
-        'Driver' => fn() => config('my-package.driver'),
-    ]);
-
-> {tip} Packages may also push to existing sections such as "Environment" and "Drivers".
 
 <a name="configuration"></a>
 ### Configuration
@@ -326,6 +308,30 @@ If your package contains anonymous components, they must be placed within a `com
 ```blade
 <x-courier::alert />
 ```
+
+<a name="about-artisan-command"></a>
+### "About" Artisan Command
+
+Laravel's built-in `about` Artisan command provides a synopsis of the application's environment and configuration. Packages may push additional information to this command's output via the `AboutCommand` class. Typically, this information may be added from your package service provider's `register` method:
+
+    use Illuminate\Foundation\Console\AboutCommand;
+
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        AboutCommand::add('My Package', 'Version', '1.0.0');
+    }
+
+The `about` command's values may also be provided a closures if deferred execution is desirable:
+
+    AboutCommand::add('My Package', [
+        'Version' => '1.0.0',
+        'Driver' => fn () => config('my-package.driver'),
+    ]);
 
 <a name="commands"></a>
 ## Commands

--- a/packages.md
+++ b/packages.md
@@ -5,6 +5,7 @@
 - [Package Discovery](#package-discovery)
 - [Service Providers](#service-providers)
 - [Resources](#resources)
+    - [About](#about)
     - [Configuration](#configuration)
     - [Migrations](#migrations)
     - [Routes](#routes)
@@ -85,6 +86,24 @@ A service provider extends the `Illuminate\Support\ServiceProvider` class and co
 
 <a name="resources"></a>
 ## Resources
+
+<a name="about"></a>
+### About
+
+Packages may push additional information to the output of the `about` Artisan command:
+
+    use Illuminate\Foundation\Console\AboutCommand;
+
+    AboutCommand::add('My Package', 'Version', '1.0.0');
+
+If certain data is expensive to compute, you may consider lazy-loading that information by passing a closure:
+
+    AboutCommand::add('My Package', [
+        'Version' => '1.0.0',
+        'Driver' => fn() => config('my-package.driver'),
+    ]);
+
+> {tip} Packages may also push to existing sections such as "Environment" and "Drivers".
 
 <a name="configuration"></a>
 ### Configuration


### PR DESCRIPTION
This pull request adds documentation to the new `about` command.