### PR TITLE
Change description of `e` helper to `e` function

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -88,7 +88,7 @@ The current UNIX timestamp is {{ time() }}.
 <a name="html-entity-encoding"></a>
 ### HTML Entity Encoding
 
-By default, Blade (and the Laravel `e` helper) will double encode HTML entities. If you would like to disable double encoding, call the `Blade::withoutDoubleEncoding` method from the `boot` method of your `AppServiceProvider`:
+By default, Blade (and the Laravel `e` function) will double encode HTML entities. If you would like to disable double encoding, call the `Blade::withoutDoubleEncoding` method from the `boot` method of your `AppServiceProvider`:
 
     <?php
 


### PR DESCRIPTION
Searching for:

`e` helper

in the current 10.x docs points back to this location, however searching for:

`e` function

finds the `e` function in the Strings section

In the Strings section, `e()` is referred to as the `e` function.