### PR TITLE
Document primary keys as castables not being supported

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -726,6 +726,9 @@ When using `Castable` classes, you may still provide arguments in the `$casts` d
         'address' => Address::class.':argument',
     ];
 
+> **Warning**  
+> Using ```casts``` on primary key fields is NOT supported.
+  
 <a name="anonymous-cast-classes"></a>
 #### Castables & Anonymous Cast Classes
 

--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -261,7 +261,7 @@ If you need to add a new, temporary cast at runtime, you may use the `mergeCasts
     ]);
 
 > **Warning**  
-> Attributes that are `null` will not be cast. In addition, you should never define a cast (or an attribute) that has the same name as a relationship.
+> Attributes that are `null` will not be cast. In addition, you should never define a cast (or an attribute) that has the same name as a relationship or is attached to the model's primary key.
 
 <a name="stringable-casting"></a>
 #### Stringable Casting
@@ -725,9 +725,6 @@ When using `Castable` classes, you may still provide arguments in the `$casts` d
     protected $casts = [
         'address' => Address::class.':argument',
     ];
-
-> **Warning**  
-> Using ```casts``` on primary key fields is NOT supported.
   
 <a name="anonymous-cast-classes"></a>
 #### Castables & Anonymous Cast Classes

--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -261,7 +261,7 @@ If you need to add a new, temporary cast at runtime, you may use the `mergeCasts
     ]);
 
 > **Warning**  
-> Attributes that are `null` will not be cast. In addition, you should never define a cast (or an attribute) that has the same name as a relationship or is attached to the model's primary key.
+> Attributes that are `null` will not be cast. In addition, you should never define a cast (or an attribute) that has the same name as a relationship or assign a cast to the model's primary key.
 
 <a name="stringable-casting"></a>
 #### Stringable Casting
@@ -725,7 +725,7 @@ When using `Castable` classes, you may still provide arguments in the `$casts` d
     protected $casts = [
         'address' => Address::class.':argument',
     ];
-  
+
 <a name="anonymous-cast-classes"></a>
 #### Castables & Anonymous Cast Classes
 


### PR DESCRIPTION
As per the discussion at https://github.com/laravel/framework/issues/46005, while using ```casts``` on primary keys may work in simpler scenarios, it seems to break down in more complex situations (e.g. pivot models).

This PR attempts to document that using casts on primary key fields should not be attempted.

Suggestions are welcome on how to formulate this limitation better. 