### PR TITLE
[10.x] Adds Laravel Ignition v2 to Laravel 10's upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -62,6 +62,7 @@ You should update the following dependencies in your application's `composer.jso
 <div class="content-list" markdown="1">
 
 - `laravel/framework` to `^10.0`
+- `spatie/laravel-ignition` to `^2.0`
 
 </div>
 


### PR DESCRIPTION
This pull request adds Laravel Ignition v2 to Laravel 10's upgrade guide.