### PR TITLE
Add exception message for InvalidArgumentException

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -446,7 +446,7 @@ If the user approves the authorization request, they will be redirected back to 
         throw_unless(
             strlen($state) > 0 && $state === $request->state,
             InvalidArgumentException::class,
-            'Invalid state value'
+            'Invalid state value.'
         );
 
         $response = Http::asForm()->post('http://passport-app.test/oauth/token', [

--- a/passport.md
+++ b/passport.md
@@ -445,7 +445,8 @@ If the user approves the authorization request, they will be redirected back to 
 
         throw_unless(
             strlen($state) > 0 && $state === $request->state,
-            InvalidArgumentException::class
+            InvalidArgumentException::class,
+            'Invalid state value'
         );
 
         $response = Http::asForm()->post('http://passport-app.test/oauth/token', [


### PR DESCRIPTION
Add exception message on `throw_unless` for `InvalidArgumentException`. This will guide developer to custom the message and make logs capture more readable.