### PR TITLE
Update queues.md - add explicit documentation of `sync` default queue connection

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -648,7 +648,7 @@ If you would like to conditionally dispatch a job, you may use the `dispatchIf` 
     ProcessPodcast::dispatchUnless($accountSuspended, $podcast);
     
 > **Note**
-> You may notice that your jobs are running syncrhonously even as you dispatch them to a queue, and think you are doing something wrong. However, This is standard behavior in development environments and particularly newly-created Laravel projects, in which the default queue connection is `sync`.
+> You may notice that your jobs are running synchronously even as you dispatch them to a queue, and think you are doing something wrong. However, This is standard behavior in development environments and particularly newly-created Laravel projects, in which the default queue connection is `sync`. This setting is often preferred in local environments for its convenience.
 
 <a name="delayed-dispatching"></a>
 ### Delayed Dispatching

--- a/queues.md
+++ b/queues.md
@@ -647,7 +647,7 @@ If you would like to conditionally dispatch a job, you may use the `dispatchIf` 
 
     ProcessPodcast::dispatchUnless($accountSuspended, $podcast);
     
-**Note**
+> **Note**
 > You may notice that your jobs are running syncrhonously even as you dispatch them to a queue, and think you are doing something wrong. However, This is standard behavior in development environments and particularly newly-created Laravel projects, in which the default queue connection is `sync`.
 
 <a name="delayed-dispatching"></a>

--- a/queues.md
+++ b/queues.md
@@ -646,9 +646,8 @@ If you would like to conditionally dispatch a job, you may use the `dispatchIf` 
     ProcessPodcast::dispatchIf($accountActive, $podcast);
 
     ProcessPodcast::dispatchUnless($accountSuspended, $podcast);
-    
-> **Note**
-> You may notice that your jobs are running synchronously even as you dispatch them to a queue, and think you are doing something wrong. However, This is standard behavior in development environments and particularly newly-created Laravel projects, in which the default queue connection is `sync`. This setting is often preferred in local environments for its convenience.
+
+In new Laravel applications, the `sync` driver is the default queue driver. This driver executes jobs synchronously in the foreground of the current request, which is often convenient during local development. If you would like to actually begin queueing jobs for background processing, you may specify a different queue driver within your application's `config/queue.php` configuration file.
 
 <a name="delayed-dispatching"></a>
 ### Delayed Dispatching

--- a/queues.md
+++ b/queues.md
@@ -646,6 +646,9 @@ If you would like to conditionally dispatch a job, you may use the `dispatchIf` 
     ProcessPodcast::dispatchIf($accountActive, $podcast);
 
     ProcessPodcast::dispatchUnless($accountSuspended, $podcast);
+    
+**Note**
+> You may notice that your jobs are running syncrhonously even as you dispatch them to a queue, and think you are doing something wrong. However, This is standard behavior in development environments and particularly newly-created Laravel projects, in which the default queue connection is `sync`.
 
 <a name="delayed-dispatching"></a>
 ### Delayed Dispatching


### PR DESCRIPTION
Adds more explicit documentation to the 'Dispatching Jobs' section regarding Laravel's default queue connection of `sync`.

I am using queues in Laravel for the first time, and this was a footgun for me. As I was trying to dispatch jobs to my queue, I noticed that they were running synchronously and I immediately assumed I was doing something wrong, even though I followed the docs. I would expect this to be documented a little more explicitly which would have helped with my development experience.