### PR TITLE
[10.x] Removes named parameters

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -571,7 +571,7 @@ You may use the `recorded` method to gather all requests and their corresponding
 
 ```php
 Http::fake([
-    'https://laravel.com' => Http::response(status: 500),
+    'https://laravel.com' => Http::response('', 500),
     'https://nova.laravel.com/' => Http::response(),
 ]);
 
@@ -590,7 +590,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\Response;
 
 Http::fake([
-    'https://laravel.com' => Http::response(status: 500),
+    'https://laravel.com' => Http::response('', 500),
     'https://nova.laravel.com/' => Http::response(),
 ]);
 

--- a/pennant.md
+++ b/pennant.md
@@ -316,7 +316,7 @@ public function boot(): void
 {
     EnsureFeaturesAreActive::whenInactive(
         function (Request $request, array $features) {
-            return new Response(status: 403);
+            return new Response('', 403);
         }
     );
 


### PR DESCRIPTION
As Laravel doesn't support named parameters, feels like we are sending mixed messages by documenting their usage.

Proposing we remove them from the docs.

Maybe this could be improved with a named constructor `Response::empty(403)`.