### PR TITLE
[10.x] Add transport key to Mailgun driver in Laravel mail config

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -61,6 +61,7 @@ composer require symfony/mailgun-mailer symfony/http-client
 Next, set the `default` option in your application's `config/mail.php` configuration file to `mailgun`. After configuring your application's default mailer, verify that your `config/services.php` configuration file contains the following options:
 
     'mailgun' => [
+        'transport' => 'mailgun',
         'domain' => env('MAILGUN_DOMAIN'),
         'secret' => env('MAILGUN_SECRET'),
     ],


### PR DESCRIPTION
This PR adds the `transport` key to the Mailgun driver example.

**Why is this important?**
- **Consistency:** By specifying the `transport` key explicitly, we make the driver configuration more consistent with the other configurations.
- **Clarity:** For developers unfamiliar with the specifics of the Mailgun driver, having the transport explicitly defined can make the configuration more self-explanatory.