### PR TITLE
[9.x] Fix Torchlight annotations

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -143,7 +143,7 @@ export default defineConfig({
     plugins: [
         laravel({
             // ...
-            valetTls: 'my-app.test', // [!tl add]
+            valetTls: 'my-app.test', // [tl! add]
         }),
     ],
 });
@@ -159,14 +159,14 @@ const host = 'my-app.test'; // [tl! add]
 
 export default defineConfig({
     // ...
-    server: { // [!tl add]
-        host, // [!tl add]
-        hmr: { host }, // [!tl add]
-        https: { // [!tl add]
-            key: fs.readFileSync(`/path/to/${host}.key`), // [!tl add]
-            cert: fs.readFileSync(`/path/to/${host}.crt`), // [!tl add]
-        }, // [!tl add]
-    }, // [!tl add]
+    server: { // [tl! add]
+        host, // [tl! add]
+        hmr: { host }, // [tl! add]
+        https: { // [tl! add]
+            key: fs.readFileSync(`/path/to/${host}.key`), // [tl! add]
+            cert: fs.readFileSync(`/path/to/${host}.crt`), // [tl! add]
+        }, // [tl! add]
+    }, // [tl! add]
 });
 ```
 


### PR DESCRIPTION
This PR fixes the Torchlight annotations on the `Asset Bundling (Vite)` page.

In some annotations, the exclamation mark is placed before `tl`, but it should be placed after to be interpreted correctly.

This currently results in additional comments being rendered in the docs, as the following screenshot illustrates.

<img width="500" alt="Screenshot 2022-10-26 at 22 07 29" src="https://user-images.githubusercontent.com/649677/198126430-9d53cc8e-d192-4356-a3cd-ee2d817bcd47.png">
