### PR TITLE
Missing `return` on local scope example

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1343,7 +1343,7 @@ Scopes should always return the same query builder instance or `void`:
          */
         public function scopeActive($query)
         {
-            $query->where('active', 1);
+            return $query->where('active', 1);
         }
     }
 


### PR DESCRIPTION
Add `return` to second local scope example for scopeActive