### PR TITLE
[10.x] Adds more examples to time manipulation

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -134,7 +134,7 @@ If you would like to [spy](http://docs.mockery.io/en/latest/reference/spies.html
 <a name="interacting-with-time"></a>
 ## Interacting With Time
 
-When testing, you may occasionally need to modify the time returned by helpers such as `now` or `Illuminate\Support\Carbon::now()`, or some of Laravel's generated timestamps like when creating Eloquent Models. Thankfully, Laravel's base feature test class includes helpers that allow you to manipulate the current time.
+When testing, you may occasionally need to modify the time returned by helpers such as `now` or `Illuminate\Support\Carbon::now()`, or some of Laravel's generated timestamps like on Eloquent Models. Thankfully, Laravel's base feature test class includes helpers that allow you to manipulate the current time.
 
 The `travel()` method can be used to freeze the time into the future or the past, and resume the current flow of time using `back()`.
 

--- a/mocking.md
+++ b/mocking.md
@@ -155,7 +155,7 @@ Alternatively, you may execute a callback while the time is frozen, like traveli
     $this->travel(5)->days(function () {
         // Test something five days into the future...
     });
-
+    
     $this->travelTo(now()->subDays(10), function () {
         // Test something during a given moment...
     });
@@ -163,12 +163,12 @@ Alternatively, you may execute a callback while the time is frozen, like traveli
 You can also use `freeze()` to stop the current time, or use `freezeSecond()` to do the same but rewinding the time to the start of the current second for less-granular comparisons.
 
     use Illuminate\Support\Carbon;
-
+    
     // Freeze time and resume normal time after executing closure...
     $this->freezeTime(function (Carbon $time) {
         // ...
     });
-
+    
     // Freeze the current second and resume normal time after executing closure...
     $this->freezeSecond(function (Carbon $time) {
         // ...
@@ -202,7 +202,7 @@ Imagine that the forum thread receives a reply three days after it was created. 
         // One week later after creation, the thread should not be locked.
         $this->travel(1)->week();
         $this->assertFalse($thread->isLockedByInactivity());
-
+        
         // A week later from the last reply, it becomes locked.
         $this->travel(3)->days();
         $this->assertTrue($thread->isLockedByInactivity());

--- a/mocking.md
+++ b/mocking.md
@@ -187,7 +187,7 @@ To give a concrete example, imagine that forum threads save internally their mom
         $this->assertTrue($thread->isLockedByInactivity());
     }
 
-Imagine that the forum thread receives a reply three days after it was created. Logically, the thread would become locked after a week of that last reply. That reply can be created in using the convenient _wormhole_ callback.
+Imagine that the forum thread receives a reply three days after it was created. Logically, the thread would become locked after a week of that last reply. That reply can be created using the convenient _wormhole_ callback.
 
     use App\Models\Thread;
     use App\Models\Post;

--- a/mocking.md
+++ b/mocking.md
@@ -134,32 +134,76 @@ If you would like to [spy](http://docs.mockery.io/en/latest/reference/spies.html
 <a name="interacting-with-time"></a>
 ## Interacting With Time
 
-When testing, you may occasionally need to modify the time returned by helpers such as `now` or `Illuminate\Support\Carbon::now()`. Thankfully, Laravel's base feature test class includes helpers that allow you to manipulate the current time:
+When testing, you may occasionally need to modify the time returned by helpers such as `now` or `Illuminate\Support\Carbon::now()`, or some of Laravel's generated timestamps like when creating Eloquent Models. Thankfully, Laravel's base feature test class includes helpers that allow you to manipulate the current time.
+
+The `travel()` method can be used to freeze the time into the future or the past, and resume the current flow of time using `back()`.
+
+    // Go 10 days into the future.
+    $this->travel(10)->days();
+    
+    // Go one month into the past.
+    $this->travel(-1)->month();
+    
+    // Set an explicit moment.
+    $this->travelTo('2015-07-04 20:00:00');
+    
+    // Resume the normal flow of time.
+    $this->travel()->back();
+
+Alternatively, you may execute a callback while the time is frozen, like traveling into a _wormhole_ and then returning back. After the callback ends, the time will resume as normal.
+
+    $this->travel(5)->days(function () {
+        // Test something five days into the future...
+    });
+
+    $this->travelTo(now()->subDays(10), function () {
+        // Test something during a given moment...
+    });
+
+You can also use `freeze()` to stop the current time, or use `freezeSecond()` to do the same but rewinding the time to the start of the current second for less-granular comparisons.
 
     use Illuminate\Support\Carbon;
 
-    public function test_time_can_be_manipulated(): void
+    // Freeze time and resume normal time after executing closure...
+    $this->freezeTime(function (Carbon $time) {
+        // ...
+    });
+
+    // Freeze the current second and resume normal time after executing closure...
+    $this->freezeSecond(function (Carbon $time) {
+        // ...
+    })
+
+To give a concrete example, imagine that forums threads save internally their moment of last activity. We need to test that a thread becomes locked for inactivity after one week. We can move the time forward after the thread is created to test that.
+
+    use App\Models\Thread;
+    
+    public function test_forum_threads_locks_after_one_week_of_inactivity()
     {
-        // Travel into the future...
-        $this->travel(5)->milliseconds();
-        $this->travel(5)->seconds();
-        $this->travel(5)->minutes();
-        $this->travel(5)->hours();
-        $this->travel(5)->days();
-        $this->travel(5)->weeks();
-        $this->travel(5)->years();
+        $thread = Thread::factory()->create();
+        
+        $this->travel(1)->week();
+        
+        $this->assertTrue($thread->isLockedByInactivity());
+    }
 
-        // Freeze time and resume normal time after executing closure...
-        $this->freezeTime(function (Carbon $time) {
-            // ...
-        });
+Imagine that the forum thread receives a reply three days after it was created. Logically, the thread would become locked after a week of that last reply. That reply can be created in using the convenient _wormhole_ callback.
 
-        // Travel into the past...
-        $this->travel(-5)->hours();
+    use App\Models\Thread;
+    use App\Models\Post;
+    
+    public function test_forum_threads_locks_after_one_week_of_last_post()
+    {
+        $thread = Thread::factory()->create();
+        
+        // Travel three days forward, post a reply, and come back.
+        $this->travel(3)->days(fn () => Post::factory()->for($thread)->create());
+        
+        // One week later after creation, the thread should not be locked.
+        $this->travel(1)->week();
+        $this->assertFalse($thread->isLockedByInactivity());
 
-        // Travel to an explicit time...
-        $this->travelTo(now()->subHours(6));
-
-        // Return back to the present time...
-        $this->travelBack();
+        // A week later from the last reply, it becomes locked.
+        $this->travel(3)->days();
+        $this->assertTrue($thread->isLockedByInactivity());
     }

--- a/mocking.md
+++ b/mocking.md
@@ -174,7 +174,7 @@ You can also use `freeze()` to stop the current time, or use `freezeSecond()` to
         // ...
     })
 
-To give a concrete example, imagine that forums threads save internally their moment of last activity. We need to test that a thread becomes locked for inactivity after one week. We can move the time forward after the thread is created to test that.
+To give a concrete example, imagine that forum threads save internally their moment of last activity. We need to test that a thread becomes locked for inactivity after one week. We can move the time forward after the thread is created to test that.
 
     use App\Models\Thread;
     

--- a/mocking.md
+++ b/mocking.md
@@ -136,7 +136,7 @@ If you would like to [spy](http://docs.mockery.io/en/latest/reference/spies.html
 
 When testing, you may occasionally need to modify the time returned by helpers such as `now` or `Illuminate\Support\Carbon::now()`, or some of Laravel's generated timestamps like on Eloquent Models. Thankfully, Laravel's base feature test class includes helpers that allow you to manipulate the current time.
 
-The `travel()` method can be used to freeze the time into the future or the past, and resume the current flow of time using `back()`.
+The `travel()` method can be used to freeze time into the future or the past, and resume the current flow of time using `back()`.
 
     // Go 10 days into the future.
     $this->travel(10)->days();


### PR DESCRIPTION
I thought the Time manipulation of the _Mocking_ section of testing could have more details on what is offered, and why you may use it.