### PR TITLE
Mention pusher/pusher-php-server upgrade from ^4.0|^5.0 to ^5.0 in upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -60,9 +60,7 @@ You should update the following dependencies in your application's `composer.jso
 
 </div>
 
-In addition, please replace `facade/ignition` with `"spatie/laravel-ignition": "^1.0"` in your application's `composer.json` file.
-
-If using Pusher, please update `pusher/pusher-php-server` to `^5.0`.
+In addition, please replace `facade/ignition` with `"spatie/laravel-ignition": "^1.0"` and `pusher/pusher-php-server` (if applicable) with `"pusher/pusher-php-server": "^5.0"` in your application's `composer.json` file.
 
 Furthermore, the following first-party packages have received new major releases to support Laravel 9.x. If applicable, you should read their individual upgrade guides before upgrading:
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -62,6 +62,8 @@ You should update the following dependencies in your application's `composer.jso
 
 In addition, please replace `facade/ignition` with `"spatie/laravel-ignition": "^1.0"` in your application's `composer.json` file.
 
+If using Pusher, please update `pusher/pusher-php-server` to `^5.0`.
+
 Furthermore, the following first-party packages have received new major releases to support Laravel 9.x. If applicable, you should read their individual upgrade guides before upgrading:
 
 <div class="content-list" markdown="1">


### PR DESCRIPTION
Support for `pusher/pusher-php-server:^4.0` was dropped in Laravel 9 (see https://github.com/laravel/framework/pull/36528 ).

Because the constraint is just a `suggest`, users are not prevented from running Laravel 9 with `pusher/pusher-php-server:^4.0`. Users with this combination will experience runtime errors like `preg_match(): Argument #2 ($subject) must be of type string, array given`

(I wasn't sure where to fit in this "please upgrade this optional package" text in the docs)