### PR TITLE
[9.x] Adds an example for request missing parameter using an array

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -414,6 +414,10 @@ To determine if a given key is absent from the request, you may use the `missing
         //
     }
 
+    if ($request->missing(['name', 'email'])) {
+        //
+    }
+
     $request->whenMissing('name', function ($input) {
         // The "name" value is missing...
     }, function () {


### PR DESCRIPTION
I have seen some projects using several times 
```php
$request->missing('name')
```
Maybe adding an example that shows you can use an array should help.

```php
$request->missing(['name', 'email'])
```