### PR TITLE
add warning to updateOrCreate

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -887,6 +887,9 @@ In the example below, if a flight exists with a `departure` location of `Oakland
         ['price' => 99, 'discounted' => 1]
     );
 
+> **Warning**  
+> updateOrCreate performs two queries, first for finding, and then for creating (if it does not exists) or updating (if it exists). These two queries may be interrupted in rare occasions which will raise a QueryException on unique values or create duplicates.
+
 If you would like to perform multiple "upserts" in a single query, then you should use the `upsert` method instead. The method's first argument consists of the values to insert or update, while the second argument lists the column(s) that uniquely identify records within the associated table. The method's third and final argument is an array of the columns that should be updated if a matching record already exists in the database. The `upsert` method will automatically set the `created_at` and `updated_at` timestamps if timestamps are enabled on the model:
 
     Flight::upsert([


### PR DESCRIPTION
updateOrCreate performs two queries which may be interrupted, which can raise Exception or create duplicates. This warning may help developer when using it.