### PR TITLE
Removed incorrect MinIO temporaryUrl warning

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -202,9 +202,6 @@ In order for Laravel's Flysystem integration to generate proper URLs when using 
 AWS_URL=http://localhost:9000/local
 ```
 
-> **Warning**  
-> Generating temporary storage URLs via the `temporaryUrl` method is not supported when using MinIO.
-
 <a name="obtaining-disk-instances"></a>
 ## Obtaining Disk Instances
 


### PR DESCRIPTION
I'm able to successfully get signed URLs working over MinIO with no issues at all. I believe that this part of the documentation is incorrect.