### PR TITLE
[9.x] Fixed the Session `missing()` method description

### DIFF
--- a/session.md
+++ b/session.md
@@ -156,7 +156,7 @@ To determine if an item is present in the session, even if its value is `null`, 
         //
     }
 
-To determine if an item is not present in the session, you may use the `missing` method. The `missing` method returns `true` if the item is `null` or if the item is not present:
+To determine if an item is not present in the session, you may use the `missing` method. The `missing` method returns `true` if the item is not present:
 
     if ($request->session()->missing('users')) {
         //


### PR DESCRIPTION
The Session `missing()` method will return `false` if the item is `null`, since it's defined as the inverse of the `exists()` method:

https://github.com/laravel/framework/blob/fc9dc59b8e9f42092cc0499a56c357265acb2ed4/src/Illuminate/Session/Store.php#L268