### PR TITLE
[10.x] Fix type hint

### DIFF
--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -97,7 +97,7 @@ Then, define a `model` property on the corresponding factory:
         /**
          * The name of the factory's corresponding model.
          *
-         * @var string
+         * @var class-string<\Illuminate\Database\Eloquent\Model>
          */
         protected $model = Flight::class;
     }


### PR DESCRIPTION
This prevents PHPStan from displaying the following error:

`PHPDoc type string of property is not covariant with PHPDoc type class-string<Illuminate\Database\Eloquent\Model> of overridden property`