### PR TITLE
Update upgrade.md

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -191,6 +191,8 @@ protected $casts = [
 ];
 ```
 
+In the previous version, the Eloquent `getDates()` method was returning a list of attributes including timestamps and all attributes defined in `$dates` property. After moving dates to the `$casts` you should expect only two timestamps or an empty array.
+
 <a name="relation-getbasequery-method"></a>
 #### Relation `getBaseQuery` Method
 


### PR DESCRIPTION
Upgrade to Laravel 10 forced to move all attributes from `$dates` to `$casts`. It was a breaking change as we were struggling with a lot of errors related to forms.

It turned out that it was caused by [the change](https://github.com/mgralikowski/framework/commit/0d7ac95d98986171ea2419cf8c35768e380e1595) in the getDates() method.

Example of usage of this method: https://github.com/LaravelCollective/html/blob/64ddfdcaeeb8d332bd98bef442bef81e39c3910b/src/Eloquent/FormAccessible.php#L31

Generally, I think the name of this method now is misleading a bit, as it is limited only to timestamps. 
I am not the only one who noticed that -> https://github.com/laravel/framework/pull/42587#issuecomment-1462502416
