### PR TITLE
[9.x] SQLite 3.38.0+ Supports whereJsonContains

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -491,7 +491,7 @@ Laravel also supports querying JSON column types on databases that provide suppo
                     ->where('preferences->dining->meal', 'salad')
                     ->get();
 
-You may use `whereJsonContains` to query JSON arrays. This feature is not supported by the SQLite database:
+You may use `whereJsonContains` to query JSON arrays. This feature is not supported by SQLite database versions less than 3.38.0:
 
     $users = DB::table('users')
                     ->whereJsonContains('options->languages', 'en')


### PR DESCRIPTION
See: https://www.sqlite.org/json1.html

> The JSON functions and operators are built into SQLite by default, as of SQLite version 3.38.0 (2022-02-22). They can be omitted by adding the -DSQLITE_OMIT_JSON compile-time option. Prior to version 3.38.0, the JSON functions were an extension that would only be included in builds if the -DSQLITE_ENABLE_JSON1 compile-time option was included. In other words, the JSON functions went from being opt-in with SQLite version 3.37.2 and earlier to opt-out with SQLite version 3.38.0 and later.

The code for this is already supported as a result of PR https://github.com/laravel/framework/pull/41802