### PR TITLE
Add link to the list of moved scaffolding files

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -113,11 +113,9 @@ Symfony Console, which is the underlying component that powers Artisan, expects 
 
 **Likelihood Of Impact: High**
 
-All authentication scaffolding has been moved to the `laravel/ui` repository. If you are using Laravel's authentication scaffolding, you should install the `^2.0` release of this package and the package should be installed in all environments. If you were previously including this package in the `require-dev` portion of your application's `composer.json` file, you should move it to the `require` section:
+All authentication scaffolding has been [moved](https://github.com/laravel/framework/commit/aebd93d5f67de55473f3f0ff5056abbfc5972102) to the `laravel/ui` repository. If you are using Laravel's authentication scaffolding, you should install the `^2.0` release of this package and the package should be installed in all environments. If you were previously including this package in the `require-dev` portion of your application's `composer.json` file, you should move it to the `require` section:
 
     composer require laravel/ui "^2.0"
-
-You can view the list of moved files in the [Github repository](https://github.com/laravel/framework/commit/aebd93d5f67de55473f3f0ff5056abbfc5972102).
 
 #### The `TokenRepositoryInterface`
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -117,6 +117,8 @@ All authentication scaffolding has been moved to the `laravel/ui` repository. If
 
     composer require laravel/ui "^2.0"
 
+You can view the list of moved files in the [Github repository](https://github.com/laravel/framework/commit/aebd93d5f67de55473f3f0ff5056abbfc5972102).
+
 #### The `TokenRepositoryInterface`
 
 **Likelihood Of Impact: Low**


### PR DESCRIPTION
It is not clear what traits were part of the authentication scaffolding since they are mentioned individually in multiple places in previous versions of the docs.

Users upgrading from older versions may not know whether they are using those traits or not.

In this PR, I am adding a link to the commit where the list of files can be checked. Alternatively, we could also list all traits directly in the documentation instead of linking to a commit.