### PR TITLE
Use consistent namespace for AncientScope

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1238,7 +1238,7 @@ To assign a global scope to a model, you should override the model's `booted` me
 
     namespace App\Models;
 
-    use App\Scopes\AncientScope;
+    use App\Models\Scopes\AncientScope;
     use Illuminate\Database\Eloquent\Model;
 
     class User extends Model


### PR DESCRIPTION
The AncientScope class is declared above with the namespace `App\Models\Scopes` but is then imported from `App\Scopes\AncientScope`. The namespace does not match the declaration nor the default structure when created with the `make:scope` command.