### PR TITLE
[10.x] Mention minimum DBAL version in upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -73,6 +73,7 @@ You should update the following dependencies in your application's `composer.jso
 
 - `laravel/framework` to `^10.0`
 - `laravel/sanctum` to `^3.2`
+- `doctrine/dbal` to `^3.0`
 - `spatie/laravel-ignition` to `^2.0`
 
 </div>


### PR DESCRIPTION
DBAL v2 is no longer supported: https://github.com/laravel/framework/pull/44733