### PR TITLE
[9.x] Move Docker to "Included Software"

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -74,6 +74,7 @@ Homestead runs on any Windows, macOS, or Linux system and includes Nginx, PHP, M
 - Sqlite3
 - PostgreSQL 13
 - Composer
+- Docker
 - Node (With Yarn, Bower, Grunt, and Gulp)
 - Redis
 - Memcached
@@ -106,7 +107,6 @@ Homestead runs on any Windows, macOS, or Linux system and includes Nginx, PHP, M
 - Chronograf
 - CouchDB
 - Crystal & Lucky Framework
-- Docker
 - Elasticsearch
 - EventStoreDB
 - Gearman
@@ -330,7 +330,6 @@ features:
     - chronograf: true
     - couchdb: true
     - crystal: true
-    - docker: true
     - elasticsearch:
         version: 7.9.0
     - eventstore: true


### PR DESCRIPTION
Docker was moved to the base box on `laravel/settler` and can no longer be installed as optional software.

https://github.com/laravel/settler/commit/8b1f706f507d2be1b019d178955bb6b98e996582

https://github.com/laravel/homestead/pull/1716