### PR TITLE
[9.x] Update Sail shell alias docs

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -3,7 +3,7 @@
 - [Introduction](#introduction)
 - [Installation & Setup](#installation)
     - [Installing Sail Into Existing Applications](#installing-sail-into-existing-applications)
-    - [Configuring A Bash Alias](#configuring-a-bash-alias)
+    - [Configuring A Shell Alias](#configuring-a-shell-alias)
 - [Starting & Stopping Sail](#starting-and-stopping-sail)
 - [Executing Commands](#executing-sail-commands)
     - [Executing PHP Commands](#executing-php-commands)
@@ -71,8 +71,8 @@ If you would like to develop within a [Devcontainer](https://code.visualstudio.c
 php artisan sail:install --devcontainer
 ```
 
-<a name="configuring-a-bash-alias"></a>
-### Configuring A Bash Alias
+<a name="configuring-a-shell-alias"></a>
+### Configuring A Shell Alias
 
 By default, Sail commands are invoked using the `vendor/bin/sail` script that is included with all new Laravel applications:
 
@@ -80,13 +80,15 @@ By default, Sail commands are invoked using the `vendor/bin/sail` script that is
 ./vendor/bin/sail up
 ```
 
-However, instead of repeatedly typing `vendor/bin/sail` to execute Sail commands, you may wish to configure a Bash alias that allows you to execute Sail's commands more easily:
+However, instead of repeatedly typing `vendor/bin/sail` to execute Sail commands, you may wish to configure a shell alias that allows you to execute Sail's commands more easily:
 
 ```shell
-alias sail='[ -f sail ] && bash sail || bash vendor/bin/sail'
+alias sail='[ -f sail ] && sh sail || sh vendor/bin/sail'
 ```
 
-Once the Bash alias has been configured, you may execute Sail commands by simply typing `sail`. The remainder of this documentation's examples will assume that you have configured this alias:
+To make sure this is always available, you may add this to your shell configuration file in your home directory, such as `~/.zshrc` or `~/.bashrc`, and then restart your shell.
+
+Once the shell alias has been configured, you may execute Sail commands by simply typing `sail`. The remainder of this documentation's examples will assume that you have configured this alias:
 
 ```shell
 sail up


### PR DESCRIPTION
This PR updates the "Configuring a Bash Alias" section of the documentation by making the following changes:

* Renames the section to "Configuring A Shell Alias" because this is not Bash-specific, and Bash is no longer the default shell on macOS.
* Updates the alias to not depend on `bash`. `sh` should be a safe alternative, but it also seems to work fine without specifying a shell.
* Adds a note on adding this to the user's shell configuration to make it always available. I've seen people run the alias command in their terminal, run `sail up`, and then open a new terminal and are understandably surprised when `sail artisan migrate` doesn't work. I'm not sure if specifying actual filenames is a little dicey, but hopefully, it at least helps the user understand that they need to take further steps to make the alias "stick".

I'd love for someone on macOS and Windows to confirm whether these changes make sense in those environments!