### PR TITLE
[9.x] use chrome driver `--detect` option

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1933,7 +1933,7 @@ jobs:
       - name: Generate Application Key
         run: php artisan key:generate
       - name: Upgrade Chrome Driver
-        run: php artisan dusk:chrome-driver `/opt/google/chrome/chrome --version | cut -d " " -f3 | cut -d "." -f1`
+        run: php artisan dusk:chrome-driver --detect
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux &
       - name: Run Laravel Server


### PR DESCRIPTION
the `--detect` flag was added to Dusk in

https://github.com/laravel/dusk/pull/816

which automatically downloads the correct driver based on the version of Chrome currently installed on the system.