### PR TITLE
[10.x] Temporarily adds `--with-all-dependencies` to require `league/flysystem-aws-s3-v3`

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -82,7 +82,7 @@ You may configure additional symbolic links in your `filesystems` configuration 
 Before using the S3 driver, you will need to install the Flysystem S3 package via the Composer package manager:
 
 ```shell
-composer require league/flysystem-aws-s3-v3 "^3.0"
+composer require league/flysystem-aws-s3-v3 "^3.0" --with-all-dependencies
 ```
 
 The S3 driver configuration information is located in your `config/filesystems.php` configuration file. This file contains an example configuration array for an S3 driver. You are free to modify this array with your own S3 configuration and credentials. For convenience, these environment variables match the naming convention used by the AWS CLI.


### PR DESCRIPTION
This pull request temporarily adds `--with-all-dependencies` to require `league/flysystem-aws-s3-v3`, as at this time, AWS Client does not support `guzzlehttp/promise@^2.0`.

https://github.com/aws/aws-sdk-php/blob/17d7df5b89bb06e915931a65f643cf3469f8994c/composer.json#L22