### PR TITLE
[10.x] Documents `Pennant::values`

### DIFF
--- a/pennant.md
+++ b/pennant.md
@@ -590,7 +590,7 @@ Likewise, when calling the conditional `unless` method, the feature's rich value
 <a name="retrieving-multiple-features"></a>
 ## Retrieving Multiple Features
 
-The `values` method allows the retrieval of multiple features for a scope:
+The `values` method allows the retrieval of multiple features for a given scope:
 
 ```php
 Feature::values(['billing-v2', 'purchase-button']);
@@ -601,15 +601,15 @@ Feature::values(['billing-v2', 'purchase-button']);
 // ]
 ```
 
-Via the `all` method, Pennant offers the ability to retrieve the values of all defined features for a scope:
+Or, you may use the `all` method to retrieve the values of all defined features for a given scope:
 
 ```php
 Feature::all();
 
 // [
-//     'site-redesign' => true,
 //     'billing-v2' => false,
 //     'purchase-button' => 'blue-sapphire',
+//     'site-redesign' => true,
 // ]
 ```
 
@@ -643,10 +643,10 @@ The `discover` method will register all of the feature classes in your applicati
 Feature::all();
 
 // [
-//     'site-redesign' => true,
+//     'App\Features\NewApi' => true,
 //     'billing-v2' => false,
 //     'purchase-button' => 'blue-sapphire',
-//     'App\Features\NewApi' => true,
+//     'site-redesign' => true,
 // ]
 ```
 

--- a/pennant.md
+++ b/pennant.md
@@ -11,13 +11,13 @@
     - [Blade Directive](#blade-directive)
     - [Middleware](#middleware)
     - [In-Memory Cache](#in-memory-cache)
-- [Retrieving All Features](#retrieving-all-features)
 - [Scope](#scope)
     - [Specifying The Scope](#specifying-the-scope)
     - [Default Scope](#default-scope)
     - [Nullable Scope](#nullable-scope)
     - [Identifying Scope](#identifying-scope)
 - [Rich Feature Values](#rich-feature-values)
+- [Retrieving All Features](#retrieving-all-features)
 - [Eager Loading](#eager-loading)
 - [Updating Values](#updating-values)
     - [Bulk Updates](#bulk-updates)
@@ -396,56 +396,6 @@ If you need to manually flush the in-memory cache, you may use the `flushCache` 
 
     Feature::flushCache();
 
-<a name="retrieving-all-features"></a>
-## Retrieving All Features
-
-Via the `all` method, Pennant offers the ability to retrieve the values of all defined features for a scope:
-
-```php
-Feature::all();
-
-// [
-//     'site-redesign' => true,
-//     'purchase-button' => 'blue-sapphire',
-// ]
-```
-
-However, class based features are dynamically registered and are not known by Pennant until they are explicitly checked. This means your application's class based features may not appear in the results returned by the `all` method if they have not already been checked during the current request.
-
-If you would like to ensure that feature classes are always included when using the `all` method, you may use Pennant's feature discovery capabilities. To get started, invoke the `discover` method in one of your application's service providers:
-
-    <?php
-
-    namespace App\Providers;
-
-    use Illuminate\Support\ServiceProvider;
-    use Laravel\Pennant\Feature;
-
-    class AppServiceProvider extends ServiceProvider
-    {
-        /**
-         * Bootstrap any application services.
-         */
-        public function boot(): void
-        {
-            Feature::discover();
-
-            // ...
-        }
-    }
-
-The `discover` method will register all of the feature classes in your application's `app/Features` directory. The `all` method will now include these classes in its results, regardless of whether they have been checked during the current request:
-
-```php
-Feature::all();
-
-// [
-//     'site-redesign' => true,
-//     'purchase-button' => 'blue-sapphire',
-//     'App\Features\NewApi' => true,
-// ]
-```
-
 <a name="scope"></a>
 ## Scope
 
@@ -636,6 +586,56 @@ Likewise, when calling the conditional `unless` method, the feature's rich value
         fn () => /* ... */,
         fn ($color) => /* ... */,
     );
+
+<a name="retrieving-all-features"></a>
+## Retrieving All Features
+
+Via the `all` method, Pennant offers the ability to retrieve the values of all defined features for a scope:
+
+```php
+Feature::all();
+
+// [
+//     'site-redesign' => true,
+//     'purchase-button' => 'blue-sapphire',
+// ]
+```
+
+However, class based features are dynamically registered and are not known by Pennant until they are explicitly checked. This means your application's class based features may not appear in the results returned by the `all` method if they have not already been checked during the current request.
+
+If you would like to ensure that feature classes are always included when using the `all` method, you may use Pennant's feature discovery capabilities. To get started, invoke the `discover` method in one of your application's service providers:
+
+    <?php
+
+    namespace App\Providers;
+
+    use Illuminate\Support\ServiceProvider;
+    use Laravel\Pennant\Feature;
+
+    class AppServiceProvider extends ServiceProvider
+    {
+        /**
+         * Bootstrap any application services.
+         */
+        public function boot(): void
+        {
+            Feature::discover();
+
+            // ...
+        }
+    }
+
+The `discover` method will register all of the feature classes in your application's `app/Features` directory. The `all` method will now include these classes in its results, regardless of whether they have been checked during the current request:
+
+```php
+Feature::all();
+
+// [
+//     'site-redesign' => true,
+//     'purchase-button' => 'blue-sapphire',
+//     'App\Features\NewApi' => true,
+// ]
+```
 
 <a name="eager-loading"></a>
 ## Eager Loading

--- a/pennant.md
+++ b/pennant.md
@@ -17,7 +17,7 @@
     - [Nullable Scope](#nullable-scope)
     - [Identifying Scope](#identifying-scope)
 - [Rich Feature Values](#rich-feature-values)
-- [Retrieving All Features](#retrieving-all-features)
+- [Retrieving Multiple Features](#retrieving-multiple-features)
 - [Eager Loading](#eager-loading)
 - [Updating Values](#updating-values)
     - [Bulk Updates](#bulk-updates)
@@ -587,8 +587,19 @@ Likewise, when calling the conditional `unless` method, the feature's rich value
         fn ($color) => /* ... */,
     );
 
-<a name="retrieving-all-features"></a>
-## Retrieving All Features
+<a name="retrieving-multiple-features"></a>
+## Retrieving Multiple Features
+
+The `values` method allows the retrieval of multiple features for a scope:
+
+```php
+Feature::values(['billing-v2', 'purchase-button']);
+
+// [
+//     'billing-v2' => false,
+//     'purchase-button' => 'blue-sapphire',
+// ]
+```
 
 Via the `all` method, Pennant offers the ability to retrieve the values of all defined features for a scope:
 
@@ -597,6 +608,7 @@ Feature::all();
 
 // [
 //     'site-redesign' => true,
+//     'billing-v2' => false,
 //     'purchase-button' => 'blue-sapphire',
 // ]
 ```
@@ -632,6 +644,7 @@ Feature::all();
 
 // [
 //     'site-redesign' => true,
+//     'billing-v2' => false,
 //     'purchase-button' => 'blue-sapphire',
 //     'App\Features\NewApi' => true,
 // ]


### PR DESCRIPTION
1. Moved the "Retrieving All Features" to after discussing "values". Felt "values" was really prior knowledge and it goes will with "Eager Loading".
2. Renamed "Retrieving Multiple Features" and added documentation on `Feature::values(['foo', 'bar'])`

The only change to the `all` docs was the addition of `'billing-v2'` to the output array to differentiate from the output of the `values` example.

## Menu

<img width="546" alt="Screen Shot 2023-02-16 at 10 22 01 am" src="https://user-images.githubusercontent.com/24803032/219215233-badb7ecd-0da9-4738-989a-eed373f57ab4.png">

## Section

<img width="795" alt="Screen Shot 2023-02-16 at 10 21 54 am" src="https://user-images.githubusercontent.com/24803032/219215264-68c375e1-720a-4346-b7dc-f87f029247d3.png">
