### PR TITLE
Note about inline attachments rendered as data urls in browser

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -919,8 +919,8 @@ When designing a mailable's template, it is convenient to quickly preview the re
         return new App\Mail\InvoicePaid($invoice);
     });
 
-> **Warning**  
-> [Inline attachments](#inline-attachments) will not be rendered when a mailable is previewed in your browser. To preview these mailables, you should send them to an email testing application such as [Mailpit](https://github.com/axllent/mailpit) or [HELO](https://usehelo.com).
+> **Note**  
+> [Inline attachments](#inline-attachments) will be rendered a data urls when a mailable is previewed in your browser.
 
 <a name="localizing-mailables"></a>
 ## Localizing Mailables

--- a/mail.md
+++ b/mail.md
@@ -919,9 +919,6 @@ When designing a mailable's template, it is convenient to quickly preview the re
         return new App\Mail\InvoicePaid($invoice);
     });
 
-> **Note**  
-> [Inline attachments](#inline-attachments) will be rendered a data urls when a mailable is previewed in your browser.
-
 <a name="localizing-mailables"></a>
 ## Localizing Mailables
 


### PR DESCRIPTION
Change warning that inline attachments will not be rendered to a note that says attachments will be shown as data urls.