### PR TITLE
[9.x] Add a note regarding "stream_reads" when using S3 driver

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -244,6 +244,9 @@ The `download` method may be used to generate a response that forces the user's 
 
     return Storage::download('file.jpg', $name, $headers);
 
+> **Warning**
+> When using `s3` driver files won't be streamed by default and instead loaded into memory. To change this behavior, set "stream_reads" to "true". 
+
 <a name="file-urls"></a>
 ### File URLs
 

--- a/filesystem.md
+++ b/filesystem.md
@@ -245,7 +245,7 @@ The `download` method may be used to generate a response that forces the user's 
     return Storage::download('file.jpg', $name, $headers);
 
 > **Warning**
-> When using `s3` driver files won't be streamed by default and instead loaded into memory. To change this behavior, set "stream_reads" to "true". 
+> When using `s3` driver files won't be streamed by default and instead loaded into memory. To change this behavior, set `stream_reads` to `true` in `config/filesystems.php`. 
 
 <a name="file-urls"></a>
 ### File URLs


### PR DESCRIPTION
I've spent hours trying to figure out why streaming from S3 stopped working when I found out it was due to this flag "stream_reads" after updating our dependencies. 

This may be helpful for other people who want to stream big files to users. 