### PR TITLE
Add Mailpit along with Mailhog

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -935,7 +935,7 @@ When designing a mailable's template, it is convenient to quickly preview the re
     });
 
 > **Warning**  
-> [Inline attachments](#inline-attachments) will not be rendered when a mailable is previewed in your browser. To preview these mailables, you should send them to an email testing application such as [MailHog](https://github.com/mailhog/MailHog) or [HELO](https://usehelo.com).
+> [Inline attachments](#inline-attachments) will not be rendered when a mailable is previewed in your browser. To preview these mailables, you should send them to an email testing application such as [MailHog](https://github.com/mailhog/MailHog) or [Mailpit](https://github.com/axllent/mailpit) or [HELO](https://usehelo.com).
 
 <a name="localizing-mailables"></a>
 ## Localizing Mailables


### PR DESCRIPTION
Hi,

Mailpit is  a rewrite of Mailhog

https://github.com/axllent/mailpit

It far far better than Mailhog

I can send a PR to [laravel-sail](https://github.com/laravel/sail/blob/1.x/stubs/mailhog.stub) to replace Mailhog with Mailpit too.