### PR TITLE
LazyLoadingViolationException warning

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1862,6 +1862,9 @@ Model::handleLazyLoadingViolationUsing(function (Model $model, string $relation)
 });
 ```
 
+> **Warning**  
+> When retrieving only a single model, fetching relationships which have **not** been eager-loaded do not throw a LazyLoadingViolationException.
+
 <a name="inserting-and-updating-related-models"></a>
 ## Inserting & Updating Related Models
 


### PR DESCRIPTION
https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Builder.php#L411-L413

```php
Model::preventLazyLoading();

$server = Server::first();
$server->deployments->count(); // some integer value

$server = Server::limit(2)->get()->first();
$server->deployments->count(); // throws `Illuminate\Database\LazyLoadingViolationException`
```

I was not aware of this behavior until @ToothlessRebel brought it to my attention. I think it's important to note in the documentation, as I had assumed all lazy-loading was prevented when `Model::$modelsShouldPreventLazyLoading` was enabled.