### PR TITLE
Add zero $tries meaning infinite retries to queue docs

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -996,7 +996,7 @@ Alternatively, you may specify the job's connection by calling the `onConnection
 
 If one of your queued jobs is encountering an error, you likely do not want it to keep retrying indefinitely. Therefore, Laravel provides various ways to specify how many times or for how long a job may be attempted.
 
-One approach to specifying the maximum number of times a job may be attempted is via the `--tries` switch on the Artisan command line. This will apply to all jobs processed by the worker unless the job being processed specifies a more specific number of times it may be attempted:
+One approach to specifying the maximum number of times a job may be attempted is via the `--tries` switch on the Artisan command line. This will apply to all jobs processed by the worker unless the job being processed specifies a number of times it may be attempted itself:
 
 ```shell
 php artisan queue:work --tries=3
@@ -1019,6 +1019,10 @@ You may take a more granular approach by defining the maximum number of times a 
          */
         public $tries = 5;
     }
+
+
+> **Note**  
+> Defining `tries` as `0` will retry the job indefinitely. 
 
 <a name="time-based-attempts"></a>
 #### Time Based Attempts


### PR DESCRIPTION
I stumbled on this edge case (of feature) in laravel while working on a client code base and couldn't find any documentation for it. 

Apparently a job with `0` $tries will be retried indefinitely. What is more, I tried defining `0` on the job and `1` on the worker, because if `0` meant infinite then,  `1` attempt  would be more specific to `infinite` attempts right? But the laravel workers doesn't check for specificity, it is the default if the Job didn't specify anything. 

The word `specific` threw me off, because what does it mean to be more specific? In this case it meant: The job as a `$tries` set, which means it is more granular and thus more specific. While I read it as, a `$tries` value which is more specific, and thus the least amount of `attempts` .