### PR TITLE
[9.x] Adds working example to Closure Request Guards chapter

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -571,9 +571,9 @@ As you can see in the example above, the callback passed to the `extend` method 
 <a name="closure-request-guards"></a>
 ### Closure Request Guards
 
-The simplest way to implement a custom, HTTP request based authentication system is by using the `Auth::viaRequest` method. This method allows you to quickly define your authentication process using a single closure.
+The simplest way to implement a custom, HTTP request based authentication system is by using the `viaRequest` method of `Illuminate\Auth\AuthManager`. This method allows you to quickly define your authentication process using a single closure.
 
-To get started, call the `Auth::viaRequest` method within the `boot` method of your `AuthServiceProvider`. The `viaRequest` method accepts an authentication driver name as its first argument. This name can be any string that describes your custom guard. The second argument passed to the method should be a closure that receives the incoming HTTP request and returns a user instance or, if authentication fails, `null`:
+To get started, call the `$authManager->viaRequest` method within the `boot` method of your `AuthServiceProvider`. The `viaRequest` method accepts an authentication driver name as its first argument. This name can be any string that describes your custom guard. The second argument passed to the method should be a closure that receives the incoming HTTP request and returns a user instance or, if authentication fails, `null`:
 
     use App\Models\User;
     use Illuminate\Http\Request;
@@ -584,11 +584,11 @@ To get started, call the `Auth::viaRequest` method within the `boot` method of y
      *
      * @return void
      */
-    public function boot()
+    public function boot(AuthManager $authManager)
     {
         $this->registerPolicies();
 
-        Auth::viaRequest('custom-token', function (Request $request) {
+        $authManager->viaRequest('custom-token', function (Request $request) {
             return User::where('token', $request->token)->first();
         });
     }


### PR DESCRIPTION
In the last version of Laravel the method `viaRequest` was moved from `Illuminate\Support\Facades\Auth` to `Illuminate\Auth\AuthManager`, so the documentation shows a non-working example.