### PR TITLE
[10.x] Add `Retrieving Multiple Models` section in eloquent

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -19,6 +19,7 @@
 - [Retrieving Single Models / Aggregates](#retrieving-single-models)
     - [Retrieving Or Creating Models](#retrieving-or-creating-models)
     - [Retrieving Aggregates](#retrieving-aggregates)
+- [Retrieving Multiple Models](#retrieving-multiple-models) 
 - [Inserting & Updating Models](#inserting-and-updating-models)
     - [Inserts](#inserts)
     - [Updates](#updates)
@@ -653,6 +654,17 @@ When interacting with Eloquent models, you may also use the `count`, `sum`, `max
     $count = Flight::where('active', 1)->count();
 
     $max = Flight::where('active', 1)->max('price');
+
+<a name="retrieving-multiple-models"></a>
+## Retrieving Multiple Models 
+
+If you want to get a list of entity, you can use `findMany` method:
+
+```php
+$flights = Flight::findMany([1, 2, 3]);
+```
+
+The `findMany` method returns a [Collection](/docs/{{version}}/collections) instance.
 
 <a name="inserting-and-updating-models"></a>
 ## Inserting & Updating Models


### PR DESCRIPTION
Is a feature that is not exists in docs.
We can change into like:

```php
Flight::find([1, 2, 3]);
```