### PR TITLE
[10.x] - Declare $carry as nullable

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1928,7 +1928,7 @@ The `reduce` method reduces the collection to a single value, passing the result
 
     $collection = collect([1, 2, 3]);
 
-    $total = $collection->reduce(function (int $carry, int $item) {
+    $total = $collection->reduce(function (?int $carry, int $item) {
         return $carry + $item;
     });
 


### PR DESCRIPTION
The first example of the `reduce` method does not specify a value for the first iteration.

This will result in a TypeError when using the example; specifying the first parameter as nullable will resolve this.