### PR TITLE
[9.x] Fix typo in vite.md

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -255,7 +255,7 @@ export default defineConfig({
                     // The Vue plugin will parse absolute URLs and treat them
                     // as absolute paths to files on disk. Setting this to
                     // `false` will leave absolute URLs un-touched so they can
-                    // reference assets in the public directly as expected.
+                    // reference assets in the public directory as expected.
                     includeAbsolute: false,
                 },
             },


### PR DESCRIPTION
Replaces "public directly" with "public directory" in vite.md