### PR TITLE
[9.x] Adds collection comparison operators list

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -3036,8 +3036,7 @@ The `where` method filters the collection by a given key / value pair:
 
 The `where` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`whereStrict`](#method-wherestrict) method to filter using "strict" comparisons.
 
-Optionally, you may pass a comparison operator as the second parameter.
-Supported operators are '===', '!==', '!=', '==', '=', '<>', '>', '<', '>=', '<='.
+Optionally, you may pass a comparison operator as the second parameter. Supported operators are: '===', '!==', '!=', '==', '=', '<>', '>', '<', '>=', and '<=':
 
     $collection = collect([
         ['name' => 'Jim', 'deleted_at' => '2019-01-01 00:00:00'],

--- a/collections.md
+++ b/collections.md
@@ -3037,6 +3037,7 @@ The `where` method filters the collection by a given key / value pair:
 The `where` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`whereStrict`](#method-wherestrict) method to filter using "strict" comparisons.
 
 Optionally, you may pass a comparison operator as the second parameter.
+Supported operators are '===', '!==', '!=', '==', '=', '<>', '>', '<', '>=', '<='.
 
     $collection = collect([
         ['name' => 'Jim', 'deleted_at' => '2019-01-01 00:00:00'],


### PR DESCRIPTION
The Laravel docs do not provide a clear list of comparison operators for collections.