### PR TITLE
[10.x] Update support policy

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -23,11 +23,10 @@ For all Laravel releases, bug fixes are provided for 18 months and security fixe
 
 | Version | PHP (*) | Release | Bug Fixes Until | Security Fixes Until |
 | --- | --- | --- | --- | --- |
-| 6 (LTS) | 7.2 - 8.0 | September 3rd, 2019 | January 25th, 2022 | September 6th, 2022 |
-| 7 | 7.2 - 8.0 | March 3rd, 2020 | October 6th, 2020 | March 3rd, 2021 |
 | 8 | 7.3 - 8.1 | September 8th, 2020 | July 26th, 2022 | January 24th, 2023 |
-| 9 | 8.0 - 8.1 | February 8th, 2022 | August 8th, 2023 | February 8th, 2024 |
-| 10 | 8.1 | February 7th, 2023 | August 7th, 2024 | February 7th, 2025 |
+| 9 | 8.0 - 8.1 | February 8th, 2022 | August 8th, 2023 | February 6th, 2024 |
+| 10 | 8.1 | February 7th, 2023 | August 6th, 2024 | February 4th, 2025 |
+| 11 | 8.2 | February 6th, 2024 | August 5th, 2025 | February 3rd, 2026 |
 
 <div class="version-colors">
     <div class="end-of-life">


### PR DESCRIPTION
This PR updates the support policy for the upcoming Laravel v10 release. Removes info about Laravel 6.x & 7.x and updates the dates for Laravel 9.x, 10.x & 11.x to match Tuesdays which is the common release date. Adds info for Laravel 11