### PR TITLE
[10.x] Fix word in Eloquent Relationships page

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1254,7 +1254,7 @@ As demonstrated in the example above, you are free to add additional constraints
             ->orWhere('votes', '>=', 100)
             ->get();
 
-The example above will generate the following SQL. As you can see, the `or` clause instructs the query to return _any_ user with greater than 100 votes. The query is no longer constrained to a specific user:
+The example above will generate the following SQL. As you can see, the `or` clause instructs the query to return _any_ post with greater than 100 votes. The query is no longer constrained to a specific user:
 
 ```sql
 select *


### PR DESCRIPTION
Fixed a word in Eloquent Relationships page.

The `or` clause in the query is referring to posts, not the user.