### PR TITLE
[10.x] Remove PHP 7.4 reference in sail docs

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -182,7 +182,7 @@ docker run --rm \
     composer install --ignore-platform-reqs
 ```
 
-When using the `laravelsail/phpXX-composer` image, you should use the same version of PHP that you plan to use for your application (`74`, `80`, `81`, or `82`).
+When using the `laravelsail/phpXX-composer` image, you should use the same version of PHP that you plan to use for your application (`80`, `81`, or `82`).
 
 <a name="executing-artisan-commands"></a>
 ### Executing Artisan Commands


### PR DESCRIPTION
The latest Sail version doesn't support PHP 7.4 anymore and therefor this can be removed.