### PR TITLE
Added description of how to view the app

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -183,6 +183,9 @@ npm run dev
 npm run build
 ```
 
+> **Note**  
+> The Vite Local URL is only used for the compiling of assets. To view your application, including Hot Module Replacement, use the app URL of your local server.
+
 <a name="working-with-scripts"></a>
 ## Working With JavaScript
 


### PR DESCRIPTION
When using Vite for a standalone project, the Vite URL shows the application. I wasn't clear that with Laravel Vite, this URL is only used internally. I hope this addition will make it clear to future users that, while they must still run Vite server, they should then return to the orginal local app url to continue with development.