### PR TITLE
Include a section on transforming the paginator's collection using the through method 

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -12,6 +12,7 @@
     - [Converting Results To JSON](#converting-results-to-json)
 - [Customizing The Pagination View](#customizing-the-pagination-view)
     - [Using Bootstrap](#using-bootstrap)
+- [Transform paginated collection](#transform-paginated-collection)  
 - [Paginator and LengthAwarePaginator Instance Methods](#paginator-instance-methods)
 - [Cursor Paginator Instance Methods](#cursor-paginator-instance-methods)
 
@@ -331,6 +332,17 @@ Laravel includes pagination views built using [Bootstrap CSS](https://getbootstr
         Paginator::useBootstrapFive();
         Paginator::useBootstrapFour();
     }
+
+<a name="transform-paginated-collection"></a>
+## Transform paginated collection 
+
+Sometimes you may need to perform transform on the items returned by the paginator. The `through` method provides a very clean way to achieve this. It allows you to transform each item in the slice of items using a given callback.  This provides the ability to painlessly modify the data returned by the paginator without affecting the paginator's meta information.
+
+    $users->through(function ($user){
+
+        return $user;
+
+    });
 
 <a name="paginator-instance-methods"></a>
 ## Paginator / LengthAwarePaginator Instance Methods


### PR DESCRIPTION
Currently, there is no information in the docs on how to use the 'through' method on the returned pagination collection. It could be helpful to include a section on this as it is a very useful method when working with the paginated data. 