### PR TITLE
[9.x] Change global scope namespace to `App\Models\Scopes`

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1162,7 +1162,7 @@ The `Scope` interface requires you to implement one method: `apply`. The `apply`
 
     <?php
 
-    namespace App\Scopes;
+    namespace App\Models\Scopes;
 
     use Illuminate\Database\Eloquent\Builder;
     use Illuminate\Database\Eloquent\Model;


### PR DESCRIPTION
The command `php artisan make:scope MyScope` will put the scope in the `App\Models\Scopes` namespace. This PR will update the example code namespace.