### PR TITLE
Add termination statement after the closure in custom validation rule

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -2155,6 +2155,7 @@ Once the rule has been created, we are ready to define its behavior. A rule obje
         {
             if (strtoupper($value) !== $value) {
                 $fail('The :attribute must be uppercase.');
+                return;
             }
         }
     }


### PR DESCRIPTION
Add ```return``` statement after the closure to stop further code execution in custom validation rule.