### PR TITLE
[10.x] Consider 'Models' folder for the models path usages

### DIFF
--- a/container.md
+++ b/container.md
@@ -445,7 +445,7 @@ Sometimes you may wish to invoke a method on an object instance while allowing t
 
 You may invoke the `generate` method via the container like so:
 
-    use App\Models\UserReport;
+    use App\UserReport;
     use Illuminate\Support\Facades\App;
 
     $report = App::call([new UserReport, 'generate']);

--- a/container.md
+++ b/container.md
@@ -445,7 +445,7 @@ Sometimes you may wish to invoke a method on an object instance while allowing t
 
 You may invoke the `generate` method via the container like so:
 
-    use App\UserReport;
+    use App\Models\UserReport;
     use Illuminate\Support\Facades\App;
 
     $report = App::call([new UserReport, 'generate']);

--- a/octane.md
+++ b/octane.md
@@ -473,8 +473,8 @@ While building your application, you should take special care to avoid creating 
 When using Swoole, you may execute operations concurrently via light-weight background tasks. You may accomplish this using Octane's `concurrently` method. You may combine this method with PHP array destructuring to retrieve the results of each operation:
 
 ```php
-use App\User;
-use App\Server;
+use App\Models\User;
+use App\Models\Server;
 use Laravel\Octane\Facades\Octane;
 
 [$users, $servers] = Octane::concurrently([

--- a/queues.md
+++ b/queues.md
@@ -265,7 +265,7 @@ In certain cases, you may want to define a specific "key" that makes the job uni
 
     <?php
 
-    use App\Product;
+    use App\Models\Product;
     use Illuminate\Contracts\Queue\ShouldQueue;
     use Illuminate\Contracts\Queue\ShouldBeUnique;
 
@@ -306,7 +306,7 @@ By default, unique jobs are "unlocked" after a job completes processing or fails
 
     <?php
 
-    use App\Product;
+    use App\Models\Product;
     use Illuminate\Contracts\Queue\ShouldQueue;
     use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 


### PR DESCRIPTION
The `Models` folder was missing from some of the models' usages.

P.S: `use App\\[A-Za-z]+;`