### PR TITLE
Minor Clarification on Eloquent Factory Creation

### DIFF
--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -102,6 +102,8 @@ Next, define a `model` property on the corresponding factory:
         protected $model = Flight::class;
     }
 
+You can omit setting the $model property if Laravel can automatically resolve the model class from the Factory name by following conventions.
+
 <a name="factory-states"></a>
 ### Factory States
 

--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -87,7 +87,7 @@ The `HasFactory` trait's `factory` method will use conventions to determine the 
         return FlightFactory::new();
     }
 
-Next, define a `model` property on the corresponding factory:
+Then, define a `model` property on the corresponding factory:
 
     use App\Administration\Flight;
     use Illuminate\Database\Eloquent\Factories\Factory;
@@ -101,8 +101,6 @@ Next, define a `model` property on the corresponding factory:
          */
         protected $model = Flight::class;
     }
-
-Note that setting the $model property is only required in cases where Laravel cannot automatically resolve the name from the Factory Class, when normal naming conventions were not followed.
 
 <a name="factory-states"></a>
 ### Factory States

--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -102,7 +102,7 @@ Next, define a `model` property on the corresponding factory:
         protected $model = Flight::class;
     }
 
-You can omit setting the $model property if Laravel can automatically resolve the model class from the Factory name by following conventions.
+Note that setting the $model property is only required in cases where Laravel cannot automatically resolve the name from the Factory Class, when normal naming conventions were not followed.
 
 <a name="factory-states"></a>
 ### Factory States


### PR DESCRIPTION
PR adds an indication that setting the $model is not required when normal naming conventions are being followed as Laravel is able to resolve the model class based on the name of the factory class.