### PR TITLE
[10.x] Added warning for valet use, pushing usage of valet isolate instead

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -102,6 +102,9 @@ Valet will automatically start its required services each time your machine boot
 <a name="php-versions"></a>
 #### PHP Versions
 
+> **Note**  
+> Instead of modifying your global PHP version, you can instruct Valet to use per-site PHP versions via the `isolate` [command](#per-site-php-versions).
+
 Valet allows you to switch PHP versions using the `valet use php@version` command. Valet will install the specified PHP version via Homebrew if it is not already installed:
 
 ```shell
@@ -109,9 +112,6 @@ valet use php@8.1
 
 valet use php
 ```
-
-> **Warning**  
-> You probably want to use `valet isolate` instead of this command, especially if you have any globally installed Composer packages.
 
 You may also create a `.valetphprc` file in the root of your project. The `.valetphprc` file should contain the PHP version the site should use:
 

--- a/valet.md
+++ b/valet.md
@@ -110,6 +110,9 @@ valet use php@8.1
 valet use php
 ```
 
+> **Warning**  
+> You probably want to use `valet isolate` instead of this command, especially if you have any globally installed Composer packages.
+
 You may also create a `.valetphprc` file in the root of your project. The `.valetphprc` file should contain the PHP version the site should use:
 
 ```shell


### PR DESCRIPTION
So many times I hear people using `valet use` and breaking their setup. I feel like this warning should help push people to use `valet isolate` when it's more likely than not the command they're actually wanting to/should use.