### PR TITLE
[10.x] Fix Service Mocking Link on Upgrade Guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -18,7 +18,7 @@
 <div class="content-list" markdown="1">
 
 - [Model "Dates" Property](#model-dates-property)
-- [Service Mocking](#serving-mocking)
+- [Service Mocking](#service-mocking)
 
 </div>
 


### PR DESCRIPTION
I've updated the "Service Mocking" link in the Upgrade Guide because it wasn't redirecting the user anywhere.