### PR TITLE
[10.x] Remove Importing 'Illuminate\Support\Str'

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -523,8 +523,6 @@ If you need to prepare or sanitize any data from the request before you apply yo
 
 Likewise, if you need to normalize any request data after validation is complete, you may use the `passedValidation` method:
 
-    use Illuminate\Support\Str;
-
     /**
      * Handle a passed validation attempt.
      */


### PR DESCRIPTION
The Str class has not been used in the example of the passedValidation method, So I just removed the line that imports the class.