### PR TITLE
Indicate how states and factory callbacks can be used together

### DIFF
--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -158,7 +158,7 @@ Factory callbacks are registered using the `afterMaking` and `afterCreating` met
         // ...
     }
 
-You can also use factory callbacks in combination with states to only perform additional tasks when required.
+You may also register factory callbacks within state methods to perform additional tasks after making or creating a model that are specific to a given state:
 
     use App\Models\User;
     use Illuminate\Database\Eloquent\Factories\Factory;

--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -140,7 +140,6 @@ Factory callbacks are registered using the `afterMaking` and `afterCreating` met
 
     use App\Models\User;
     use Illuminate\Database\Eloquent\Factories\Factory;
-    use Illuminate\Support\Str;
 
     class UserFactory extends Factory
     {
@@ -157,6 +156,27 @@ Factory callbacks are registered using the `afterMaking` and `afterCreating` met
         }
 
         // ...
+    }
+
+You can also use factory callbacks in combination with states to only perform additional tasks when required.
+
+    use App\Models\User;
+    use Illuminate\Database\Eloquent\Factories\Factory;
+
+    /**
+     * Indicate that the user is suspended.
+     */
+    public function suspended(): Factory
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'account_status' => 'suspended',
+            ];
+        })->afterMaking(function (User $user) {
+            // ...
+        })->afterCreating(function (User $user) {
+            // ...
+        });
     }
 
 <a name="creating-models-using-factories"></a>

--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -158,7 +158,7 @@ Factory callbacks are registered using the `afterMaking` and `afterCreating` met
         // ...
     }
 
-You may also register factory callbacks within state methods to perform additional tasks after making or creating a model that are specific to a given state:
+You may also register factory callbacks within state methods to perform additional tasks that are specific to a given state:
 
     use App\Models\User;
     use Illuminate\Database\Eloquent\Factories\Factory;


### PR DESCRIPTION
The current docs on [factory callbacks](https://laravel.com/docs/10.x/eloquent-factories#factory-states) seem to read as though `afterMaking` and `afterCreating` can only be used inside the `configure` method.

I think it's worth highlighting that they can be used separately and in combination with a factory state so they can be used conditionally.