### PR TITLE
Update sail.md to reflect initial setup for MinIO

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -247,6 +247,8 @@ In order for Laravel's Flysystem integration to generate proper URLs when using 
 AWS_URL=http://localhost:9000/local
 ```
 
+As with Amazon S3, you will need to create your bucket; this can be done via the MinIO console, which by default is available at `http://localhost:8900` with the username `sail` and password `password`.
+
 <a name="running-tests"></a>
 ## Running Tests
 

--- a/sail.md
+++ b/sail.md
@@ -247,7 +247,7 @@ In order for Laravel's Flysystem integration to generate proper URLs when using 
 AWS_URL=http://localhost:9000/local
 ```
 
-As with Amazon S3, you will need to create your bucket; this can be done via the MinIO console, which by default is available at `http://localhost:8900` with the username `sail` and password `password`.
+You may create buckets via the MinIO console, which is available at `http://localhost:8900`. The default username for the MinIO console is `sail` while the default password is `password`.
 
 <a name="running-tests"></a>
 ## Running Tests


### PR DESCRIPTION
On first run, the MinIO container starts without any buckets. Clarify to indicate that on first run the user must create the `local` bucket.