### PR TITLE
Added $mail->build, otherwise subject remains null

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -452,6 +452,8 @@ You may pass a closure to the `assertSent`, `assertNotSent`, `assertQueued`, or 
 When calling the `Mail` facade's assertion methods, the mailable instance accepted by the provided closure exposes helpful methods for examining the mailable:
 
     Mail::assertSent(OrderShipped::class, function ($mail) use ($user) {
+        $mail->build();
+
         return $mail->hasTo($user->email) &&
                $mail->hasCc('...') &&
                $mail->hasBcc('...') &&


### PR DESCRIPTION
For both queued mails and non-queued (sync) mails, the `subject` propertie of `$mail` is `null` unless the mail is `build()` first.

Solution provided by bobbybouwmann on: https://laracasts.com/discuss/channels/testing/php-unit-testing-mail