### PR TITLE
[9.x] Reverts prohibited definition

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1447,7 +1447,7 @@ The field under validation must be present in the input data but can be empty.
 <a name="rule-prohibited"></a>
 #### prohibited
 
-The field under validation may not be present.
+The field under validation must be an empty string or not present.
 
 <a name="rule-prohibited-if"></a>
 #### prohibited_if:_anotherfield_,_value_,...


### PR DESCRIPTION
As it currently stands, and with our recent work on prohibited, the prohibited rule does allow an empty string; it is not implicit.

This may be merged independently of the other PRs, as this is currently correct.