### PR TITLE
Replace route link to more accurate point

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -77,7 +77,7 @@ Before broadcasting any events, you will first need to register the `App\Provide
 <a name="queue-configuration"></a>
 #### Queue Configuration
 
-You will also need to configure and run a [queue worker](/docs/{{version}}/queues). All event broadcasting is done via queued jobs so that the response time of your application is not seriously affected by events being broadcast.
+You will also need to configure and run a [queue worker](/docs/{{version}}/queues#running-the-queue-worker). All event broadcasting is done via queued jobs so that the response time of your application is not seriously affected by events being broadcast.
 
 <a name="pusher-channels"></a>
 ### Pusher Channels


### PR DESCRIPTION
## Description 
- The discussion is about running a queue worker `You will also need to configure and run a [queue worker](https://laravel.com/docs/9.x/queues).` But, it points to queues main page. It should be linked to `(https://laravel.com/docs/9.x/queues#running-the-queue-worker)`.
- Such specific routing is available is same page of documentation, such as `Typically, this value should be set via the ABLY_KEY [environment variable](https://laravel.com/docs/9.x/configuration#environment-configuration):`