### PR TITLE
Adds some missing steps when using additional symfony transports

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -1176,7 +1176,7 @@ Once the Sendinblue mailer package has been installed, you may add an entry for 
         'key' => 'your-api-key',
     ],
 
-Finally, you may use the `Mail` facade's `extend` method to register the transport with Laravel. Typically, this should be done within the `boot` method of a service provider:
+Next, you may use the `Mail` facade's `extend` method to register the transport with Laravel. Typically, this should be done within the `boot` method of a service provider:
 
     use Illuminate\Support\Facades\Mail;
     use Symfony\Component\Mailer\Bridge\Sendinblue\Transport\SendinblueTransportFactory;
@@ -1199,11 +1199,10 @@ Finally, you may use the `Mail` facade's `extend` method to register the transpo
             );
         });
     }
-    
-Once your additional transport has been installed and registered, you shold create a mailer definition within your application's config/mail.php configuration file that utilizes the new transport:
+
+Once your transport has been registered, you may create a mailer definition within your application's config/mail.php configuration file that utilizes the new transport:
 
     'sendinblue' => [
         'transport' => 'sendinblue',
         // ...
     ],
-

--- a/mail.md
+++ b/mail.md
@@ -1167,7 +1167,7 @@ Once your custom transport has been defined and registered, you may create a mai
 Laravel includes support for some existing Symfony maintained mail transports like Mailgun and Postmark. However, you may wish to extend Laravel with support for additional Symfony maintained transports. You can do so by requiring the necessary Symfony mailer via Composer and registering the transport with Laravel. For example, you may install and register the "Sendinblue" Symfony mailer:
 
 ```none
-composer require symfony/sendinblue-mailer
+composer require symfony/sendinblue-mailer symfony/http-client
 ```
 
 Once the Sendinblue mailer package has been installed, you may add an entry for your Sendinblue API credentials to your application's `services` configuration file:

--- a/mail.md
+++ b/mail.md
@@ -1199,3 +1199,11 @@ Finally, you may use the `Mail` facade's `extend` method to register the transpo
             );
         });
     }
+    
+Once your additional transport has been installed and registered, you shold create a mailer definition within your application's config/mail.php configuration file that utilizes the new transport:
+
+    'sendinblue' => [
+        'transport' => 'sendinblue',
+        // ...
+    ],
+


### PR DESCRIPTION
The current documentation was missing a few steps needed to use other symfony transports.

I've updated the composer require command to include the `symfony/http-client` depdendency and added docs about adding the new transport to `config/mail.php`