### PR TITLE
[9.x] Include closure examples for where JSON assertions

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -364,6 +364,7 @@ Laravel also offers a beautiful way to fluently test your application's JSON res
             ->assertJson(fn (AssertableJson $json) =>
                 $json->where('id', 1)
                      ->where('name', 'Victoria Faith')
+                     ->where('email', fn ($email) => str($email)->is('victoria@gmail.com'));
                      ->whereNot('status', 'pending')
                      ->missing('password')
                      ->etc()
@@ -419,6 +420,7 @@ In these situations, we may use the fluent JSON object's `has` method to make as
                  ->first(fn ($json) =>
                     $json->where('id', 1)
                          ->where('name', 'Victoria Faith')
+                         ->where('email', fn ($email) => str($email)->is('victoria@gmail.com'));
                          ->missing('password')
                          ->etc()
                  )
@@ -445,6 +447,7 @@ When testing these routes, you may use the `has` method to assert against the nu
                  ->has('users.0', fn ($json) =>
                     $json->where('id', 1)
                          ->where('name', 'Victoria Faith')
+                         ->where('email', fn ($email) => str($email)->is('victoria@gmail.com'));
                          ->missing('password')
                          ->etc()
                  )
@@ -458,6 +461,7 @@ However, instead of making two separate calls to the `has` method to assert agai
                  ->has('users', 3, fn ($json) =>
                     $json->where('id', 1)
                          ->where('name', 'Victoria Faith')
+                         ->where('email', fn ($email) => str($email)->is('victoria@gmail.com'));
                          ->missing('password')
                          ->etc()
                  )

--- a/http-tests.md
+++ b/http-tests.md
@@ -364,7 +364,7 @@ Laravel also offers a beautiful way to fluently test your application's JSON res
             ->assertJson(fn (AssertableJson $json) =>
                 $json->where('id', 1)
                      ->where('name', 'Victoria Faith')
-                     ->where('email', fn ($email) => str($email)->is('victoria@gmail.com'));
+                     ->where('email', fn ($email) => str($email)->is('victoria@gmail.com'))
                      ->whereNot('status', 'pending')
                      ->missing('password')
                      ->etc()
@@ -420,7 +420,7 @@ In these situations, we may use the fluent JSON object's `has` method to make as
                  ->first(fn ($json) =>
                     $json->where('id', 1)
                          ->where('name', 'Victoria Faith')
-                         ->where('email', fn ($email) => str($email)->is('victoria@gmail.com'));
+                         ->where('email', fn ($email) => str($email)->is('victoria@gmail.com'))
                          ->missing('password')
                          ->etc()
                  )
@@ -447,7 +447,7 @@ When testing these routes, you may use the `has` method to assert against the nu
                  ->has('users.0', fn ($json) =>
                     $json->where('id', 1)
                          ->where('name', 'Victoria Faith')
-                         ->where('email', fn ($email) => str($email)->is('victoria@gmail.com'));
+                         ->where('email', fn ($email) => str($email)->is('victoria@gmail.com'))
                          ->missing('password')
                          ->etc()
                  )
@@ -461,7 +461,7 @@ However, instead of making two separate calls to the `has` method to assert agai
                  ->has('users', 3, fn ($json) =>
                     $json->where('id', 1)
                          ->where('name', 'Victoria Faith')
-                         ->where('email', fn ($email) => str($email)->is('victoria@gmail.com'));
+                         ->where('email', fn ($email) => str($email)->is('victoria@gmail.com'))
                          ->missing('password')
                          ->etc()
                  )


### PR DESCRIPTION
I found myself wanting to make an assertion similar to what was proposed within this [PR](https://github.com/laravel/framework/pull/43846) and didn't realise you could pass a closure to the `->where()` method so figured a few examples in the docs would help with visibility.