### PR TITLE
Update Scout docs to clarify configuration of queue connection and name

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -112,6 +112,13 @@ Once you have configured a queue driver, set the value of the `queue` option in 
 
 Even when the `queue` option is set to `false`, it's important to remember that some Scout drivers like Algolia and Meilisearch always index records asynchronously. Meaning, even though the index operation has completed within your Laravel application, the search engine itself may not reflect the new and updated records immediately.
 
+If you would like additional control over the connection and queue that your Scout jobs are queued on, you may pass an array to the `queue` option:
+
+    'queue' => [
+        'connection' => 'redis',
+        'queue' => 'scout'
+    ],
+
 <a name="configuration"></a>
 ## Configuration
 

--- a/scout.md
+++ b/scout.md
@@ -112,7 +112,7 @@ Once you have configured a queue driver, set the value of the `queue` option in 
 
 Even when the `queue` option is set to `false`, it's important to remember that some Scout drivers like Algolia and Meilisearch always index records asynchronously. Meaning, even though the index operation has completed within your Laravel application, the search engine itself may not reflect the new and updated records immediately.
 
-If you would like additional control over the connection and queue that your Scout jobs are queued on, you may pass an array to the `queue` option:
+To specify the connection and queue that your Scout jobs utilize, you may define the `queue` configuration option as an array:
 
     'queue' => [
         'connection' => 'redis',


### PR DESCRIPTION
Whilst the ability to pass an array of queue configuration details to the `scout.queue` option is possible, it was not previously documented.
