### PR TITLE
indicate postgres-specific handling for ipAddress

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -607,7 +607,7 @@ The `ipAddress` method creates a `VARCHAR` equivalent column:
 
     $table->ipAddress('visitor');
     
-When using Postgres, an `INET` column will be created instead.
+When using Postgres, an `INET` column will be created.
 
 <a name="column-method-json"></a>
 #### `json()` {.collection-method}

--- a/migrations.md
+++ b/migrations.md
@@ -606,6 +606,8 @@ The `integer` method creates an `INTEGER` equivalent column:
 The `ipAddress` method creates a `VARCHAR` equivalent column:
 
     $table->ipAddress('visitor');
+    
+When using Postgres, an `INET` column will be created instead.
 
 <a name="column-method-json"></a>
 #### `json()` {.collection-method}


### PR DESCRIPTION
The Postgres grammar creates an `INET` column instead of a `VARCHAR`. https://github.com/laravel/framework/blob/be2ddb5c31b0b9ebc2738d9f37a9d4c960aa3199/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php#L943