### PR TITLE
Update Passport `--uuids` prompt info

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -115,7 +115,7 @@ Finally, in your application's `config/auth.php` configuration file, you should 
 <a name="client-uuids"></a>
 #### Client UUIDs
 
-You may also run the `passport:install` command with the `--uuids` option present. This option will instruct Passport that you would like to use UUIDs instead of auto-incrementing integers as the Passport `Client` model's primary key values. After running the `passport:install` command with the `--uuids` option, you will be given additional instructions regarding disabling Passport's default migrations:
+You may also run the `passport:install` command with the `--uuids` option present. This option will instruct Passport that you would like to use UUIDs instead of auto-incrementing integers as the Passport `Client` model's primary key values. After running the `passport:install` command with the `--uuids` option. Passport will automatically update the published migrations and prompt you to optionally rollback and re-run your migrations:
 
 ```shell
 php artisan passport:install --uuids


### PR DESCRIPTION
https://laravel.com/docs/9.x/passport#client-uuids

The docs state that after running `php artisan passport:install --uuids`, that;
>  you will be given additional instructions regarding disabling Passport's default migrations

There's no mention of disabling the default migrations and instead Passport prompts you to rollback and re-run the previous migrations. I'm submitting this change as I was slightly confused as the docs didn't reflect the prompt.