### PR TITLE
Made installation scripts order suitable for exec

### DIFF
--- a/starter-kits.md
+++ b/starter-kits.md
@@ -45,9 +45,9 @@ The default Breeze "stack" is the Blade stack, which utilizes simple [Blade temp
 ```shell
 php artisan breeze:install
 
+php artisan migrate
 npm install
 npm run dev
-php artisan migrate
 ```
 
 Next, you may navigate to your application's `/login` or `/register` URLs in your web browser. All of Breeze's routes are defined within the `routes/auth.php` file.
@@ -68,9 +68,9 @@ php artisan breeze:install vue
 
 php artisan breeze:install react
 
+php artisan migrate
 npm install
 npm run dev
-php artisan migrate
 ```
 
 Next, you may navigate to your application's `/login` or `/register` URLs in your web browser. All of Breeze's routes are defined within the `routes/auth.php` file.


### PR DESCRIPTION
`npm run dev` keeps running so it's better to put `php artisan migrate` before this command so that it executes successfully if copied and pasted for execution.