### PR TITLE
Document faking a sub-set of jobs

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -555,9 +555,6 @@ You may pass a closure to the `assertPushed` or `assertNotPushed` methods in ord
 
 If you only need to fake specific jobs while allowing your other jobs to execute normally, you may pass the class names of the jobs that should be faked to the `fake` method:
 
-    /**
-     * Test order process.
-     */
     public function test_orders_can_be_shipped()
     {
         Queue::fake([

--- a/mocking.md
+++ b/mocking.md
@@ -553,10 +553,7 @@ You may pass a closure to the `assertPushed` or `assertNotPushed` methods in ord
         return $job->order->id === $order->id;
     });
 
-<a name="faking-a-subset-of-jqueued-obs"></a>
-#### Faking A Subset Of Queued Jobs
-
-If you only want to fake a specific set of jobs, you may pass them to the `fake` method:
+If you only need to fake specific jobs while allowing your other jobs to execute normally, you may pass the class names of the jobs that should be faked to the `fake` method:
 
     /**
      * Test order process.

--- a/mocking.md
+++ b/mocking.md
@@ -553,6 +553,26 @@ You may pass a closure to the `assertPushed` or `assertNotPushed` methods in ord
         return $job->order->id === $order->id;
     });
 
+<a name="faking-a-subset-of-jqueued-obs"></a>
+#### Faking A Subset Of Queued Jobs
+
+If you only want to fake a specific set of jobs, you may pass them to the `fake` method:
+
+    /**
+     * Test order process.
+     */
+    public function test_orders_can_be_shipped()
+    {
+        Queue::fake([
+            ShipOrder::class,
+        ]);
+        
+        // Perform order shipping...
+
+        // Assert a job was pushed twice...
+        Queue::assertPushed(ShipOrder::class, 2);
+    }
+
 <a name="job-chains"></a>
 ### Job Chains
 


### PR DESCRIPTION
It previously was not possible to fake only a subset of jobs - now it is but needs to be documented.