### PR TITLE
[9.x] Documentation about which schema file uses Laravel when running migrations + new feature

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -45,6 +45,27 @@ The `Illuminate\Foundation\Testing\RefreshDatabase` trait does not migrate your 
 
 If you would like to totally reset the database using migrations, you may use the `Illuminate\Foundation\Testing\DatabaseMigrations` trait instead. However, the `DatabaseMigrations` trait is significantly slower than the `RefreshDatabase` trait.
 
+In any of the two cases, when resetting the database, if you are [squashing migrations](/docs/{{version}}/migrations#squashing-migrations) Laravel will pick by default the schema file with the name of your database connection. Chances are that you use a different database connection in your `phpunit.xml` file. If you want to use the same schema dump as in your normal database, define a `$dump` property in your base test class with the path to the dump:
+
+    <?php
+
+    namespace Tests;
+
+    use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+    abstract class TestCase extends BaseTestCase
+    {
+        use CreatesApplication;
+        use LazilyRefreshDatabase;
+
+        /**
+         * Indicates which schema file should be used when running migrations.
+         *
+         * @var string
+         */
+        protected $dump = 'database/schema/mysql-schema.dump';
+    }
+
 <a name="model-factories"></a>
 ## Model Factories
 

--- a/migrations.md
+++ b/migrations.md
@@ -58,7 +58,9 @@ php artisan schema:dump
 php artisan schema:dump --prune
 ```
 
-When you execute this command, Laravel will write a "schema" file to your application's `database/schema` directory. Now, when you attempt to migrate your database and no other migrations have been executed, Laravel will execute the schema file's SQL statements first. After executing the schema file's statements, Laravel will execute any remaining migrations that were not part of the schema dump.
+When you execute this command, Laravel will write a "schema" file to your application's `database/schema` directory using the name of your database connection. Now, when you attempt to migrate your database and no other migrations have been executed, Laravel will execute first the SQL statements of the schema file of the database connection you are using. After executing the schema file's statements, Laravel will execute any remaining migrations that were not part of the schema dump.
+
+Note that, if you are running tests, chances are that you are using a different connection name to the one you regularly use for your non-testing database. Therefore, make sure you have a schema file named with your testing connection name or [ensure your tests use your schema file named with the non-testing connection name](/docs/{{version}}/database-testing#resetting-the-database-after-each-test).
 
 You should commit your database schema file to source control so that other new developers on your team may quickly create your application's initial database structure.
 


### PR DESCRIPTION
This PR has 2 goals:

1- Document an opaque part of Laravel: if you are [squashing migrations](https://laravel.com/docs/9.x/migrations#squashing-migrations), the documentation should explain which file name is used when running a migration. It uses the connection name to find out the schema file in your database folder. That's explained in the changes to the migrations.md file.

2- As part of these improvements, I wanted to give Laravel a new functionality: be able to choose which schema file you want to use when running tests which require a migration. Chances are that you use a different connection name (such as "testing") than the standard connection name for your database. I've created a [PR](https://github.com/laravel/framework/pull/44686) with that feature and I'm documenting it here. Those are the changes in the database-testing.md file.

Now, my intention is to get both PR's merged. But if the one in the framework is not merged, I consider that at least, the 1st goal of this PR should be merged. I consider important to let the developers know how Laravel chooses which dump file to use when migrating.

Happy coding!