### PR TITLE
Updated pint version command typo

### DIFF
--- a/pint.md
+++ b/pint.md
@@ -36,7 +36,7 @@ You can instruct Pint to fix code style issues by invoking the `pint` binary tha
 Pint will display a thorough list of all of the files that it updates. You can view even more detail about Pint's changes by providing the `-v` option when invoking Pint:
 
 ```shell
-./vendor/bin/pint -v
+./vendor/bin/pint -V
 ```
 
 If you would like Pint to simply inspect your code for style errors without actually changing the files, you may use the `--test` option:


### PR DESCRIPTION
Hi,

to show the version of pint it must be with the "v" in uppercase, used like this in the example will start Pint with applying the changes.


-v (lowercase)

```
./vendor/bin/pint -v 

  .................................................................................................................................................................

  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── PSR 12  
    PASS   ...................................................................................................................... 123 files  

```

-V  (uppercase)
```
./vendor/bin/pint -V
Pint 1.2.0
``````

Thanks!