### PR TITLE
[10.x] Add `laravel/sanctum` to the list of dependencies to update

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -72,6 +72,7 @@ You should update the following dependencies in your application's `composer.jso
 <div class="content-list" markdown="1">
 
 - `laravel/framework` to `^10.0`
+- `laravel/sanctum` to `^3.2`
 - `spatie/laravel-ignition` to `^2.0`
 
 </div>


### PR DESCRIPTION
## Problem

**I'm trying to upgrade from laravel 9 to laravel 10.**

I've followed [the Upgrade Guide](https://laravel.com/docs/10.x/upgrade#updating-dependencies) by updating the dependencies like this:

![error-upgrade-to-laravel-10-composer-json](https://user-images.githubusercontent.com/63894003/219541720-52ddfd47-4d0d-4911-a07a-a5cda8f3522d.png)

Then I'm stuck with this error:

![error-upgrade-to-laravel-10](https://user-images.githubusercontent.com/63894003/219539746-defb75c4-11bf-4b6a-b5e6-5a44dda9c516.png)

## Solution

I tried to change only the `laravel/sanctum` to `^3.2` (https://github.com/laravel/laravel/commit/af241e157245de5013ea97aabdf3b5aa789bf01a). And **it's works**!

So, I think is necessary to **mention the `laravel/sanctum` version update** in [the Upgrade Guide](https://laravel.com/docs/10.x/upgrade#updating-dependencies).
