### PR TITLE
[9.x] Note that the range specified in the 'between' validation rule is inclusive

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -978,7 +978,7 @@ The field under validation must be a value preceding or equal to the given date.
 <a name="rule-between"></a>
 #### between:_min_,_max_
 
-The field under validation must have a size between the given _min_ and _max_. Strings, numerics, arrays, and files are evaluated in the same fashion as the [`size`](#rule-size) rule.
+The field under validation must have a size between the given _min_ and _max_ (inclusive). Strings, numerics, arrays, and files are evaluated in the same fashion as the [`size`](#rule-size) rule.
 
 <a name="rule-boolean"></a>
 #### boolean


### PR DESCRIPTION
Note that the range specified in the 'between' validation rule is inclusive.

I needed to know this today, and I couldn't find it anywhere. I had to test it to find out.