### PR TITLE
Update return type of example `before` method for policy filters

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -514,7 +514,7 @@ For certain users, you may wish to authorize all actions within a given policy. 
      *
      * @param  \App\Models\User  $user
      * @param  string  $ability
-     * @return void|bool
+     * @return void|null|bool
      */
     public function before(User $user, $ability)
     {


### PR DESCRIPTION
The [current return type](https://github.com/laravel/docs/blame/c3ee189/authorization.md#L517) of the example, `void|bool`, contradicts the [description below the example](https://github.com/laravel/docs/blame/c3ee189/authorization.md#L526) that explains the meaning of an explicit `null` return value.