### PR TITLE
[10.x] Remove classes from `encryption` that are not necessary to be imported

### DIFF
--- a/encryption.md
+++ b/encryption.md
@@ -26,8 +26,6 @@ You may encrypt a value using the `encryptString` method provided by the `Crypt`
 
     namespace App\Http\Controllers;
 
-    use App\Http\Controllers\Controller;
-    use App\Models\User;
     use Illuminate\Http\RedirectResponse;
     use Illuminate\Http\Request;
     use Illuminate\Support\Facades\Crypt;


### PR DESCRIPTION
User model has never been used in the first example of Encryption and `DigitalOceanTokenController` also is in the same namespace as `Controller`.