### PR TITLE
[10.x] Add Change Error Theme into `Error-Handling`

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -27,7 +27,7 @@ During local development, you should set the `APP_DEBUG` environment variable to
 <a name="error-theme"></a>
 ### Error Theme
 
-If you want to change error theme you can add `IGNITION_THEME` into `.env` file:
+The default Laravel theme is `dark`. If you want to change error theme you can add `IGNITION_THEME` into `.env` file:
 
 ```dotenv
 IGNITION_THEME=light

--- a/errors.md
+++ b/errors.md
@@ -27,7 +27,7 @@ During local development, you should set the `APP_DEBUG` environment variable to
 <a name="error-theme"></a>
 ### Error Theme
 
-The default Laravel theme is `dark`. If you want to change error theme you can add `IGNITION_THEME` into `.env` file:
+The default Laravel theme is `dark`. If you want to change the error theme, you can add `IGNITION_THEME` into the `.env` file:
 
 ```dotenv
 IGNITION_THEME=light

--- a/errors.md
+++ b/errors.md
@@ -2,6 +2,7 @@
 
 - [Introduction](#introduction)
 - [Configuration](#configuration)
+    - [Error Theme](#error-theme) 
 - [The Exception Handler](#the-exception-handler)
     - [Reporting Exceptions](#reporting-exceptions)
     - [Exception Log Levels](#exception-log-levels)
@@ -22,6 +23,15 @@ When you start a new Laravel project, error and exception handling is already co
 The `debug` option in your `config/app.php` configuration file determines how much information about an error is actually displayed to the user. By default, this option is set to respect the value of the `APP_DEBUG` environment variable, which is stored in your `.env` file.
 
 During local development, you should set the `APP_DEBUG` environment variable to `true`. **In your production environment, this value should always be `false`. If the value is set to `true` in production, you risk exposing sensitive configuration values to your application's end users.**
+
+<a name="error-theme"></a>
+### Error Theme
+
+If you want to change error theme you can add `IGNITION_THEME` into `.env` file:
+
+```dotenv
+IGNITION_THEME=light
+```
 
 <a name="the-exception-handler"></a>
 ## The Exception Handler


### PR DESCRIPTION
Suppose you want to change the theme of the error pages!
It is not written in any part of the documentation.
This section is a good place for those who want to change the theme of the error page.