### PR TITLE
fix roadrunner installation instructions

### DIFF
--- a/octane.md
+++ b/octane.md
@@ -62,7 +62,7 @@ If you plan to develop your application using [Laravel Sail](/docs/{{version}}/s
 ```shell
 ./vendor/bin/sail up
 
-./vendor/bin/sail composer require laravel/octane spiral/roadrunner
+./vendor/bin/sail composer require laravel/octane spiral/roadrunner spiral/roadrunner-cli
 ```
 
 Next, you should start a Sail shell and use the `rr` executable to retrieve the latest Linux based build of the RoadRunner binary:


### PR DESCRIPTION
It seems like the `spiral/roadrunner` package does not ship the `rr` binary anymore, so the current installation instructions won't work. According to [the roadrunner documentation](https://roadrunner.dev/docs/intro-install/2023.x/en#composer) you need to require the additional `spiral/roadrunner-cli` package to download binaries.