### PR TITLE
Documents the fluent string helper `headline`

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -190,6 +190,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [exactly](#method-fluent-str-exactly)
 [explode](#method-fluent-str-explode)
 [finish](#method-fluent-str-finish)
+[headline](#method-fluent-str-headline)
 [inlineMarkdown](#method-fluent-str-inline-markdown)
 [is](#method-fluent-str-is)
 [isAscii](#method-fluent-str-is-ascii)
@@ -2357,6 +2358,21 @@ The `finish` method adds a single instance of the given value to a string if it 
     $adjusted = Str::of('this/string/')->finish('/');
 
     // this/string/
+
+<a name="method-fluent-str-headline"></a>
+#### `headline` {.collection-method}
+
+The `headline` method will convert strings delimited by casing, hyphens, or underscores into a space delimited string with each word's first letter capitalized:
+
+    use Illuminate\Support\Str;
+
+    $headline = Str::of('taylor_otwell')->headline();
+
+    // Taylor Otwell
+
+    $headline = Str::of('EmailNotificationSent')->headline();
+
+    // Email Notification Sent
 
 <a name="method-fluent-str-inline-markdown"></a>
 #### `inlineMarkdown` {.collection-method}


### PR DESCRIPTION
Adding documentation for the fluent string helper `headline`. 

```php
$headline = Str::of('string_here')->headline()
```
