### PR TITLE
[10.x] Specifies that Laravel now requires Composer 2.2 or greater

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -57,7 +57,7 @@
 
 #### Composer 2.2.0 Required
 
-Laravel now requires Composer 2.2.0 or greater.
+Laravel now requires [Composer](https://getcomposer.org) 2.2.0 or greater.
 
 #### PHP 8.1.0 Required
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -55,6 +55,10 @@
 
 **Likelihood Of Impact: High**
 
+#### Composer 2.2 Required
+
+Laravel now requires Composer 2.2 or greater.
+
 #### PHP 8.1.0 Required
 
 Laravel now requires PHP 8.1.0 or greater.

--- a/upgrade.md
+++ b/upgrade.md
@@ -55,9 +55,9 @@
 
 **Likelihood Of Impact: High**
 
-#### Composer 2.2 Required
+#### Composer 2.2.0 Required
 
-Laravel now requires Composer 2.2 or greater.
+Laravel now requires Composer 2.2.0 or greater.
 
 #### PHP 8.1.0 Required
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -55,13 +55,13 @@
 
 **Likelihood Of Impact: High**
 
-#### Composer 2.2.0 Required
-
-Laravel now requires [Composer](https://getcomposer.org) 2.2.0 or greater.
-
 #### PHP 8.1.0 Required
 
 Laravel now requires PHP 8.1.0 or greater.
+
+#### Composer 2.2.0 Required
+
+Laravel now requires [Composer](https://getcomposer.org) 2.2.0 or greater.
 
 #### Composer Dependencies
 


### PR DESCRIPTION
This pull request follow up on https://github.com/laravel/framework/pull/46096, and specifies that Laravel now requires Composer 2.2 or greater.