### PR TITLE
Fix markdown typo on migrations.md file

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -5,7 +5,7 @@
     - [Squashing Migrations](#squashing-migrations)
 - [Migration Structure](#migration-structure)
 - [Running Migrations](#running-migrations)
-    - [Rolling Back Migrations](#rolling-back-migrations)]
+    - [Rolling Back Migrations](#rolling-back-migrations)
 - [Tables](#tables)
     - [Creating Tables](#creating-tables)
     - [Updating Tables](#updating-tables)


### PR DESCRIPTION
Removed typo with extra square bracket