### PR TITLE
Remove duplicate service provider registration

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -74,7 +74,7 @@ php artisan telescope:install
 php artisan migrate
 ```
 
-After running `telescope:install`, you should remove the `TelescopeServiceProvider` service provider registration from your application's `config/app.php` configuration file. Instead, manually register Telescope's service providers in the `register` method of your `App\Providers\AppServiceProvider` class. We will ensure the current environment is `local` before registering the providers:
+After running `telescope:install`, you should remove the `TelescopeServiceProvider` service provider registration from your application's `config/app.php` configuration file. Instead, manually register Telescope service provider in the `register` method of your `App\Providers\AppServiceProvider` class. We will ensure the current environment is `local` before registering the provider:
 
     /**
      * Register any application services.
@@ -83,7 +83,6 @@ After running `telescope:install`, you should remove the `TelescopeServiceProvid
     {
         if ($this->app->environment('local')) {
             $this->app->register(\Laravel\Telescope\TelescopeServiceProvider::class);
-            $this->app->register(TelescopeServiceProvider::class);
         }
     }
 


### PR DESCRIPTION
Hi guys, I just noticed there is a duplicate in the AppServiceProvider register method for the Telescope Service Provider. As I know, there is just one Telescope Service Provider, but there are two ways how to resolve the class (either by passing the full path into the closure or by just entering the classname and make use of the "use" statement). So I guess what happened here is that both ways have been added to the doc, but it does confuse, because as per current documentation the service provider would be registered twice? .. Anyways, please let me know if I miss something.