### PR TITLE
[9.x] Move environment variables to the "job" level

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1920,6 +1920,11 @@ jobs:
 
   dusk-php:
     runs-on: ubuntu-latest
+    env:
+      APP_URL: "http://127.0.0.1:8000"
+      DB_USERNAME: root
+      DB_PASSWORD: root
+      MAIL_MAILER: log
     steps:
       - uses: actions/checkout@v3
       - name: Prepare The Environment
@@ -1939,8 +1944,6 @@ jobs:
       - name: Run Laravel Server
         run: php artisan serve --no-reload &
       - name: Run Dusk Tests
-        env:
-          APP_URL: "http://127.0.0.1:8000"
         run: php artisan dusk
       - name: Upload Screenshots
         if: failure()


### PR DESCRIPTION
Github Actions allows you to place environment variables at either the "workflow", "job", or "step" level.  This commit moves them from the "step" level to the "job" level.

https://docs.github.com/en/actions/learn-github-actions/environment-variables

Dusk is a unique situation because running `php artisan dusk` starts the tests in one process, but hitting `$this->browse()` within the test spawns a **new** process, that **DOES NOT** inherit the environment variables set at the "step" level.

Therefore, for Dusk CI on Github, it's better to set ENV variables at the "job" level so both the "test process" and "browser process" inherit them.

Added the `DB_USERNAME`, `DB_PASSWORD`, and `MAIL_MAILER` env variables. The current value in the default `.env.example` for the password is empty, so we'll set it here to match the default Github Action MySQL password. The default `MAIL_MAILER` value is "smtp" and points to Mailhog, which **is not** running on Github Actions, and will throw an Exception if an email is attempted to be sent, so we'll use "log" to avoid that.