### PR TITLE
[9.x] Added docs for lineIf and attachMany

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -535,7 +535,7 @@ Unlike attaching files in mailable objects, you may not attach a file directly f
 
 Multiple files can be attached in a single call with the `attachMany` method:
 
-	/**
+    /**
      * Get the mail representation of the notification.
      *
      * @param  mixed  $notifiable
@@ -551,7 +551,7 @@ Multiple files can be attached in a single call with the `attachMany` method:
                             'as' => 'Vapor Logo.svg', 
                             'mime' => 'text/css',
                         ],
-						new class() implements Attachable
+                        new class() implements Attachable
                         {
                             public function toMailAttachment()
                             {

--- a/notifications.md
+++ b/notifications.md
@@ -317,6 +317,7 @@ The `MailMessage` class contains a few simple methods to help you build transact
         return (new MailMessage)
                     ->greeting('Hello!')
                     ->line('One of your invoices has been paid!')
+                    ->lineIf($this->amount > 0, "The amount received was {$this->amount}")
                     ->action('View Invoice', $url)
                     ->line('Thank you for using our application!');
     }
@@ -530,6 +531,36 @@ Unlike attaching files in mailable objects, you may not attach a file directly f
         return (new InvoicePaidMailable($this->invoice))
                     ->to($notifiable->email)
                     ->attachFromStorage('/path/to/file');
+    }
+
+Multiple files can be attached in a single call with the `attachMany` method:
+
+	/**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+                    ->greeting('Hello!')
+                    ->attachMany([
+                        '/forge.svg',
+                        '/vapor.svg' => [
+                            'as' => 'Vapor Logo.svg', 
+                            'mime' => 'text/css',
+                        ],
+						new class() implements Attachable
+                        {
+                            public function toMailAttachment()
+                            {
+                                return Attachment::fromPath('/foo.jpg')
+                                    ->as('bar')
+                                    ->withMime('image/png');
+                            }
+                        },
+                    ]);
     }
 
 <a name="raw-data-attachments"></a>


### PR DESCRIPTION
This pull request adds an example for my [contribution](https://github.com/laravel/framework/pull/43387) in conditional lines in MailMessage to look more "laravelic".

Also, I added docs for the `attachMany` method from this [pull request](https://github.com/laravel/framework/pull/43080).

English is not my native language, so if someone can improve this pull request I would appreciate it.