### PR TITLE
Document sync driver not supporting after_commit

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -769,6 +769,9 @@ If a transaction is rolled back due to an exception that occurs during the trans
 > **Note**  
 > Setting the `after_commit` configuration option to `true` will also cause any queued event listeners, mailables, notifications, and broadcast events to be dispatched after all open database transactions have been committed.
 
+> **Warning**  
+> The `after_commit` configuration option is not supported when using the ```sync``` queue driver, as all jobs are dispatched immediately.
+
 <a name="specifying-commit-dispatch-behavior-inline"></a>
 #### Specifying Commit Dispatch Behavior Inline
 


### PR DESCRIPTION
https://github.com/laravel/framework/issues/46296

Currently, the ```after_commit``` option is silently ignored by the ```sync``` queue driver, which may cause unexpected behaviour for developers.

This PR attempts to document that the ```after_commit``` option is not  supported, to avoid confusion.