### PR TITLE
Fix "Synchronous Dispatching" documentation

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -723,7 +723,7 @@ If you would like to specify that a job should not be immediately available for 
 <a name="dispatching-after-the-response-is-sent-to-browser"></a>
 #### Dispatching After The Response Is Sent To Browser
 
-Alternatively, the `dispatchAfterResponse` method delays dispatching a job until after the HTTP response is sent to the user's browser if your web server is using FastCGI. This will still allow the user to begin using the application even though a queued job is still executing. This should typically only be used for jobs that take about a second, such as sending an email. Since they are processed within the current HTTP request, jobs dispatched in this fashion do not require a queue worker to be running in order for them to be processed:
+Alternatively, the `dispatchAfterResponse` method delays dispatching a job until after the HTTP response is sent to the user's browser if your web server is using FastCGI. This will still allow the user to begin using the application even though a queued job is still executing.
 
     use App\Jobs\SendNotification;
 
@@ -741,7 +741,7 @@ You may also `dispatch` a closure and chain the `afterResponse` method onto the 
 <a name="synchronous-dispatching"></a>
 ### Synchronous Dispatching
 
-If you would like to dispatch a job immediately (synchronously), you may use the `dispatchSync` method. When using this method, the job will not be queued and will be executed immediately within the current process:
+If you would like to dispatch a job immediately (synchronously), you may use the `dispatchSync` method. When using this method, the job will not be queued and will be executed immediately within the current process. This should typically only be used for jobs that take about a second, such as sending an email. Since they are processed within the current HTTP request, jobs dispatched in this fashion do not require a queue worker to be running in order for them to be processed:
 
     <?php
 


### PR DESCRIPTION
The documentation for `Synchronous Dispatching` in 9.x is wrongly put under `Dispatching After The Response Is Sent To Browser`. [9.x current current link to highlight](https://laravel.com/docs/9.x/queues#:~:text=This%20should%20typically%20only%20be%20used%20for%20jobs%20that%20take%20about%20a%20second%2C%20such%20as%20sending%20an%20email.%20Since%20they%20are%20processed%20within%20the%20current%20HTTP%20request%2C%20jobs%20dispatched%20in%20this%20fashion%20do%20not%20require%20a%20queue%20worker%20to%20be%20running%20in%20order%20for%20them%20to%20be%20processed%3A)