### PR TITLE
[10.x] Add note about UUID/ULID keys on notifications table

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -782,6 +782,9 @@ php artisan notifications:table
 php artisan migrate
 ```
 
+> **Note**  
+> If your notifiable models are using [UUID or ULID primary keys](/docs/{{version}}/eloquent#uuid-and-ulid-keys), you will need to replace the `morphs()` method with [`uuidMorphs()`](docs/{{version}}/migrations#column-method-uuidMorphs) or [`ulidMorphs`](/docs/{{version}}/migrations#column-method-ulidMorphs) in the generated migration.
+
 <a name="formatting-database-notifications"></a>
 ### Formatting Database Notifications
 

--- a/notifications.md
+++ b/notifications.md
@@ -783,7 +783,7 @@ php artisan migrate
 ```
 
 > **Note**  
-> If your notifiable models are using [UUID or ULID primary keys](/docs/{{version}}/eloquent#uuid-and-ulid-keys), you will need to replace the `morphs()` method with [`uuidMorphs()`](docs/{{version}}/migrations#column-method-uuidMorphs) or [`ulidMorphs`](/docs/{{version}}/migrations#column-method-ulidMorphs) in the notification table migration.
+> If your notifiable models are using [UUID or ULID primary keys](/docs/{{version}}/eloquent#uuid-and-ulid-keys), you should replace the `morphs()` method with [`uuidMorphs()`](docs/{{version}}/migrations#column-method-uuidMorphs) or [`ulidMorphs`](/docs/{{version}}/migrations#column-method-ulidMorphs) in the notification table migration.
 
 <a name="formatting-database-notifications"></a>
 ### Formatting Database Notifications

--- a/notifications.md
+++ b/notifications.md
@@ -783,7 +783,7 @@ php artisan migrate
 ```
 
 > **Note**  
-> If your notifiable models are using [UUID or ULID primary keys](/docs/{{version}}/eloquent#uuid-and-ulid-keys), you will need to replace the `morphs()` method with [`uuidMorphs()`](docs/{{version}}/migrations#column-method-uuidMorphs) or [`ulidMorphs`](/docs/{{version}}/migrations#column-method-ulidMorphs) in the generated migration.
+> If your notifiable models are using [UUID or ULID primary keys](/docs/{{version}}/eloquent#uuid-and-ulid-keys), you will need to replace the `morphs()` method with [`uuidMorphs()`](docs/{{version}}/migrations#column-method-uuidMorphs) or [`ulidMorphs`](/docs/{{version}}/migrations#column-method-ulidMorphs) in the notification table migration.
 
 <a name="formatting-database-notifications"></a>
 ### Formatting Database Notifications


### PR DESCRIPTION
When using UUID/ULID primary keys on notifiable models, you can get a confusing error with the default migration created by `artisan notifications:table` when it tries to store the UUID in an integer column:

```
SQLSTATE[01000]: Warning: 1265 Data truncated for column 'notifiable_id' at row 1 at /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Connection.php:578
```

This PR adds a note to the [Database Notifications](https://laravel.com/docs/10.x/notifications#database-notifications) section of the docs reminding users to update the migration to use the `uuidMorphs`/`ulidMorphs` methods.
