### PR TITLE
Fix erroneous typehint for `Stringable::replaceMatches`

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -3003,10 +3003,9 @@ The `replaceMatches` method replaces all portions of a string matching a pattern
 The `replaceMatches` method also accepts a closure that will be invoked with each portion of the string matching the given pattern, allowing you to perform the replacement logic within the closure and return the replaced value:
 
     use Illuminate\Support\Str;
-    use Illuminate\Support\Stringable;
 
-    $replaced = Str::of('123')->replaceMatches('/\d/', function (Stringable $match) {
-        return '['.$match[0].']';
+    $replaced = Str::of('123')->replaceMatches('/\d/', function (array $matches) {
+        return '['.$matches[0].']';
     });
 
     // '[1][2][3]'


### PR DESCRIPTION
Fixes the error:
```
{closure}(): Argument #1 ($match) must be of type Illuminate\Support\Stringable, array given
```

Relates to: https://github.com/laravel/framework/blob/6d690edda8c5b0d400a8753def02d9ecd3e98e40/src/Illuminate/Support/Stringable.php#L661-L676