### PR TITLE
Update link to API docs

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -97,4 +97,4 @@
     - [Socialite](/docs/{{version}}/socialite)
     - [Telescope](/docs/{{version}}/telescope)
     - [Valet](/docs/{{version}}/valet)
-- [API Documentation](/api/9.x)
+- [API Documentation](/api/10.x)

--- a/documentation.md
+++ b/documentation.md
@@ -97,4 +97,4 @@
     - [Socialite](/docs/{{version}}/socialite)
     - [Telescope](/docs/{{version}}/telescope)
     - [Valet](/docs/{{version}}/valet)
-- [API Documentation](/api/10.x)
+- [API Documentation](/api/master)


### PR DESCRIPTION
Change `9.x` to `10.x` in the master docs.

Or maybe it should lead to `master`? That apparently didn't work at some point in time (#7249) but at the moment https://laravel.com/api/master/ is a fine page.