### PR TITLE
fixed legacy PHP syntax in Optional Routing 

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -197,11 +197,11 @@ If your route has dependencies that you would like the Laravel service container
 
 Occasionally you may need to specify a route parameter that may not always be present in the URI. You may do so by placing a `?` mark after the parameter name. Make sure to give the route's corresponding variable a default value:
 
-    Route::get('/user/{name?}', function (string $name = null) {
+    Route::get('/user/{name?}', function (?string $name = null) {
         return $name;
     });
 
-    Route::get('/user/{name?}', function (string $name = 'John') {
+    Route::get('/user/{name?}', function (?string $name = 'John') {
         return $name;
     });
 


### PR DESCRIPTION
The current docs contains some unrecommended legacy PHP syntax to make types nullable.

See PHP docs for referencece:
https://www.php.net/manual/en/language.types.declarations.php

> Note:
>
> It is also possible to achieve nullable arguments by making null the default value. This is not recommended as if the default value is changed in a child class a type compatibility violation will be raised as the null type will need to be added to the type declaration.
> 
> Example #2 Old way to make arguments nullable
> ```php
> <?php
> class C {}
>
> function f(C $c = null) {
>    var_dump($c);
> }
>
> f(new C);
> f(null);
> ?>
> ```
