### PR TITLE
[9.x] Document `setVisible` and `setHidden`

### DIFF
--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -75,6 +75,8 @@ In addition, the `Illuminate\Database\Eloquent\Collection` class provides a supe
 [makeVisible](#method-makeVisible)
 [makeHidden](#method-makeHidden)
 [only](#method-only)
+[setVisible](#method-setVisible)
+[setHidden](#method-setHidden)
 [toQuery](#method-toquery)
 [unique](#method-unique)
 
@@ -192,6 +194,20 @@ The `makeHidden` method [hides attributes](/docs/{{version}}/eloquent-serializat
 The `only` method returns all of the models that have the given primary keys:
 
     $users = $users->only([1, 2, 3]);
+
+<a name="method-setVisible"></a>
+#### `setVisible($attributes)` {.collection-method}
+
+The `setVisible` method [temporarily overrides](/docs/{{version}}/eloquent-serialization#temporarily-modifying-attribute-visibility) all of the visible attributes on each model in the collection:
+
+    $users = $users->setVisible(['id', 'name']);
+
+<a name="method-setHidden"></a>
+#### `setHidden($attributes)` {.collection-method}
+
+The `setHidden` method [temporarily overrides](/docs/{{version}}/eloquent-serialization#temporarily-modifying-attribute-visibility) all of the hidden attributes on each model in the collection:
+
+    $users = $users->setHidden(['email', 'password', 'remember_token']);
 
 <a name="method-toquery"></a>
 #### `toQuery()` {.collection-method}

--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -123,6 +123,12 @@ Likewise, if you would like to hide some attributes that are typically visible, 
 
     return $user->makeHidden('attribute')->toArray();
 
+If you wish to temporarily override all of the visible or hidden attributes, you may use the `setVisible` and `setHidden` methods respectively:
+
+    return $user->setVisible(['id', 'name'])->toArray();
+
+    return $user->setHidden(['email', 'password', 'remember_token'])->toArray();
+
 <a name="appending-values-to-json"></a>
 ## Appending Values To JSON
 


### PR DESCRIPTION
This PR documents the `setVisible` and `setHidden` methods on Eloquent models and collections.