### PR TITLE
[9.x] promote lazy about command registration in boot function

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -314,26 +314,19 @@ If your package contains anonymous components, they must be placed within a `com
 <a name="about-artisan-command"></a>
 ### "About" Artisan Command
 
-Laravel's built-in `about` Artisan command provides a synopsis of the application's environment and configuration. Packages may push additional information to this command's output via the `AboutCommand` class. Typically, this information may be added from your package service provider's `register` method:
+Laravel's built-in `about` Artisan command provides a synopsis of the application's environment and configuration. Packages may push additional information to this command's output via the `AboutCommand` class. Typically, this information may be added from your package service provider's `boot` method:
 
     use Illuminate\Foundation\Console\AboutCommand;
 
     /**
-     * Register any application services.
+     * Bootstrap any application services.
      *
      * @return void
      */
-    public function register()
+    public function boot()
     {
-        AboutCommand::add('My Package', 'Version', '1.0.0');
+        AboutCommand::add('My Package', fn () => ['Version' => '1.0.0']);
     }
-
-The `about` command's values may also be provided a closures if deferred execution is desirable:
-
-    AboutCommand::add('My Package', [
-        'Version' => '1.0.0',
-        'Driver' => fn () => config('my-package.driver'),
-    ]);
 
 <a name="commands"></a>
 ## Commands


### PR DESCRIPTION
As outlined in https://github.com/laravel/framework/pull/43329, I believe that we should only promote the use, internally and in the docs, of the lazy binding of data values to the about command.

This can improve boot performance and memory usage for invocations of the framework for via an incoming HTTP request or console command.

Additionally, I've suggested moving the example to the `boot` function rather than the `register` function. This is to ensure that services have completely booted before they are interacted with, e.g. if someone is adding a value from the cache or DB into the mix:

```php
AboutCommand::add('My Package', 'Average throughput', Cache::get('avg_thoughput'));
```

we'd want this specified in the `boot` func to ensure the Cache is actually ready for use. The closure does away with the need for this, but because it is still possible to register things in the above manner, I believe we should generally promote use of the `boot` function.