### PR TITLE
[10.x] Removed PHP 8.1 warnings

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -412,9 +412,6 @@ If a custom format is applied to the `date` or `datetime` cast, such as `datetim
 <a name="enum-casting"></a>
 ### Enum Casting
 
-> **Warning**  
-> Enum casting is only available for PHP 8.1+.
-
 Eloquent also allows you to cast your attribute values to PHP [Enums](https://www.php.net/manual/en/language.enumerations.backed.php). To accomplish this, you may specify the attribute and enum you wish to cast in your model's `$casts` property array:
 
     use App\Enums\ServerStatus;

--- a/validation.md
+++ b/validation.md
@@ -1194,9 +1194,6 @@ The `Enum` rule is a class based rule that validates whether the field under val
         'status' => [new Enum(ServerStatus::class)],
     ]);
 
-> **Warning**  
-> Enums are only available on PHP 8.1+.
-
 <a name="rule-exclude"></a>
 #### exclude
 


### PR DESCRIPTION
Removed PHP 8.1 requirement warnings as `laravel/laravel` and `laravel/framework` already requires `^8.1`

---

Additional warnings found not included in this pull request:
- [Octane](https://github.com/laravel/docs/blob/10.x/octane.md) (Line 50)