### PR TITLE
[10.x] Add more info for the 'singletons' property for the same object

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -100,6 +100,13 @@ If your service provider registers many simple bindings, you may wish to use the
         ];
     }
 
+To register simple bindings in the `singletons` property for the same object, you can use
+
+    public $singletons = [
+        Service::class,
+        Connection::class,
+    ];
+
 <a name="the-boot-method"></a>
 ### The Boot Method
 


### PR DESCRIPTION
To register simple bindings in the `singletons` property for the same object we can do it in three ways:

First:
```php
<?php

namespace App\Providers;

use App\Services\Service;
use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    /**
     * Register any application services.
     */
    public function register(): void
    {
        $this->app->singleton(Service::class, function (Application $app) {
            return new Service();
        });
    }
}
```

Second:
```php
<?php

namespace App\Providers;

use App\Services\Service;
use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    /**
     * All of the container singletons that should be registered.
     *
     * @var array
     */
    public $singletons = [
        Service::class => Service::class,
    ];
}
```

Third:
```php
<?php

namespace App\Providers;

use App\Services\Service;
use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    /**
     * All of the container singletons that should be registered.
     *
     * @var array
     */
    public $singletons = [
        Service::class,
    ];
}
```

So we can extend doc to show third way