### PR TITLE
Add watch option for roadrunner server

### DIFF
--- a/octane.md
+++ b/octane.md
@@ -82,8 +82,10 @@ After installing the RoadRunner binary, you may exit your Sail shell session. Yo
 Next, update the `command` directive of your application's `docker/supervisord.conf` file so that Sail serves your application using Octane instead of the PHP development server:
 
 ```ini
-command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=80
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --watch --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=80
 ```
+
+This option ["reloads the server on changes"](#watching-for-file-changes). For production remove the `--watch` option. 
 
 Finally, ensure the `rr` binary is executable and build your Sail images:
 

--- a/octane.md
+++ b/octane.md
@@ -82,10 +82,8 @@ After installing the RoadRunner binary, you may exit your Sail shell session. Yo
 Next, update the `command` directive of your application's `docker/supervisord.conf` file so that Sail serves your application using Octane instead of the PHP development server:
 
 ```ini
-command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --watch --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=80
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=80 --watch
 ```
-
-This option ["reloads the server on changes"](#watching-for-file-changes). For production remove the `--watch` option. 
 
 Finally, ensure the `rr` binary is executable and build your Sail images:
 


### PR DESCRIPTION
This will add the watch option for the roadrunner server. If you follow the docs you will maybe be stuck with a laravel projects where you can't see changes because of the missing watch option. This will fix it