### PR TITLE
Add minimum charge amount for stripe single charge

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -1590,7 +1590,7 @@ The `charge` method will throw an exception if the charge fails. If the charge i
     }
 
 > **Warning**  
-> The `charge` method accepts the payment amount in the lowest denominator of the currency used by your application. For example, if customers are paying in United States Dollars, amounts should be specified in pennies.
+> The `charge` method accepts the payment amount in the lowest denominator of the currency used by your application. For example, if customers are paying in United States Dollars, amounts should be specified in pennies. The minimum amount is $0.50 US or equivalent in charge currency.
 
 <a name="charge-with-invoice"></a>
 ### Charge With Invoice


### PR DESCRIPTION
## Description
- This PR adds the minimum amount of charge. Though, It has been described explicitly [here.](https://stripe.com/docs/api/charges/create) But, I think it would increase DX while working and debugging. 