### PR TITLE
[10.x] Change channel prefix for presence channel example

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -878,7 +878,7 @@ Presence channels may receive events just like public or private channels. Using
     public function broadcastOn(): array
     {
         return [
-            new PresenceChannel('room.'.$this->message->room_id),
+            new PresenceChannel('chat.'.$this->message->room_id),
         ];
     }
 


### PR DESCRIPTION
This is a super minor typo fix :) But, it makes the channel names consistent between examples to eliminate any possible confusion.