### PR TITLE
[9.x] Fix Guzzle Middleware example

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -273,7 +273,7 @@ Since Laravel's HTTP client is powered by Guzzle, you may take advantage of [Guz
 
     $response = Http::withMiddleware(
         Middleware::mapRequest(function (RequestInterface $request) {
-            $request->withHeader('X-Example', 'Value');
+            $request = $request->withHeader('X-Example', 'Value');
             
             return $request;
         })


### PR DESCRIPTION
The `withHeader` method returns a request instance with the provided value replacing the specified header and doesn't change the current request itself.