### PR TITLE
Fix typo in `Eloquent local scopes`

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1208,7 +1208,7 @@ Scopes should always return the same query builder instance or `void`:
          */
         public function scopeActive($query)
         {
-            $query->where('active', 1);
+            return $query->where('active', 1);
         }
     }
 


### PR DESCRIPTION
The local scope is missing the `return` element. This change fixes that