### PR TITLE
[9.x] Make Laravel handle URLs ending .php

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -73,7 +73,7 @@ server {
 
     error_page 404 /index.php;
 
-    location ~ \.php$ {
+    location = /index.php {
         fastcgi_pass unix:/var/run/php/php8.0-fpm.sock;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;


### PR DESCRIPTION
This little fix enables Laravel to handle URLs ending with `.php`.

Otherwise, requests like `/not-existing-file.php` return a `File not found.` plain text response instead of Laravel's error page, while nginx writes the following to it's error log:
```
[error] 16#16: *85881 FastCGI sent in stderr: "Primary script unknown" while reading response header from upstream
```