### PR TITLE
[9.x] Add Vite Facade to Class Reference

### DIFF
--- a/facades.md
+++ b/facades.md
@@ -304,3 +304,4 @@ Validator  |  [Illuminate\Validation\Factory](https://laravel.com/api/{{version}
 Validator (Instance)  |  [Illuminate\Validation\Validator](https://laravel.com/api/{{version}}/Illuminate/Validation/Validator.html)  |  &nbsp;
 View  |  [Illuminate\View\Factory](https://laravel.com/api/{{version}}/Illuminate/View/Factory.html)  |  `view`
 View (Instance)  |  [Illuminate\View\View](https://laravel.com/api/{{version}}/Illuminate/View/View.html)  |  &nbsp;
+Vite  |  [Illuminate\Foundation\Vite](https://laravel.com/api/{{version}}/Illuminate/Foundation/Vite.html)  |  &nbsp;


### PR DESCRIPTION
The url of vite facade api document should be `https://laravel.com/api/9.x/Illuminate/Foundation/Vite.html` which apparently is not ready yet.

But I'll send a PR anyway.