### PR TITLE
Replace 'append' with 'prepend' in Vite example.

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -808,7 +808,7 @@ For example, the `vite-imagetools` plugin outputs URLs like the following while 
 
 The `vite-imagetools` plugin is expecting that the output URL will be intercepted by Vite and the plugin may then handle all URLs that start with `/@imagetools`. If you are using plugins that are expecting this behaviour, you will need to manually correct the URLs. You can do this in your `vite.config.js` file by using the `transformOnServe` option. 
 
-In this particular example, we will append the dev server URL to all occurrences of `/@imagetools` within the generated code:
+In this particular example, we will prepend the dev server URL to all occurrences of `/@imagetools` within the generated code:
 
 ```js
 import { defineConfig } from 'vite';


### PR DESCRIPTION
The example in "Correcting Dev Server URLs" shows code that will prepend the dev server URL, but the description says "append". This PR fixes that.

Before:
<img width="780" alt="image" src="https://user-images.githubusercontent.com/151829/236627843-5d8ef5ba-e673-493f-90c8-44490f57f026.png">
