### PR TITLE
Decimal cast update

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -220,7 +220,7 @@ The `$casts` property should be an array where the key is the name of the attrib
 - `datetime`
 - `immutable_date`
 - `immutable_datetime`
-- `decimal:`<code>&lt;digits&gt;</code>
+- <code>decimal:&lt;precision&gt;</code>
 - `double`
 - `encrypted`
 - `encrypted:array`


### PR DESCRIPTION
The current docs have two things that need to be adjusted to give better clarity into the `decimal` cast.

First, there is a space between "decimal:" and "<digits>" that is created because of putting two code blocks next to each other. It could easily be conceived that the cast should be written as `decimal: 2`, for example with a space between the colon and the precision value. This PR corrects that by wrapping the entire cast example in a single code block.

Secondly, the "digits" parameter has been changed to be "precision" as that gives better understanding as to what that value is intended to do/be. While the `asDecimal` method in `HasAttributes` and the `number_format` function call this parameter "decimals", both "decimals" and "digits" are vague as to their intended purpose in the usage of this cast.

Let me know if you need me to adjust or change anything or you have any questions. Thanks!