### PR TITLE
Return installation using `laravel new` to docs

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -56,6 +56,13 @@ After you have installed PHP and Composer, you may create a new Laravel project 
 composer create-project laravel/laravel example-app
 ```
 
+Or, you may install the Laravel Installer as a global Composer dependency:
+
+```nothing
+composer global require laravel/installer
+laravel new example-app
+```
+
 After the project has been created, start Laravel's local development server using the Laravel's Artisan CLI `serve` command:
 
 ```nothing

--- a/installation.md
+++ b/installation.md
@@ -56,10 +56,11 @@ After you have installed PHP and Composer, you may create a new Laravel project 
 composer create-project laravel/laravel example-app
 ```
 
-Or, you may install the Laravel Installer as a global Composer dependency:
+Or, you may create new Laravel projects by globally installing the Laravel installer via Composer:
 
 ```nothing
 composer global require laravel/installer
+
 laravel new example-app
 ```
 


### PR DESCRIPTION
I've noticed that the installation docs don't mention `laravel new`. Maybe I missed that it'ss deprecated, if so, please ignore this PR. Otherwise, it would be great to see it in the docs.

I suggest:

* mentioning the basic usage in a compact way in the installation guide
* (in a separate PR), move the docs tregarding the `-git` and other command-line options to the `README.md` of the `laravel/installer` repo, and link the installation page to it.