### PR TITLE
[10.x] Add recommendation about appending Model data

### DIFF
--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -183,6 +183,9 @@ At runtime, you may instruct a model instance to append additional attributes us
 
     return $user->setAppends(['is_admin'])->toArray();
 
+> **Note**
+> It is recommended to be _very_ selective of which attributes you place in your `$appends` property, and to generally prefer run-time configuration. If you are using `select()` to limit the number of fields you retrieve for a Model, and using [`Model::preventAccessingMissingAttributes()`](https://laravel.com/docs/9.x/eloquent#configuring-eloquent-strictness) it's very possible you will run into exceptions in unexpected places.
+
 <a name="date-serialization"></a>
 ## Date Serialization
 


### PR DESCRIPTION
add a note recommending the usage of run-time attribute appending over global `$appends` usage.

at first glance, the Model `$appends` property seems extremely convenient, but there are some gotchas with it that newer users may not be aware of. I believe we should add a documented recommendation to help make users aware of the possible issues.  I'm not exactly sure how to word the second sentence, so if there are any recommendations, I would be glad to hear them.

I've been caught many times by this in the past. I've added a property to the `$appends` model property so it shows up in an API endpoint where it's needed, or some interactive javascript on a page.  Later, perhaps in a different JSON endpoint, I'll retrieve the same Models, but not include a necessary field in my `::select()` for an automatically appended accessor. With `preventAccessingMissingAttributes()` enabled, this will throw an exception, and I'll be forced to either include that additional field I don't need, or use `setAppends([])` to override the appended accessors, neither ideal situations.

Most recently, I've also been caught with this because of Telescope.  Apparently Telescope is turning any Models in the request into JSON, so if I'm not selecting the appropriate fields and have `preventAccessingMissingAttributes()` enabled, I'm also getting the exception.