### PR TITLE
[10.x] import correct Builder namespace

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1704,12 +1704,15 @@ If you would like to override all items within the `$with` property for a single
 Sometimes you may wish to eager load a relationship but also specify additional query conditions for the eager loading query. You can accomplish this by passing an array of relationships to the `with` method where the array key is a relationship name and the array value is a closure that adds additional constraints to the eager loading query:
 
     use App\Models\User;
+    use Illuminate\Contracts\Database\Eloquent\Builder;
 
     $users = User::with(['posts' => function (Builder $query) {
         $query->where('title', 'like', '%code%');
     }])->get();
 
 In this example, Eloquent will only eager load posts where the post's `title` column contains the word `code`. You may call other [query builder](/docs/{{version}}/queries) methods to further customize the eager loading operation:
+
+    use Illuminate\Contracts\Database\Eloquent\Builder;
 
     $users = User::with(['posts' => function (Builder $query) {
         $query->orderBy('created_at', 'desc');

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1712,8 +1712,6 @@ Sometimes you may wish to eager load a relationship but also specify additional 
 
 In this example, Eloquent will only eager load posts where the post's `title` column contains the word `code`. You may call other [query builder](/docs/{{version}}/queries) methods to further customize the eager loading operation:
 
-    use Illuminate\Contracts\Database\Eloquent\Builder;
-
     $users = User::with(['posts' => function (Builder $query) {
         $query->orderBy('created_at', 'desc');
     }])->get();


### PR DESCRIPTION
when constraining the eager loaded relationship, the class actually passed into the closure is an instance of the actual relationship class, which implements `Illuminate\Contracts\Database\Eloquent\Builder`, and **not** `Illuminate\Database\Eloquent\Builder`.

it would be very easy for a user to be confused, since in most of these other examples an `Illuminate\Database\Eloquent\Builder` is actually passed to the closure.