### PR TITLE
Add documentation about the DatabaseTrunates trait

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -43,7 +43,7 @@ Before proceeding much further, let's discuss how to reset your database after e
 
 The `Illuminate\Foundation\Testing\RefreshDatabase` trait does not migrate your database if your schema is up to date. Instead, it will only execute the test within a database transaction. Therefore, any records added to the database by test cases that do not use this trait may still exist in the database.
 
-If you would like to totally reset the database using migrations, you may use the `Illuminate\Foundation\Testing\DatabaseMigrations` trait instead. However, the `DatabaseMigrations` trait is significantly slower than the `RefreshDatabase` trait.
+If you would like to totally reset the database, you may use the `Illuminate\Foundation\Testing\DatabaseMigrations` or the `Illuminate\Foundation\Testing\DatabaseTruncates` traits instead. However, both of these options are significantly slower than the `RefreshDatabase` trait.
 
 <a name="model-factories"></a>
 ## Model Factories


### PR DESCRIPTION
As this trait is most beneficial in Dusk tests, the bulk of the information is in the Dusk docs.

I've used the same header from Database Testing "Resetting The Database After Each Test"