### PR TITLE
Updated docs to direct people to place RateLimiter in boot method

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -665,7 +665,7 @@ Using the `Route::fallback` method, you may define a route that will be executed
 <a name="defining-rate-limiters"></a>
 ### Defining Rate Limiters
 
-Laravel includes powerful and customizable rate limiting services that you may utilize to restrict the amount of traffic for a given route or group of routes. To get started, you should define rate limiter configurations that meet your application's needs. Typically, this should be done within the `configureRateLimiting` method of your application's `App\Providers\RouteServiceProvider` class, which already includes a rate limiter definition that is applied to the routes in your application's `routes/api.php` file:
+Laravel includes powerful and customizable rate limiting services that you may utilize to restrict the amount of traffic for a given route or group of routes. To get started, you should define rate limiter configurations that meet your application's needs. Typically, this should be done within the `boot` method of your application's `App\Providers\RouteServiceProvider` class, which already includes a rate limiter definition that is applied to the routes in your application's `routes/api.php` file:
 
 ```php
 use Illuminate\Cache\RateLimiting\Limit;
@@ -673,13 +673,15 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 
 /**
- * Configure the rate limiters for the application.
+ * Define your route model bindings, pattern filters, and other route configuration.
  */
-protected function configureRateLimiting(): void
+public function boot(): void
 {
     RateLimiter::for('api', function (Request $request) {
         return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
     });
+    
+    ...
 }
 ```
 
@@ -690,13 +692,15 @@ Rate limiters are defined using the `RateLimiter` facade's `for` method. The `fo
     use Illuminate\Support\Facades\RateLimiter;
 
     /**
-     * Configure the rate limiters for the application.
+     * Define your route model bindings, pattern filters, and other route configuration.
      */
-    protected function configureRateLimiting(): void
+    public function boot(): void
     {
         RateLimiter::for('global', function (Request $request) {
             return Limit::perMinute(1000);
         });
+
+        ...
     }
 
 If the incoming request exceeds the specified rate limit, a response with a 429 HTTP status code will automatically be returned by Laravel. If you would like to define your own response that should be returned by a rate limit, you may use the `response` method:


### PR DESCRIPTION
The RouteServiceProvider::configureRateLimiting method no longer exists in the 10.1.* app skeleton, but the documentation still refers to it (it used to exist in 10.0.*). This can cause some confusion.

Old App Skeleton: https://github.com/laravel/laravel/blob/v10.0.7/app/Providers/RouteServiceProvider.php

New App Skeleton: https://github.com/laravel/laravel/blob/v10.1.0/app/Providers/RouteServiceProvider.php