### PR TITLE
[10.x] Sail doc updated with multiple service choice instruction

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -62,6 +62,7 @@ To choose multiple sail services, you can specify them as comma separated string
 0,3,5,7
 ```
 or
+
 ```shell
 mysql,redis,meilisearch,selenium
 ```

--- a/sail.md
+++ b/sail.md
@@ -56,6 +56,16 @@ After Sail has been installed, you may run the `sail:install` Artisan command. T
 php artisan sail:install
 ```
 
+To choose multiple sail services, you can specify them as comma separated string like this:
+
+```shell
+0,3,5,7
+```
+or
+```shell
+mysql,redis,meilisearch,selenium
+```
+
 Finally, you may start Sail. To continue learning how to use Sail, please continue reading the remainder of this documentation:
 
 ```shell


### PR DESCRIPTION
In this PR, the sail doc is updated with instruction about how to choose multiple sail services after running `php artisan sail:install`. 