### PR TITLE
[9.x] Removes section on local network sharing

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -12,7 +12,6 @@
 - [Sharing Sites](#sharing-sites)
     - [Sharing Sites Via Ngrok](#sharing-sites-via-ngrok)
     - [Sharing Sites Via Expose](#sharing-sites-via-expose)
-    - [Sharing Sites On Your Local Network](#sharing-sites-on-your-local-network)
 - [Site Specific Environment Variables](#site-specific-environment-variables)
 - [Proxying Services](#proxying-services)
 - [Custom Valet Drivers](#custom-valet-drivers)
@@ -287,17 +286,6 @@ expose
 ```
 
 To stop sharing your site, you may press `Control + C`.
-
-<a name="sharing-sites-on-your-local-network"></a>
-### Sharing Sites On Your Local Network
-
-Valet restricts incoming traffic to the internal `127.0.0.1` interface by default so that your development machine isn't exposed to security risks from the Internet.
-
-If you wish to allow other devices on your local network to access the Valet sites on your machine via your machine's IP address (eg: `192.168.1.10/application.test`), you will need to manually edit the appropriate Nginx configuration file for that site to remove the restriction on the `listen` directive. You should remove the `127.0.0.1:` prefix on the `listen` directive for ports 80 and 443.
-
-If you have not run `valet secure` on the project, you can open up network access for all non-HTTPS sites by editing the `/usr/local/etc/nginx/valet/valet.conf` file. However, if you're serving the project site over HTTPS (you have run `valet secure` for the site) then you should edit the `~/.config/valet/Nginx/app-name.test` file.
-
-Once you have updated your Nginx configuration, run the `valet restart` command to apply the configuration changes.
 
 <a name="site-specific-environment-variables"></a>
 ## Site Specific Environment Variables


### PR DESCRIPTION
This PR removes the section on local sharing which was added to the documentation in https://github.com/laravel/docs/pull/5677. The reasoning for this removal is that the feature doesn't exist in Laravel Valet. If a user follows the steps outlined in the documentation they'll always get back the default Laravel Valet 404 not found page.

I'm not sure why it was added to the documentation, but it seems at least @driesvints knows this feature doesn't exist. Given issue (https://github.com/laravel/valet/issues/1093) was converted to a discussion for feature requests (https://github.com/laravel/valet/discussions/1143) instead of an issue.

There is also the following comment on another issue regarding local network access (https://github.com/laravel/valet/issues/440#issuecomment-579830736) where a user suggested a fix for getting local networking to work, but that requires changing internals for Laravel Valet.

As Laravel Valet is now there is no feature for local network sharing and the section can be removed.