### PR TITLE
[10.x] Notes on using Pennant outside of a HTTP context

### DIFF
--- a/pennant.md
+++ b/pennant.md
@@ -215,6 +215,8 @@ Feature::allAreInactive(['new-api', 'site-redesign']);
 Feature::someAreInactive(['new-api', 'site-redesign']);
 ```
 
+> **Note** When using Pennant outside of a HTTP context, e.g. in an Artisan command or a queued job, you should manually [specify the scope](#specifying-the-scope) when checking a feature or set the [default scope](#default-scope).
+
 <a name="conditional-execution"></a>
 ### Conditional Execution
 
@@ -329,6 +331,7 @@ It is also possible to customize the default scope Pennant uses to check feature
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Pennant\Feature;
 
@@ -339,9 +342,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Feature::resolveScopeUsing(function ($driver) {
-            return request()->user()->team;
-        });
+        Feature::resolveScopeUsing(fn ($driver) => Auth::user()->team);
 
         // ...
     }

--- a/pennant.md
+++ b/pennant.md
@@ -168,6 +168,12 @@ return Feature::for($user)->active('new-api')
         : $this->resolveLegacyApiResponse($request);
 ```
 
+> **Note** 
+> When using Pennant outside of a HTTP context, such as in an Artisan command or a queued job, you should typically [explicitly specify the feature's scope](#specifying-the-scope). Alternatively, you may define a [default scope](#default-scope) that accounts for both authenticated HTTP contexts and unauthenticated contexts.
+
+<a name="checking-class-based-features"></a>
+#### Checking Class Based Features
+
 For class based features, you should provide the class name when checking the feature:
 
 ```php
@@ -214,8 +220,6 @@ Feature::allAreInactive(['new-api', 'site-redesign']);
 // Determine if any of the given features are inactive...
 Feature::someAreInactive(['new-api', 'site-redesign']);
 ```
-
-> **Note** When using Pennant outside of a HTTP context, e.g. in an Artisan command or a queued job, you should manually [specify the scope](#specifying-the-scope) when checking a feature or set the [default scope](#default-scope).
 
 <a name="conditional-execution"></a>
 ### Conditional Execution

--- a/pennant.md
+++ b/pennant.md
@@ -169,7 +169,7 @@ return Feature::for($user)->active('new-api')
 ```
 
 > **Note** 
-> When using Pennant outside of a HTTP context, such as in an Artisan command or a queued job, you should typically [explicitly specify the feature's scope](#specifying-the-scope). Alternatively, you may define a [default scope](#default-scope) that accounts for both authenticated HTTP contexts and unauthenticated contexts.
+> When using Pennant outside of an HTTP context, such as in an Artisan command or a queued job, you should typically [explicitly specify the feature's scope](#specifying-the-scope). Alternatively, you may define a [default scope](#default-scope) that accounts for both authenticated HTTP contexts and unauthenticated contexts.
 
 <a name="checking-class-based-features"></a>
 #### Checking Class Based Features

--- a/pennant.md
+++ b/pennant.md
@@ -346,7 +346,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Feature::resolveScopeUsing(fn ($driver) => Auth::user()->team);
+        Feature::resolveScopeUsing(fn ($driver) => Auth::user()?->team);
 
         // ...
     }


### PR DESCRIPTION
## Note
<img width="790" alt="Screen Shot 2023-02-10 at 12 13 53 pm" src="https://user-images.githubusercontent.com/24803032/217975448-f4ca4776-a6c6-4e92-a353-110cbfdcfd8f.png">

## Auth facade, instead of `request()->user()`
<img width="716" alt="Screen Shot 2023-02-10 at 12 14 14 pm" src="https://user-images.githubusercontent.com/24803032/217975461-ad3e7f27-54ab-4e80-96dd-5f7b9d7c8e9c.png">
