### PR TITLE
Update ISO-8601 date example in Eloquent: Mutators & Casting

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -419,7 +419,7 @@ To specify the format that should be used when actually storing a model's dates 
 <a name="date-casting-and-timezones"></a>
 #### Date Casting, Serialization, & Timezones
 
-By default, the `date` and `datetime` casts will serialize dates to a UTC ISO-8601 date string (`1986-05-28T21:05:54.000000Z`), regardless of the timezone specified in your application's `timezone` configuration option. You are strongly encouraged to always use this serialization format, as well as to store your application's dates in the UTC timezone by not changing your application's `timezone` configuration option from its default `UTC` value. Consistently using the UTC timezone throughout your application will provide the maximum level of interoperability with other date manipulation libraries written in PHP and JavaScript.
+By default, the `date` and `datetime` casts will serialize dates to a UTC ISO-8601 date string (`YYYY-MM-DDTHH:MM:SS.uuuuuuZ`), regardless of the timezone specified in your application's `timezone` configuration option. You are strongly encouraged to always use this serialization format, as well as to store your application's dates in the UTC timezone by not changing your application's `timezone` configuration option from its default `UTC` value. Consistently using the UTC timezone throughout your application will provide the maximum level of interoperability with other date manipulation libraries written in PHP and JavaScript.
 
 If a custom format is applied to the `date` or `datetime` cast, such as `datetime:Y-m-d H:i:s`, the inner timezone of the Carbon instance will be used during date serialization. Typically, this will be the timezone specified in your application's `timezone` configuration option.
 


### PR DESCRIPTION
This commit replaces the actual date example in the "Eloquent: Mutators & Casting" section with a more generic representation of the UTC ISO-8601 format. The change aims to prevent search engines from misinterpreting the example date as the publication date of the documentation page and to provide a clearer representation of the format for readers.

![128](https://user-images.githubusercontent.com/7737506/230716028-e83add42-6b42-412f-a2e7-d93682da32cf.png)

refer to 
"https://developers.google.com/search/blog/2019/03/help-google-search-know-best-date-for#:~:text=Google%20determines%20a%20date%20using,can%20be%20prone%20to%20issues."

