### PR TITLE
Clarification about rate limiter

### DIFF
--- a/rate-limiting.md
+++ b/rate-limiting.md
@@ -66,6 +66,10 @@ If you would like to manually interact with the rate limiter, a variety of other
         return 'Too many attempts!';
     }
 
+    RateLimiter::hit('send-message:'.$user->id);
+
+    // Send message...
+
 Alternatively, you may use the `remaining` method to retrieve the number of attempts remaining for a given key. If a given key has retries remaining, you may invoke the `hit` method to increment the number of total attempts:
 
     use Illuminate\Support\Facades\RateLimiter;
@@ -88,6 +92,10 @@ When a key has no more attempts left, the `availableIn` method returns the numbe
 
         return 'You may try again in '.$seconds.' seconds.';
     }
+
+    RateLimiter::hit('send-message:'.$user->id);
+
+    // Send message...
 
 <a name="clearing-attempts"></a>
 ### Clearing Attempts


### PR DESCRIPTION
It might seem obvious once you get it, but it took me a while (too much... 🤦🏻 ) to realize that the `tooManyAttempts` method does not increment the attempts count, therefore the code snippet was somewhat misleading. 
I think this small change would make super clear how to manually interact with the limiter.

**Before:**
![Screenshot 2023-05-22 at 1 24 29 PM](https://github.com/laravel/docs/assets/12717225/c855272d-e2ad-439d-ad70-9f544dadfbc0)

**After:**
![Screenshot 2023-05-22 at 1 29 00 PM](https://github.com/laravel/docs/assets/12717225/3282aa3c-bbb2-4b22-9535-1123f4e78fa6)
