### PR TITLE
Add note about container name update

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -492,3 +492,6 @@ After running this command, the Dockerfiles and other configuration files used b
 ```shell
 sail build --no-cache
 ```
+
+> **Note**  
+> Whenever you change the image name for your application container in your application's `docker-compose.yml` file, ensure to update the value of `APP_SERVICE` to the new name of your image.


### PR DESCRIPTION
If the value of `APP_SERVICE` is not the application's image name (defaults to `laravel.test`), `sail artisan ...` commands results in error similar to `service "laravel.test" is not running container #1`