### PR TITLE
fixed typo

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -381,7 +381,7 @@ Instead of rate limiting in the handle method, we could define a job middleware 
         {
             Redis::throttle('key')
                     ->block(0)->allow(1)->every(5)
-                    ->then(function () use (object $job, Closure $next) {
+                    ->then(function () use ($job, $next) {
                         // Lock obtained...
 
                         $next($job);


### PR DESCRIPTION
Since is not allowed to pass value type in a function use statement, example code from docs are wrong:

![image](https://user-images.githubusercontent.com/585263/225345272-d394e0c2-5ac2-4dc9-9e99-8a0b541c3ffb.png)
