### PR TITLE
[10.x] Removes `@return $this` when returning static

### DIFF
--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -146,8 +146,6 @@ Factory callbacks are registered using the `afterMaking` and `afterCreating` met
     {
         /**
          * Configure the model factory.
-         *
-         * @return $this
          */
         public function configure(): static
         {

--- a/validation.md
+++ b/validation.md
@@ -2166,7 +2166,6 @@ If your custom validation rule class needs to access all of the other data under
          * Set the data under validation.
          *
          * @param  array<string, mixed>  $data
-         * @return $this
          */
         public function setData(array $data): static
         {


### PR DESCRIPTION
Based on https://github.com/laravel/laravel/pull/6119, this pull request removes `@return $this` when returning static.