### PR TITLE
Fix Slack notification routing

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -301,7 +301,7 @@ Sometimes you may need to send a notification to someone who is not stored as a 
 
     Notification::route('mail', 'taylor@example.com')
                 ->route('vonage', '5555555555')
-                ->route('slack', 'https://hooks.slack.com/services/...')
+                ->route('slack', '#slack-channel')
                 ->route('broadcast', [new Channel('channel-name')])
                 ->notify(new InvoicePaid($invoice));
 

--- a/notifications.md
+++ b/notifications.md
@@ -1226,6 +1226,10 @@ For instance, returning `#support-channel` from the `routeNotificationForSlack` 
         }
     }
 
+#### Note for people upgrading from laravel 9.x to 10.x
+
+If you are migrating from the old version of laravel and end up updating the `laravel/slack-notification-channel` package to the new version, and you want to use the block notation format, then you will have to replace your Slack channel routes from the `https://hooks.slack.com/services/...` format to the `#channel` format.
+
 <a name="notifying-external-slack-workspaces"></a>
 ### Notifying External Slack Workspaces
 

--- a/notifications.md
+++ b/notifications.md
@@ -1226,10 +1226,6 @@ For instance, returning `#support-channel` from the `routeNotificationForSlack` 
         }
     }
 
-#### Note for people upgrading from laravel 9.x to 10.x
-
-If you are migrating from the old version of laravel and end up updating the `laravel/slack-notification-channel` package to the new version, and you want to use the block notation format, then you will have to replace your Slack channel routes from the `https://hooks.slack.com/services/...` format to the `#channel` format.
-
 <a name="notifying-external-slack-workspaces"></a>
 ### Notifying External Slack Workspaces
 


### PR DESCRIPTION
Need to edit the example for sure.

The new version (^3.0) of the `slack-notification-channel` package, fails if we provide the route as a slack hook `(https://hooks.slack.com/services/...)` instead of a channel `#slack-channel`.

Apart from the example fix, I have also added a note for people who would be upgrading. This is exactly the issue I faced. The upgrade seems to be backwards compatible except when you start using block-notation. Then, you also need to update the route type from a URL/URI to `#sample-channel`