### PR TITLE
[9.x] Adds `Benchmark` facade documentation

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -2,6 +2,8 @@
 
 - [Introduction](#introduction)
 - [Available Methods](#available-methods)
+- [Other Utilities](#other-utilities)
+    - [Benchmarking](#benchmarking)
 
 <a name="introduction"></a>
 ## Introduction
@@ -3948,3 +3950,29 @@ The `with` function returns the value it is given. If a closure is passed as the
     $result = with(5, null);
 
     // 5
+
+<a name="other-utilities"></a>
+## Other Utilities
+
+<a name="benchmarking"></a>
+### Benchmarking
+
+Sometimes you may wish to quickly test the performance of certain parts of your application. On those occasions, you may utilize the `Benchmark` support class to measure the number of milliseconds it takes for the given callbacks to complete:
+
+    <?php
+
+    use App\Models\User;
+    use Illuminate\Support\Benchmark;
+
+    Benchmark::dd(fn () => User::find(1)); // 0.1 ms
+
+    Benchmark::dd([
+        'Scenario 1' => fn () => User::count(), // 0.5 ms
+        'Scenario 2' => fn () => User::all()->count(), // 20.0 ms
+    ]);
+
+By default, the given callbacks will be executed once (one iteration), and their duration will be displayed in the browser / console.
+
+To invoke a callback more than once, you may specify the number of iterations that the callback should be invoked as the second argument to the method. When executing a callback more than once, the `Benchmark` class will return the average amount of milliseconds it took to execute the callback across all iterations:
+
+    Benchmark::dd(fn () => User::count(), iterations: 10); // 0.5 ms

--- a/testing.md
+++ b/testing.md
@@ -6,7 +6,6 @@
 - [Running Tests](#running-tests)
     - [Running Tests In Parallel](#running-tests-in-parallel)
     - [Reporting Test Coverage](#reporting-test-coverage)
-- [Benchmark](#benchmark)
 
 <a name="introduction"></a>
 ## Introduction
@@ -209,24 +208,3 @@ You may use the `--min` option to define a minimum test coverage threshold for y
 ```shell
 php artisan test --coverage --min=80.3
 ```
-
-<a name="benchmark"></a>
-## Benchmark
-
-Sometimes, you may wish to test the performance of certain parts of your application. On those occasions, you may utilize the `Benchmark` support class to measure the time taken for the given callbacks to complete:
-
-    <?php
-
-    use Illuminate\Support\Benchmark;
-
-    Benchmark::dd([
-        fn () => User::count(), // 0.5 ms
-        fn () => User::all()->count(), // 20.0 ms
-    ]);
-
-By default, the given callbacks will be executed once (one iteration), and their duration will be displayed in the browser / console. 
-
-If you wish to define the number of iterations you may use the second argument of the `dd` method:
-
-    // 10 iterations:
-    Benchmark::dd(fn () => User::count(), 10); // 0.5 ms

--- a/testing.md
+++ b/testing.md
@@ -224,7 +224,7 @@ Occasionally, you may want to test the performance of certain pieces of the appl
         fn () => User::all()->count(), // 20.0 ms
     ]);
 
-By default, the given callbacks will be executed 10 times each, and the average time the callback toke to run will be returned.
+By default, the given callbacks will be executed 10 times each, and the average time the callbacks toke to run will be displayed on the browser / console.
 
 If you wish to use a different number of repetitions you may use the `repeat` method:
 

--- a/testing.md
+++ b/testing.md
@@ -213,22 +213,20 @@ php artisan test --coverage --min=80.3
 <a name="benchmark"></a>
 ## Benchmark
 
-Sometimes, you may wish to test the performance of certain parts of your application. On those occasions, you may utilize the `Benchmark` facade to measure the time taken for the given callbacks to complete:
+Sometimes, you may wish to test the performance of certain parts of your application. On those occasions, you may utilize the `Benchmark` support class to measure the time taken for the given callbacks to complete:
 
     <?php
 
-    use Illuminate\Support\Facades\Benchmark;
+    use Illuminate\Support\Benchmark;
 
-    Benchmark::measure([
+    Benchmark::dd([
         fn () => User::count(), // 0.5 ms
         fn () => User::all()->count(), // 20.0 ms
     ]);
 
-By default, the given callbacks will be executed 10 times each, and their average completion duration will be displayed in the browser / console.
+By default, the given callbacks will be executed once (one iteration), and their duration will be displayed in the browser / console. 
 
-If you wish to define the number of repetitions you may use the `repeat` method:
+If you wish to define the number of iterations you may use the second argument of the `dd` method:
 
-    Benchmark::repeat(100)->measure(function () {
-        User::count();
-    });
-
+    // 10 iterations:
+    Benchmark::dd(fn () => User::count(), 10); // 0.5 ms

--- a/testing.md
+++ b/testing.md
@@ -213,7 +213,7 @@ php artisan test --coverage --min=80.3
 <a name="benchmark"></a>
 ## Benchmark
 
-Occasionally, you may want to test the performance of certain pieces of the application. For that, you may use the `Benchmark` facade to measure the time the given callbacks take to complete:
+Sometimes, you may wish to test the performance of certain parts of your application. On those occasions, you may utilize the `Benchmark` facade to measure the time taken for the given callbacks to complete:
 
     <?php
 
@@ -224,9 +224,9 @@ Occasionally, you may want to test the performance of certain pieces of the appl
         fn () => User::all()->count(), // 20.0 ms
     ]);
 
-By default, the given callbacks will be executed 10 times each, and the average time the callbacks toke to run will be displayed on the browser / console.
+By default, the given callbacks will be executed 10 times each, and their average completion duration will be displayed in the browser / console.
 
-If you wish to use a different number of repetitions you may use the `repeat` method:
+If you wish to define the number of repetitions you may use the `repeat` method:
 
     Benchmark::repeat(100)->measure(function () {
         User::count();

--- a/testing.md
+++ b/testing.md
@@ -6,6 +6,7 @@
 - [Running Tests](#running-tests)
     - [Running Tests In Parallel](#running-tests-in-parallel)
     - [Reporting Test Coverage](#reporting-test-coverage)
+- [Benchmark](#benchmark)
 
 <a name="introduction"></a>
 ## Introduction
@@ -208,3 +209,26 @@ You may use the `--min` option to define a minimum test coverage threshold for y
 ```shell
 php artisan test --coverage --min=80.3
 ```
+
+<a name="benchmark"></a>
+## Benchmark
+
+Occasionally, you may want to test the performance of certain pieces of the application. For that, you may use the `Benchmark` facade to measure the time the given callbacks take to complete:
+
+    <?php
+
+    use Illuminate\Support\Facades\Benchmark;
+
+    Benchmark::measure([
+        fn () => User::count(), // 0.5 ms
+        fn () => User::all()->count(), // 20.0 ms
+    ]);
+
+By default, the given callbacks will be executed 10 times each, and the average time the callback toke to run will be returned.
+
+If you wish to use a different number of repetitions you may use the `repeat` method:
+
+    Benchmark::repeat(100)->measure(function () {
+        User::count();
+    });
+


### PR DESCRIPTION
This pull request adds documentation for the `Benchmark` facade.

Refers to https://github.com/laravel/framework/pull/44252.