### PR TITLE
Custom mail transport needs to call parent constructor

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -1104,6 +1104,8 @@ Laravel includes a variety of mail transports; however, you may wish to write yo
          */
         public function __construct(ApiClient $client)
         {
+            parent::__construct();
+            
             $this->client = $client;
         }
 


### PR DESCRIPTION
I think the example for the mailchimp custom transport needs to be updated.

I followed the example given while trying to create a custom transport and ran into an issue.

Without calling the parent constructor for AbstractTransport the following exception is thrown:

```
Typed property Symfony\Component\Mailer\Transport\AbstractTransport::$dispatcher must not be accessed before initialization
```