### PR TITLE
Add missing ->deleteFileAfterSend(true) example

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -287,7 +287,7 @@ The `download` method may be used to generate a response that forces the user's 
 
     return response()->download($pathToFile, $name, $headers);
     
-    return response()->download($pathToFile)->deleteFileAfterSend(true);
+    return response()->download($pathToFile)->deleteFileAfterSend();
 
 > **Warning**  
 > Symfony HttpFoundation, which manages file downloads, requires the file being downloaded to have an ASCII filename.

--- a/responses.md
+++ b/responses.md
@@ -286,6 +286,8 @@ The `download` method may be used to generate a response that forces the user's 
     return response()->download($pathToFile);
 
     return response()->download($pathToFile, $name, $headers);
+    
+    return response()->download($pathToFile)->deleteFileAfterSend(true);
 
 > **Warning**  
 > Symfony HttpFoundation, which manages file downloads, requires the file being downloaded to have an ASCII filename.


### PR DESCRIPTION
Was documented in 5.x, but somehow disappeared