### PR TITLE
[10.x] Add missing Sail configuration for Selenium

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -297,6 +297,8 @@ By default, Sail will create a dedicated `testing` database so that your tests d
 ```yaml
 selenium:
     image: 'selenium/standalone-chrome'
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
     volumes:
         - '/dev/shm:/dev/shm'
     networks:

--- a/sail.md
+++ b/sail.md
@@ -326,6 +326,8 @@ If your local machine contains an Apple Silicon chip, your `selenium` service mu
 ```yaml
 selenium:
     image: 'seleniarm/standalone-chromium'
+    extra_hosts:
+        - 'host.docker.internal:host-gateway'
     volumes:
         - '/dev/shm:/dev/shm'
     networks:


### PR DESCRIPTION
## Description of Changes
Add missing `extra_hosts` line for Selenium Container to work when using Dusk via Sail:

As per: https://github.com/laravel/sail/blob/1.x/stubs/selenium.stub

## Background
I installed a blank Laravel 10.x application yesterday and removed the Selenium container from `docker-compose.yml` in the process. Later that day I tried to restore it using the documentation but the `extra_hosts` line was missing. This prevented `sail dusk` from working, the connection to Selenium times out.

Adding this missing line to `docker-compose.yml` fixes everything and Dusk is now fully working inside my Sail container.

I am using Apple Silicon so I assumed that this issue was specific to that documentation, but I then realised it also applies to the non-Apple documentation as well. Given that it's in the default stub in Sail it makes sense that the documentation should match here. So I have updated both locations.

Please let me know if I'm missing anything. I'm currently only working on Laravel 10.x so I'm unsure if this also impacts the 9.x and master documentation.

Thanks!