### PR TITLE
Update migrations.md

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -1155,6 +1155,8 @@ Command  |  Description
 `$table->fullText('body')->language('english');`  |  Adds a full text index of the specified language (PostgreSQL).
 `$table->spatialIndex('location');`  |  Adds a spatial index (except SQLite).
 
+**Note:** Eloquent models (and therefore also route model binding), does not support composite primary keys!
+
 <a name="index-lengths-mysql-mariadb"></a>
 #### Index Lengths & MySQL / MariaDB
 


### PR DESCRIPTION
As mentioned [here](https://github.com/laravel/framework/issues/5517) likely will maybe never support composite primary keys. I thought it would be great if that immediately would be pointed out at the documentation. I had some troubles with that and it confused me a bit, that the Schema Builder supports composite primary keys but not Eloquent. 