### PR TITLE
Corrected access level for TestCase setUp method when using Pest

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -551,7 +551,7 @@ abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
 
-    public function setUp(): void// [tl! add:start]
+    protected function setUp(): void// [tl! add:start]
     {
         parent::setUp();
 


### PR DESCRIPTION
Just noticed a small issue in the docs.
When using Pest if the setUp method is public you will get the following exception error

<img width="936" alt="Screenshot 2022-09-24 at 00 57 36" src="https://user-images.githubusercontent.com/53559175/192071041-948cf783-e9b0-4fb2-85d7-d8d0d1951167.png">

Corrected the docs updated the setup method to protected matching Pest Testable trait and the default BaseTestCase.