### PR TITLE
[9.x] Add example why to use Passport over Sanctum

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -56,6 +56,8 @@
 
 Before getting started, you may wish to determine if your application would be better served by Laravel Passport or [Laravel Sanctum](/docs/{{version}}/sanctum). If your application absolutely needs to support OAuth2, then you should use Laravel Passport.
 
+Another use case for Passport is, if you need lifetime tokens for [machine-to-machine](client-credentials-grant-tokens) authentication, as well expiring access tokens for users ([can be done without OAuth2](personal-access-tokens)). For example, the endpoint in [issuing API tokens](/docs/{{version}}/sanctum#mobile-application-authentication) could be protected by a lifetime token for the mobile app itself, to prevent others from doing a brute force attack.  
+
 However, if you are attempting to authenticate a single-page application, mobile application, or issue API tokens, you should use [Laravel Sanctum](/docs/{{version}}/sanctum). Laravel Sanctum does not support OAuth2; however, it provides a much simpler API authentication development experience.
 
 <a name="installation"></a>


### PR DESCRIPTION
I think this is probably the most common scenario of why people who don't want to use OAuth2 still use Passport over Sanctum by choice, after reading the docs.

I think it's common practice to protect the login API route with a lifetime token, but only hand out expiring access tokens for the users. Also, it may happen that other apps besides the mobile app need to have access to your application, if you use sanctum with an expiring token, your only option is to create a [custom model with api_tokens](https://laravel.com/docs/6.x/api-authentication), but then you lose the token scope / token abilities feature. Also, the API Authentication docs that explain how you would do that, have been removed from the docs since 7.x, so I guess it's not wanted that people do that, right?