### PR TITLE
Notice `dispatchAfterResponse` needs webserver with FastCGI

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -688,7 +688,7 @@ If you would like to specify that a job should not be immediately available for 
 <a name="dispatching-after-the-response-is-sent-to-browser"></a>
 #### Dispatching After The Response Is Sent To Browser
 
-Alternatively, the `dispatchAfterResponse` method delays dispatching a job until after the HTTP response is sent to the user's browser. This will still allow the user to begin using the application even though a queued job is still executing. This should typically only be used for jobs that take about a second, such as sending an email. Since they are processed within the current HTTP request, jobs dispatched in this fashion do not require a queue worker to be running in order for them to be processed:
+Alternatively, the `dispatchAfterResponse` method delays dispatching a job until after the HTTP response is sent to the user's browser if your web server is using FastCGI. This will still allow the user to begin using the application even though a queued job is still executing. This should typically only be used for jobs that take about a second, such as sending an email. Since they are processed within the current HTTP request, jobs dispatched in this fashion do not require a queue worker to be running in order for them to be processed:
 
     use App\Jobs\SendNotification;
 


### PR DESCRIPTION
Just like in [terminable middleware](https://laravel.com/docs/6.x/middleware#terminable-middleware), the user should be noticed that the web server should implement FastCGI.

I ran through this issue myself on a dead simple app. I decided to go with a  database driver queue, but it would be a better experience if I had known faster. It took me a while and a chat with a friend to realize this :)

I hope I made the docs better! Thanks for Laravel ❤️