### PR TITLE
Clarify how the SerializesModels trait works

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -213,7 +213,9 @@ Job classes are very simple, normally containing only a `handle` method that is 
 
 In this example, note that we were able to pass an [Eloquent model](/docs/{{version}}/eloquent) directly into the queued job's constructor. Because of the `SerializesModels` trait that the job is using, Eloquent models and their loaded relationships will be gracefully serialized and unserialized when the job is processing.
 
-If your queued job accepts an Eloquent model in its constructor, only the identifier for the model will be serialized onto the queue. When the job is actually handled, the queue system will automatically re-retrieve the full model instance and its loaded relationships from the database. This approach to model serialization allows for much smaller job payloads to be sent to your queue driver.
+If your queued job uses the `SerializesModels` trait and accepts an Eloquent model in its constructor, only the identifier for the model will be serialized onto the queue. When the job is actually handled, the queue system will automatically re-retrieve the full model instance and its loaded relationships from the database. This approach to model serialization allows for much smaller job payloads to be sent to your queue driver.
+
+Otherwise the Eloquent models and their loaded relationships will be serialized and unserialized when the job is processing. The model will not be loaded from the database again.
 
 <a name="handle-method-dependency-injection"></a>
 #### `handle` Method Dependency Injection


### PR DESCRIPTION
Because of the paragraph in the section it is not 100% clear, that only the identifier for the model will be serialized onto the queue.

I talked to three people and all of them got it wrong:
They told me that we have to use the trait if we want to get all properties and relations serialized and if we do not use it, it would only serialize the identifier for the model and refresh it from database.

Therefore, I would propose this change.