### PR TITLE
Fix value object casting example

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -600,8 +600,10 @@ As an example, we will define a custom cast class that casts multiple model valu
             }
 
             return [
-                'address_line_one' => $value->lineOne,
-                'address_line_two' => $value->lineTwo,
+                $key => [
+                    'address_line_one' => $value->lineOne,
+                    'address_line_two' => $value->lineTwo,
+                ]
             ];
         }
     }
@@ -781,8 +783,10 @@ By combining "castables" with PHP's [anonymous classes](https://www.php.net/manu
                 public function set($model, $key, $value, $attributes)
                 {
                     return [
-                        'address_line_one' => $value->lineOne,
-                        'address_line_two' => $value->lineTwo,
+                        $key => [
+                            'address_line_one' => $value->lineOne,
+                            'address_line_two' => $value->lineTwo,
+                        ]
                     ];
                 }
             };


### PR DESCRIPTION
The properties of the `Address` should be wrapped in a `$key` key when returning in the custom cast `set` method.