### PR TITLE
[9.x] Including static assets in Vite builds

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -333,7 +333,7 @@ module.exports = {
 <a name="blade-processing-static-assets"></a>
 ### Processing Static Assets With Vite
 
-When referencing assets in your JavaScript or CSS, Vite automatically processes and version them. However, when building Blade templated applications, Vite can still be used to process and version static assets that you reference solely in Blade templates.
+When referencing assets in your JavaScript or CSS, Vite automatically processes and version them. However, when building Blade templated applications, Vite can also process and version static assets that you reference solely in Blade templates.
 
 In order to do this you will need to make Vite aware of the assets your application depends on by importing your static assets into the applications' entry point - even if you do not plan to use any JavaScript in your application. 
 

--- a/vite.md
+++ b/vite.md
@@ -333,11 +333,9 @@ module.exports = {
 <a name="blade-processing-static-assets"></a>
 ### Processing Static Assets With Vite
 
-When referencing assets in your JavaScript or CSS, Vite automatically processes and versions them. However, when building Blade templated applications, Vite can also process and version static assets that you reference solely in Blade templates.
+When referencing assets in your JavaScript or CSS, Vite automatically processes and versions them. In addition, when building Blade based applications, Vite can also process and version static assets that you reference solely in Blade templates.
 
-In order to do this you will need to make Vite aware of the assets your application depends on by importing your static assets into the applications' entry point - even if you do not plan to use any JavaScript in your application. 
-
-Let's say we want to process and version all images stored in `resources/images` and also the fonts stored in `resources/fonts`. To achieve this, we can add the following in the `resources/js/app.js` entry point:
+However, in order to accomplish this, you need to make Vite aware of your assets by importing the static assets into the application's entry point. For example, if you want to process and version all images stored in `resources/images` and all fonts stored in `resources/fonts`, you should add the following in your application's `resources/js/app.js` entry point:
 
 ```js
 import.meta.glob([
@@ -346,7 +344,7 @@ import.meta.glob([
 ]);
 ```
 
-These assets will now be processed by Vite on build. You can then reference these assets in Blade templates with the `Vite::asset()` helper to get the versioned URL for each asset:
+These assets will now be processed by Vite when running `npm run build`. You can then reference these assets in Blade templates using the `Vite::asset` method, which will return the versioned URL for a given asset:
 
 ```blade
 <img src="{{ Vite::asset('resources/images/logo.png') }}">

--- a/vite.md
+++ b/vite.md
@@ -328,6 +328,29 @@ module.exports = {
 <a name="working-with-blade-and-routes"></a>
 ## Working With Blade & Routes
 
+### Processing static assets with Vite
+
+When building JavaScript templated applications, Vite automatically detects your assets to process and version them. However, when building Blade templated applications, Vite may still be used to process and version your static assets, such as images or fonts. 
+
+In order to do this, we will need to manually make Vite aware of the assets your application depends on. You can do this by importing your static assets into the applications' entry point (even if you do not plan to use any JavaScript in your application). 
+
+Let's say we want to version all images stored in `resources/images` and also version the fonts we have stored in `resources/fonts`. To achieve this, we can add the following in the `resources/js/app.js` entry point:
+
+```js
+import.meta.glob([
+  '../images/**',
+  '../fonts/**',
+]);
+```
+
+These assets will now be versioned and included in your build assets. You can reference these assets in Blade templates with the `Vite::asset()` helper to get the versioned URL for each asset:
+
+```blade
+<img src="{{ Vite::asset('resources/images/logo.png') }}">
+```
+
+### Refreshing On Save
+
 When your application is built using traditional server-side rendering with Blade, Vite can improve your development workflow by automatically refreshing the browser when you make changes to view files in your application. To get started, you can simply specify the `refresh` option as `true`.
 
 ```js

--- a/vite.md
+++ b/vite.md
@@ -15,6 +15,8 @@
   - [URL Processing](#url-processing)
 - [Working With Stylesheets](#working-with-stylesheets)
 - [Working With Blade & Routes](#working-with-blade-and-routes)
+  - [Processing Static Assets With Vite](#blade-processing-static-assets)
+  - [Refreshing On Save](#blade-refreshing-on-save)
 - [Custom Base URLs](#custom-base-urls)
 - [Environment Variables](#environment-variables)
 - [Server-Side Rendering (SSR)](#ssr)
@@ -328,7 +330,8 @@ module.exports = {
 <a name="working-with-blade-and-routes"></a>
 ## Working With Blade & Routes
 
-### Processing static assets with Vite
+<a name="blade-processing-static-assets"></a>
+### Processing Static Assets With Vite
 
 When building JavaScript templated applications, Vite automatically detects your assets to process and version them. However, when building Blade templated applications, Vite may still be used to process and version your static assets, such as images or fonts. 
 
@@ -349,6 +352,7 @@ These assets will now be versioned and included in your build assets. You can re
 <img src="{{ Vite::asset('resources/images/logo.png') }}">
 ```
 
+<a name="blade-refreshing-on-save"></a>
 ### Refreshing On Save
 
 When your application is built using traditional server-side rendering with Blade, Vite can improve your development workflow by automatically refreshing the browser when you make changes to view files in your application. To get started, you can simply specify the `refresh` option as `true`.

--- a/vite.md
+++ b/vite.md
@@ -333,7 +333,7 @@ module.exports = {
 <a name="blade-processing-static-assets"></a>
 ### Processing Static Assets With Vite
 
-When referencing assets in your JavaScript or CSS, Vite automatically processes and version them. However, when building Blade templated applications, Vite can also process and version static assets that you reference solely in Blade templates.
+When referencing assets in your JavaScript or CSS, Vite automatically processes and versions them. However, when building Blade templated applications, Vite can also process and version static assets that you reference solely in Blade templates.
 
 In order to do this you will need to make Vite aware of the assets your application depends on by importing your static assets into the applications' entry point - even if you do not plan to use any JavaScript in your application. 
 

--- a/vite.md
+++ b/vite.md
@@ -335,7 +335,7 @@ module.exports = {
 
 When referencing assets in your JavaScript or CSS, Vite automatically processes and version them. However, when building Blade templated applications, Vite can still be used to process and version static assets that you reference solely in Blade templates.
 
-In order to do this you will need to make Vite aware of the assets your application depends on. You can do this by importing your static assets into the applications' entry point - even if you do not plan to use any JavaScript in your application. 
+In order to do this you will need to make Vite aware of the assets your application depends on by importing your static assets into the applications' entry point - even if you do not plan to use any JavaScript in your application. 
 
 Let's say we want to process and version all images stored in `resources/images` and also the fonts stored in `resources/fonts`. To achieve this, we can add the following in the `resources/js/app.js` entry point:
 

--- a/vite.md
+++ b/vite.md
@@ -333,11 +333,11 @@ module.exports = {
 <a name="blade-processing-static-assets"></a>
 ### Processing Static Assets With Vite
 
-When building JavaScript templated applications, Vite automatically detects your assets to process and version them. However, when building Blade templated applications, Vite may still be used to process and version your static assets, such as images or fonts. 
+When referencing assets in your JavaScript or CSS, Vite automatically processes and version them. However, when building Blade templated applications, Vite can still be used to process and version static assets that you reference solely in Blade templates.
 
-In order to do this, we will need to manually make Vite aware of the assets your application depends on. You can do this by importing your static assets into the applications' entry point (even if you do not plan to use any JavaScript in your application). 
+In order to do this you will need to make Vite aware of the assets your application depends on. You can do this by importing your static assets into the applications' entry point - even if you do not plan to use any JavaScript in your application. 
 
-Let's say we want to version all images stored in `resources/images` and also version the fonts we have stored in `resources/fonts`. To achieve this, we can add the following in the `resources/js/app.js` entry point:
+Let's say we want to process and version all images stored in `resources/images` and also the fonts stored in `resources/fonts`. To achieve this, we can add the following in the `resources/js/app.js` entry point:
 
 ```js
 import.meta.glob([
@@ -346,7 +346,7 @@ import.meta.glob([
 ]);
 ```
 
-These assets will now be versioned and included in your build assets. You can reference these assets in Blade templates with the `Vite::asset()` helper to get the versioned URL for each asset:
+These assets will now be processed by Vite on build. You can then reference these assets in Blade templates with the `Vite::asset()` helper to get the versioned URL for each asset:
 
 ```blade
 <img src="{{ Vite::asset('resources/images/logo.png') }}">


### PR DESCRIPTION
Depends on: https://github.com/laravel/framework/pull/43702

---

Note that we are attempting to improve this experience in the further by allowing assets to be specified in the Vite config and rather than via an entry point, so these docs will be iterated on once we improve things. Currently we are waiting on https://github.com/vitejs/vite/pull/9693 to be merged / tagged before we can continue on, so this is a nice stopgap solution.