### PR TITLE
[9.x] Update assigning middleware examples

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -28,8 +28,6 @@ php artisan make:middleware EnsureTokenIsValid
 
 This command will place a new `EnsureTokenIsValid` class within your `app/Http/Middleware` directory. In this middleware, we will only allow access to the route if the supplied `token` input matches a specified value. Otherwise, we will redirect the users back to the `home` URI:
 
-    <?php
-
     namespace App\Http\Middleware;
 
     use Closure;
@@ -66,8 +64,6 @@ It's best to envision middleware as a series of "layers" HTTP requests must pass
 
 Of course, a middleware can perform tasks before or after passing the request deeper into the application. For example, the following middleware would perform some task **before** the request is handled by the application:
 
-    <?php
-
     namespace App\Http\Middleware;
 
     use Closure;
@@ -84,8 +80,6 @@ Of course, a middleware can perform tasks before or after passing the request de
 
 However, this middleware would perform its task **after** the request is handled by the application:
 
-    <?php
-
     namespace App\Http\Middleware;
 
     use Closure;
@@ -97,6 +91,26 @@ However, this middleware would perform its task **after** the request is handled
             $response = $next($request);
 
             // Perform action
+
+            return $response;
+        }
+    }
+
+You may even define the middleware to perform its task **before** and **after** the request is handled by the application:
+
+    namespace App\Http\Middleware;
+
+    use Closure;
+
+    class BeforeAndAfterMiddleware
+    {
+        public function handle($request, Closure $next)
+        {
+            // Perform action before request is handled
+            
+            $response = $next($request);
+
+            // Perform action after request is handled
 
             return $response;
         }
@@ -131,23 +145,23 @@ If you would like to assign middleware to specific routes, you should first assi
 
 Once the middleware has been defined in the HTTP kernel, you may use the `middleware` method to assign middleware to a route:
 
-    Route::get('/profile', function () {
+    Route::middleware('auth')->get('/profile', function () {
         //
-    })->middleware('auth');
+    });
 
 You may assign multiple middleware to the route by passing an array of middleware names to the `middleware` method:
 
-    Route::get('/', function () {
+    Route::middleware(['first', 'second'])->get('/', function () {
         //
-    })->middleware(['first', 'second']);
+    });
 
 When assigning middleware, you may also pass the fully qualified class name:
 
     use App\Http\Middleware\EnsureTokenIsValid;
 
-    Route::get('/profile', function () {
+    Route::middleware(EnsureTokenIsValid::class)->get('/profile', function () {
         //
-    })->middleware(EnsureTokenIsValid::class);
+    });
 
 <a name="excluding-middleware"></a>
 #### Excluding Middleware


### PR DESCRIPTION
Update the examples of assigning middleware to be more align with the style in the default Laravel project at `routes/api.php` : https://github.com/laravel/laravel/blob/9.x/routes/api.php

Add an example of `BeforeAndAfterMiddleware`