### PR TITLE
[9.x] Fix menthod signature

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1577,7 +1577,7 @@ To register an observer, you need to call the `observe` method on the model you 
      *
      * @return void
      */
-    public function boot()
+    public static function boot()
     {
         User::observe(UserObserver::class);
     }


### PR DESCRIPTION
This change fixes the `boot()` method signature for registering model observer class trough the `Model::boot()` method (it is a static one).