### PR TITLE
[9.x] Add missing middleware to $middlewarePriority list

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -232,6 +232,7 @@ Rarely, you may need your middleware to execute in a specific order but not have
      * @var string[]
      */
     protected $middlewarePriority = [
+        \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
         \Illuminate\Cookie\Middleware\EncryptCookies::class,
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,


### PR DESCRIPTION
In the documentation, the `\Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class` middleware class is not listed on the array `$middlewarePriority` but is present on the implementation of `Illuminate\Foundation\Http\Kernel`.