### PR TITLE
Clarify middleware avoid chainable header methods

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -79,6 +79,10 @@ Or, you may use the `withHeaders` method to specify an array of headers to be ad
                     'X-Header-Two' => 'Header Value',
                 ]);
 
+> **Warning**  
+> In middleware you should instead set the response headers using the methods on its `ResponseHeaderBag`, e.g. `$response->headers->set(...);`.
+> The framework returns other types of Symfony Responses on which the chainable header methods are undefined, e.g. `BinaryFileResponse` and `StreamedResponse`.
+
 <a name="cache-control-middleware"></a>
 #### Cache Control Middleware
 


### PR DESCRIPTION
See PR #8305 for the rationale on why a note is needed; TLDR: developers are having their middleware break when following current Response docs.

On that PR @taylorotwell gave feedback to not put big code blocks in a warning,  
so this is a redo, with a more concise paragraph.