### PR TITLE
Added clarification for using nullOnDelete() method with nullable() c…

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -1239,6 +1239,8 @@ Method  |  Description
 `$table->restrictOnDelete();`| Deletes should be restricted.
 `$table->nullOnDelete();`    | Deletes should set the foreign key value to null.
 
+When using the `nullOnDelete()` method, make sure to include the `nullable()` column modifier before the `constrained()` method. This will allow the foreign key column to be nullable in the database schema.
+
 Any additional [column modifiers](#column-modifiers) must be called before the `constrained` method:
 
     $table->foreignId('user_id')


### PR DESCRIPTION
This commit adds an important clarification to the Laravel documentation regarding the usage of the nullOnDelete() method in conjunction with the nullable() column modifier before the constrained() method.

The added information emphasizes the need to include the nullable() column modifier before calling constrained() when using nullOnDelete(). This ensures that the foreign key column associated with nullOnDelete() is allowed to be nullable in the database schema.

By providing this clarification, users of Laravel can now better understand the correct order of operations when using nullOnDelete() and avoid any potential confusion or issues.