### PR TITLE
[10.x] Notification Fake: Document `assertTimesSent` removal

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -275,6 +275,19 @@ The deprecated `MocksApplicationServices` trait has been removed from the framew
 
 If your application uses these methods, we recommend you transition to `Event::fake`, `Bus::fake`, and `Notification::fake`, respectively. You can learn more about mocking via fakes in the corresponding documentation for the component you are attempting to fake.
 
+<a name="assert-times-sent"></a>
+#### Notifcations: The `assertTimesSent` Method
+
+**Likelihood Of Impact: Medium**
+
+The deprecated `Notification::assertTimesSent` method has been removed. If your application uses this method, we recommend you to replace this with `Notfication::assertSentTimes`. You may also have to change the parameter ordering to suit the expected parameters of this new method:
+
+    // Before
+    Notification::assertTimesSent(1, ExampleNotification::class);
+
+    // After
+    Notification::assertSentTimes(ExampleNotification::class, 1);
+
 ### Validation
 
 <a name="closure-validation-rule-messages"></a>


### PR DESCRIPTION
The `Notification::assertTimesSent()` method was deprecated in Laravel 8.x and then actually removed in 10.x with currently no mention in the docs, from what I can see, for it to be removed (I guess this had been assumed). I couldn't see anything in the guides for 8 or 9 about this becoming deprecated either, though. 

Removed via:

https://github.com/laravel/framework/pull/42592

Originally deprecated in:

https://github.com/laravel/framework/commit/667cca8db300f55cd8fccd575eaa46f5156b0408

- https://laravel.com/api/7.x/Illuminate/Support/Testing/Fakes/NotificationFake.html#method_assertTimesSent
- https://laravel.com/api/8.x/Illuminate/Support/Testing/Fakes/NotificationFake.html#method_assertTimesSent
- https://laravel.com/api/9.x/Illuminate/Support/Testing/Fakes/NotificationFake.html#method_assertTimesSent
- https://laravel.com/api/10.x/Illuminate/Support/Testing/Fakes/NotificationFake.html#method_assertTmesSent

I have no idea about who/what constitutes for measuring the impact level, so please feel free to change / request modification, of course.

I tried to use similar language to what was already in the upgrade guide, at least for the Laravel 10 upgrade.