### PR TITLE
HTML5 selected attribute

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -819,7 +819,7 @@ In addition to public variables being available to your component template, any 
 You may execute this method from your component template by invoking the variable matching the name of the method:
 
 ```blade
-<option {{ $isSelected($value) ? 'selected="selected"' : '' }} value="{{ $value }}">
+<option {{ $isSelected($value) ? 'selected' : '' }} value="{{ $value }}">
     {{ $label }}
 </option>
 ```


### PR DESCRIPTION
Insted of selected="selected", that sounds very old and to prevent horizzontal scroll on desktop

before:
![image](https://user-images.githubusercontent.com/7362607/188498551-14eafe5c-aed7-46ba-91ea-76371adf5a7c.png)

after:
![image](https://user-images.githubusercontent.com/7362607/188498603-1a41cceb-d7d0-4d24-b05c-b3d175d9ebb8.png)

