### PR TITLE
[9.x] Add mention of the app() helper in the Container docs.

### DIFF
--- a/container.md
+++ b/container.md
@@ -366,12 +366,14 @@ If some of your class' dependencies are not resolvable via the container, you ma
 
     $transistor = $this->app->makeWith(Transistor::class, ['id' => 1]);
 
-If you are outside of a service provider in a location of your code that does not have access to the `$app` variable, you may use the `App` [facade](/docs/{{version}}/facades) to resolve a class instance from the container:
+If you are outside of a service provider in a location of your code that does not have access to the `$app` variable, you may use the `App` [facade](/docs/{{version}}/facades) or the `app()` [helper](/docs/{{version}}/helpers#method-app) to resolve a class instance from the container:
 
     use App\Services\Transistor;
     use Illuminate\Support\Facades\App;
 
     $transistor = App::make(Transistor::class);
+
+    $transistor = app(Transistor::class);
 
 If you would like to have the Laravel container instance itself injected into a class that is being resolved by the container, you may type-hint the `Illuminate\Container\Container` class on your class' constructor:
 

--- a/container.md
+++ b/container.md
@@ -366,7 +366,7 @@ If some of your class' dependencies are not resolvable via the container, you ma
 
     $transistor = $this->app->makeWith(Transistor::class, ['id' => 1]);
 
-If you are outside of a service provider in a location of your code that does not have access to the `$app` variable, you may use the `App` [facade](/docs/{{version}}/facades) or the `app()` [helper](/docs/{{version}}/helpers#method-app) to resolve a class instance from the container:
+If you are outside of a service provider in a location of your code that does not have access to the `$app` variable, you may use the `App` [facade](/docs/{{version}}/facades) or the `app` [helper](/docs/{{version}}/helpers#method-app) to resolve a class instance from the container:
 
     use App\Services\Transistor;
     use Illuminate\Support\Facades\App;


### PR DESCRIPTION
The `app()` helper is (probably) the most concise way of resolving an instance from the container, but it's not mentioned in context next to the other methods. This PR adds that information.