### PR TITLE
Cited useCurrentOnUpdate modifier to be MySQL specific.

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -966,7 +966,7 @@ Modifier  |  Description
 `->storedAs($expression)`  |  Create a stored generated column (MySQL / PostgreSQL).
 `->unsigned()`  |  Set INTEGER columns as UNSIGNED (MySQL).
 `->useCurrent()`  |  Set TIMESTAMP columns to use CURRENT_TIMESTAMP as default value.
-`->useCurrentOnUpdate()`  |  Set TIMESTAMP columns to use CURRENT_TIMESTAMP when a record is updated.
+`->useCurrentOnUpdate()`  |  Set TIMESTAMP columns to use CURRENT_TIMESTAMP when a record is updated (MySQL).
 `->virtualAs($expression)`  |  Create a virtual generated column (MySQL).
 `->generatedAs($expression)`  |  Create an identity column with specified sequence options (PostgreSQL).
 `->always()`  |  Defines the precedence of sequence values over input for an identity column (PostgreSQL).


### PR DESCRIPTION
Currently it seems `useCurrentOnUpdate` would work in any database, but both PostgreSQL & SQLite ignore this modifier.