### PR TITLE
[10.x] reset password page security tweak

### DIFF
--- a/passwords.md
+++ b/passwords.md
@@ -84,7 +84,7 @@ Before moving on, let's examine this route in more detail. First, the request's 
 
 The `sendResetLink` method returns a "status" slug. This status may be translated using Laravel's [localization](/docs/{{version}}/localization) helpers in order to display a user-friendly message to the user regarding the status of their request. The translation of the password reset status is determined by your application's `lang/{lang}/passwords.php` language file. An entry for each possible value of the status slug is located within the `passwords` language file.
 
-It is important to note that this endpoint will always return a success message even if the password entered is invalid. This is by design, so that an attacker cannot brute force the endpoint to determine if an email address is valid.
+It is important to note that this endpoint will always return a success message even if the email address entered is invalid. This is by design, so that an attacker cannot brute force the endpoint to determine if an email address is valid.
 
 > **Note**
 > By default, the Laravel application skeleton does not include the `lang` directory. If you would like to customize Laravel's language files, you may publish them via the `lang:publish` Artisan command.

--- a/passwords.md
+++ b/passwords.md
@@ -77,14 +77,14 @@ Next, we will define a route that handles the form submission request from the "
             $request->only('email')
         );
 
-        return $status === Password::RESET_LINK_SENT
-                    ? back()->with(['status' => __($status)])
-                    : back()->withErrors(['email' => __($status)]);
+        return back()->with(['status' => __(Password::RESET_LINK_SENT)]);
     })->middleware('guest')->name('password.email');
 
 Before moving on, let's examine this route in more detail. First, the request's `email` attribute is validated. Next, we will use Laravel's built-in "password broker" (via the `Password` facade) to send a password reset link to the user. The password broker will take care of retrieving the user by the given field (in this case, the email address) and sending the user a password reset link via Laravel's built-in [notification system](/docs/{{version}}/notifications).
 
 The `sendResetLink` method returns a "status" slug. This status may be translated using Laravel's [localization](/docs/{{version}}/localization) helpers in order to display a user-friendly message to the user regarding the status of their request. The translation of the password reset status is determined by your application's `lang/{lang}/passwords.php` language file. An entry for each possible value of the status slug is located within the `passwords` language file.
+
+It is important to note that this endpoint will always return a success message even if the password entered is invalid. This is by design, so that an attacker cannot brute force the endpoint to determine if an email address is valid.
 
 > **Note**
 > By default, the Laravel application skeleton does not include the `lang` directory. If you would like to customize Laravel's language files, you may publish them via the `lang:publish` Artisan command.


### PR DESCRIPTION
It is commonly accepted security best practice on a modern system that a reset password page should be non-committal about if a user existed or not. This is to prevent simple attacks against the reset password page to determine if a user is registered on a system or not by email address or username. Such attacks could then be combined with other attacks to break into user accounts.

As such i have changed the way the reset page returns its status to always return success. This would need to be combined with further tweaks to change the wording, i am not capable of making this change as it would involve changes to I18N content.

Please view this PR as a start of a longer discussion as to how to handle this simple tweak. I don't expect this is fine as-is, but wanted to broach the issue to test the water and see if this is something which should be adjusted to improve the security of projects built with Laravel.