### PR TITLE
[11.x] Bump supported database versions

### DIFF
--- a/database.md
+++ b/database.md
@@ -19,10 +19,10 @@ Almost every modern web application interacts with a database. Laravel makes int
 
 <div class="content-list" markdown="1">
 
-- MariaDB 10.3+ ([Version Policy](https://mariadb.org/about/#maintenance-policy))
-- MySQL 5.7+ ([Version Policy](https://en.wikipedia.org/wiki/MySQL#Release_history))
-- PostgreSQL 10.0+ ([Version Policy](https://www.postgresql.org/support/versioning/))
-- SQLite 3.8.8+
+- MariaDB 10.11+ ([Version Policy](https://mariadb.org/about/#maintenance-policy))
+- MySQL 8.0+ ([Version Policy](https://en.wikipedia.org/wiki/MySQL#Release_history))
+- PostgreSQL 12.0+ ([Version Policy](https://www.postgresql.org/support/versioning/))
+- SQLite 3.35.0+
 - SQL Server 2017+ ([Version Policy](https://docs.microsoft.com/en-us/lifecycle/products/?products=sql-server))
 
 </div>


### PR DESCRIPTION
Related to #8923

| Database | On Laravel 10 | End of Life | Bumped to |
| ------------- | ------------- | ------------- | ------------- |
| MariaDB  | 10.10+ | Nov 2023 | 10.11+ |
| MySQL  | 5.7+ | Oct 2023 | 8.0+ |
| PostgreSQL | 11.0+ | Nov 2023 | 12.0+ |
| SQLite | 3.8.8+ | - | 3.35.0 |