### PR TITLE
[10.x] scheduling: withoutOverlapping: Make sure the cache driver configuration is not array or null

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -273,6 +273,9 @@ If needed, you may specify how many minutes must pass before the "without overla
 
 Behind the scenes, the `withoutOverlapping` method utilizes your application's [cache](/docs/{{version}}/cache) to obtain locks. If necessary, you can clear these cache locks using the `schedule:clear-cache` Artisan command. This is typically only necessary if a task becomes stuck due to an unexpected server problem.
 
+> **Warning**  
+> Make sure the cache driver configuration is not `array` or `null`.
+
 <a name="running-tasks-on-one-server"></a>
 ### Running Tasks On One Server
 


### PR DESCRIPTION
To work with `withoutOverlapping`