### PR TITLE
[10.x] Add note to feature middleware about authentication

### DIFF
--- a/pennant.md
+++ b/pennant.md
@@ -296,8 +296,10 @@ Next, you may assign the middleware to a route and specify the features that are
 ```php
 Route::get('/api/servers', function () {
     // ...
-})->middleware(['features:new-api,servers-api']);
+})->middleware(['auth', 'features:new-api,servers-api']);
 ```
+
+> **Note** As the `feature` middleware will check against the currently authenticated user, you should ensure that any authentication related middleware is applied _before_ the `feature` middleware.
 
 <a name="customizing-the-response"></a>
 #### Customizing The Response


### PR DESCRIPTION
We don't have to include the `'auth'` in the example, but I thought it might help.

<img width="847" alt="Screen Shot 2023-02-13 at 12 40 52 pm" src="https://user-images.githubusercontent.com/24803032/218352081-d6be8100-6c27-490d-bf75-e40e4f542b46.png">
