### PR TITLE
Remove faulty parameter

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -683,7 +683,7 @@ class AddContentSecurityPolicyHeaders
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
-    public function handle(Request $request, Closure $next, string $role): Response
+    public function handle(Request $request, Closure $next): Response
     {
         Vite::useCspNonce();
 


### PR DESCRIPTION
This might have ended up here when copy-pasting from somewhere else. But of course it'll throw an exception when using the snippet as-is.