### PR TITLE
Add warning about docker context sail

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -62,6 +62,9 @@ Finally, you may start Sail. To continue learning how to use Sail, please contin
 ./vendor/bin/sail up
 ```
 
+> **Warning**  
+> Docker Desktop for Linux users are advised to use the `default` docker context instead of `desktop-linux` to prevent permission issues when using Sail.
+
 <a name="adding-additional-services"></a>
 #### Adding Additional Services
 


### PR DESCRIPTION
Is related to this https://github.com/laravel/sail/issues/81#issuecomment-1626401679

Installing Sail when using the `desktop-linux` docker context (which is the default for Docker Desktop on Linux) results in permission issues on for example the Storage folder.