### PR TITLE
Changing routing password steps

### DIFF
--- a/passwords.md
+++ b/passwords.md
@@ -46,50 +46,7 @@ To learn more about this middleware, please consult the [`TrustHosts` middleware
 <a name="routing"></a>
 ## Routing
 
-To properly implement support for allowing users to reset their passwords, we will need to define several routes. First, we will need a pair of routes to handle allowing the user to request a password reset link via their email address. Second, we will need a pair of routes to handle actually resetting the password once the user visits the password reset link that is emailed to them and completes the password reset form.
-
-<a name="requesting-the-password-reset-link"></a>
-### Requesting The Password Reset Link
-
-<a name="the-password-reset-link-request-form"></a>
-#### The Password Reset Link Request Form
-
-First, we will define the routes that are needed to request password reset links. To get started, we will define a route that returns a view with the password reset link request form:
-
-    Route::get('/forgot-password', function () {
-        return view('auth.forgot-password');
-    })->middleware('guest')->name('password.request');
-
-The view that is returned by this route should have a form containing an `email` field, which will allow the user to request a password reset link for a given email address.
-
-<a name="password-reset-link-handling-the-form-submission"></a>
-#### Handling The Form Submission
-
-Next, we will define a route that handles the form submission request from the "forgot password" view. This route will be responsible for validating the email address and sending the password reset request to the corresponding user:
-
-    use Illuminate\Http\Request;
-    use Illuminate\Support\Facades\Password;
-
-    Route::post('/forgot-password', function (Request $request) {
-        $request->validate(['email' => 'required|email']);
-
-        $status = Password::sendResetLink(
-            $request->only('email')
-        );
-
-        return $status === Password::RESET_LINK_SENT
-                    ? back()->with(['status' => __($status)])
-                    : back()->withErrors(['email' => __($status)]);
-    })->middleware('guest')->name('password.email');
-
-Before moving on, let's examine this route in more detail. First, the request's `email` attribute is validated. Next, we will use Laravel's built-in "password broker" (via the `Password` facade) to send a password reset link to the user. The password broker will take care of retrieving the user by the given field (in this case, the email address) and sending the user a password reset link via Laravel's built-in [notification system](/docs/{{version}}/notifications).
-
-The `sendResetLink` method returns a "status" slug. This status may be translated using Laravel's [localization](/docs/{{version}}/localization) helpers in order to display a user-friendly message to the user regarding the status of their request. The translation of the password reset status is determined by your application's `lang/{lang}/passwords.php` language file. An entry for each possible value of the status slug is located within the `passwords` language file.
-
-You may be wondering how Laravel knows how to retrieve the user record from your application's database when calling the `Password` facade's `sendResetLink` method. The Laravel password broker utilizes your authentication system's "user providers" to retrieve database records. The user provider used by the password broker is configured within the `passwords` configuration array of your `config/auth.php` configuration file. To learn more about writing custom user providers, consult the [authentication documentation](/docs/{{version}}/authentication#adding-custom-user-providers).
-
-> **Note**  
-> When manually implementing password resets, you are required to define the contents of the views and routes yourself. If you would like scaffolding that includes all necessary authentication and verification logic, check out the [Laravel application starter kits](/docs/{{version}}/starter-kits).
+To properly implement support for allowing users to reset their passwords, we will need to define several routes. First, we will need a pair of routes to handle actually resetting the password once the user visits the password reset link that is emailed to them and completes the password reset form. Second, we will need a pair of routes to handle allowing the user to request a password reset link via their email address.
 
 <a name="resetting-the-password"></a>
 ### Resetting The Password
@@ -148,6 +105,49 @@ If the token, email address, and password given to the password broker are valid
 The `reset` method returns a "status" slug. This status may be translated using Laravel's [localization](/docs/{{version}}/localization) helpers in order to display a user-friendly message to the user regarding the status of their request. The translation of the password reset status is determined by your application's `lang/{lang}/passwords.php` language file. An entry for each possible value of the status slug is located within the `passwords` language file.
 
 Before moving on, you may be wondering how Laravel knows how to retrieve the user record from your application's database when calling the `Password` facade's `reset` method. The Laravel password broker utilizes your authentication system's "user providers" to retrieve database records. The user provider used by the password broker is configured within the `passwords` configuration array of your `config/auth.php` configuration file. To learn more about writing custom user providers, consult the [authentication documentation](/docs/{{version}}/authentication#adding-custom-user-providers).
+
+<a name="requesting-the-password-reset-link"></a>
+### Requesting The Password Reset Link
+
+<a name="the-password-reset-link-request-form"></a>
+#### The Password Reset Link Request Form
+
+First, we will define the routes that are needed to request password reset links. To get started, we will define a route that returns a view with the password reset link request form:
+
+    Route::get('/forgot-password', function () {
+        return view('auth.forgot-password');
+    })->middleware('guest')->name('password.request');
+
+The view that is returned by this route should have a form containing an `email` field, which will allow the user to request a password reset link for a given email address.
+
+<a name="password-reset-link-handling-the-form-submission"></a>
+#### Handling The Form Submission
+
+Next, we will define a route that handles the form submission request from the "forgot password" view. This route will be responsible for validating the email address and sending the password reset request to the corresponding user:
+
+    use Illuminate\Http\Request;
+    use Illuminate\Support\Facades\Password;
+
+    Route::post('/forgot-password', function (Request $request) {
+        $request->validate(['email' => 'required|email']);
+
+        $status = Password::sendResetLink(
+            $request->only('email')
+        );
+
+        return $status === Password::RESET_LINK_SENT
+                    ? back()->with(['status' => __($status)])
+                    : back()->withErrors(['email' => __($status)]);
+    })->middleware('guest')->name('password.email');
+
+Before moving on, let's examine this route in more detail. First, the request's `email` attribute is validated. Next, we will use Laravel's built-in "password broker" (via the `Password` facade) to send a password reset link to the user. The password broker will take care of retrieving the user by the given field (in this case, the email address) and sending the user a password reset link via Laravel's built-in [notification system](/docs/{{version}}/notifications).
+
+The `sendResetLink` method returns a "status" slug. This status may be translated using Laravel's [localization](/docs/{{version}}/localization) helpers in order to display a user-friendly message to the user regarding the status of their request. The translation of the password reset status is determined by your application's `lang/{lang}/passwords.php` language file. An entry for each possible value of the status slug is located within the `passwords` language file.
+
+You may be wondering how Laravel knows how to retrieve the user record from your application's database when calling the `Password` facade's `sendResetLink` method. The Laravel password broker utilizes your authentication system's "user providers" to retrieve database records. The user provider used by the password broker is configured within the `passwords` configuration array of your `config/auth.php` configuration file. To learn more about writing custom user providers, consult the [authentication documentation](/docs/{{version}}/authentication#adding-custom-user-providers).
+
+> **Note**  
+> When manually implementing password resets, you are required to define the contents of the views and routes yourself. If you would like scaffolding that includes all necessary authentication and verification logic, check out the [Laravel application starter kits](/docs/{{version}}/starter-kits).
 
 <a name="deleting-expired-tokens"></a>
 ## Deleting Expired Tokens


### PR DESCRIPTION
<h3>Summary 📰</h3>

Following the documentation to reset password, at step `Handling The Form Submission` on `Requesting The Password Reset Link`, I found a error, the `UrlGenerator` class call the route method passing `password.reset` as parameter, but this route is on next step of the documentation. To fix that i suggest move `Resetting The Password` to the top.

<h3>Relevant logs and/or screenshots 🖼️</h3>

Application log

![image](https://user-images.githubusercontent.com/55237822/203388331-0327de46-7850-4923-9287-5db19bbef468.png)
