### PR TITLE
[9.x] Added documentation for Storage::mimeType()

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -346,6 +346,10 @@ The `lastModified` method returns the UNIX timestamp of the last time the file w
 
     $time = Storage::lastModified('file.jpg');
 
+To obtain the MIME type of a given file, the `mimeType` method can be used:
+    
+    $mime = Storage::mimeType('file.jpg')
+
 <a name="file-paths"></a>
 #### File Paths
 

--- a/filesystem.md
+++ b/filesystem.md
@@ -346,8 +346,8 @@ The `lastModified` method returns the UNIX timestamp of the last time the file w
 
     $time = Storage::lastModified('file.jpg');
 
-To obtain the MIME type of a given file, the `mimeType` method can be used:
-    
+The MIME type of a given file may be obtained via the `mimeType` method:
+
     $mime = Storage::mimeType('file.jpg')
 
 <a name="file-paths"></a>


### PR DESCRIPTION
Currently the documentation does not mention `Storage::mimeType()`. This PR adds a small line of documentation to bring awareness to this function.