### PR TITLE
[9.x] Update Routing to Reflect Both Relationship Names on Implicit Binding

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -498,7 +498,7 @@ When implicitly binding multiple Eloquent models in a single route definition, y
         return $post;
     });
 
-When using a custom keyed implicit binding as a nested route parameter, Laravel will automatically scope the query to retrieve the nested model by its parent using conventions to guess the relationship name on the parent. In this case, it will be assumed that the `User` model has a relationship named `posts` (the plural form of the route parameter name) which can be used to retrieve the `Post` model.
+When using a custom keyed implicit binding as a nested route parameter, Laravel will automatically scope the query to retrieve the nested model by its parent using conventions to guess the relationship name on both the parent and the child. In this case, it will be assumed that the `User` model has a relationship named `posts` (the plural form of the route parameter name) which can be used to retrieve the `Post` model. It will also be assumed that the `Post` model has a relationship named `user`. This is important when using custom relationship names. 
 
 If you wish, you may instruct Laravel to scope "child" bindings even when a custom key is not provided. To do so, you may invoke the `scopeBindings` method when defining your route:
 


### PR DESCRIPTION
In recent work, I came across this issue when implicitly binding with a custom relationship name. Take the following example: 

- A `User` model with the `HasMany` relationship `posts` to a `Post` model. 
- A `Post` model with the custom `BelongsTo` relationship `owner` to a `User` model. 

When using implicit binding, a request of `GET /users/{user}/posts/{post:slug}` will fail with a 404 response even if the relationship exists at the database level. To properly utilize implicit binding here, the request needs to be `GET /users/{owner}/posts/{post:slug}`.

Since the documentation only currently references one side of the relationship, I wanted to update it to reflect both. 