### PR TITLE
Missing comma before argument in example code.

### DIFF
--- a/rate-limiting.md
+++ b/rate-limiting.md
@@ -51,7 +51,7 @@ If necessary, you may provide a fourth argument to the `attempt` method, which i
         $perTwoMinutes = 5,
         function() {
             // Send message...
-        }
+        },
         $decayRate = 120,
     );
 


### PR DESCRIPTION
Was copying and pasting some example code from docs and discovered missing comma before 4th argument in the example.

I'll admit I'm embarrassed to submit such a pathetic PR.