### PR TITLE
[10.x] Update SSR server location and include `inertia:start-ssr` command

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -646,7 +646,7 @@ Then, to build and start the SSR server, you may run the following commands:
 
 ```sh
 npm run build
-node bootstrap/ssr/ssr.mjs
+node bootstrap/ssr/ssr.js
 ```
 
 > **Note**  

--- a/vite.md
+++ b/vite.md
@@ -649,6 +649,12 @@ npm run build
 node bootstrap/ssr/ssr.js
 ```
 
+If you are using [server-side rendering with Inertia](https://inertiajs.com/server-side-rendering), you may instead use the `inertia:start-ssr` Artisan command to start the SSR server:
+
+```sh
+php artisan inertia:start-ssr
+```
+
 > **Note**  
 > Laravel's [starter kits](/docs/{{version}}/starter-kits) already include the proper Laravel, Inertia SSR, and Vite configuration. Check out [Laravel Breeze](/docs/{{version}}/starter-kits#breeze-and-inertia) for the fastest way to get started with Laravel, Inertia SSR, and Vite.
 

--- a/vite.md
+++ b/vite.md
@@ -649,7 +649,7 @@ npm run build
 node bootstrap/ssr/ssr.js
 ```
 
-If you are using [server-side rendering with Inertia](https://inertiajs.com/server-side-rendering), you may instead use the `inertia:start-ssr` Artisan command to start the SSR server:
+If you are using [SSR with Inertia](https://inertiajs.com/server-side-rendering), you may instead use the `inertia:start-ssr` Artisan command to start the SSR server:
 
 ```sh
 php artisan inertia:start-ssr


### PR DESCRIPTION
Fixes: https://github.com/laravel/framework/issues/47670

With the recent change to ESM, the SSR server location in the docs needs to be updated.

I've also included a note about the `inertia:start-ssr` Artisan command, which automatically handles this for Inertia users.