### PR TITLE
add note about publishing first-party package assets

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -167,6 +167,9 @@ To keep the assets up-to-date and avoid issues in future updates, you may add th
 }
 ```
 
+> **Note**
+> If your `composer.json`’s array of `post-update-cmd` scripts already contains `@php artisan vendor:publish --tag=laravel-assets --ansi --force`, you can omit this.
+
 <a name="running-horizon"></a>
 ## Running Horizon
 

--- a/telescope.md
+++ b/telescope.md
@@ -168,6 +168,9 @@ To keep the assets up-to-date and avoid issues in future updates, you may add th
 }
 ```
 
+> **Note**
+> If your `composer.json`’s array of `post-update-cmd` scripts already contains `@php artisan vendor:publish --tag=laravel-assets --ansi --force`, you can omit this.
+
 <a name="filtering"></a>
 ## Filtering
 


### PR DESCRIPTION
Horizon and Telescope both use the laravel-assets tag so are included in `php artisan vendor:publish --tag=laravel-assets`