### PR TITLE
Replace code example using `LARAVEL_START` constant with `now()`

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -3529,7 +3529,7 @@ To illustrate the usage of this method, imagine an application that submits invo
 
     Invoice::pending()->cursor()
         ->takeUntilTimeout(
-            Carbon::createFromTimestamp(LARAVEL_START)->add(14, 'minutes')
+            now()->add(14, 'minutes')
         )
         ->each(fn ($invoice) => $invoice->submit());
 


### PR DESCRIPTION
It appears that `LARAVEL_START` no longer exists (in my v9.31 instance at least), so I propose replacing the carbon command utilising this with `now()`