### PR TITLE
[9.x] Add missing Cashier Stripe webhook event

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -1468,6 +1468,7 @@ To ensure your application can handle Stripe webhooks, be sure to configure the 
 - `customer.subscription.deleted`
 - `customer.updated`
 - `customer.deleted`
+- `invoice.payment_succeeded`
 - `invoice.payment_action_required`
 
 For convenience, Cashier includes a `cashier:webhook` Artisan command. This command will create a webhook in Stripe that listens to all of the events required by Cashier:


### PR DESCRIPTION
The `php artisan cashier:webhook` command creates a webhook which also listens for the `invoice.payment_succeeded` event. I've added it to the list to ensure people don't miss it when creating the webhook and adding events manually instead of using the command.