### PR TITLE
[10.x ] Update notifications.md to replace unused anchor link

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -36,7 +36,7 @@
 - [SMS Notifications](#sms-notifications)
     - [Prerequisites](#sms-prerequisites)
     - [Formatting SMS Notifications](#formatting-sms-notifications)
-    - [Formatting Shortcode Notifications](#formatting-shortcode-notifications)
+    - [Unicode Content](#unicode-content)
     - [Customizing The "From" Number](#customizing-the-from-number)
     - [Adding A Client Reference](#adding-a-client-reference)
     - [Routing SMS Notifications](#routing-sms-notifications)


### PR DESCRIPTION
This PR replaces the unused 'Formatting Shortcode Notifications' anchor link to the currently non-linked 'Unicode Content' section