### PR TITLE
Fixing new subscription via invoice example

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -647,9 +647,14 @@ The `create` method, which accepts [a Stripe payment method identifier](#storing
 
 Instead of collecting a customer's recurring payments automatically, you may instruct Stripe to email an invoice to the customer each time their recurring payment is due. Then, the customer may manually pay the invoice once they receive it. The customer does not need to provide a payment method up front when collecting recurring payments via invoices:
 
-    $user->newSubscription('default', 'price_monthly')->createAndSendInvoice();
+    $user->newSubscription('default', 'price_monthly')->createAndSendInvoice([], [
+        'days_until_due' => 30
+    ]);
 
-The amount of time a customer has to pay their invoice before their subscription is canceled is determined by your subscription and invoice settings within the [Stripe dashboard](https://dashboard.stripe.com/settings/billing/automatic).
+The amount of time a customer has to pay their invoice before their subscription is canceled is determined by the second argument, 30 days in the above example.
+
+> **Warning**  
+> The `days_until_due` argument is required. If not provided, the Stripe subscription request will fail.
 
 <a name="subscription-quantities"></a>
 #### Quantities

--- a/billing.md
+++ b/billing.md
@@ -651,10 +651,7 @@ Instead of collecting a customer's recurring payments automatically, you may ins
         'days_until_due' => 30
     ]);
 
-The amount of time a customer has to pay their invoice before their subscription is canceled is determined by the second argument, 30 days in the above example.
-
-> **Warning**  
-> The `days_until_due` argument is required. If not provided, the Stripe subscription request will fail.
+The amount of time a customer has to pay their invoice before their subscription is cancelled is determined by the `days_until_due` option.
 
 <a name="subscription-quantities"></a>
 #### Quantities


### PR DESCRIPTION
The current documentation on the creation of new subscription with payment on invoice does not work until the `days_until_due` argument is supplied. So I modified the example code snippet to: 

```
    $user->newSubscription('default', 'price_monthly')->createAndSendInvoice([], [
        'days_until_due' => 30
    ]);
```