### PR TITLE
[10.x] Add missing `RequestException` use statement in HTTP Client docs

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -244,6 +244,7 @@ If a request attempt fails, you may wish to make a change to the request before 
 
     use Exception;
     use Illuminate\Http\Client\PendingRequest;
+    use Illuminate\Http\Client\RequestException;
 
     $response = Http::withToken($this->getToken())->retry(2, 0, function (Exception $exception, PendingRequest $request) {
         if (! $exception instanceof RequestException || $exception->response->status() !== 401) {


### PR DESCRIPTION
This PR adds a `use` statement for the `RequestException` referenced in the code sample below it, as the other classes referenced in the sample are also imported:

```php
use Exception;
use Illuminate\Http\Client\PendingRequest;
 
$response = Http::withToken($this->getToken())->retry(2, 0, function (Exception $exception, PendingRequest $request) {
    if (! $exception instanceof RequestException || $exception->response->status() !== 401) {
        return false;
    }
 
    $request->withToken($this->getNewToken());
 
    return true;
})->post(/* ... */);
```