### PR TITLE
[10.x] Use promoted properties

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -736,27 +736,12 @@ You should define all of the component's data attributes in its class constructo
     class Alert extends Component
     {
         /**
-         * The alert type.
-         *
-         * @var string
-         */
-        public $type;
-
-        /**
-         * The alert message.
-         *
-         * @var string
-         */
-        public $message;
-
-        /**
          * Create the component instance.
          */
-        public function __construct(string $type, string $message)
-        {
-            $this->type = $type;
-            $this->message = $message;
-        }
+        public function __construct(
+            public string $type,
+            public string $message,
+        ) {}
 
         /**
          * Get the view / contents that represent the component.

--- a/broadcasting.md
+++ b/broadcasting.md
@@ -376,19 +376,11 @@ The `ShouldBroadcast` interface requires you to implement a single method: `broa
         use SerializesModels;
 
         /**
-         * The user that created the server.
-         *
-         * @var \App\Models\User
-         */
-        public $user;
-
-        /**
          * Create a new event instance.
          */
-        public function __construct(User $user)
-        {
-            $this->user = $user;
-        }
+        public function __construct(
+            public User $user,
+        ) {}
 
         /**
          * Get the channels the event should broadcast on.

--- a/collections.md
+++ b/collections.md
@@ -1656,17 +1656,11 @@ The `pipeInto` method creates a new instance of the given class and passes the c
     class ResourceCollection
     {
         /**
-         * The Collection instance.
-         */
-        public $collection;
-
-        /**
          * Create a new ResourceCollection instance.
          */
-        public function __construct(Collection $collection)
-        {
-            $this->collection = $collection;
-        }
+        public function __construct(
+          public Collection $collection,
+        ) {}
     }
 
     $collection = collect([1, 2, 3]);

--- a/container.md
+++ b/container.md
@@ -37,19 +37,11 @@ Let's look at a simple example:
     class UserController extends Controller
     {
         /**
-         * The user repository implementation.
-         *
-         * @var UserRepository
-         */
-        protected $users;
-
-        /**
          * Create a new controller instance.
          */
-        public function __construct(UserRepository $users)
-        {
-            $this->users = $users;
-        }
+        public function __construct(
+            protected UserRepository $users,
+        ) {}
 
         /**
          * Show the profile for the given user.
@@ -396,19 +388,11 @@ For example, you may type-hint a repository defined by your application in a con
     class UserController extends Controller
     {
         /**
-         * The user repository instance.
-         *
-         * @var \App\Repositories\UserRepository
-         */
-        protected $users;
-
-        /**
          * Create a new controller instance.
          */
-        public function __construct(UserRepository $users)
-        {
-            $this->users = $users;
-        }
+        public function __construct(
+            protected UserRepository $users,
+        ) {}
 
         /**
          * Show the user with the given ID.

--- a/contracts.md
+++ b/contracts.md
@@ -49,19 +49,11 @@ For example, take a look at this event listener:
     class CacheOrderInformation
     {
         /**
-         * The Redis factory implementation.
-         *
-         * @var \Illuminate\Contracts\Redis\Factory
-         */
-        protected $redis;
-
-        /**
          * Create a new event handler instance.
          */
-        public function __construct(Factory $redis)
-        {
-            $this->redis = $redis;
-        }
+        public function __construct(
+            protected Factory $redis,
+        ) {}
 
         /**
          * Handle the event.

--- a/controllers.md
+++ b/controllers.md
@@ -466,17 +466,11 @@ The Laravel [service container](/docs/{{version}}/container) is used to resolve 
     class UserController extends Controller
     {
         /**
-         * The user repository instance.
-         */
-        protected $users;
-
-        /**
          * Create a new controller instance.
          */
-        public function __construct(UserRepository $users)
-        {
-            $this->users = $users;
-        }
+        public function __construct(
+            protected UserRepository $users,
+        ) {}
     }
 
 <a name="method-injection"></a>

--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -655,19 +655,11 @@ A classic example of an inbound only cast is a "hashing" cast. For example, we m
     class Hash implements CastsInboundAttributes
     {
         /**
-         * The hashing algorithm.
-         *
-         * @var string
-         */
-        protected $algorithm;
-
-        /**
          * Create a new cast class instance.
          */
-        public function __construct(string $algorithm = null)
-        {
-            $this->algorithm = $algorithm;
-        }
+        public function __construct(
+            protected string $algorithm = null,
+        ) {}
 
         /**
          * Prepare the given value for storage.

--- a/events.md
+++ b/events.md
@@ -201,19 +201,11 @@ An event class is essentially a data container which holds the information relat
         use Dispatchable, InteractsWithSockets, SerializesModels;
 
         /**
-         * The order instance.
-         *
-         * @var \App\Models\Order
-         */
-        public $order;
-
-        /**
          * Create a new event instance.
          */
-        public function __construct(Order $order)
-        {
-            $this->order = $order;
-        }
+        public function __construct(
+            public Order $order,
+        ) {}
     }
 
 As you can see, this event class contains no logic. It is a container for the `App\Models\Order` instance that was purchased. The `SerializesModels` trait used by the event will gracefully serialize any Eloquent models if the event object is serialized using PHP's `serialize` function, such as when utilizing [queued listeners](#queued-event-listeners).

--- a/horizon.md
+++ b/horizon.md
@@ -305,19 +305,11 @@ Horizon allows you to assign “tags” to jobs, including mailables, broadcast 
         use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
         /**
-         * The video instance.
-         *
-         * @var \App\Models\Video
-         */
-        public $video;
-
-        /**
          * Create a new job instance.
          */
-        public function __construct(Video $video)
-        {
-            $this->video = $video;
-        }
+        public function __construct(
+            public Video $video,
+        ) {}
 
         /**
          * Execute the job.

--- a/mail.md
+++ b/mail.md
@@ -282,19 +282,11 @@ Typically, you will want to pass some data to your view that you can utilize whe
         use Queueable, SerializesModels;
 
         /**
-         * The order instance.
-         *
-         * @var \App\Models\Order
-         */
-        public $order;
-
-        /**
          * Create a new message instance.
          */
-        public function __construct(Order $order)
-        {
-            $this->order = $order;
-        }
+        public function __construct(
+            public Order $order,
+        ) {}
 
         /**
          * Get the message content definition.
@@ -333,19 +325,11 @@ If you would like to customize the format of your email's data before it is sent
         use Queueable, SerializesModels;
 
         /**
-         * The order instance.
-         *
-         * @var \App\Models\Order
-         */
-        protected $order;
-
-        /**
          * Create a new message instance.
          */
-        public function __construct(Order $order)
-        {
-            $this->order = $order;
-        }
+        public function __construct(
+            protected Order $order,
+        ) {}
 
         /**
          * Get the message content definition.
@@ -1060,20 +1044,12 @@ Laravel includes a variety of mail transports; however, you may wish to write yo
     class MailchimpTransport extends AbstractTransport
     {
         /**
-         * The Mailchimp API client.
-         *
-         * @var \MailchimpTransactional\ApiClient
-         */
-        protected $client;
-
-        /**
          * Create a new Mailchimp transport instance.
          */
-        public function __construct(ApiClient $client)
-        {
+        public function __construct(
+            protected ApiClient $client,
+        ) {
             parent::__construct();
-            
-            $this->client = $client;
         }
 
         /**

--- a/queues.md
+++ b/queues.md
@@ -182,19 +182,11 @@ Job classes are very simple, normally containing only a `handle` method that is 
         use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
         /**
-         * The podcast instance.
-         *
-         * @var \App\Models\Podcast
-         */
-        public $podcast;
-
-        /**
          * Create a new job instance.
          */
-        public function __construct(Podcast $podcast)
-        {
-            $this->podcast = $podcast;
-        }
+        public function __construct(
+            public Podcast $podcast,
+        ) {}
 
         /**
          * Execute the job.
@@ -1748,19 +1740,11 @@ When a particular job fails, you may want to send an alert to your users or reve
         use InteractsWithQueue, Queueable, SerializesModels;
 
         /**
-         * The podcast instance.
-         *
-         * @var \App\Podcast
-         */
-        public $podcast;
-
-        /**
          * Create a new job instance.
          */
-        public function __construct(Podcast $podcast)
-        {
-            $this->podcast = $podcast;
-        }
+        public function __construct(
+            public Podcast $podcast,
+        ) {}
 
         /**
          * Execute the job.

--- a/views.md
+++ b/views.md
@@ -201,19 +201,11 @@ Now that we have registered the composer, the `compose` method of the `App\View\
     class ProfileComposer
     {
         /**
-         * The user repository implementation.
-         *
-         * @var \App\Repositories\UserRepository
-         */
-        protected $users;
-
-        /**
          * Create a new profile composer.
          */
-        public function __construct(UserRepository $users)
-        {
-            $this->users = $users;
-        }
+        public function __construct(
+            protected UserRepository $users,
+        ) {}
 
         /**
          * Bind data to the view.


### PR DESCRIPTION
using promoted properties makes the docs more succinct.

I did not switch to promoted properties when the properties were not explicitly defined in the code already.

