### PR TITLE
[10.x] create "Deprecations" documentation

### DIFF
--- a/deprecations.md
+++ b/deprecations.md
@@ -1,0 +1,16 @@
+# Deprecations
+
+- [Introduction](#introduction)
+    - [Route Middleware](#route-middleware)
+
+<a name="introduction"></a>
+## Introduction
+
+Laravel will, when necessary, deprecate certain features or code within the framework. In an effort to help you track those changes, and update your applications prior to the deprecated code being removed, this page will highlight some of those deprecations. The best way to find **all** the deprecated code is to search `laravel/framework` for `@deprecated`.
+
+<a name="route-middleware"></a>
+### Route Middleware
+
+In the `\Illuminate\Foundation\Http\Kernel` class, the `$routeMiddleware` property was renamed to `$middlewareAliases` to better reflect its purpose. The `$routeMiddleware` property and the `getRouteMiddleware()` method have been deprecated, and will be removed in Laravel 11.
+
+https://github.com/laravel/framework/commit/78eb546e9c789ac84af87bb362535cc2883e4db4

--- a/documentation.md
+++ b/documentation.md
@@ -2,6 +2,7 @@
     - [Release Notes](/docs/{{version}}/releases)
     - [Upgrade Guide](/docs/{{version}}/upgrade)
     - [Contribution Guide](/docs/{{version}}/contributions)
+    - [Deprecations](/docs/{{version}}/deprecations)
 - ## Getting Started
     - [Installation](/docs/{{version}}/installation)
     - [Configuration](/docs/{{version}}/configuration)


### PR DESCRIPTION
In light of the recent comments on https://github.com/laravel/framework/pull/42587#issuecomment-1433285452, I thought it might be worthwhile to create some documentation on deprecations in the framework to make them more obvious to users  who maybe aren't digging through the code and watching the commits all the time.

We have two "events" that are helpful to document:

- code is deprecated
- deprecated code is removed

We currently, as @driesvints pointed out, document in the Upgrade Guide when **deprecated code is removed**.  We, however, don't currently document when **code is deprecated**.  I don't think it makes sense to add this to the Upgrade Guide, as it could add a lot of noise, and is not immediately relevant to people performing upgrades.  This is why I think having a separate page for it makes the most sense. Having this page will help avoid users getting blindsided in the upgrade process from removed code possibly requiring larger refactors.

I definitely still think the code is the best place to go as the source of truth for finding deprecated code, but I also kind of see the side of it never being explicitly presented to the masses.

This page will contain documentation on code or features that have been deprecated in the framework, possibly some notes on how to update, and possibly when the code will be removed.