### PR TITLE
Fix parameter order in signed URL expiry example

### DIFF
--- a/urls.md
+++ b/urls.md
@@ -102,7 +102,7 @@ If you would like to generate a temporary signed route URL that expires after a 
     use Illuminate\Support\Facades\URL;
 
     return URL::temporarySignedRoute(
-        'unsubscribe', now()->addMinutes(30), ['user' => 1]
+        'unsubscribe', ['user' => 1], now()->addMinutes(30)
     );
 
 <a name="validating-signed-route-requests"></a>


### PR DESCRIPTION
Puts the route params and expiry date parameters in the correct order in the signed URL with expiry date example.