### PR TITLE
[10.x] Types upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -57,3 +57,5 @@ You should update the following dependencies in your application's `composer.jso
 ### Miscellaneous
 
 We also encourage you to view the changes in the `laravel/laravel` [GitHub repository](https://github.com/laravel/laravel). While many of these changes are not required, you may wish to keep these files in sync with your application. Some of these changes will be covered in this upgrade guide, but others, such as changes to configuration files or comments, will not be. You can easily view the changes with the [GitHub comparison tool](https://github.com/laravel/laravel/compare/9.x...10.x) and choose which updates are important to you.
+
+It's important to note that many of the changes shown by the comparison tool are due to our organization's adoption of PHP native types. However, these changes are backwards compatible and the adoption of them during the migration to Laravel 10 is optional.

--- a/upgrade.md
+++ b/upgrade.md
@@ -56,6 +56,6 @@ You should update the following dependencies in your application's `composer.jso
 <a name="miscellaneous"></a>
 ### Miscellaneous
 
-We also encourage you to view the changes in the `laravel/laravel` [GitHub repository](https://github.com/laravel/laravel). While many of these changes are not required, you may wish to keep these files in sync with your application. Some of these changes will be covered in this upgrade guide, but others, such as changes to configuration files or comments, will not be. You can easily view the changes with the [GitHub comparison tool](https://github.com/laravel/laravel/compare/9.x...10.x) and choose which updates are important to you.
+We also encourage you to view the changes in the `laravel/laravel` [GitHub repository](https://github.com/laravel/laravel). While many of these changes are not required, you may wish to keep these files in sync with your application. Some of these changes will be covered in this upgrade guide, but others, such as changes to configuration files or comments, will not be.
 
-It's important to note that many of the changes shown by the comparison tool are due to our organization's adoption of PHP native types. However, these changes are backwards compatible and the adoption of them during the migration to Laravel 10 is optional.
+You can easily view the changes with the [GitHub comparison tool](https://github.com/laravel/laravel/compare/9.x...10.x) and choose which updates are important to you. However, many of the changes shown by the GitHub comparison tool are due to our organization's adoption of PHP native types. These changes are backwards compatible and the adoption of them during the migration to Laravel 10 is optional.


### PR DESCRIPTION
I spent several hours analyzing every potential edge case that could result in breaking changes on my types PR for the core of Laravel. After thorough review, I have determined that there are no possible breaking changes. Therefore, the upgrade guide for this PR will be empty.

Of course, I've added a small note explaining this to the user.