### PR TITLE
Document how to customize pagination information for resources

### DIFF
--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -491,6 +491,24 @@ Paginated responses always contain `meta` and `links` keys with information abou
 }
 ```
 
+#### Customizing pagination information
+If you wish to customize the pagination information, you can add a `paginationInformation` method to the resource:
+
+    /**
+     * Customize the pagination information for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  array $paginated
+     * @param  array $default
+     * @return array
+     */
+    public function paginationInformation($request, $paginated, $default)
+    {
+        return Arr::except($default, 'links');
+    }
+    
+In this example, the response will no longer contain the `links` array.
+
 <a name="conditional-attributes"></a>
 ### Conditional Attributes
 

--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -491,8 +491,10 @@ Paginated responses always contain `meta` and `links` keys with information abou
 }
 ```
 
-#### Customizing pagination information
-If you wish to customize the pagination information, you can add a `paginationInformation` method to the resource:
+<a name="customizing-the-pagination-information"></a>
+#### Customizing The Pagination Information
+
+If you would like to customize the information included in the `links` or `meta` keys of the pagination response, you may define a `paginationInformation` method on the resource. This method will receive the `$paginated` data and the array of `$default` information, which is an array containing the `links` and `meta` keys:
 
     /**
      * Customize the pagination information for the resource.
@@ -504,7 +506,9 @@ If you wish to customize the pagination information, you can add a `paginationIn
      */
     public function paginationInformation($request, $paginated, $default)
     {
-        return Arr::except($default, 'links');
+        $default['links']['custom'] = 'https://example.com';
+
+        return $default;
     }
     
 In this example, the response will no longer contain the `links` array.


### PR DESCRIPTION
A Google search on "how to customize eloquent resource pagination metadata" shows that I'm not the only one who wants to know how to do this. Unfortunately none of the results provide the correct answer.

After a bit of digging, I discovered that [PaginatedResourceResponse](https://github.com/laravel/framework/blob/136ed754f2d80e5c7cd407a4262eb2eac478e7e8/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php#L53-L56) allows you to override the default result. And as far as I can tell, this feature hasn't been documented.