### PR TITLE
Naming Resource Route Parameters - edit doc

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -320,9 +320,17 @@ By default, `Route::resource` will create the route parameters for your resource
         'users' => 'admin_user'
     ]);
 
- The example above generates the following URI for the resource's `show` route:
+ The example above generates the following URI for the resource's `show, edit, update, destroy` route:
 
-    /users/{admin_user}
+Verb      | URI                    | Action       | Route Name
+----------|------------------------|--------------|---------------------
+GET       | `/users`              | index        | users.index
+GET       | `/users/create`       | create       | users.create
+POST      | `/users`              | store        | users.store
+GET       | `/users/{admin_user}`      | show         | users.show
+GET       | `/users/{admin_user}/edit` | edit         | users.edit
+PUT/PATCH | `/users/{admin_user}`      | update       | users.update
+DELETE    | `/users/{admin_user}`      | destroy      | users.destroy
 
 <a name="restful-scoping-resource-routes"></a>
 ### Scoping Resource Routes


### PR DESCRIPTION
```php
Route::resource('users', AdminUserController::class)->parameters([
    'users' => 'admin_user'
]);
```
when run command: `php artisan route:list --path=users`

![image](https://user-images.githubusercontent.com/22742444/233608948-7fb1a288-d789-41f4-84e7-8616247da445.png)
