### PR TITLE
[10.x] Remove importing `Controller` from one example in hashing.md

### DIFF
--- a/hashing.md
+++ b/hashing.md
@@ -31,7 +31,6 @@ You may hash a password by calling the `make` method on the `Hash` facade:
 
     namespace App\Http\Controllers;
 
-    use App\Http\Controllers\Controller;
     use Illuminate\Http\RedirectResponse;
     use Illuminate\Http\Request;
     use Illuminate\Support\Facades\Hash;


### PR DESCRIPTION
 Importing `Controller` is unnecessary When `PasswordController` is in the same namespace as `Controller`.