### PR TITLE
Explain how to bind Exception Handler after upgrade

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -128,9 +128,11 @@ The exception handler's `ignore` method is now `public` instead of `protected`. 
 public function ignore(string $class);
 ```
 
-#### Exception Handler Contract
+#### Exception Handler Contract Binding
 
-Previously, in order to override the default's app Exception Handler container instance you had to use the abstract `\App\Exceptions\Handler::class`. Now you must use `\Illuminate\Contracts\Debug\ExceptionHandler::class`
+**Likelihood Of Impact: Very Low**
+
+Previously, in order to override the default exception handler, custom implementations were bound into the container using the `\App\Exceptions\Handler::class` type. However, you should now bind custom implementations using the `\Illuminate\Contracts\Debug\ExceptionHandler::class` type.
 
 ### Blade
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -128,6 +128,10 @@ The exception handler's `ignore` method is now `public` instead of `protected`. 
 public function ignore(string $class);
 ```
 
+#### Exception Handler Contract
+
+Previously, in order to override the default's app Exception Handler container instance you had to use the abstract `\App\Exceptions\Handler::class`. Now you must use `\Illuminate\Contracts\Debug\ExceptionHandler::class`
+
 ### Blade
 
 #### Lazy Collections & The `$loop` Variable


### PR DESCRIPTION
I'm adding this because I faced this in our app. This is the message I originally sent to Laravel's Discord for help

> In Laravel 8 I override the method `getHttpExceptionView` from the Exception Handler class and changed the binded instance with this code
> 
> ```php
> app()->bind(\App\Exceptions\Handler::class, Handler::class);
> ```
>  
> I did it this way because I need to change the path for the error views depending on the URL you're visitng. Like different app domains
> 
> This code does not work anymore with Laravel 9.