### PR TITLE
Fix filesystem config option name for S3

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -147,7 +147,7 @@ Laravel's Flysystem integrations work great with SFTP; however, a sample configu
 
 By default, your application's `filesystems` configuration file contains a disk configuration for the `s3` disk. In addition to using this disk to interact with Amazon S3, you may use it to interact with any S3 compatible file storage service such as [MinIO](https://github.com/minio/minio) or [DigitalOcean Spaces](https://www.digitalocean.com/products/spaces/).
 
-Typically, after updating the disk's credentials to match the credentials of the service you are planning to use, you only need to update the value of the `url` configuration option. This option's value is typically defined via the `AWS_ENDPOINT` environment variable:
+Typically, after updating the disk's credentials to match the credentials of the service you are planning to use, you only need to update the value of the `endpoint` configuration option. This option's value is typically defined via the `AWS_ENDPOINT` environment variable:
 
     'endpoint' => env('AWS_ENDPOINT', 'https://minio:9000'),
 


### PR DESCRIPTION
Fix the filesystem config option that corresponds to the `AWS_ENDPOINT` environment variable.