### PR TITLE
Update eloquent-relationships.md

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -820,10 +820,10 @@ A one-to-one polymorphic relation is similar to a typical one-to-one relation; h
     images
         id - integer
         url - string
-        imageable_id - integer
-        imageable_type - string
+        image_id - integer
+        image_type - string
 
-Note the `imageable_id` and `imageable_type` columns on the `images` table. The `imageable_id` column will contain the ID value of the post or user, while the `imageable_type` column will contain the class name of the parent model. The `imageable_type` column is used by Eloquent to determine which "type" of parent model to return when accessing the `imageable` relation. In this case, the column would contain either `App\Models\Post` or `App\Models\User`.
+Note the `image_id` and `image_type` columns on the `images` table. The `image_id` column will contain the ID value of the post or user, while the `image_type` column will contain the class name of the parent model. The `image_type` column is used by Eloquent to determine which "type" of parent model to return when accessing the `imageable` relation. In this case, the column would contain either `App\Models\Post` or `App\Models\User`.
 
 <a name="one-to-one-polymorphic-model-structure"></a>
 #### Model Structure
@@ -907,7 +907,7 @@ If necessary, you may specify the name of the "id" and "type" columns utilized b
      */
     public function imageable(): MorphTo
     {
-        return $this->morphTo(__FUNCTION__, 'imageable_type', 'imageable_id');
+        return $this->morphTo(__FUNCTION__, 'image_type', 'image_id');
     }
 
 <a name="one-to-many-polymorphic-relations"></a>


### PR DESCRIPTION
Hi, I just noticed that in laravel nova by default you use without '**able**' suffix convencion in polymorphic models. '**able**' suffix causes problems in laravel nova and you need to add additional arguments to method.

example:
`$this->morphMany(Resource::class, 'resource', 'resourcable_type', 'resourcable_id');`

Laravel nova was looking for **resource_type** and **resource_id** columns in db by default.