### PR TITLE
[9.x] Document which dump file Laravel picks when running migrations

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -60,10 +60,11 @@ php artisan schema:dump --prune
 
 When you execute this command, Laravel will write a "schema" file to your application's `database/schema` directory. The schema file's name will correspond to the database connection. Now, when you attempt to migrate your database and no other migrations have been executed, Laravel will execute first the SQL statements of the schema file of the database connection you are using. After executing the schema file's statements, Laravel will execute any remaining migrations that were not part of the schema dump.
 
-If your application's tests use a different database connection than the one you typically use during local development, you should ensure you have a dumped a schema file using that database connection so that your tests are able to build your database:
+If your application's tests use a different database connection than the one you typically use during local development, you should ensure you have a dumped a schema file using that database connection so that your tests are able to build your database. You may wish to do this after dumping the database connection you typically use during local development:
 
 ```shell
-php artisan schema:dump --database=testing
+php artisan schema:dump
+php artisan schema:dump --database=testing --prune
 ```
 
 You should commit your database schema file to source control so that other new developers on your team may quickly create your application's initial database structure.

--- a/migrations.md
+++ b/migrations.md
@@ -58,7 +58,9 @@ php artisan schema:dump
 php artisan schema:dump --prune
 ```
 
-When you execute this command, Laravel will write a "schema" file to your application's `database/schema` directory. Now, when you attempt to migrate your database and no other migrations have been executed, Laravel will execute the schema file's SQL statements first. After executing the schema file's statements, Laravel will execute any remaining migrations that were not part of the schema dump.
+When you execute this command, Laravel will write a "schema" file to your application's `database/schema` directory using the name of your database connection. Now, when you attempt to migrate your database and no other migrations have been executed, Laravel will execute first the SQL statements of the schema file of the database connection you are using. After executing the schema file's statements, Laravel will execute any remaining migrations that were not part of the schema dump.
+
+Note that, if you are running tests, chances are that you are using a different connection name to the one you regularly use for your non-testing database. Therefore, make sure you have a schema file named with your testing connection name or ensure your tests use your schema file named with the non-testing connection name.
 
 You should commit your database schema file to source control so that other new developers on your team may quickly create your application's initial database structure.
 

--- a/migrations.md
+++ b/migrations.md
@@ -58,9 +58,13 @@ php artisan schema:dump
 php artisan schema:dump --prune
 ```
 
-When you execute this command, Laravel will write a "schema" file to your application's `database/schema` directory using the name of your database connection. Now, when you attempt to migrate your database and no other migrations have been executed, Laravel will execute first the SQL statements of the schema file of the database connection you are using. After executing the schema file's statements, Laravel will execute any remaining migrations that were not part of the schema dump.
+When you execute this command, Laravel will write a "schema" file to your application's `database/schema` directory. The schema file's name will correspond to the database connection. Now, when you attempt to migrate your database and no other migrations have been executed, Laravel will execute first the SQL statements of the schema file of the database connection you are using. After executing the schema file's statements, Laravel will execute any remaining migrations that were not part of the schema dump.
 
-Note that, if you are running tests, chances are that you are using a different connection name to the one you regularly use for your non-testing database. Therefore, make sure you have a schema file named with your testing connection name or ensure your tests use your schema file named with the non-testing connection name.
+If your application's tests use a different database connection than the one you typically use during local development, you should ensure you have a dumped a schema file using that database connection so that your tests are able to build your database:
+
+```shell
+php artisan schema:dump --database=testing
+```
 
 You should commit your database schema file to source control so that other new developers on your team may quickly create your application's initial database structure.
 


### PR DESCRIPTION
The goal of this PR is to document an opaque part of Laravel: if you are [squashing migrations](https://laravel.com/docs/9.x/migrations#squashing-migrations), the documentation should explain which file name is used when running a migration. It uses the connection name to find out the schema file in your database folder. That's explained in the changes to the migrations.md file.

Happy coding!