### PR TITLE
Typo in example

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -997,8 +997,8 @@ As you might expect, the "HTML" assertions assert that the HTML version of your 
         $mailable->assertHasAttachment('/path/to/file');
         $mailable->assertHasAttachment(Attachment::fromPath('/path/to/file'));
         $mailable->assertHasAttachedData($pdfData, 'name.pdf', ['mime' => 'application/pdf']);
-        $mailable->assertHasAttachementFromStorage('/path/to/file', 'name.pdf', ['mime' => 'application/pdf']);
-        $mailable->assertHasAttachementFromStorageDisk('s3', '/path/to/file', 'name.pdf', ['mime' => 'application/pdf']);
+        $mailable->assertHasAttachmentFromStorage('/path/to/file', 'name.pdf', ['mime' => 'application/pdf']);
+        $mailable->assertHasAttachmentFromStorageDisk('s3', '/path/to/file', 'name.pdf', ['mime' => 'application/pdf']);
     }
 
 <a name="testing-mailable-sending"></a>


### PR DESCRIPTION
Typo in example: assertHasAttachementFromStorage and assertHasAttachementFromStorageDisk both have an 'e' too many.