### PR TITLE
[10.x] Clarifies issues when passing the `name` attribute to components

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -935,7 +935,7 @@ All of the attributes that are not part of the component's constructor will auto
 > Using directives such as `@env` within component tags is not supported at this time. For example, `<x-alert :live="@env('production')"/>` will not be compiled.
 
 > **Warning**  
-> Because of limitations on how slots are named, it is not possible to use `name` as the first attribute when specifying attributes. If you want to pass this attribute to the underlying component, you must provide it as the second or third element. For instance, you can use `<x-slot:input class="text-input-lg" name="my_field">...`.
+> Because of limitations on how slots are named, it is not possible to use `name` HTML attribute as the first attribute when passing attributes to the underlying component. If you want to pass this attribute, you must provide it as the second or third element. For instance, you can use `<x-slot:input class="text-input-lg" name="my_field">...`.
 
 <a name="default-merged-attributes"></a>
 #### Default / Merged Attributes

--- a/blade.md
+++ b/blade.md
@@ -934,6 +934,9 @@ All of the attributes that are not part of the component's constructor will auto
 > **Warning**  
 > Using directives such as `@env` within component tags is not supported at this time. For example, `<x-alert :live="@env('production')"/>` will not be compiled.
 
+> **Warning**  
+> Because of limitations on how slots are named, it is not possible to use `name` as the first attribute when specifying attributes. If you want to pass this attribute to the underlying component, you must provide it as the second or third element. For instance, you can use `<x-slot:input class="text-input-lg" name="my_field">...`.
+
 <a name="default-merged-attributes"></a>
 #### Default / Merged Attributes
 


### PR DESCRIPTION
The purpose of this pull request is to address concerns regarding passing the `name` attribute on components slots, which was reported here: https://github.com/laravel/framework/issues/47057. @taylorotwell If you believe that this issue should be addressed in Laravel 10 or 11, please inform me, and I will follow up.