### PR TITLE
[9.x] Update mocking.md - Test anonymous notifiables

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -548,6 +548,14 @@ You may pass a closure to the `assertSentTo` or `assertNotSentTo` methods in ord
             return $notification->order->id === $order->id;
         }
     );
+    
+You also can test anonymous notifiables:
+
+    use Illuminate\Notifications\AnonymousNotifiable;
+    
+    Notification::assertSentTo(new AnonymousNotifiable(), Notification::class, function($notification, $channels, $notifiable) {
+        return $notifiable->routes['mail'] == 'mail@example.com';
+    });
 
 <a name="on-demand-notifications"></a>
 #### On-Demand Notifications


### PR DESCRIPTION
extends notification documentation

Available since Laravel 5.5 see [#21379](https://github.com/laravel/framework/pull/21379)