### PR TITLE
Better explanation of the need of DBAL library for column type migrations

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -1034,12 +1034,15 @@ When modifying a column, you must explicitly include all of the modifiers you wa
         $table->integer('votes')->unsigned()->default(1)->comment('my comment')->change();
     });
 
-<a name="modifying-columns-on-sqlite"></a>
-#### Modifying Columns On SQLite
+<a name="the-doctrine-dbal-library"></a>
+#### The Doctrine DBAL library
 
-If your application is utilizing an SQLite database, you must install the `doctrine/dbal` package using the Composer package manager before modifying a column. The Doctrine DBAL library is used to determine the current state of the column and to create the SQL queries needed to make the requested changes to your column:
+The package is required if your application is utilizing an **SQLite database** or if you want to change type of a column. You must install the `doctrine/dbal` package using the Composer package manager to change most types. The Doctrine DBAL library is used to determine the current state of the column and to create the SQL queries needed to make the requested changes to your column:
 
-    composer require doctrine/dbal
+	composer require doctrine/dbal
+
+> **Warning**
+> When using the `doctrine/dbal` package, the following column types can be modified: `bigInteger`, `binary`, `boolean`, `char`, `date`, `dateTime`, `dateTimeTz`, `decimal`, `double`, `integer`, `json`, `longText`, `mediumText`, `smallInteger`, `string`, `text`, `time`, `tinyText`, `unsignedBigInteger`, `unsignedInteger`, `unsignedSmallInteger`, `ulid`, and `uuid`.
 
 If you plan to modify columns created using the `timestamp` method, you must also add the following configuration to your application's `config/database.php` configuration file:
 
@@ -1052,9 +1055,6 @@ use Illuminate\Database\DBAL\TimestampType;
     ],
 ],
 ```
-
-> **Warning**  
-> When using the `doctrine/dbal` package, the following column types can be modified: `bigInteger`, `binary`, `boolean`, `char`, `date`, `dateTime`, `dateTimeTz`, `decimal`, `double`, `integer`, `json`, `longText`, `mediumText`, `smallInteger`, `string`, `text`, `time`, `tinyText`, `unsignedBigInteger`, `unsignedInteger`, `unsignedSmallInteger`, `ulid`, and `uuid`.
 
 <a name="renaming-columns"></a>
 ### Renaming Columns


### PR DESCRIPTION
I noticed while trying to change type of timestamp to datetime in migrations that it didn't work in MySQL. According to the current documentation, it's only needed for SQLLite while the "warning" is saying what you can do if you use the package, but that's under the SQLite header, which people will "ignore" because they use another db engine. This change will hopefully help other developers to better understand if they need the package or not.

If I need to change something or there's a better explanation, I'm open for it 😉 