### PR TITLE
Update method `canceled` to `cancelled` subscriptions on billing.md

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -828,7 +828,7 @@ The `recurring` method may be used to determine if the user is currently subscri
 
 To determine if the user was once an active subscriber but has canceled their subscription, you may use the `canceled` method:
 
-    if ($user->subscription('default')->canceled()) {
+    if ($user->subscription('default')->cancelled()) {
         //
     }
 
@@ -894,12 +894,12 @@ Most subscription states are also available as query scopes so that you may easi
     $subscriptions = Subscription::query()->active()->get();
 
     // Get all of the canceled subscriptions for a user...
-    $subscriptions = $user->subscriptions()->canceled()->get();
+    $subscriptions = $user->subscriptions()->cancelled()->get();
 
 A complete list of available scopes is available below:
 
     Subscription::query()->active();
-    Subscription::query()->canceled();
+    Subscription::query()->cancelled();
     Subscription::query()->ended();
     Subscription::query()->incomplete();
     Subscription::query()->notCanceled();


### PR DESCRIPTION
We will get the error about the method not found.
```bash
Call to undefined method Illuminate\Database\Eloquent\Relations\MorphMany::canceled()
```
What I found here is, it's actualy `cancelled`, not `canceled`. One of example:
```php
$user->subscription('default')->canceled(); // before
$user->subscription('default')->cancelled(); // after
```