### PR TITLE
changed PHP requirement for Laravel 10 (PHP 8.1 min)

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -24,7 +24,7 @@ The Laravel framework has a few system requirements. You should ensure that your
 
 <div class="content-list" markdown="1">
 
-- PHP >= 8.0
+- PHP >= 8.1
 - BCMath PHP Extension
 - Ctype PHP Extension
 - cURL PHP Extension


### PR DESCRIPTION
Because Laravel 10 requires 8.1, I changed the requirements in deployment.md

Feel free to close this PR if you are already reviewing the whole deplyoment.md file.