### PR TITLE
[10.x] Replace optional by Null-safe operator

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -453,7 +453,8 @@ Some policy methods only receive an instance of the currently authenticated user
 <a name="guest-users"></a>
 ### Guest Users
 
-By default, all gates and policies automatically return `false` if the incoming HTTP request was not initiated by an authenticated user. However, you may allow these authorization checks to pass through to your gates and policies by declaring an "optional" type-hint or supplying a `null` default value for the user argument definition:
+By default, all gates and policies automatically return `false` if the incoming HTTP request was not initiated by an authenticated user. However, you may allow these authorization checks to pass through to your gates and policies by declaring an "
+" type-hint or supplying a `null` default value for the user argument definition:
 
     <?php
 
@@ -469,7 +470,7 @@ By default, all gates and policies automatically return `false` if the incoming 
          */
         public function update(?User $user, Post $post): bool
         {
-            return optional($user)->id === $post->user_id;
+            return $user?->id === $post->user_id;
         }
     }
 

--- a/authorization.md
+++ b/authorization.md
@@ -453,8 +453,7 @@ Some policy methods only receive an instance of the currently authenticated user
 <a name="guest-users"></a>
 ### Guest Users
 
-By default, all gates and policies automatically return `false` if the incoming HTTP request was not initiated by an authenticated user. However, you may allow these authorization checks to pass through to your gates and policies by declaring an "
-" type-hint or supplying a `null` default value for the user argument definition:
+By default, all gates and policies automatically return `false` if the incoming HTTP request was not initiated by an authenticated user. However, you may allow these authorization checks to pass through to your gates and policies by declaring an "optional" type-hint or supplying a `null` default value for the user argument definition:
 
     <?php
 

--- a/cache.md
+++ b/cache.md
@@ -362,7 +362,7 @@ If the lock is not available at the moment you request it, you may instruct Lara
     } catch (LockTimeoutException $e) {
         // Unable to acquire lock...
     } finally {
-        optional($lock)->release();
+        $lock?->release();
     }
 
 The example above may be simplified by passing a closure to the `block` method. When a closure is passed to this method, Laravel will attempt to acquire the lock for the specified number of seconds and will automatically release the lock once the closure has been executed:


### PR DESCRIPTION
Since Laravel requires PHP 8, [Null-safe operators](https://php.watch/versions/8.0/null-safe-operator) can replace the `optional()` helper function.