### PR TITLE
[10.x] Add `fullUrlWithoutQuery` method in requests

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -135,6 +135,12 @@ If you would like to append query string data to the current URL, you may call t
 
     $request->fullUrlWithQuery(['type' => 'phone']);
 
+If you would like to get current URL without query string, you may call the `fullUrlWithoutQuery` method.
+
+```php
+$request->fullUrlWithoutQuery(['type']);
+```
+
 <a name="retrieving-the-request-host"></a>
 #### Retrieving The Request Host
 

--- a/requests.md
+++ b/requests.md
@@ -135,7 +135,7 @@ If you would like to append query string data to the current URL, you may call t
 
     $request->fullUrlWithQuery(['type' => 'phone']);
 
-If you would like to get current URL without query string, you may call the `fullUrlWithoutQuery` method.
+If you would like to get the current URL without a given query string parameter, you may utilize the `fullUrlWithoutQuery` method:
 
 ```php
 $request->fullUrlWithoutQuery(['type']);


### PR DESCRIPTION
The `fullUrlWithoutQuery` method is a useful method in Request, but there isn't in docs!!