### PR TITLE
Added quotation marks around docker run command

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -164,7 +164,7 @@ You may install the application's dependencies by navigating to the application'
 ```shell
 docker run --rm \
     -u "$(id -u):$(id -g)" \
-    -v $(pwd):/var/www/html \
+    -v "$(pwd):/var/www/html" \
     -w /var/www/html \
     laravelsail/php81-composer:latest \
     composer install --ignore-platform-reqs


### PR DESCRIPTION
When the full path contains uppercases characters, Docker complains with `docker: invalid reference format: repository name must be lowercase.`.

By encapsulating the path in quotation marks, this problem is solved. This pull request implements that.

See also: https://stackoverflow.com/a/52818152/7410951