### PR TITLE
Add reference to --seeder option

### DIFF
--- a/seeding.md
+++ b/seeding.md
@@ -138,10 +138,11 @@ php artisan db:seed
 php artisan db:seed --class=UserSeeder
 ```
 
-You may also seed your database using the `migrate:fresh` command in combination with the `--seed` option, which will drop all tables and re-run all of your migrations. This command is useful for completely re-building your database:
+You may also seed your database using the `migrate:fresh` command in combination with the `--seed` option, which will drop all tables and re-run all of your migrations. This command is useful for completely re-building your database. You may use the `--seeder` option to specify a specific seeder class to run individually:
 
 ```shell
 php artisan migrate:fresh --seed
+php artisan migrate:fresh --seed --seeder=UserSeeder 
 ```
 
 <a name="forcing-seeding-production"></a>

--- a/seeding.md
+++ b/seeding.md
@@ -138,10 +138,11 @@ php artisan db:seed
 php artisan db:seed --class=UserSeeder
 ```
 
-You may also seed your database using the `migrate:fresh` command in combination with the `--seed` option, which will drop all tables and re-run all of your migrations. This command is useful for completely re-building your database. You may use the `--seeder` option to specify a specific seeder class to run individually:
+You may also seed your database using the `migrate:fresh` command in combination with the `--seed` option, which will drop all tables and re-run all of your migrations. This command is useful for completely re-building your database. The `--seeder` option may be used to specify a specific seeder to run:
 
 ```shell
 php artisan migrate:fresh --seed
+
 php artisan migrate:fresh --seed --seeder=UserSeeder 
 ```
 


### PR DESCRIPTION
Where the `DB` command uses the `--class` option, the `migrate` command uses `--seed`, this can be confusing and may mean other developers miss this as an option.