### PR TITLE
[10.x] Add `Retrieving Multiple Models` section in eloquent

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -563,7 +563,7 @@ Using the subquery functionality available to the query builder's `select` and `
 <a name="retrieving-multiple-models"></a>
 ### Retrieving Multiple Models
 
-If you want to get a list of entity, you can use `findMany` method:
+If you want to get a list of entities by ids, you can use `findMany` method:
 
 ```php
 $flights = Flight::findMany([1, 2, 3]);

--- a/eloquent.md
+++ b/eloquent.md
@@ -16,10 +16,10 @@
     - [Chunk Using Lazy Collections](#chunking-using-lazy-collections)
     - [Cursors](#cursors)
     - [Advanced Subqueries](#advanced-subqueries)
+    - [Retrieving Multiple Models](#retrieving-multiple-models)
 - [Retrieving Single Models / Aggregates](#retrieving-single-models)
     - [Retrieving Or Creating Models](#retrieving-or-creating-models)
     - [Retrieving Aggregates](#retrieving-aggregates)
-- [Retrieving Multiple Models](#retrieving-multiple-models) 
 - [Inserting & Updating Models](#inserting-and-updating-models)
     - [Inserts](#inserts)
     - [Updates](#updates)
@@ -560,6 +560,17 @@ Using the subquery functionality available to the query builder's `select` and `
         ->limit(1)
     ])->get();
 
+<a name="retrieving-multiple-models"></a>
+### Retrieving Multiple Models
+
+If you want to get a list of entity, you can use `findMany` method:
+
+```php
+$flights = Flight::findMany([1, 2, 3]);
+```
+
+The `findMany` method returns a [Collection](/docs/{{version}}/collections) instance.
+
 <a name="subquery-ordering"></a>
 #### Subquery Ordering
 
@@ -654,17 +665,6 @@ When interacting with Eloquent models, you may also use the `count`, `sum`, `max
     $count = Flight::where('active', 1)->count();
 
     $max = Flight::where('active', 1)->max('price');
-
-<a name="retrieving-multiple-models"></a>
-## Retrieving Multiple Models 
-
-If you want to get a list of entity, you can use `findMany` method:
-
-```php
-$flights = Flight::findMany([1, 2, 3]);
-```
-
-The `findMany` method returns a [Collection](/docs/{{version}}/collections) instance.
 
 <a name="inserting-and-updating-models"></a>
 ## Inserting & Updating Models

--- a/eloquent.md
+++ b/eloquent.md
@@ -19,6 +19,7 @@
 - [Retrieving Single Models / Aggregates](#retrieving-single-models)
     - [Retrieving Or Creating Models](#retrieving-or-creating-models)
     - [Retrieving Aggregates](#retrieving-aggregates)
+- [Retrieving Multiple Models](#retrieving-multiple-models) 
 - [Inserting & Updating Models](#inserting-and-updating-models)
     - [Inserts](#inserts)
     - [Updates](#updates)
@@ -653,6 +654,17 @@ When interacting with Eloquent models, you may also use the `count`, `sum`, `max
     $count = Flight::where('active', 1)->count();
 
     $max = Flight::where('active', 1)->max('price');
+
+<a name="retrieving-multiple-models"></a>
+## Retrieving Multiple Models 
+
+If you want to get a list of entity, you can use `findMany` method:
+
+```php
+$flights = Flight::findMany([1, 2, 3]);
+```
+
+The `findMany` method returns a [Collection](/docs/{{version}}/collections) instance.
 
 <a name="inserting-and-updating-models"></a>
 ## Inserting & Updating Models


### PR DESCRIPTION
In the `Retrieving Models` section in eloquent, we don't have any area about retrieving models by id!!
I knew about findMany, but most developers didn't know about the findMany method!

Continue: https://github.com/laravel/docs/pull/8789