### PR TITLE
Add warning to switch docker context

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -159,7 +159,15 @@ Once these tools are installed, you may open any Laravel project by executing th
 <a name="getting-started-on-linux"></a>
 ### Getting Started On Linux
 
-If you're developing on Linux and [Docker Compose](https://docs.docker.com/compose/install/) is already installed, you can use a simple terminal command to create a new Laravel project. For example, to create a new Laravel application in a directory named "example-app", you may run the following command in your terminal:
+If you're developing on Linux and [Docker Compose](https://docs.docker.com/compose/install/) is already installed, you can use a simple terminal command to create a new Laravel project.
+
+First, if you are using Docker Desktop for Linux, you should execute the following command. If you are not using Docker Desktop for Linux, you may skip this step:
+
+```shell
+docker context use default
+```
+
+Then, to create a new Laravel application in a directory named "example-app", you may run the following command in your terminal:
 
 ```shell
 curl -s https://laravel.build/example-app | bash

--- a/sail.md
+++ b/sail.md
@@ -62,6 +62,9 @@ Finally, you may start Sail. To continue learning how to use Sail, please contin
 ./vendor/bin/sail up
 ```
 
+> **Warning**  
+> Docker Desktop for Linux users are advised to switch to the `default` docker context `docker context use default` to prevent file permission issues.
+
 <a name="adding-additional-services"></a>
 #### Adding Additional Services
 

--- a/sail.md
+++ b/sail.md
@@ -62,8 +62,8 @@ Finally, you may start Sail. To continue learning how to use Sail, please contin
 ./vendor/bin/sail up
 ```
 
-> **Warning**  
-> Docker Desktop for Linux users are advised to switch to the `default` docker context `docker context use default` to prevent file permission issues.
+> **Warning**
+> If you are using Docker Desktop for Linux, you should use the `default` Docker context by executing the following command: `docker context use default`.
 
 <a name="adding-additional-services"></a>
 #### Adding Additional Services


### PR DESCRIPTION
Related to this issue: https://github.com/laravel/sail/issues/81#issuecomment-1626401679

Now includes how to switch docker context.

Please let me know if there is another place in the docs where this warning is more suitable.