### PR TITLE
[10.x] Update eloquent.md updateOrCreate 

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -880,7 +880,7 @@ If you wish, you may instruct Laravel to throw an exception when attempting to f
 
 Occasionally, you may need to update an existing model or create a new model if no matching model exists. Like the `firstOrCreate` method, the `updateOrCreate` method persists the model, so there's no need to manually call the `save` method.
 
-In the example below, if a flight exists with a `departure` location of `Oakland` and a `destination` location of `San Diego`, its `price` and `discounted` columns will be updated. If no such flight exists, a new flight will be created which has the attributes resulting from merging the first argument array with the second argument array:
+In the example below, if a flight exists with a `departure` location of `Oakland` and a `destination` location of `San Diego`, its `price` and `discounted` columns will be updated. If no such flight exists, a new flight will be filled with the attributes resulting from merging the first argument array with the second argument array:
 
     $flight = Flight::updateOrCreate(
         ['departure' => 'Oakland', 'destination' => 'San Diego'],


### PR DESCRIPTION
This may be the worlds smallest change but I just wanted to give a hint that the `updateOrCreate` function uses `->fill()` rather than `->create()`. I know this is covered in the section above https://laravel.com/docs/master/eloquent#mass-assignment-exceptions but it would potentially save others from looking at the API docs.

I was confused when working on my model that values were not being saved because the attributes were not fillable.

https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Builder.php#L578