### PR TITLE
Add information about maximum number of Octane concurrently tasks

### DIFF
--- a/octane.md
+++ b/octane.md
@@ -479,7 +479,7 @@ Concurrent tasks processed by Octane utilize Swoole's "task workers", and execut
 php artisan octane:start --workers=4 --task-workers=6
 ```
 
-The maximum number of tasks in the array that can be passed to the method is limited to 1024 due to a restriction in [Swoole's Task system](https://openswoole.com/docs/modules/swoole-server-taskWaitMulti#description).
+Please note that the array that you pass into the `concurrently` method cannot contain more than 1024 tasks due to a restriction in [Swoole's Task system](https://openswoole.com/docs/modules/swoole-server-taskWaitMulti#description).
 
 <a name="ticks-and-intervals"></a>
 ## Ticks & Intervals

--- a/octane.md
+++ b/octane.md
@@ -479,7 +479,7 @@ Concurrent tasks processed by Octane utilize Swoole's "task workers", and execut
 php artisan octane:start --workers=4 --task-workers=6
 ```
 
-Please note that the array that you pass into the `concurrently` method cannot contain more than 1024 tasks due to a restriction in [Swoole's Task system](https://openswoole.com/docs/modules/swoole-server-taskWaitMulti#description).
+When invoking the `concurrently` method, you should not provide more than 1024 tasks due to limitations imposed by Swoole's task system.
 
 <a name="ticks-and-intervals"></a>
 ## Ticks & Intervals

--- a/octane.md
+++ b/octane.md
@@ -479,6 +479,8 @@ Concurrent tasks processed by Octane utilize Swoole's "task workers", and execut
 php artisan octane:start --workers=4 --task-workers=6
 ```
 
+The maximum number of tasks in the array that can be passed to the method is limited to 1024 due to a restriction in [Swoole's Task system](https://openswoole.com/docs/modules/swoole-server-taskWaitMulti#description).
+
 <a name="ticks-and-intervals"></a>
 ## Ticks & Intervals
 


### PR DESCRIPTION
As requested in https://github.com/laravel/octane/issues/609, this PR adds information about the maximum number of tasks that can be passed into `Octane::concurrently` at once.