### PR TITLE
Added doc for validation rules `doesnt_end_with` and `doesnt_start_with`

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -821,6 +821,8 @@ Below is a list of all available validation rules and their function:
 [Digits Between](#rule-digits-between)
 [Dimensions (Image Files)](#rule-dimensions)
 [Distinct](#rule-distinct)
+[Doesnt End With](#rule-doesnt-end-with)
+[Doesnt Start With](#rule-doesnt-start-with)
 [Email](#rule-email)
 [Ends With](#rule-ends-with)
 [Enum](#rule-enum)
@@ -1070,6 +1072,16 @@ Distinct uses loose variable comparisons by default. To use strict comparisons, 
 You may add `ignore_case` to the validation rule's arguments to make the rule ignore capitalization differences:
 
     'foo.*.id' => 'distinct:ignore_case'
+
+<a name="rule-doesnt-end-with"></a>
+#### doesnt_end_with:_foo_,_bar_,...
+
+The field under validation must not end with one of the given values.
+
+<a name="rule-doesnt-start-with"></a>
+#### doesnt_start_with:_foo_,_bar_,...
+
+The field under validation must not start with one of the given values.
 
 <a name="rule-email"></a>
 #### email


### PR DESCRIPTION
This PR update doc for validation rules `doesnt_start_with` ([#42683](https://github.com/laravel/framework/pull/42683), [de35bf2](https://github.com/laravel/framework/commit/de35bf2a8ab40013d997c62b5a80cdb907c73b99)) and `doesnt_end_with` ([#43518](https://github.com/laravel/framework/pull/43518) _not yet released_)