### PR TITLE
fix octane roadrunner port for server

### DIFF
--- a/octane.md
+++ b/octane.md
@@ -82,7 +82,7 @@ After installing the RoadRunner binary, you may exit your Sail shell session. Yo
 Next, update the `command` directive of your application's `docker/supervisord.conf` file so that Sail serves your application using Octane instead of the PHP development server:
 
 ```ini
-command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=8000
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=80
 ```
 
 Finally, ensure the `rr` binary is executable and build your Sail images:


### PR DESCRIPTION
The port for roadrunner is changed to 8000 but the default port is 80. 8000 is not exposed in the docker-compose.yml