### PR TITLE
[9.x] Introduce validation `:ascii` options

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -949,6 +949,9 @@ The field under validation must be entirely Unicode alphabetic characters contai
 The field under validation may have Unicode alpha-numeric characters contained in `\p{L}` `\p{M}` `\p{N}`, as well as ascii dashes `-` and ascii underscores `_`.
 
 > **Warning**  
+> Unicode dashes and underscores such as `―` and `＿` are not accepted.
+
+> **Warning**  
 > To restrict it to `a-z` `A-Z` `0-9` `_` `-` in the ascii range, give the `:ascii` option.
 
 <a name="rule-alpha-num"></a>

--- a/validation.md
+++ b/validation.md
@@ -940,15 +940,24 @@ The field under validation must be a value after or equal to the given date. For
 
 The field under validation must be entirely alphabetic characters.
 
+> **Warning**  
+> A wide range of Unicode letters are accepted by default. To restrict it to `a-z` `A-Z` in ascii range, give `:ascii` option.
+
 <a name="rule-alpha-dash"></a>
 #### alpha_dash
 
 The field under validation may have alpha-numeric characters, as well as dashes and underscores.
 
+> **Warning**  
+> A wide range of Unicode letters and numbers are accepted by default. To restrict it to `a-z` `A-Z` `0-9` `_` `-` in ascii range, give `:ascii` option.
+
 <a name="rule-alpha-num"></a>
 #### alpha_num
 
 The field under validation must be entirely alpha-numeric characters.
+
+> **Warning**  
+> A wide range of Unicode letters and numbers are accepted by default. To restrict it to `a-z` `A-Z` `0-9` in ascii range, give `:ascii` option.
 
 <a name="rule-array"></a>
 #### array

--- a/validation.md
+++ b/validation.md
@@ -938,29 +938,35 @@ The field under validation must be a value after or equal to the given date. For
 <a name="rule-alpha"></a>
 #### alpha
 
-The field under validation must be entirely Unicode alphabetic characters contained in [`\p{L}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=) [`\p{M}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=).
+The field under validation must be entirely Unicode alphabetic characters contained in [`\p{L}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=) and [`\p{M}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=).
 
-> **Warning**  
-> To restrict it to `a-z` `A-Z` in the ascii range, give the `:ascii` option.
+To restrict this validation rule to characters in the ASCII range (`a-z` and `A-Z`), you may provide the `ascii` option to the validation rule:
+
+```php
+'username' => 'alpha:ascii',
+```
 
 <a name="rule-alpha-dash"></a>
 #### alpha_dash
 
-The field under validation may have Unicode alpha-numeric characters contained in [`\p{L}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=) [`\p{M}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=) [`\p{N}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AN%3A%5D&g=&i=), as well as ascii dashes `-` and ascii underscores `_`.
+The field under validation must be entirely Unicode alpha-numeric characters contained in [`\p{L}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=), [`\p{M}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=), [`\p{N}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AN%3A%5D&g=&i=), as well as ASCII dashes (`-`) and ASCII underscores (`_`).
 
-> **Warning**  
-> Unicode dashes and underscores such as `―` and `＿` are not accepted.
+To restrict this validation rule to characters in the ASCII range (`a-z` and `A-Z`), you may provide the `ascii` option to the validation rule:
 
-> **Warning**  
-> To restrict it to `a-z` `A-Z` `0-9` `_` `-` in the ascii range, give the `:ascii` option.
+```php
+'username' => 'alpha_dash:ascii',
+```
 
 <a name="rule-alpha-num"></a>
 #### alpha_num
 
-The field under validation must be entirely Unicode alpha-numeric characters contained in [`\p{L}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=) [`\p{M}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=) [`\p{N}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AN%3A%5D&g=&i=).
+The field under validation must be entirely Unicode alpha-numeric characters contained in [`\p{L}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=), [`\p{M}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=), and [`\p{N}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AN%3A%5D&g=&i=).
 
-> **Warning**  
-> To restrict it to `a-z` `A-Z` `0-9` in the ascii range, give the `:ascii` option.
+To restrict this validation rule to characters in the ASCII range (`a-z` and `A-Z`), you may provide the `ascii` option to the validation rule:
+
+```php
+'username' => 'alpha_num:ascii',
+```
 
 <a name="rule-array"></a>
 #### array

--- a/validation.md
+++ b/validation.md
@@ -938,26 +938,26 @@ The field under validation must be a value after or equal to the given date. For
 <a name="rule-alpha"></a>
 #### alpha
 
-The field under validation must be entirely alphabetic characters.
+The field under validation must be entirely Unicode alphabetic characters contained in `\p{L}` `\p{M}`.
 
 > **Warning**  
-> A wide range of Unicode letters are accepted by default. To restrict it to `a-z` `A-Z` in the ascii range, give the `:ascii` option.
+> To restrict it to `a-z` `A-Z` in the ascii range, give the `:ascii` option.
 
 <a name="rule-alpha-dash"></a>
 #### alpha_dash
 
-The field under validation may have alpha-numeric characters, as well as dashes and underscores.
+The field under validation may have Unicode alpha-numeric characters contained in `\p{L}` `\p{M}` `\p{N}`, as well as ascii dashes `-` and ascii underscores `_`.
 
 > **Warning**  
-> A wide range of Unicode letters and numbers are accepted by default. To restrict it to `a-z` `A-Z` `0-9` `_` `-` in the ascii range, give the `:ascii` option.
+> To restrict it to `a-z` `A-Z` `0-9` `_` `-` in the ascii range, give the `:ascii` option.
 
 <a name="rule-alpha-num"></a>
 #### alpha_num
 
-The field under validation must be entirely alpha-numeric characters.
+The field under validation must be entirely Unicode alpha-numeric characters contained in `\p{L}` `\p{M}` `\p{N}`.
 
 > **Warning**  
-> A wide range of Unicode letters and numbers are accepted by default. To restrict it to `a-z` `A-Z` `0-9` in the ascii range, give the `:ascii` option.
+> To restrict it to `a-z` `A-Z` `0-9` in the ascii range, give the `:ascii` option.
 
 <a name="rule-array"></a>
 #### array

--- a/validation.md
+++ b/validation.md
@@ -941,7 +941,7 @@ The field under validation must be a value after or equal to the given date. For
 The field under validation must be entirely alphabetic characters.
 
 > **Warning**  
-> A wide range of Unicode letters are accepted by default. To restrict it to `a-z` `A-Z` in ascii range, give `:ascii` option.
+> A wide range of Unicode letters are accepted by default. To restrict it to `a-z` `A-Z` in the ascii range, give the `:ascii` option.
 
 <a name="rule-alpha-dash"></a>
 #### alpha_dash
@@ -949,7 +949,7 @@ The field under validation must be entirely alphabetic characters.
 The field under validation may have alpha-numeric characters, as well as dashes and underscores.
 
 > **Warning**  
-> A wide range of Unicode letters and numbers are accepted by default. To restrict it to `a-z` `A-Z` `0-9` `_` `-` in ascii range, give `:ascii` option.
+> A wide range of Unicode letters and numbers are accepted by default. To restrict it to `a-z` `A-Z` `0-9` `_` `-` in the ascii range, give the `:ascii` option.
 
 <a name="rule-alpha-num"></a>
 #### alpha_num
@@ -957,7 +957,7 @@ The field under validation may have alpha-numeric characters, as well as dashes 
 The field under validation must be entirely alpha-numeric characters.
 
 > **Warning**  
-> A wide range of Unicode letters and numbers are accepted by default. To restrict it to `a-z` `A-Z` `0-9` in ascii range, give `:ascii` option.
+> A wide range of Unicode letters and numbers are accepted by default. To restrict it to `a-z` `A-Z` `0-9` in the ascii range, give the `:ascii` option.
 
 <a name="rule-array"></a>
 #### array

--- a/validation.md
+++ b/validation.md
@@ -938,7 +938,7 @@ The field under validation must be a value after or equal to the given date. For
 <a name="rule-alpha"></a>
 #### alpha
 
-The field under validation must be entirely Unicode alphabetic characters contained in `\p{L}` `\p{M}`.
+The field under validation must be entirely Unicode alphabetic characters contained in [`\p{L}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=) [`\p{M}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=).
 
 > **Warning**  
 > To restrict it to `a-z` `A-Z` in the ascii range, give the `:ascii` option.
@@ -946,7 +946,7 @@ The field under validation must be entirely Unicode alphabetic characters contai
 <a name="rule-alpha-dash"></a>
 #### alpha_dash
 
-The field under validation may have Unicode alpha-numeric characters contained in `\p{L}` `\p{M}` `\p{N}`, as well as ascii dashes `-` and ascii underscores `_`.
+The field under validation may have Unicode alpha-numeric characters contained in [`\p{L}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=) [`\p{M}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=) [`\p{N}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AN%3A%5D&g=&i=), as well as ascii dashes `-` and ascii underscores `_`.
 
 > **Warning**  
 > Unicode dashes and underscores such as `―` and `＿` are not accepted.
@@ -957,7 +957,7 @@ The field under validation may have Unicode alpha-numeric characters contained i
 <a name="rule-alpha-num"></a>
 #### alpha_num
 
-The field under validation must be entirely Unicode alpha-numeric characters contained in `\p{L}` `\p{M}` `\p{N}`.
+The field under validation must be entirely Unicode alpha-numeric characters contained in [`\p{L}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=) [`\p{M}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=) [`\p{N}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AN%3A%5D&g=&i=).
 
 > **Warning**  
 > To restrict it to `a-z` `A-Z` `0-9` in the ascii range, give the `:ascii` option.


### PR DESCRIPTION
- laravel/framework#45769

Since this rule has been misunderstood by many, I'm convinced that `:ascii` option needs to be informed to users with a warning box.

I would be happy to correct my poor English.