### PR TITLE
Running parallel tests require brianium/paratest

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -107,7 +107,7 @@ php artisan test --testsuite=Feature --stop-on-failure
 <a name="running-tests-in-parallel"></a>
 ### Running Tests In Parallel
 
-By default, Laravel and PHPUnit execute your tests sequentially within a single process. However, you may greatly reduce the amount of time it takes to run your tests by running tests simultaneously across multiple processes. To get started, ensure your application depends on version `^5.3` or greater of the `nunomaduro/collision` package. Then, include the `--parallel` option when executing the `test` Artisan command:
+By default, Laravel and PHPUnit execute your tests sequentially within a single process. However, you may greatly reduce the amount of time it takes to run your tests by running tests simultaneously across multiple processes. To get started, ensure your application depends on version `^5.3` or greater of the `nunomaduro/collision` package. You also need `brianium/paratest` as dev dependency. Then, include the `--parallel` option when executing the `test` Artisan command:
 
 ```shell
 php artisan test --parallel

--- a/testing.md
+++ b/testing.md
@@ -107,9 +107,11 @@ php artisan test --testsuite=Feature --stop-on-failure
 <a name="running-tests-in-parallel"></a>
 ### Running Tests In Parallel
 
-By default, Laravel and PHPUnit execute your tests sequentially within a single process. However, you may greatly reduce the amount of time it takes to run your tests by running tests simultaneously across multiple processes. To get started, ensure your application depends on version `^5.3` or greater of the `nunomaduro/collision` package. You also need `brianium/paratest` as dev dependency. Then, include the `--parallel` option when executing the `test` Artisan command:
+By default, Laravel and PHPUnit execute your tests sequentially within a single process. However, you may greatly reduce the amount of time it takes to run your tests by running tests simultaneously across multiple processes. To get started, you should install the `brianium/paratest` Composer package as a "dev" dependency. Then, include the `--parallel` option when executing the `test` Artisan command:
 
 ```shell
+composer require brianium/paratest --dev
+
 php artisan test --parallel
 ```
 


### PR DESCRIPTION
Reproduction steps:

1. Install a fresh version of Laravel 10 with `composer create-project laravel/laravel=10.0.4 example-app`
2. Run `php artisan test -p`

This returns the following error message:
```
NunoMaduro\Collision\Adapters\Laravel\Exceptions\RequirementsException 

Running Collision 7.x artisan test command in parallel requires at least ParaTest (brianium/paratest) 7.x
```

By reading the docs, I got the impression that all I needed to do was to require "nunomaduro/collision" to get parallel tests running, but it's not the case.