### PR TITLE
Fix method signature in queue docs for `->catch()` callback

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -1344,7 +1344,7 @@ The `anonymousComponentNamespace` method accepts the "path" to the anonymous com
      */
     public function boot()
     {
-        Blade::anonymousComponentNamespace('flights.bookings', 'flights');
+        Blade::anonymousComponentNamespace('flights.bookings.components', 'flights');
     }
 
 Given the example above, you may render a `panel` component that exists within the newly registered component directory like so:

--- a/queues.md
+++ b/queues.md
@@ -797,6 +797,7 @@ If you would like to specify the connection and queue that should be used for th
 
 When chaining jobs, you may use the `catch` method to specify a closure that should be invoked if a job within the chain fails. The given callback will receive the `Throwable` instance that caused the job failure:
 
+    use Illuminate\Bus\Batch;
     use Illuminate\Support\Facades\Bus;
     use Throwable;
 
@@ -804,7 +805,7 @@ When chaining jobs, you may use the `catch` method to specify a closure that sho
         new ProcessPodcast,
         new OptimizePodcast,
         new ReleasePodcast,
-    ])->catch(function (Throwable $e) {
+    ])->catch(function (Batch $batch, Throwable $e) {
         // A job within the chain has failed...
     })->dispatch();
 


### PR DESCRIPTION
Today I got an error in my error reporting tool about a wrong parameter type. I checked with the docs and it looks like the docs are wrong, since the `$batch` parameter is given before the `$exception` parameter.

See [this part](https://github.com/laravel/framework/blob/7fa4beb386a139cabb730a7e3b9571ba8ea2a181/src/Illuminate/Bus/Batch.php#L334) of the source code.