### PR TITLE
[9.x] Refer to general laravel-assets tag

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -176,13 +176,13 @@ When upgrading to a new major version of Horizon, it's important that you carefu
 php artisan horizon:publish
 ```
 
-To keep the assets up-to-date and avoid issues in future updates, you may add the `horizon:publish` command to the `post-update-cmd` scripts in your application's `composer.json` file:
+To keep the assets up-to-date and avoid issues in future updates, you may add the `vendor:publish --tag=laravel-assets` command to the `post-update-cmd` scripts in your application's `composer.json` file:
 
 ```json
 {
     "scripts": {
         "post-update-cmd": [
-            "@php artisan horizon:publish --ansi"
+            "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
         ]
     }
 }

--- a/telescope.md
+++ b/telescope.md
@@ -156,13 +156,13 @@ In addition, when upgrading to any new Telescope version, you should re-publish 
 php artisan telescope:publish
 ```
 
-To keep the assets up-to-date and avoid issues in future updates, you may add the `telescope:publish` command to the `post-update-cmd` scripts in your application's `composer.json` file:
+To keep the assets up-to-date and avoid issues in future updates, you may add the `vendor:publish --tag=laravel-assets` command to the `post-update-cmd` scripts in your application's `composer.json` file:
 
 ```json
 {
     "scripts": {
         "post-update-cmd": [
-            "@php artisan telescope:publish --ansi"
+            "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
         ]
     }
 }


### PR DESCRIPTION
Refer to the general `laravel-assets` tag when upgrading Horizon and Telescope that's already present in the skeleton.