### PR TITLE
[9.x] Fix Paddle dunning link

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -947,7 +947,7 @@ You may use the `onGenericTrial` method if you wish to know specifically that th
 
 Paddle can notify your application of a variety of events via webhooks. By default, a route that points to Cashier's webhook controller is registered by the Cashier service provider. This controller will handle all incoming webhook requests.
 
-By default, this controller will automatically handle cancelling subscriptions that have too many failed charges ([as defined by your Paddle subscription settings](https://vendors.paddle.com/subscription-settings)), subscription updates, and payment method changes; however, as we'll soon discover, you can extend this controller to handle any Paddle webhook event you like.
+By default, this controller will automatically handle cancelling subscriptions that have too many failed charges ([as defined by your Paddle dunning settings](https://vendors.paddle.com/recover-settings#dunning-form-id)), subscription updates, and payment method changes; however, as we'll soon discover, you can extend this controller to handle any Paddle webhook event you like.
 
 To ensure your application can handle Paddle webhooks, be sure to [configure the webhook URL in the Paddle control panel](https://vendors.paddle.com/alerts-webhooks). By default, Cashier's webhook controller responds to the `/paddle/webhook` URL path. The full list of all webhooks you should enable in the Paddle control panel are:
 


### PR DESCRIPTION
I've updated the link to Paddle dashboard, because the previous one returned 404.

Based on the context, I assumed it should link to dunning settings:
<img width="819" alt="CleanShot 2022-07-25 at 17 12 53@2x" src="https://user-images.githubusercontent.com/4208233/180814080-99952393-de9c-4c4e-b042-d49cd280489f.png">

Let me know if that's not what the old link was representing.