### PR TITLE
[9.x] change upgrading valet command

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -129,12 +129,12 @@ If your application needs a database, check out [DBngin](https://dbngin.com). DB
 <a name="resetting-your-installation"></a>
 #### Resetting Your Installation
 
-If you are having trouble getting your Valet installation to run properly, executing the `composer global update` command followed by `valet install` will reset your installation and can solve a variety of problems. In rare cases, it may be necessary to "hard reset" Valet by executing `valet uninstall --force` followed by `valet install`.
+If you are having trouble getting your Valet installation to run properly, executing the `composer global require laravel/valet` command followed by `valet install` will reset your installation and can solve a variety of problems. In rare cases, it may be necessary to "hard reset" Valet by executing `valet uninstall --force` followed by `valet install`.
 
 <a name="upgrading-valet"></a>
 ### Upgrading Valet
 
-You may update your Valet installation by executing the `composer global update` command in your terminal. After upgrading, it is good practice to run the `valet install` command so Valet can make additional upgrades to your configuration files if necessary.
+You may update your Valet installation by executing the `composer global require laravel/valet` command in your terminal. After upgrading, it is good practice to run the `valet install` command so Valet can make additional upgrades to your configuration files if necessary.
 
 <a name="serving-sites"></a>
 ## Serving Sites


### PR DESCRIPTION
ref: https://github.com/laravel/valet/issues/1322

This PR is a change suggestion for the "Upgrading/Resetting Valet" command from `composer global update` to `composer global require laravel/valet`

`composer global update` for some reason won't bump to a major version (from 2.18.10 to 3.2.2)..even `composer global update laravel/valet` won't do it.

Using the same installation command might be confusing for some users; however, it seems to be the safest way to upgrade.