### PR TITLE
[10.x] Adds docs for `whereExists` query objects

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -687,9 +687,11 @@ The `whereExists` method allows you to write "where exists" SQL clauses. The `wh
                })
                ->get();
 
-You may also provide a query object instead of a closure:
+Alternatively, you may provide a query object to the `whereExists` method instead of a closure:
 
-    $orders = DB::table('orders')->select(DB::raw(1))->whereColumn('orders.user_id', 'users.id');
+    $orders = DB::table('orders')
+                    ->select(DB::raw(1))
+                    ->whereColumn('orders.user_id', 'users.id');
 
     $users = DB::table('users')
                         ->whereExists($orders)

--- a/queries.md
+++ b/queries.md
@@ -687,7 +687,15 @@ The `whereExists` method allows you to write "where exists" SQL clauses. The `wh
                })
                ->get();
 
-The query above will produce the following SQL:
+You may also provide a query object instead of a closure:
+
+    $orders = DB::table('orders')->select(DB::raw(1))->whereColumn('orders.user_id', 'users.id');
+
+    $users = DB::table('users')
+                        ->whereExists($orders)
+                        ->get();
+
+Both of the examples above will produce the following SQL:
 
 ```sql
 select * from users


### PR DESCRIPTION
Updated the `whereExists` docs to include the new ability to pass closures OR query objects.

Hi! First time pusher. I was looking for a way to pass a query object to the `whereExists` method just like the `whereIn` method has. After realizing it didn't exist yet I went to the repo to see how hard it would be to implement, but thankfully the wonderful @gdebrauwer had already done it(twice)! So I'm doing my small part by getting the docs updated so everyone knows about it. 