### PR TITLE
[10.x] Fix Missing Config Params on SFTP Driver

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -135,6 +135,7 @@ Laravel's Flysystem integrations work great with SFTP; however, a sample configu
         'privateKey' => env('SFTP_PRIVATE_KEY'),
         'passphrase' => env('SFTP_PASSPHRASE'),
 
+        // Settings for file/directory permissions, defaults to `private`
         'visibility' => 'public', // `private` = 0600, `public` = 0700
         'directory_visibility' => 'public', // `private` = 0700, `public` = 0755
 

--- a/filesystem.md
+++ b/filesystem.md
@@ -135,9 +135,9 @@ Laravel's Flysystem integrations work great with SFTP; however, a sample configu
         'privateKey' => env('SFTP_PRIVATE_KEY'),
         'passphrase' => env('SFTP_PASSPHRASE'),
 
-        // Settings for file/directory permissions, defaults to `private`
-        'visibility' => 'public', // `private` = 0600, `public` = 0700
-        'directory_visibility' => 'public', // `private` = 0700, `public` = 0755
+        // Settings for file / directory permissions...
+        'visibility' => 'private', // `private` = 0600, `public` = 0700
+        'directory_visibility' => 'private', // `private` = 0700, `public` = 0755
 
         // Optional SFTP Settings...
         // 'hostFingerprint' => env('SFTP_HOST_FINGERPRINT'),

--- a/filesystem.md
+++ b/filesystem.md
@@ -135,6 +135,9 @@ Laravel's Flysystem integrations work great with SFTP; however, a sample configu
         'privateKey' => env('SFTP_PRIVATE_KEY'),
         'passphrase' => env('SFTP_PASSPHRASE'),
 
+        'visibility' => 'public', // `private` = 0600, `public` = 0700
+        'directory_visibility' => 'public', `private` = 0700, `public` = 0755
+
         // Optional SFTP Settings...
         // 'hostFingerprint' => env('SFTP_HOST_FINGERPRINT'),
         // 'maxTries' => 4,

--- a/filesystem.md
+++ b/filesystem.md
@@ -136,7 +136,7 @@ Laravel's Flysystem integrations work great with SFTP; however, a sample configu
         'passphrase' => env('SFTP_PASSPHRASE'),
 
         'visibility' => 'public', // `private` = 0600, `public` = 0700
-        'directory_visibility' => 'public', `private` = 0700, `public` = 0755
+        'directory_visibility' => 'public', // `private` = 0700, `public` = 0755
 
         // Optional SFTP Settings...
         // 'hostFingerprint' => env('SFTP_HOST_FINGERPRINT'),


### PR DESCRIPTION
This will save people a few hours of searching as setting file and directory permissions for the SFTP driver is not well documented. This is particularly useful for people upgrading from SFTP v2 as config params have changed in SFTP v3.

Hope this helps.