### PR TITLE
Fixed typo in events.

### DIFF
--- a/events.md
+++ b/events.md
@@ -522,7 +522,7 @@ To dispatch an event, you may call the static `dispatch` method on the event. Th
     OrderShipped::dispatchUnless($condition, $order);
 
 > **Note**  
-> When testing, it can be helpful to assert that certain events were dispatched without actually triggering their listeners. Laravel's [built-in testing helpers](#testing) makes it a cinch.
+> When testing, it can be helpful to assert that certain events were dispatched without actually triggering their listeners. Laravel's [built-in testing helpers](#testing) make it a cinch.
 
 <a name="event-subscribers"></a>
 ## Event Subscribers


### PR DESCRIPTION
Fixed a typo by changing
"...helpers makes it a cinch"
to
"...helpers make it a cinch"