### PR TITLE
Clarity for Meilisearch Configuring Indexes Settings

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -206,7 +206,7 @@ Filterable attributes are any attributes you plan to filter on when invoking Sco
 ],
 ```
 
-After configuring your scout index settings, you must invoke the `scout:sync-index-settings` Artisan command. This command will inform MeiliSearch of your currently configured indexes settings. For convenience, you may wish to make this command part of your deployment process:
+After configuring your application's index settings, you must invoke the `scout:sync-index-settings` Artisan command. This command will inform MeiliSearch of your currently configured index settings. For convenience, you may wish to make this command part of your deployment process:
 
 ```shell
 php artisan scout:sync-index-settings
@@ -552,7 +552,7 @@ You may use the `whereIn` method to constrain results against a given set of val
 Since a search index is not a relational database, more advanced "where" clauses are not currently supported.
 
 > **Warning**
-> If your application is using MeiliSearch, you must configure your application's [filterable attributes settings](#configuring-indexes-settings-for-meilisearch) before utilizing Scout's "where" clauses.
+> If your application is using MeiliSearch, you must configure your application's [filterable attributes](#configuring-filterable-data-for-meilisearch) before utilizing Scout's "where" clauses.
 
 <a name="pagination"></a>
 ### Pagination

--- a/scout.md
+++ b/scout.md
@@ -181,10 +181,12 @@ By default, the entire `toArray` form of a given model will be persisted to its 
         }
     }
 
-<a name="configuring-indexes-settings-for-meilisearch"></a>
-#### Configuring Indexes Settings (MeiliSearch)
+<a name="configuring-filterable-data-for-meilisearch"></a>
+#### Configuring Filterable Data / Index Settings (MeiliSearch)
 
-Unlike Scout's other drivers, MeiliSearch requires you to pre-define index search settings such as filterable attributes, sortable attributes, and [other supported settings fields](https://docs.meilisearch.com/reference/api/settings.html). Filterable attributes are any attributes you plan to filter on when invoking Scout's `where` method. Sortable attributes are any atributes you plan to sort on when invoking Scout's `orderBy` method.  To define your index settings, adjust the `index-settings` portion of your `meilisearch` configuration entry in your application's `scout` configuration file:
+Unlike Scout's other drivers, MeiliSearch requires you to pre-define index search settings such as filterable attributes, sortable attributes, and [other supported settings fields](https://docs.meilisearch.com/reference/api/settings.html).
+
+Filterable attributes are any attributes you plan to filter on when invoking Scout's `where` method, while sortable attributes are any attributes you plan to sort by when invoking Scout's `orderBy` method. To define your index settings, adjust the `index-settings` portion of your `meilisearch` configuration entry in your application's `scout` configuration file:
 
 ```php
 'meilisearch' => [
@@ -192,14 +194,13 @@ Unlike Scout's other drivers, MeiliSearch requires you to pre-define index searc
     'key' => env('MEILISEARCH_KEY', null),
     'index-settings' => [
         'users' => [
-            'searchableAttributes' => ['name','email'],
             'filterableAttributes'=> ['id', 'name', 'email'],
-            'sortableAttributes' => ['created_at']
-            // Other settings fields
+            'sortableAttributes' => ['created_at'],
+            // Other settings fields...
         ],
         'flights' => [
             'filterableAttributes'=> ['id', 'destination'],
-            'sortableAttributes' => ['updated_at']
+            'sortableAttributes' => ['updated_at'],
         ],
     ],
 ],

--- a/scout.md
+++ b/scout.md
@@ -182,7 +182,7 @@ By default, the entire `toArray` form of a given model will be persisted to its 
     }
 
 <a name="configuring-filterable-data-for-meilisearch"></a>
-#### Configuring Filterable Data / Index Settings (MeiliSearch)
+#### Configuring Filterable Data & Index Settings (MeiliSearch)
 
 Unlike Scout's other drivers, MeiliSearch requires you to pre-define index search settings such as filterable attributes, sortable attributes, and [other supported settings fields](https://docs.meilisearch.com/reference/api/settings.html).
 

--- a/scout.md
+++ b/scout.md
@@ -181,10 +181,10 @@ By default, the entire `toArray` form of a given model will be persisted to its 
         }
     }
 
-<a name="configuring-filterable-data-for-meilisearch"></a>
-#### Configuring Filterable Data (MeiliSearch)
+<a name="configuring-indexes-settings-for-meilisearch"></a>
+#### Configuring Indexes Settings (MeiliSearch)
 
-Unlike Scout's other drivers, MeiliSearch requires you to pre-define the attributes that will be "filterable". Filterable attributes are any attributes you plan to filter on when invoking Scout's `where` method. To define your filterable attributes, adjust the `index-settings` portion of your `meilisearch` configuration entry in your application's `scout` configuration file:
+Unlike Scout's other drivers, MeiliSearch requires you to pre-define index search settings such as filterable attributes, sortable attributes, and [other supported settings fields](https://docs.meilisearch.com/reference/api/settings.html). Filterable attributes are any attributes you plan to filter on when invoking Scout's `where` method. Sortable attributes are any atributes you plan to sort on when invoking Scout's `orderBy` method.  To define your index settings, adjust the `index-settings` portion of your `meilisearch` configuration entry in your application's `scout` configuration file:
 
 ```php
 'meilisearch' => [
@@ -192,16 +192,20 @@ Unlike Scout's other drivers, MeiliSearch requires you to pre-define the attribu
     'key' => env('MEILISEARCH_KEY', null),
     'index-settings' => [
         'users' => [
+            'searchableAttributes' => ['name','email'],
             'filterableAttributes'=> ['id', 'name', 'email'],
+            'sortableAttributes' => ['created_at']
+            // Other settings fields
         ],
         'flights' => [
             'filterableAttributes'=> ['id', 'destination'],
+            'sortableAttributes' => ['updated_at']
         ],
     ],
 ],
 ```
 
-After configuring your application's filterable attributes, you must invoke the `scout:sync-index-settings` Artisan command. This command will inform MeiliSearch of your currently configured filterable attributes. For convenience, you may wish to make this command part of your deployment process:
+After configuring your scout index settings, you must invoke the `scout:sync-index-settings` Artisan command. This command will inform MeiliSearch of your currently configured indexes settings. For convenience, you may wish to make this command part of your deployment process:
 
 ```shell
 php artisan scout:sync-index-settings
@@ -547,7 +551,7 @@ You may use the `whereIn` method to constrain results against a given set of val
 Since a search index is not a relational database, more advanced "where" clauses are not currently supported.
 
 > **Warning**
-> If your application is using MeiliSearch, you must configure your application's [filterable attributes](#configuring-filterable-data-for-meilisearch) before utilizing Scout's "where" clauses.
+> If your application is using MeiliSearch, you must configure your application's [filterable attributes settings](#configuring-indexes-settings-for-meilisearch) before utilizing Scout's "where" clauses.
 
 <a name="pagination"></a>
 ### Pagination


### PR DESCRIPTION
The current documentation for `Configuring Indexes Settings (Meilisearch)` may imply that ONLY `filterableAttributes` can be configured.

This PR intends to clarify that other supported fields can also be configured. These includes `searchableAttributes`,`filterableAttributes`,`sortableAttributes`,`rankingRules`, `stopWords`, and [settings supported by Meilisearch](https://docs.meilisearch.com/reference/api/settings.html#settings-object).

Each of the fields serves different roles e.g
- `searchableAttributes` - the fields that should be checked for matching query words
- `filterableAttributes` - fields that can be used to filter results using Scout's `where` method.
- `sortableAttributes` - fields that can be used to to sort search results using Scout's `orderBy` method. 
