### PR TITLE
[9.x] Update Laravel Sail Docs

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -170,7 +170,7 @@ docker run --rm \
     composer install --ignore-platform-reqs
 ```
 
-When using the `laravelsail/phpXX-composer` image, you should use the same version of PHP that you plan to use for your application (`74`, `80`, `81` or `82`).
+When using the `laravelsail/phpXX-composer` image, you should use the same version of PHP that you plan to use for your application (`74`, `80`, `81`, or `82`).
 
 <a name="executing-artisan-commands"></a>
 ### Executing Artisan Commands


### PR DESCRIPTION
Updated Laravel Sail documentation to consider PHP 8.2 in the installation instructions for existing projects.
