### PR TITLE
Add note to specify default scopes are ignored for personal access tokens

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -1064,6 +1064,9 @@ If a client does not request any specific scopes, you may configure your Passpor
         'place-orders',
     ]);
 
+> **Note**
+> These default scopes do not apply to personal access tokens.
+
 <a name="assigning-scopes-to-tokens"></a>
 ### Assigning Scopes To Tokens
 


### PR DESCRIPTION
The default passport scopes aren't passed through in 

`PersonalAccessGrant` at

```php
$this->getRequestParameter('scope', $request)
```

which means they have no effect on the scopes for personal access tokens. IMO, worth documenting