### PR TITLE
[10.x] Clarifies connection property

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -110,26 +110,6 @@ Within both of these methods, you may use the Laravel schema builder to expressi
         }
     };
 
-<a name="setting-the-migration-connection"></a>
-#### Setting The Migration Connection
-
-If your migration will be interacting with a database connection other than your application's default database connection, you should set the `$connection` property of your migration:
-
-    /**
-     * The database connection that should be used by the migration.
-     *
-     * @var string
-     */
-    protected $connection = 'pgsql';
-
-    /**
-     * Run the migrations.
-     */
-    public function up(): void
-    {
-        // ...
-    }
-
 <a name="running-migrations"></a>
 ## Running Migrations
 


### PR DESCRIPTION
In light of https://github.com/laravel/framework/issues/21009, and now https://github.com/laravel/framework/issues/47082, it appears that utilizing this particular property can result in inconsistencies. As the "migrations" table exists on the main connection, while one or more particular migrations are applied in different connections.

As solution, I propose we only document the `--database` CLI option. This option effectively ensures the consistent state of migrations by applying all migrations on the same connection.