### PR TITLE
[9.x] Update for the default PHP version used by sail.

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -353,7 +353,7 @@ sail tinker
 <a name="sail-php-versions"></a>
 ## PHP Versions
 
-Sail currently supports serving your application via PHP 8.2, 8.1, PHP 8.0, or PHP 7.4. The default PHP version used by Sail is currently PHP 8.1. To change the PHP version that is used to serve your application, you should update the `build` definition of the `laravel.test` container in your application's `docker-compose.yml` file:
+Sail currently supports serving your application via PHP 8.2, 8.1, PHP 8.0, or PHP 7.4. The default PHP version used by Sail is currently PHP 8.2. To change the PHP version that is used to serve your application, you should update the `build` definition of the `laravel.test` container in your application's `docker-compose.yml` file:
 
 ```yaml
 # PHP 8.2


### PR DESCRIPTION
This PR updates the default PHP version currently used by sail for v9.x.

Actual Framework version installed: v.9.48.0
PHP Version: 8.2