### PR TITLE
[10.x] add a small tip on how to clear the config cache

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -201,14 +201,14 @@ Once the configuration has been cached, your application's `.env` file will not 
 
 For this reason, you should ensure you are only calling the `env` function from within your application's configuration (`config`) files. You can see many examples of this by examining Laravel's default configuration files. Configuration values may be accessed from anywhere in your application using the `config` function [described above](#accessing-configuration-values).
 
-> **Warning**  
-> If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded; therefore, the `env` function will only return external, system level environment variables.
-
-You may use the `config:clear` command to clear the config cache:
+The `config:clear` command may be used to purge the cached configuration:
 
 ```shell
 php artisan config:clear
 ```
+
+> **Warning**  
+> If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded; therefore, the `env` function will only return external, system level environment variables.
 
 <a name="debug-mode"></a>
 ## Debug Mode

--- a/configuration.md
+++ b/configuration.md
@@ -204,6 +204,12 @@ For this reason, you should ensure you are only calling the `env` function from 
 > **Warning**  
 > If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded; therefore, the `env` function will only return external, system level environment variables.
 
+You may use the `config:clear` command to clear the config cache:
+
+```shell
+php artisan config:clear
+```
+
 <a name="debug-mode"></a>
 ## Debug Mode
 


### PR DESCRIPTION
This change adds a small tip on how to clear the config cache. Because for now documentation tells us how to create a cache, but doesn't tell us how to clear the existing cache