### PR TITLE
[9.x] Avoid to make an implicit use of union types with `void` functions

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -233,6 +233,8 @@ Sometimes, you may wish to grant all abilities to a specific user. You may use t
         if ($user->isAdministrator()) {
             return true;
         }
+
+        return null;
     });
 
 If the `before` closure returns a non-null result that result will be considered the result of the authorization check.
@@ -243,6 +245,8 @@ You may use the `after` method to define a closure to be executed after all othe
         if ($user->isAdministrator()) {
             return true;
         }
+
+        return null;
     });
 
 Similar to the `before` method, if the `after` closure returns a non-null result that result will be considered the result of the authorization check.

--- a/collections.md
+++ b/collections.md
@@ -719,6 +719,8 @@ If you would like to stop iterating through the items, you may return `false` fr
         if (/* condition */) {
             return false;
         }
+
+        return null;
     });
 
 <a name="method-eachspread"></a>

--- a/errors.md
+++ b/errors.md
@@ -180,6 +180,7 @@ The closure passed to the `renderable` method should return an instance of `Illu
 
 You may also use the `renderable` method to override the rendering behavior for built-in Laravel or Symfony exceptions such as `NotFoundHttpException`. If the closure given to the `renderable` method does not return a value, Laravel's default exception rendering will be utilized:
 
+    use Illuminate\Http\JsonResponse;
     use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
     /**
@@ -189,12 +190,14 @@ You may also use the `renderable` method to override the rendering behavior for 
      */
     public function register()
     {
-        $this->renderable(function (NotFoundHttpException $e, $request) {
+        $this->renderable(function (NotFoundHttpException $e, $request): ?JsonResponse {
             if ($request->is('api/*')) {
                 return response()->json([
                     'message' => 'Record not found.'
                 ], 404);
             }
+
+            return null;
         });
     }
 

--- a/fortify.md
+++ b/fortify.md
@@ -178,6 +178,8 @@ public function boot()
             Hash::check($request->password, $user->password)) {
             return $user;
         }
+
+        return null;
     });
 
     // ...


### PR DESCRIPTION
Mixing any type and `void` is allowed by PHP if the functions are not using type declarations. In fact, internally it converts those return values to `null`. But from a stricter point of view, this behavior is conceptually wrong. That's why union types don't allow to use `void` alongside other types.
This PR tries to cover that, by using an explicit `return null` statement instead of just do nothing.
The return type declaration was added just to clarify the situation, but IMO, it can be omitted if it goes against the current recommendations.

See:
* https://wiki.php.net/rfc/void_return_type
* https://www.php.net/manual/es/migration71.new-features.php#migration71.new-features.void-functions
* https://php.watch/versions/8.0/union-types.