### PR TITLE
remove duplicated line of code in events

### DIFF
--- a/events.md
+++ b/events.md
@@ -561,11 +561,6 @@ Event subscribers are classes that may subscribe to multiple events from within 
                 Login::class,
                 [UserEventSubscriber::class, 'handleUserLogin']
             );
-
-            $events->listen(
-                Logout::class,
-                [UserEventSubscriber::class, 'handleUserLogout']
-            );
         }
     }
 


### PR DESCRIPTION
Removed duplicate line of code in the Writing Event Subscribers section