### PR TITLE
[9.x] add a small tip on how to clear the config cache

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -200,6 +200,12 @@ You should typically run the `php artisan config:cache` command as part of your 
 > **Warning**  
 > If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded; therefore, the `env` function will only return external, system level environment variables.
 
+You may use the `config:clear` command to clear the config cache:
+
+```shell
+php artisan config:clear
+```
+
 <a name="debug-mode"></a>
 ## Debug Mode
 

--- a/configuration.md
+++ b/configuration.md
@@ -197,14 +197,14 @@ To give your application a speed boost, you should cache all of your configurati
 
 You should typically run the `php artisan config:cache` command as part of your production deployment process. The command should not be run during local development as configuration options will frequently need to be changed during the course of your application's development.
 
-> **Warning**  
-> If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded; therefore, the `env` function will only return external, system level environment variables.
-
-You may use the `config:clear` command to clear the config cache:
+The `config:clear` command may be used to purge the cached configuration:
 
 ```shell
 php artisan config:clear
 ```
+
+> **Warning**  
+> If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded; therefore, the `env` function will only return external, system level environment variables.
 
 <a name="debug-mode"></a>
 ## Debug Mode


### PR DESCRIPTION
This change adds a small tip on how to clear the config cache. Because for now documentation tells us how to create a cache, but doesn't tell us how to clear the existing cache