### PR TITLE
Update queries.md

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -485,7 +485,7 @@ The `whereNot` and `orWhereNot` methods may be used to negate a given group of q
 <a name="json-where-clauses"></a>
 ### JSON Where Clauses
 
-Laravel also supports querying JSON column types on databases that provide support for JSON column types. Currently, this includes MySQL 5.7+, PostgreSQL, SQL Server 2016, and SQLite 3.9.0 (with the [JSON1 extension](https://www.sqlite.org/json1.html)). To query a JSON column, use the `->` operator:
+Laravel also supports querying JSON column types on databases that provide support for JSON column types. Currently, this includes MySQL 5.7+, PostgreSQL, SQL Server 2016, and SQLite 3.39.0 (with the [JSON1 extension](https://www.sqlite.org/json1.html)). To query a JSON column, use the `->` operator:
 
     $users = DB::table('users')
                     ->where('preferences->dining->meal', 'salad')


### PR DESCRIPTION
The pointed version for SQLite doesn't exist. I'm assuming the intended version was 3.39.0. According to the SQLite Json functions documentation, it was introduced as an opt-in param in version 3.37 but made as default in version 3.38, so I believe the functionality would also work with that version. Still needs confirmation.