### PR TITLE
[9.x] Fix Vite CSP middleware example

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -486,7 +486,7 @@ class AddContentSecurityPolicyHeaders
     {
         Vite::useCspNonce();
 
-        return $next($response)->withHeaders([
+        return $next($request)->withHeaders([
             'Content-Security-Policy' => "script-src 'nonce-".Vite::cspNonce()."'",
         ]);
     }


### PR DESCRIPTION
This fixes a mistake in the Vite CSP middleware example