### PR TITLE
Add preventsAccessingMissingAttributes to "Configuring Eloquent Strictness" section

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -384,6 +384,15 @@ Also, you may instruct Laravel to throw an exception when attempting to fill an 
 Model::preventSilentlyDiscardingAttributes(! $this->app->isProduction());
 ```
 
+Third method you can use to configure Eloquent "strictness" is `preventAccessingMissingAttributes`. When it's enabled Eloquent throws `MissingAttributeException` every time you try to access model attribute that doesn't exist or was not retrieved from database. It is especially convenient when you use `select` method to query specific columns from database and forget to add new column to `select` call. 
+
+```php
+Model::preventAccessingMissingAttributes(! $this->app->isProduction());
+
+$user = User::select("id", "name")->first();
+$user->email; // throws MissingAttributeException instead of returning null
+```
+
 <a name="retrieving-models"></a>
 ## Retrieving Models
 


### PR DESCRIPTION
Hello.

I don't know why but documentation doesn't mention `preventsAccessingMissingAttributes` method which I find very handy. It helped me many times while developing. Use cases:

- you forgot to run `php artisan migrate`
- you forgot to add new column in `select`
- you forgot to add foreign key in `select` and eager loading doesn't work
- you dropped column from database but it's still in your code
- you have typo in attribute name somewhere in your code