### PR TITLE
quote command argument to prevent shell filename expansion

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1697,7 +1697,7 @@ sudo supervisorctl reread
 
 sudo supervisorctl update
 
-sudo supervisorctl start laravel-worker:*
+sudo supervisorctl start "laravel-worker:*"
 ```
 
 For more information on Supervisor, consult the [Supervisor documentation](http://supervisord.org/index.html).


### PR DESCRIPTION
Using an unquoted asterisk `*` in a command argument may lead to expansion into filenames - that's definitely not wanted here.