### PR TITLE
Added mandatory cluster option to documentation

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -97,7 +97,7 @@ PUSHER_APP_SECRET=your-pusher-secret
 PUSHER_APP_CLUSTER=mt1
 ```
 
-The `config/broadcasting.php` file's `pusher` configuration also allows you to specify additional `options` that are supported by Channels, such as the cluster.
+The `config/broadcasting.php` file's `pusher` configuration also allows you to specify additional `options` that are supported by Channels, such as the disableStats.
 
 Next, you will need to change your broadcast driver to `pusher` in your `.env` file:
 
@@ -239,6 +239,7 @@ window.Echo = new Echo({
     wsPort: 443,
     disableStats: true,
     encrypted: true,
+    cluster: import.meta.env.VITE_PUSHER_APP_CLUSTER ?? '',
 });
 ```
 


### PR DESCRIPTION
The documentation also need to be updated because cluster option in pusher/pusher-js#655 is mandatory.

So even if you use another websocket client like ably, you still need to define the "cluster" option as a string (you can have empty string) in the bootstrap.js

There is also changes to the Pusher "additional `options`" info that pusher-js cluster is no longer optional, so i decided to change `cluster` option to `disableStats` for an example of optional configuration