### PR TITLE
Added colum type docs for filtering in meilisearch

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -181,6 +181,37 @@ By default, the entire `toArray` form of a given model will be persisted to its 
         }
     }
 
+Please note that since Meilisearch filtering can be performed only on numeric data, you also have to specify column type to filter with: `>`, `>=`, `<`, and `<=`.
+
+```
+<?php
+
+    namespace App\Models;
+
+    use Illuminate\Database\Eloquent\Model;
+    use Laravel\Scout\Searchable;
+
+    class Post extends Model
+    {
+        use Searchable;
+
+        /**
+         * Get the indexable data array for the model.
+         *
+         * @return array
+         */
+        public function toSearchableArray()
+        {
+            return [
+                'id' => (int) $this->id,
+                'name' => (string) $this->name,
+                'price' => (float) $this->price,
+            ];
+        }
+    }
+
+```
+
 <a name="configuring-filterable-data-for-meilisearch"></a>
 #### Configuring Filterable Data & Index Settings (MeiliSearch)
 

--- a/scout.md
+++ b/scout.md
@@ -183,14 +183,13 @@ By default, the entire `toArray` form of a given model will be persisted to its 
 
 Some search engines such as MeiliSearch will only perform filter operations (`>`, `<`, etc.) on data of the correct type. So, when using these search engines and customizing your searchable data, you should ensure that numeric values are cast to their correct type:
 
-        public function toSearchableArray()
-        {
-            return [
-                'id' => (int) $this->id,
-                'name' => $this->name,
-                'price' => (float) $this->price,
-            ];
-        }
+    public function toSearchableArray()
+    {
+        return [
+            'id' => (int) $this->id,
+            'name' => $this->name,
+            'price' => (float) $this->price,
+        ];
     }
 
 <a name="configuring-filterable-data-for-meilisearch"></a>

--- a/scout.md
+++ b/scout.md
@@ -181,36 +181,17 @@ By default, the entire `toArray` form of a given model will be persisted to its 
         }
     }
 
-Please note that since Meilisearch filtering can be performed only on numeric data, you also have to specify column type to filter with: `>`, `>=`, `<`, and `<=`.
+Some search engines such as MeiliSearch will only perform filter operations (`>`, `<`, etc.) on data of the correct type. So, when using these search engines and customizing your searchable data, you should ensure that numeric values are cast to their correct type:
 
-```
-<?php
-
-    namespace App\Models;
-
-    use Illuminate\Database\Eloquent\Model;
-    use Laravel\Scout\Searchable;
-
-    class Post extends Model
-    {
-        use Searchable;
-
-        /**
-         * Get the indexable data array for the model.
-         *
-         * @return array
-         */
         public function toSearchableArray()
         {
             return [
                 'id' => (int) $this->id,
-                'name' => (string) $this->name,
+                'name' => $this->name,
                 'price' => (float) $this->price,
             ];
         }
     }
-
-```
 
 <a name="configuring-filterable-data-for-meilisearch"></a>
 #### Configuring Filterable Data & Index Settings (MeiliSearch)


### PR DESCRIPTION
Added documentation for manage good fltering on meilisearch.
Since meilisearch can perform `>`, `>=`, `<`, and `<=` only on numeric values and will ignore all other types of values.

[https://docs.meilisearch.com/learn/advanced/filtering_and_faceted_search.html#conditions](https://docs.meilisearch.com/learn/advanced/filtering_and_faceted_search.html#conditions)

Specifying attributes types allows meilisearch to filter attributes correctly, otherwise it will ignore filter request. 

E.g.: if you try to filter `price < 500`, without specifying types, meilisearch do not perform filtering. 
Instead, setting `price => (int) $price,` into `toSearchableArray()` will filter models that have `price < 500`
