### PR TITLE
Copy filesystem informations from sail to filesystem | Minio |  AWS_URL + temporary urls

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -187,6 +187,9 @@ Typically, after updating the disk's credentials to match the credentials of the
 
     'endpoint' => env('AWS_ENDPOINT', 'https://minio:9000'),
 
+<a name="minio"></a>
+#### MinIO
+
 In order for Laravel's Flysystem integration to generate proper URLs when using MinIO, you should define the `AWS_URL` environment variable so that it matches your application's local URL and includes the bucket name in the URL path:
 
 ```ini

--- a/filesystem.md
+++ b/filesystem.md
@@ -187,6 +187,15 @@ Typically, after updating the disk's credentials to match the credentials of the
 
     'endpoint' => env('AWS_ENDPOINT', 'https://minio:9000'),
 
+In order for Laravel's Flysystem integration to generate proper URLs when using MinIO, you should define the `AWS_URL` environment variable so that it matches your application's local URL and includes the bucket name in the URL path:
+
+```ini
+AWS_URL=http://localhost:9000/local
+```
+
+> **Warning**  
+> Generating temporary storage URLs via the `temporaryUrl` method is not supported when using MinIO.
+
 <a name="obtaining-disk-instances"></a>
 ## Obtaining Disk Instances
 


### PR DESCRIPTION
This information is hidden on the pages relating Laravel Sail. I consider it be note worthy here as well. I spent hours on researching for bugs and upgrade package versions only to accidentially read the actual reason in the docs relating Laravel Sail.