### PR TITLE
Move tagged cache access info to correct section

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -271,7 +271,7 @@ When the `cache` function is called without any arguments, it returns an instanc
 <a name="storing-tagged-cache-items"></a>
 ### Storing Tagged Cache Items
 
-Cache tags allow you to tag related items in the cache and then flush all cached values that have been assigned a given tag. You may access a tagged cache by passing in an ordered array of tag names. Items stored via tags may not be accessed without also providing the tags that were used to store the value. For example, let's access a tagged cache and `put` a value into the cache:
+Cache tags allow you to tag related items in the cache and then flush all cached values that have been assigned a given tag. You may access a tagged cache by passing in an ordered array of tag names. For example, let's access a tagged cache and `put` a value into the cache:
 
     Cache::tags(['people', 'artists'])->put('John', $john, $seconds);
 
@@ -280,7 +280,7 @@ Cache tags allow you to tag related items in the cache and then flush all cached
 <a name="accessing-tagged-cache-items"></a>
 ### Accessing Tagged Cache Items
 
-To retrieve a tagged cache item, pass the same ordered list of tags to the `tags` method and then call the `get` method with the key you wish to retrieve:
+Items stored via tags may not be accessed without also providing the tags that were used to store the value. To retrieve a tagged cache item, pass the same ordered list of tags to the `tags` method and then call the `get` method with the key you wish to retrieve:
 
     $john = Cache::tags(['people', 'artists'])->get('John');
 


### PR DESCRIPTION
This is a very important piece of info that can be overlooked as I did, and the effects will not be noticed until it's too late. Honestly, it should be either bolded or included as a warning.