### PR TITLE
Specify default timeout value for the HTTP Client

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -195,11 +195,11 @@ If you would like to quickly add a bearer token to the request's `Authorization`
 <a name="timeout"></a>
 ### Timeout
 
-The `timeout` method may be used to specify the maximum number of seconds to wait for a response:
+The `timeout` method may be used to specify the maximum number of seconds to wait for a response. By default, the HTTP client will timeout after 30 seconds:
 
     $response = Http::timeout(3)->get(/* ... */);
 
-If the given timeout is exceeded, an instance of `Illuminate\Http\Client\ConnectionException` will  be thrown. By default, Laravel sets a timeout of 30 seconds.
+If the given timeout is exceeded, an instance of `Illuminate\Http\Client\ConnectionException` will  be thrown.
 
 You may specify the maximum number of seconds to wait while trying to connect to a server using the `connectTimeout` method:
 


### PR DESCRIPTION
When a timeout occurs with long running HTTP Client requests, the only information about a default value is found in the upgrade guide from L8 to L9. This PR adds a small note about the default value right by it's setting category, which could help developers that haven't gone through a upgrade.

Maybe a even better 2-in-1 information than in this PR would be something like the following block...

> To disable the default timeout of 30 seconds, you can overwrite it as follows:
>
> ```php
> $response = Http::timeout(0)->get(/* ... */);
> ```