### PR TITLE
Update default node version to 18

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -386,7 +386,7 @@ sail up
 <a name="sail-node-versions"></a>
 ## Node Versions
 
-Sail installs Node 16 by default. To change the Node version that is installed when building your images, you may update the `build.args` definition of the `laravel.test` service in your application's `docker-compose.yml` file:
+Sail installs Node 18 by default. To change the Node version that is installed when building your images, you may update the `build.args` definition of the `laravel.test` service in your application's `docker-compose.yml` file:
 
 ```yaml
 build:


### PR DESCRIPTION
Hello, default node version installed from Dockerfile is 18 now.