### PR TITLE
[10.x] Added single space around construct

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -455,7 +455,7 @@ If you need to group an "or" condition within parentheses, you may pass a closur
 
     $users = DB::table('users')
                 ->where('votes', '>', 100)
-                ->orWhere(function(Builder $query) {
+                ->orWhere(function (Builder $query) {
                     $query->where('name', 'Abigail')
                           ->where('votes', '>', 50);
                 })


### PR DESCRIPTION
Added single space around construct in "Or Where Clauses" example