### PR TITLE
[9.x] value helper function further parameters passed to closure

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -4045,6 +4045,14 @@ The `value` function returns the value it is given. However, if you pass a closu
     });
 
     // false
+    
+Further parameters may be passed to the value function and if the first parameter is a closure these additional parameters will be passed to the closure.
+
+    $result = value(function ($parameter) {
+        return $parameter;
+    }, true);
+    
+    // true
 
 <a name="method-view"></a>
 #### `view()` {.collection-method}

--- a/helpers.md
+++ b/helpers.md
@@ -4046,13 +4046,13 @@ The `value` function returns the value it is given. However, if you pass a closu
 
     // false
     
-Further parameters may be passed to the value function and if the first parameter is a closure these additional parameters will be passed to the closure.
+Additional arguments may be passed to the `value` function. If the first argument is a closure then the additional parameters will be passed to the closure as arguments, otherwise they will be ignored:
 
-    $result = value(function ($parameter) {
+    $result = value(function ($name) {
         return $parameter;
-    }, true);
+    }, 'Taylor');
     
-    // true
+    // 'Taylor'
 
 <a name="method-view"></a>
 #### `view()` {.collection-method}


### PR DESCRIPTION
Updated the docs for the `value` function to [reflect the fact parameters can be passed to the closure if one is provided as the first parameter and then additional parameters are given](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Collections/helpers.php#L186-L189).