### PR TITLE
[10.x] Add validation docs for `gt` and `gte` with value as the parameter

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1338,12 +1338,12 @@ The field under validation must not be empty when it is present.
 <a name="rule-gt"></a>
 #### gt:_field_
 
-The field under validation must be greater than the given _field_. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the [`size`](#rule-size) rule.
+The field under validation must be greater than the given _field_ or _value_. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the [`size`](#rule-size) rule.
 
 <a name="rule-gte"></a>
 #### gte:_field_
 
-The field under validation must be greater than or equal to the given _field_. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the [`size`](#rule-size) rule.
+The field under validation must be greater than or equal to the given _field_ or _value_. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the [`size`](#rule-size) rule.
 
 <a name="rule-image"></a>
 #### image


### PR DESCRIPTION
It seems that if a field is not found, the validation rule falls back to the value. This was not immediately clear when reading the documentation. It would be great to capture this in the header title of this rule, but I'm not sure how to capture that properly (maybe `gte:_field_ or gte:_value_`?)