### PR TITLE
Change example nginx document root path

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -57,7 +57,7 @@ server {
     listen 80;
     listen [::]:80;
     server_name example.com;
-    root /srv/example.com/public;
+    root /srv/www/example.com/public;
 
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-Content-Type-Options "nosniff";


### PR DESCRIPTION
On systems where SELinux is enabled, files placed into the previous example nginx root path would be blocked from being read by nginx. This update provides an example path that would work on these systems because `/srv/www/*` is in the default SELinux fcontext ruleset.