### PR TITLE
[10.x] Add ESM export to Vite `postcss.config.js` example

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -429,6 +429,17 @@ module.exports = {
 };
 ```
 
+If the `type` in your `package.json` is set to module you'd need to use ESM exports:
+
+```js
+export default {
+    plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+    },
+};
+```
+
 > **Note**
 > Laravel's [starter kits](/docs/{{version}}/starter-kits) already include the proper Tailwind, PostCSS, and Vite configuration. Or, if you would like to use Tailwind and Laravel without using one of our starter kits, check out [Tailwind's installation guide for Laravel](https://tailwindcss.com/docs/guides/laravel).
 

--- a/vite.md
+++ b/vite.md
@@ -421,17 +421,6 @@ The following example demonstrates how Vite will treat relative and absolute URL
 You can learn more about Vite's CSS support within the [Vite documentation](https://vitejs.dev/guide/features.html#css). If you are using PostCSS plugins such as [Tailwind](https://tailwindcss.com), you may create a `postcss.config.js` file in the root of your project and Vite will automatically apply it:
 
 ```js
-module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
-};
-```
-
-If the `type` in your `package.json` is set to module you'd need to use ESM exports:
-
-```js
 export default {
     plugins: {
         tailwindcss: {},


### PR DESCRIPTION
The current docs only describe a `module.exports` example for `postcss.config.js`. With the changes to the skeleton (laravel/laravel#6090) the export would have to be changed to an ESM export