### PR TITLE
[8.x] Consider 'Models' folder for the models path usages

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -252,7 +252,7 @@ When a user is viewing one of their orders, we don't want them to have to refres
 
     namespace App\Events;
 
-    use App\Order;
+    use App\Models\Order;
     use Illuminate\Broadcasting\Channel;
     use Illuminate\Broadcasting\InteractsWithSockets;
     use Illuminate\Broadcasting\PresenceChannel;

--- a/container.md
+++ b/container.md
@@ -457,7 +457,7 @@ Sometimes you may wish to invoke a method on an object instance while allowing t
 
 You may invoke the `generate` method via the container like so:
 
-    use App\UserReport;
+    use App\Models\UserReport;
     use Illuminate\Support\Facades\App;
 
     $report = App::call([new UserReport, 'generate']);

--- a/container.md
+++ b/container.md
@@ -457,7 +457,7 @@ Sometimes you may wish to invoke a method on an object instance while allowing t
 
 You may invoke the `generate` method via the container like so:
 
-    use App\Models\UserReport;
+    use App\UserReport;
     use Illuminate\Support\Facades\App;
 
     $report = App::call([new UserReport, 'generate']);

--- a/octane.md
+++ b/octane.md
@@ -458,8 +458,8 @@ While building your application, you should take special care to avoid creating 
 When using Swoole, you may execute operations concurrently via light-weight background tasks. You may accomplish this using Octane's `concurrently` method. You may combine this method with PHP array destructuring to retrieve the results of each operation:
 
 ```php
-use App\User;
-use App\Server;
+use App\Models\User;
+use App\Models\Server;
 use Laravel\Octane\Facades\Octane;
 
 [$users, $servers] = Octane::concurrently([

--- a/queues.md
+++ b/queues.md
@@ -263,7 +263,7 @@ In certain cases, you may want to define a specific "key" that makes the job uni
 
     <?php
 
-    use App\Product;
+    use App\Models\Product;
     use Illuminate\Contracts\Queue\ShouldQueue;
     use Illuminate\Contracts\Queue\ShouldBeUnique;
 
@@ -303,7 +303,7 @@ By default, unique jobs are "unlocked" after a job completes processing or fails
 
     <?php
 
-    use App\Product;
+    use App\Models\Product;
     use Illuminate\Contracts\Queue\ShouldQueue;
     use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 

--- a/releases.md
+++ b/releases.md
@@ -170,7 +170,7 @@ Laravel's job batching feature allows you to easily execute a batch of jobs and 
 The new `batch` method of the `Bus` facade may be used to dispatch a batch of jobs. Of course, batching is primarily useful when combined with completion callbacks. So, you may use the `then`, `catch`, and `finally` methods to define completion callbacks for the batch. Each of these callbacks will receive an `Illuminate\Bus\Batch` instance when they are invoked:
 
     use App\Jobs\ProcessPodcast;
-    use App\Podcast;
+    use App\Models\Podcast;
     use Illuminate\Bus\Batch;
     use Illuminate\Support\Facades\Bus;
     use Throwable;


### PR DESCRIPTION
The `Models` folder was missing from some of the models' usages.

P.S: `use App\\[A-Za-z]+;`