### PR TITLE
[10.x] Adds artisan test `--profile` flag to release notes

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -145,3 +145,20 @@ Process::assertRan('ls -la');
 ```
 
 For more information on interacting with processes, please consult the [comprehensive process documentation](/docs/{{version}}/processes).
+
+<a name="profile-tests-using-artisan-test-command"></a>
+### Profile Tests Using Artisan test Command
+
+_Profile tests when using the Artisan test command was contributed by [Nuno Maduro](https://github.com/nunomaduro)_.
+
+The Artisan `test` command has received a new `--profile` option that that allows you to identify the slowest tests in your application:
+
+```shell
+php artisan test --profile
+```
+
+The slowest tests will be displayed directly within the CLI output.
+
+<p align="center">
+    <img width="100%" src="https://user-images.githubusercontent.com/5457236/217328439-d8d983ec-d0fc-4cde-93d9-ae5bccf5df14.png"/>
+</p>

--- a/releases.md
+++ b/releases.md
@@ -146,18 +146,18 @@ Process::assertRan('ls -la');
 
 For more information on interacting with processes, please consult the [comprehensive process documentation](/docs/{{version}}/processes).
 
-<a name="profile-tests-using-artisan-test-command"></a>
-### Profile Tests Using Artisan test Command
+<a name="test-profiling"></a>
+### Test Profiling
 
-_Profile tests when using the Artisan test command was contributed by [Nuno Maduro](https://github.com/nunomaduro)_.
+_Test profiling was contributed by [Nuno Maduro](https://github.com/nunomaduro)_.
 
-The Artisan `test` command has received a new `--profile` option that that allows you to identify the slowest tests in your application:
+The Artisan `test` command has received a new `--profile` option that allows you to easily identify the slowest tests in your application:
 
 ```shell
 php artisan test --profile
 ```
 
-The slowest tests will be displayed directly within the CLI output.
+For convenience, the slowest tests will be displayed directly within the CLI output:
 
 <p align="center">
     <img width="100%" src="https://user-images.githubusercontent.com/5457236/217328439-d8d983ec-d0fc-4cde-93d9-ae5bccf5df14.png"/>


### PR DESCRIPTION
This pull request adds the new artisan test `--profile` flag to release notes. The image used, is this one:

<p align="center">
    <img width="100%" src="https://user-images.githubusercontent.com/5457236/217328439-d8d983ec-d0fc-4cde-93d9-ae5bccf5df14.png"/>
</p>