### PR TITLE
[9.x] Add early introduction to queue:work command

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -55,6 +55,12 @@ Laravel queues provide a unified queueing API across a variety of different queu
 
 Laravel's queue configuration options are stored in your application's `config/queue.php` configuration file. In this file, you will find connection configurations for each of the queue drivers that are included with the framework, including the database, [Amazon SQS](https://aws.amazon.com/sqs/), [Redis](https://redis.io), and [Beanstalkd](https://beanstalkd.github.io/) drivers, as well as a synchronous driver that will execute jobs immediately (for use during local development). A `null` queue driver is also included which discards queued jobs.
 
+You may use `queue:work` Artisan command to start the default queue worker as defined in your application's queue configuration.
+
+```shell
+php artisan queue:work
+```
+
 > **Note**  
 > Laravel now offers Horizon, a beautiful dashboard and configuration system for your Redis powered queues. Check out the full [Horizon documentation](/docs/{{version}}/horizon) for more information.
 


### PR DESCRIPTION
Add early introduction to the default `php artisan queue:work` Artisan command (without any options).