### PR TITLE
Use globEager in the Vite JS Code Example so that the given Vite::asset example works

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -360,7 +360,7 @@ When referencing assets in your JavaScript or CSS, Vite automatically processes 
 However, in order to accomplish this, you need to make Vite aware of your assets by importing the static assets into the application's entry point. For example, if you want to process and version all images stored in `resources/images` and all fonts stored in `resources/fonts`, you should add the following in your application's `resources/js/app.js` entry point:
 
 ```js
-import.meta.glob([
+import.meta.globEager([
   '../images/**',
   '../fonts/**',
 ]);


### PR DESCRIPTION
When using `glob` the output for `Vite::asset('resources/images/logo.png')` will be `{base}/logo.{hash}.js` which is a js file that attempts to import `{base}/logo.hash.png`. This doesn't work when using the asset helper like in the example:

`<img src="{{ Vite::asset('resources/images/logo.png') }}">`. 

Using `globEager` will make the asset helper return `{base}/logo.{hash}.png` instead.