### PR TITLE
[9.x] Add note to 'Chain Failures' and 'Queueing Closures' section to not use '$this' in callbacks

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -858,6 +858,8 @@ When chaining jobs, you may use the `catch` method to specify a closure that sho
     ])->catch(function (Throwable $e) {
         // A job within the chain has failed...
     })->dispatch();
+    
+> {note} Since chain callbacks are serialized and executed at a later time by the Laravel queue, you should not use the `$this` variable within the callbacks.
 
 <a name="customizing-the-queue-and-connection"></a>
 ### Customizing The Queue & Connection
@@ -1486,6 +1488,8 @@ Using the `catch` method, you may provide a closure that should be executed if t
     })->catch(function (Throwable $e) {
         // This job has failed...
     });
+    
+> {note} Since callbacks are serialized and executed at a later time by the Laravel queue, you should not use the `$this` variable within the callbacks.
 
 <a name="running-the-queue-worker"></a>
 ## Running The Queue Worker

--- a/queues.md
+++ b/queues.md
@@ -859,7 +859,7 @@ When chaining jobs, you may use the `catch` method to specify a closure that sho
         // A job within the chain has failed...
     })->dispatch();
     
-> {note} Since chain callbacks are serialized and executed at a later time by the Laravel queue, you should not use the `$this` variable within the callbacks.
+> {note} Since chain callbacks are serialized and executed at a later time by the Laravel queue, you should not use the `$this` variable within chain callbacks.
 
 <a name="customizing-the-queue-and-connection"></a>
 ### Customizing The Queue & Connection
@@ -1489,7 +1489,7 @@ Using the `catch` method, you may provide a closure that should be executed if t
         // This job has failed...
     });
     
-> {note} Since callbacks are serialized and executed at a later time by the Laravel queue, you should not use the `$this` variable within the callbacks.
+> {note} Since `catch` callbacks are serialized and executed at a later time by the Laravel queue, you should not use the `$this` variable within `catch` callbacks.
 
 <a name="running-the-queue-worker"></a>
 ## Running The Queue Worker


### PR DESCRIPTION
- add notes for queued callbacks to not use '$this'

s. https://github.com/laravel/framework/issues/38573 for a similar case related to batches