### PR TITLE
Add information about `soketi` service available

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -185,7 +185,7 @@ Once the application's Docker containers have been started, you can access the a
 <a name="choosing-your-sail-services"></a>
 ### Choosing Your Sail Services
 
-When creating a new Laravel application via Sail, you may use the `with` query string variable to choose which services should be configured in your new application's `docker-compose.yml` file. Available services include `mysql`, `pgsql`, `mariadb`, `redis`, `memcached`, `meilisearch`, `minio`, `selenium`, and `mailpit`:
+When creating a new Laravel application via Sail, you may use the `with` query string variable to choose which services should be configured in your new application's `docker-compose.yml` file. Available services include `mysql`, `pgsql`, `mariadb`, `redis`, `memcached`, `meilisearch`, `minio`, `selenium`, `soketi` and `mailpit`:
 
 ```shell
 curl -s "https://laravel.build/example-app?with=mysql,redis" | bash


### PR DESCRIPTION
Hello all,
I noticed that in the SAIL documentation there is missing information that `soketi` can be given to `with`, which can be seen when verifying in the file https://github.com/laravel/sail-server/blob/master/routes/web.php#L23
So I added this information

A view of what the /routes/web.php file looks like:
![image](https://github.com/laravel/docs/assets/12556170/d5283771-e0a0-445f-9076-7cda2f577a0f)



A preview of how it will look in the documentation:
![Zrzut ekranu z 2023-06-21 09-50-00](https://github.com/laravel/docs/assets/12556170/a5a73982-d3f5-427d-8e5f-3a04b4219e00)
