### PR TITLE
[9.x] Add `withWhereHas` documentation to Eloquent

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1660,19 +1660,16 @@ If you are eager loading a `morphTo` relationship, Eloquent will run multiple qu
 
 In this example, Eloquent will only eager load posts that have not been hidden and videos that have a `type` value of "educational".
 
-<a name="constraining-eager-loads-along-with-relationship-existence"></a>
-#### Constraining Eager Loads Along With Relationship Existence
+<a name="constraining-eager-loads-with-relationship-existence"></a>
+#### Constraining Eager Loads With Relationship Existence
 
-You may often find yourself wanting to check the existence of a relationship whilst simultaneously loading the relationship based on the same conditions.
-For this you can use `withWhereHas`.
+You may sometimes find yourself needing to check for the existence of a relationship while simultaneously loading the relationship based on the same conditions. For example, you may wish to only retrieve `User` models that have child `Post` models matching a given query condition while also eager loading the matching posts. You may accomplish this using the `withWhereHas` method:
 
     use App\Models\User;
   
     $users = User::withWhereHas('posts', function ($query) {
         $query->where('featured', true);
     )->get();
-
-In this example, Eloquent will only fetch users who have featured posts whilst also loading each users' featured posts.
 
 <a name="lazy-eager-loading"></a>
 ### Lazy Eager Loading

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1660,6 +1660,20 @@ If you are eager loading a `morphTo` relationship, Eloquent will run multiple qu
 
 In this example, Eloquent will only eager load posts that have not been hidden and videos that have a `type` value of "educational".
 
+<a name="constraining-eager-loads-along-with-relationship-existence"></a>
+#### Constraining Eager Loads Along With Relationship Existence
+
+You may often find yourself wanting to check the existence of a relationship whilst simultaneously loading the relationship based on the same conditions.
+For this you can use `withWhereHas`.
+
+    use App\Models\User;
+  
+    $users = User::withWhereHas('posts', function ($query) {
+        $query->where('featured', true);
+    )->get();
+
+In this example, Eloquent will only fetch users who have featured posts whilst also loading each users' featured posts.
+
 <a name="lazy-eager-loading"></a>
 ### Lazy Eager Loading
 


### PR DESCRIPTION
I came across this method the other day and have had many use cases for it but was unaware it existed. This PR adds a mention to the docs. I'm not sure where it is best to go, whether with `Querying Relationships` or `Eager Loading` as it covers both. I've tried to keep the example relevant with other examples in the eager loading section.

https://github.com/laravel/framework/pull/42597