### PR TITLE
[9.x] Document MinIO limitation with temporaryUrl

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -251,6 +251,9 @@ AWS_URL=http://localhost:9000/local
 
 You may create buckets via the MinIO console, which is available at `http://localhost:8900`. The default username for the MinIO console is `sail` while the default password is `password`.
 
+> **Warning**  
+> It is not possible to use the `temporaryUrl` filesystem method when using MinIO because it cannot handle a different host.
+
 <a name="running-tests"></a>
 ## Running Tests
 

--- a/sail.md
+++ b/sail.md
@@ -252,7 +252,7 @@ AWS_URL=http://localhost:9000/local
 You may create buckets via the MinIO console, which is available at `http://localhost:8900`. The default username for the MinIO console is `sail` while the default password is `password`.
 
 > **Warning**  
-> It is not possible to use the `temporaryUrl` filesystem method when using MinIO because it cannot handle a different host.
+> Generating temporary storage URLs via the `temporaryUrl` method is not supported when using MinIO.
 
 <a name="running-tests"></a>
 ## Running Tests


### PR DESCRIPTION
Documents the limitation at https://github.com/laravel/sail/issues/453.