### PR TITLE
[10.x] Add `payment_method.automatically_updated` webhook for Cashier

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -1456,8 +1456,9 @@ To ensure your application can handle Stripe webhooks, be sure to configure the 
 - `customer.subscription.deleted`
 - `customer.updated`
 - `customer.deleted`
-- `invoice.payment_succeeded`
+- `payment_method.automatically_updated`
 - `invoice.payment_action_required`
+- `invoice.payment_succeeded`
 
 For convenience, Cashier includes a `cashier:webhook` Artisan command. This command will create a webhook in Stripe that listens to all of the events required by Cashier:
 


### PR DESCRIPTION
Related PR:
- https://github.com/laravel/cashier-stripe/pull/1534

Also slightly adjusts the order of the webhooks to match the `cashier:webhook` command