### PR TITLE
[10.x] Simplify Pennant middleware.

### DIFF
--- a/pennant.md
+++ b/pennant.md
@@ -344,31 +344,15 @@ To make checking features in Blade a seamless experience, Pennant offers a `@fea
 <a name="middleware"></a>
 ### Middleware
 
-Pennant also includes a [middleware](/docs/{{version}}/middleware) that may be used to verify the currently authenticated user has access to a feature before a route is even invoked. To get started, you should add a middleware alias for the `EnsureFeaturesAreActive` middleware to your application's `app/Http/Kernel.php` file:
+Pennant also includes a [middleware](/docs/{{version}}/middleware) that may be used to verify the currently authenticated user has access to a feature before a route is even invoked. You may assign the middleware to a route and specify the features that are required to access the route. If any of the specified features are inactive for the currently authenticated user, a `400 Bad Request` HTTP response will be returned by the route. Multiple features may be passed to the static `using` method.
 
 ```php
+use Illuminate\Support\Facades\Route;
 use Laravel\Pennant\Middleware\EnsureFeaturesAreActive;
 
-protected $middlewareAliases = [
-    // ...
-    'features' => EnsureFeaturesAreActive::class,
-];
-```
-
-Next, you may assign the middleware to a route and specify the features that are required to access the route. If any of the specified features are inactive for the currently authenticated user, a `400 Bad Request` HTTP response will be returned by the route. Multiple features may be specified using a comma-delimited list:
-
-```php
 Route::get('/api/servers', function () {
     // ...
-})->middleware(['features:new-api,servers-api']);
-```
-
-The `EnsureFeaturesAreActive` middleware also provides a static `all` method which may be used to assign to the middleware to routes:
-
-```php
-Route::get('/api/servers', function () {
-    // ...
-})->middleware([EnsureFeaturesAreActive::all(['new-api', 'servers-api'])]);
+})->middleware(EnsureFeaturesAreActive::using('new-api', 'servers-api'));
 ```
 
 <a name="customizing-the-response"></a>


### PR DESCRIPTION
Simplifies and also corrects the method, as it was changed to `using`.

Before:

<img width="734" alt="Screenshot 2023-09-06 at 11 04 22 am" src="https://github.com/laravel/docs/assets/24803032/8919d35e-d5d4-4f08-b03b-e76b0a153b87">

After:


<img width="729" alt="Screenshot 2023-09-06 at 11 06 17 am" src="https://github.com/laravel/docs/assets/24803032/9036e6aa-29b8-4d53-8914-b6b7a6a03fac">

