### PR TITLE
Add clarification for job attempts

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -996,7 +996,7 @@ Alternatively, you may specify the job's connection by calling the `onConnection
 
 If one of your queued jobs is encountering an error, you likely do not want it to keep retrying indefinitely. Therefore, Laravel provides various ways to specify how many times or for how long a job may be attempted.
 
-One approach to specifying the maximum number of times a job may be attempted is via the `--tries` switch on the Artisan command line. This will apply to all jobs processed by the worker unless the job being processed specifies a number of times it may be attempted:
+One approach to specifying the maximum number of times a job may be attempted is via the `--tries` switch on the Artisan command line. This will apply to all jobs processed by the worker unless the job being processed specifies the number of times it may be attempted:
 
 ```shell
 php artisan queue:work --tries=3

--- a/queues.md
+++ b/queues.md
@@ -996,13 +996,13 @@ Alternatively, you may specify the job's connection by calling the `onConnection
 
 If one of your queued jobs is encountering an error, you likely do not want it to keep retrying indefinitely. Therefore, Laravel provides various ways to specify how many times or for how long a job may be attempted.
 
-One approach to specifying the maximum number of times a job may be attempted is via the `--tries` switch on the Artisan command line. This will apply to all jobs processed by the worker unless the job being processed specifies a more specific number of times it may be attempted:
+One approach to specifying the maximum number of times a job may be attempted is via the `--tries` switch on the Artisan command line. This will apply to all jobs processed by the worker unless the job being processed specifies a number of times it may be attempted itself:
 
 ```shell
 php artisan queue:work --tries=3
 ```
 
-If a job exceeds its maximum number of attempts, it will be considered a "failed" job. For more information on handling failed jobs, consult the [failed job documentation](#dealing-with-failed-jobs).
+If a job exceeds its maximum number of attempts, it will be considered a "failed" job. For more information on handling failed jobs, consult the [failed job documentation](#dealing-with-failed-jobs). For example, with `--tries=3` the jobs will be attempted thrice, thus retried twice. But with `--tries=1` the jobs in the worker will not be retried at all. There is one exception, if you specify the attempts to be zero with `--tries=0` the jobs will be retried indefinitely. 
 
 You may take a more granular approach by defining the maximum number of times a job may be attempted on the job class itself. If the maximum number of attempts is specified on the job, it will take precedence over the `--tries` value provided on the command line:
 

--- a/queues.md
+++ b/queues.md
@@ -996,7 +996,7 @@ Alternatively, you may specify the job's connection by calling the `onConnection
 
 If one of your queued jobs is encountering an error, you likely do not want it to keep retrying indefinitely. Therefore, Laravel provides various ways to specify how many times or for how long a job may be attempted.
 
-One approach to specifying the maximum number of times a job may be attempted is via the `--tries` switch on the Artisan command line. This will apply to all jobs processed by the worker unless the job being processed specifies a number of times it may be attempted itself:
+One approach to specifying the maximum number of times a job may be attempted is via the `--tries` switch on the Artisan command line. This will apply to all jobs processed by the worker unless the job being processed specifies a number of times it may be attempted:
 
 ```shell
 php artisan queue:work --tries=3

--- a/queues.md
+++ b/queues.md
@@ -1002,7 +1002,7 @@ One approach to specifying the maximum number of times a job may be attempted is
 php artisan queue:work --tries=3
 ```
 
-If a job exceeds its maximum number of attempts, it will be considered a "failed" job. For more information on handling failed jobs, consult the [failed job documentation](#dealing-with-failed-jobs). For example, with `--tries=3` the jobs will be attempted thrice, thus retried twice. But with `--tries=1` the jobs in the worker will not be retried at all. There is one exception, if you specify the attempts to be zero with `--tries=0` the jobs will be retried indefinitely. 
+If a job exceeds its maximum number of attempts, it will be considered a "failed" job. For more information on handling failed jobs, consult the [failed job documentation](#dealing-with-failed-jobs). If `--tries=0` is provided to the `queue:work` command, the job will retried indefinitely.
 
 You may take a more granular approach by defining the maximum number of times a job may be attempted on the job class itself. If the maximum number of attempts is specified on the job, it will take precedence over the `--tries` value provided on the command line:
 


### PR DESCRIPTION
I tried to integrate the clarification into the existing text instead of introducing a notice. As per requested on #8415

Original ticket text below

I stumbled on this edge case (of feature) in Laravel while working on a client code base and couldn't find any documentation for it. 

Apparently a job with `0` $tries will be retried indefinitely. What is more, I tried defining `0` on the job and `1` on the worker, because if `0` meant infinite then,  `1` attempt  would be more specific to `infinite` attempts right? But the Laravel workers doesn't check for specificity, it is the default if the Job didn't specify anything. 

The word `specific` threw me off, because what does it mean to be more specific? In this case it meant: The job as a `$tries` set, which means it is more granular and thus more specific. While I read it as, a `$tries` value which is more specific, and thus the least amount of `attempts`