### PR TITLE
[9.x] Mail: add warning about alwaysTo disabling cc/bcc

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -1052,6 +1052,9 @@ Finally, you may specify a global "to" address by invoking the `alwaysTo` method
         }
     }
 
+> **Warning**  
+> When using the `alwaysTo` method, CC (Carbon Copy) and BCC (Blind Carbon Copy) recipients will also be ignored.
+
 <a name="events"></a>
 ## Events
 


### PR DESCRIPTION
This little warning would have saved me some time. 

Didn't seem obvious to me and the only mentions I found about it were some old stackoverflow threads. I can't be the only one.

Tested in 9.x but it may also applies to laravel 10