### PR TITLE
Add note for using localized messages in laravel 8 for validating pas…

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1771,6 +1771,8 @@ Occasionally, you may want to attach additional validation rules to your default
         // ...
     });
 
+> {note} Translation keys are not yet working in Laravel 8 for validating `letters`, `mixedCasev`, `numbers`, `symbols` and `uncompromised`. If you want to localize those messages use translation string as a key.
+
 <a name="custom-validation-rules"></a>
 ## Custom Validation Rules
 

--- a/validation.md
+++ b/validation.md
@@ -1771,7 +1771,7 @@ Occasionally, you may want to attach additional validation rules to your default
         // ...
     });
 
-> {note} Translation keys are not yet working in Laravel 8 for validating `letters`, `mixedCasev`, `numbers`, `symbols` and `uncompromised`. If you want to localize those messages use translation string as a key.
+> {note} Translation keys are not yet working in Laravel 8 for validating `letters`, `mixedCase`, `numbers`, `symbols` and `uncompromised`. If you want to localize those messages use translation string as a key.
 
 <a name="custom-validation-rules"></a>
 ## Custom Validation Rules

--- a/validation.md
+++ b/validation.md
@@ -1771,7 +1771,7 @@ Occasionally, you may want to attach additional validation rules to your default
         // ...
     });
 
-> {note} Translation keys are not yet working in Laravel 8 for validating `letters`, `mixedCase`, `numbers`, `symbols` and `uncompromised`. If you want to localize those messages use translation string as a key.
+> {note} Translation keys are not yet working in Laravel 8 for validating `letters`, `mixedCase`, `numbers`, `symbols` and `uncompromised`. If you want to localize those messages, use the translation string as a key.
 
 <a name="custom-validation-rules"></a>
 ## Custom Validation Rules


### PR DESCRIPTION
Info should be there for those who are using short keys for localization in Laravel 8.

Fixed in Laravel 9:
https://github.com/laravel/framework/commit/df67f44f58fd7fbdbb05960c1497dcd30cdb7fd0