### PR TITLE
[10.x] Add documentation for custom pennant driver

### DIFF
--- a/pennant.md
+++ b/pennant.md
@@ -846,4 +846,3 @@ public function test_it_can_control_feature_values()
 ```
 
 If your feature is returning a `Lottery` instance, there are a handful of useful [testing helpers available](/docs/{{version}}/helpers#testing-lotteries).
->>>>>>> 10.x


### PR DESCRIPTION
This adds a section on how to add a custom driver for Pennant's storage. A stub Redis storage implementation code is used for clarity.