### PR TITLE
Improve implicit Enum binding documentation

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -535,7 +535,7 @@ Typically, a 404 HTTP response will be generated if an implicitly bound model is
 <a name="implicit-enum-binding"></a>
 ### Implicit Enum Binding
 
-PHP 8.1 introduced support for [Enums](https://www.php.net/manual/en/language.enumerations.backed.php). To compliment this feature, Laravel allows you to type-hint a [backed Enum](https://www.php.net/manual/en/language.enumerations.backed.php) on your route definition and Laravel will only invoke the route if that route segment corresponds to a valid Enum value. Otherwise, a 404 HTTP response will be returned automatically. For example, given the following Enum:
+PHP 8.1 introduced support for [Enums](https://www.php.net/manual/en/language.enumerations.backed.php). To compliment this feature, Laravel allows you to type-hint a [string-backed Enum](https://www.php.net/manual/en/language.enumerations.backed.php) on your route definition and Laravel will only invoke the route if that route segment corresponds to a valid Enum value. Otherwise, a 404 HTTP response will be returned automatically. For example, given the following Enum:
 
 ```php
 <?php


### PR DESCRIPTION
This PR will improve the route model binding documentation by explicitly stating that only string-backed Enums are supported in implicit Enum binding.

The feature that was introduced in [#40281](https://github.com/laravel/framework/pull/40281) explicitly ignores int-backed Enums which potentially leads to confusion because the binding just silently won't work when using Enums backed by integers.