### PR TITLE
[10.x] Fix placeholder in Precognition documentation

### DIFF
--- a/precognition.md
+++ b/precognition.md
@@ -365,7 +365,7 @@ const submit = (e) => {
 
 Using Laravel Precognition, you can offer live validation experiences to your users without having to duplicate your validation rules in your frontend Alpine application. To illustrate how it works, let's build a form for creating new users within our application.
 
-First, to enable Precognition for a route, the `HandlePrecognitiveRequests` middleware should be added to the route definition. You should also create a [form request](/docs/{version}/validation#form-request-validation) to house the route's validation rules:
+First, to enable Precognition for a route, the `HandlePrecognitiveRequests` middleware should be added to the route definition. You should also create a [form request](/docs/{{version}}/validation#form-request-validation) to house the route's validation rules:
 
 ```php
 use App\Http\Requests\CreateUserRequest;


### PR DESCRIPTION
The placeholder {version} in the text was corrected to {{version}} to ensure proper rendering. This change improves the accuracy of the documentation.