### PR TITLE
Add information about shouldRender method

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -715,6 +715,18 @@ If the component class is nested deeper within the `app/View/Components` directo
 <x-inputs.button/>
 ```
 
+If you would like to conditionally render your component, you may define a `shouldRender` method on your component class. If the `shouldRender` method returns `false` the component will not be rendered:
+
+    use Illuminate\Support\Str;
+
+    /**
+     * Whether the component should be rendered
+     */
+    public function shouldRender(): bool
+    {
+        return Str::length($this->message) > 0;
+    }
+
 <a name="passing-data-to-components"></a>
 ### Passing Data To Components
 
@@ -759,18 +771,6 @@ When your component is rendered, you may display the contents of your component'
     {{ $message }}
 </div>
 ```
-
-If you want to render your component only in some cases you can define `shouldRender` method:
-
-    /**
-     * Whether the component should be rendered
-     */
-    public function shouldRender(): bool
-    {
-        return Str::length($this->message) > 0;
-    }
-
-If `shouldRender` returns false component will not be rendered.
 
 <a name="casing"></a>
 #### Casing

--- a/blade.md
+++ b/blade.md
@@ -760,6 +760,18 @@ When your component is rendered, you may display the contents of your component'
 </div>
 ```
 
+If you want to render your component only in some cases you can define `shouldRender` method:
+
+    /**
+     * Whether the component should be rendered
+     */
+    public function shouldRender(): bool
+    {
+        return Str::length($this->message) > 0;
+    }
+
+If `shouldRender` returns false component will not be rendered.
+
 <a name="casing"></a>
 #### Casing
 


### PR DESCRIPTION
Another try of https://github.com/laravel/docs/pull/8583

As this method is not included in Component class stub, not everyone knows that we can render component by some conditions. Previously I had to return null from `render` method for that.

Or maybe it just should be included in Component class stub?