### PR TITLE
[10.x] Add warnings to scout and queue pages to clarify functionality

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -238,8 +238,7 @@ Because loaded relationships also get serialized, the serialized job string can 
 
 Furthermore, when a job is deserialized and model relationships are re-retrieved from the database, they will be retrieved in their entirety. Any previous relationship constraints that were applied before the model was serialized during the job queueing process will not be applied when the job is deserialized. Therefore, if you wish to work with a subset of a given relationship, you should re-constrain that relationship within your queued job.
 
-> **Warning**  
-> Model relationships are not restored if the job class uses a Collection or array of models. This is to prevent excessive resource usage with jobs that may deal with large numbers of records.
+If a job receives a collection or array of Eloquent models instead of a single model, the models within that collection will not have their relationships restored when the job is deserialized and executed. This is to prevent excessive resource usage with jobs that may deal with large numbers of records.
 
 <a name="unique-jobs"></a>
 ### Unique Jobs

--- a/queues.md
+++ b/queues.md
@@ -238,6 +238,9 @@ Because loaded relationships also get serialized, the serialized job string can 
 
 Furthermore, when a job is deserialized and model relationships are re-retrieved from the database, they will be retrieved in their entirety. Any previous relationship constraints that were applied before the model was serialized during the job queueing process will not be applied when the job is deserialized. Therefore, if you wish to work with a subset of a given relationship, you should re-constrain that relationship within your queued job.
 
+> **Warning**  
+> Model relationships are not restored if the job class uses a Collection or array of models. This is to prevent excessive resource usage with jobs that may deal with large numbers of records.
+
 <a name="unique-jobs"></a>
 ### Unique Jobs
 

--- a/queues.md
+++ b/queues.md
@@ -238,7 +238,7 @@ Because loaded relationships also get serialized, the serialized job string can 
 
 Furthermore, when a job is deserialized and model relationships are re-retrieved from the database, they will be retrieved in their entirety. Any previous relationship constraints that were applied before the model was serialized during the job queueing process will not be applied when the job is deserialized. Therefore, if you wish to work with a subset of a given relationship, you should re-constrain that relationship within your queued job.
 
-If a job receives a collection or array of Eloquent models instead of a single model, the models within that collection will not have their relationships restored when the job is deserialized and executed. This is to prevent excessive resource usage with jobs that may deal with large numbers of records.
+If a job receives a collection or array of Eloquent models instead of a single model, the models within that collection will not have their relationships restored when the job is deserialized and executed. This is to prevent excessive resource usage on jobs that deal with large numbers of models.
 
 <a name="unique-jobs"></a>
 ### Unique Jobs

--- a/scout.md
+++ b/scout.md
@@ -404,6 +404,9 @@ If you would like to modify the query that is used to retrieve all of your model
         return $query->with('author');
     }
 
+> **Warning**  
+> The `makeAllSearchableUsing` method is not applicable when using a queue to import models. [Queued Relationships](/docs/{{version}}/queues#handling-relationships) are not restored when collections are unserialized in a job.
+
 <a name="adding-records"></a>
 ### Adding Records
 

--- a/scout.md
+++ b/scout.md
@@ -405,7 +405,7 @@ If you would like to modify the query that is used to retrieve all of your model
     }
 
 > **Warning**  
-> The `makeAllSearchableUsing` method is not applicable when using a queue to import models. [Queued Relationships](/docs/{{version}}/queues#handling-relationships) are not restored when collections are unserialized in a job.
+> The `makeAllSearchableUsing` method may not be applicable when using a queue to batch import models. Relationships are [not restored](/docs/{{version}}/queues#handling-relationships) when model collections are processed by jobs.
 
 <a name="adding-records"></a>
 ### Adding Records


### PR DESCRIPTION
We recently ran into an issue with scout under the following conditions:
- Development environment with lazy-loading disabled
- Sync queue
- Scout queue enabled
- Bulk importing records to scout using `artisan scout:import modelname`

As noted in https://github.com/laravel/framework/pull/36712 relationships on collections/arrays in jobs are not restored, and this is intended behavior as of now. 

However, this also prevents scout from using previously loaded relationships configured using `makeAllSearchableUsing`.

This PR adds clarifying language so that developers know that if they want to utilize the eager loading functionality provided in scout for bulk adding, they cannot use the queue at the same time.