### PR TITLE
[10.x] Adds `linkedin-openid`

### DIFF
--- a/socialite.md
+++ b/socialite.md
@@ -39,7 +39,7 @@ When upgrading to a new major version of Socialite, it's important that you care
 
 Before using Socialite, you will need to add credentials for the OAuth providers your application utilizes. Typically, these credentials may be retrieved by creating a "developer application" within the dashboard of the service you will be authenticating with.
 
-These credentials should be placed in your application's `config/services.php` configuration file, and should use the key `facebook`, `twitter` (OAuth 1.0), `twitter-oauth-2` (OAuth 2.0), `linkedin`, `google`, `github`, `gitlab`, `bitbucket`, or `slack`, depending on the providers your application requires:
+These credentials should be placed in your application's `config/services.php` configuration file, and should use the key `facebook`, `twitter` (OAuth 1.0), `twitter-oauth-2` (OAuth 2.0), `linkedin-openid`, `google`, `github`, `gitlab`, `bitbucket`, or `slack`, depending on the providers your application requires:
 
     'github' => [
         'client_id' => env('GITHUB_CLIENT_ID'),


### PR DESCRIPTION
This pull request removes the `linkedin` provider from Socialite documention, and starts mentioning `linkedin-openid` only.

Refers to: https://github.com/laravel/socialite/pull/662.