### PR TITLE
[9.x] Passing a subquery to whereIn

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -560,15 +560,15 @@ The `whereNotIn` method verifies that the given column's value is not contained 
                         ->whereNotIn('id', [1, 2, 3])
                         ->get();
 
-You can also pass a query object as the second parameter:
+You may also provide a query object as the `whereIn` method's second argument:
 
-    $query = DB::table('users')->select('id')->where('is_active', 0);
+    $activeUsers = DB::table('users')->select('id')->where('is_active', 0);
 
     $users = DB::table('comments')
-                        ->whereIn('user_id', $query)
+                        ->whereIn('user_id', $activeUsers)
                         ->get();
 
-The query above will produce the following SQL:
+The example above will produce the following SQL:
 
 ```sql
 select * from comments where user_id in (

--- a/queries.md
+++ b/queries.md
@@ -560,6 +560,24 @@ The `whereNotIn` method verifies that the given column's value is not contained 
                         ->whereNotIn('id', [1, 2, 3])
                         ->get();
 
+You can also pass a query object as the second parameter:
+
+    $query = DB::table('users')->select('id')->where('is_active', 0);
+
+    $users = DB::table('comments')
+                        ->whereIn('user_id', $query)
+                        ->get();
+
+The query above will produce the following SQL:
+
+```sql
+select * from comments where user_id in (
+    select id
+    from users
+    where is_active = 0
+)
+```
+
 > **Warning**  
 > If you are adding a large array of integer bindings to your query, the `whereIntegerInRaw` or `whereIntegerNotInRaw` methods may be used to greatly reduce your memory usage.
 


### PR DESCRIPTION
Documents the possibility of passing a query object to `whereIn` method family as the second parameter.
This feature is tested in this PR: https://github.com/laravel/framework/pull/45452