### PR TITLE
Warning to avoid chainable header in middleware

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -79,6 +79,15 @@ Or, you may use the `withHeaders` method to specify an array of headers to be ad
                     'X-Header-Two' => 'Header Value',
                 ]);
 
+> **Warning**  
+> In middleware, however, you should set headers using the *non-chainable* methods found on the response's `ResponseHeaderBag`, e.g.
+> ```
+> $response->headers->set(...);
+> ```
+> Although the `header` and `cookie` methods are provided as a convenience on `Illuminate\Http\Response` responses,
+> the framework can return other instances of `Symfony\Component\HttpFoundation\Response`, e.g. `BinaryFileResponse` and `StreamedResponse`, on which those chainable methods are undefined.
+
+
 <a name="cache-control-middleware"></a>
 #### Cache Control Middleware
 


### PR DESCRIPTION
The instructions for how to attach headers, found in "Attaching Headers To Responses", `$response->header(...)`, cause an error when called on response types returned by other code examples in this same doc page, e.g.
- `return response()->download($pathToFile);` returns a `\Symfony\Component\HttpFoundation\BinaryFileResponse`
- `return response()->file($pathToFile);` returns a `\Symfony\Component\HttpFoundation\BinaryFileResponse`
- `return response()->streamDownload(...) ` returns a `\Symfony\Component\HttpFoundation\StreamedResponse`

Attempting to add a header to such a response, in middleware, in the suggested way,
```php
    $response = $next($request);
    $response->header(...)
```
... results in an error "Call to undefined method Symfony\Component\HttpFoundation\BinaryFileResponse::header()"

## Appears to be common
It appears that lots of devs have encountered this problem and been confused by it. e.g.
- Stackoverflow [BinaryFileResponse in Laravel undefined](https://stackoverflow.com/questions/29289177/binaryfileresponse-in-laravel-undefined), 32k views, 33 upvotes, answers with 74 upvotes
  - Caused by `return response()->download(...);`
- Stackoverflow [Call to undefined method Symfony\Component\HttpFoundation\Response::header()](https://stackoverflow.com/questions/43593351/call-to-undefined-method-symfony-component-httpfoundation-responseheader), 26k views, 22 upvotes, answer with 52 upvotes
  - Caused when started using Laravel Passport
- Various issues raised on Laravel projects, e.g. [bug fix in laravel/vapor-core](https://github.com/laravel/vapor-core/pull/10), [confusion about cors middleware error when attempting to export a file in laravel/nova-issues](https://github.com/laravel/nova-issues/discussions/4036), [confusion about this error, asked in laravel/framework](https://github.com/laravel/framework/issues/21922), [issue raised in laravel/cashier-stripe #1214](https://github.com/laravel/cashier-stripe/pull/1214), 

## Confused by the documentation = Clarify in the docs
1. The above questions are being asked because devs are "following the docs" yet encountering an error, leading to confusion
2. Users of Laravel write Middleware a lot
3. The framework's own middleware that add headers to responses, all use `$response->headers->set()` and related `ResponseHeaderBag` methods. But the docs don't currently say that's what we should do too.

Therefore, I think the docs would be improved with a small clarification to avoid the chainable methods in middleware.