### PR TITLE
[10.x] update note about appending accessors

### DIFF
--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -154,7 +154,7 @@ Occasionally, when converting models to arrays or JSON, you may wish to add attr
         }
     }
 
-If you would like the accessor **always** appended to your model's array and JSON representations, you *may* add the attribute name to the `appends` property of your model. Note that attribute names are typically referenced using their "snake case" serialized representation, even though the accessor's PHP method is defined using "camel case":
+If you would like the accessor to always be appended to your model's array and JSON representations, you may add the attribute name to the `appends` property of your model. Note that attribute names are typically referenced using their "snake case" serialized representation, even though the accessor's PHP method is defined using "camel case":
 
     <?php
 

--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -154,7 +154,7 @@ Occasionally, when converting models to arrays or JSON, you may wish to add attr
         }
     }
 
-After creating the accessor, add the attribute name to the `appends` property of your model. Note that attribute names are typically referenced using their "snake case" serialized representation, even though the accessor's PHP method is defined using "camel case":
+If you would like the accessor **always** appended to your model's array and JSON representations, you *may* add the attribute name to the `appends` property of your model. Note that attribute names are typically referenced using their "snake case" serialized representation, even though the accessor's PHP method is defined using "camel case":
 
     <?php
 


### PR DESCRIPTION
the current wording makes it seem like you have to add the attribute to the `$appends` property.  I'm hoping this new wording emphasizes that it is optional, and helps the reader understand when and why they would or would not want to use it.

this is a resubmission of #8535, hoping it is a good compromise from where I originally started.