### PR TITLE
Improve deduplicating reporting setup example

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -122,7 +122,7 @@ Sometimes you may need to report an exception but continue handling the current 
 
 If you are using the `report` function throughout your application, you may occasionally report the same exception multiple times, creating duplicate entries in your logs.
 
-If you would like to ensure that a single instance of an exception is only ever reported once, you may set the exception handler's `$deduplicateReporting` property to `true`.
+If you would like to ensure that a single instance of an exception is only ever reported once, you may set the `$withoutDuplicates` property to `true` within your application's `App\Exceptions\Handler` class:
 
 ```php
 namespace App\Exceptions;

--- a/errors.md
+++ b/errors.md
@@ -132,11 +132,11 @@ use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 class Handler extends ExceptionHandler
 {
     /**
-     * Indicates that exception reporting should be deduplicated.
+     * Indicates that an exception instance should only be reported once.
      *
      * @var bool
      */
-    protected $deduplicateReporting = true;
+    protected $withoutDuplicates = true;
 
     // ...
 }

--- a/errors.md
+++ b/errors.md
@@ -122,17 +122,23 @@ Sometimes you may need to report an exception but continue handling the current 
 
 If you are using the `report` function throughout your application, you may occasionally report the same exception multiple times, creating duplicate entries in your logs.
 
-If you would like to ensure that a single instance of an exception is only ever reported once, you may call the exception handler's `dontReportDuplicates` method. Typically, this method should be invoked from the `boot` method of your application's `AppServiceProvider`:
+If you would like to ensure that a single instance of an exception is only ever reported once, you may set the exception handler's `$deduplicateReporting` property to `true`.
 
 ```php
-use Illuminate\Contracts\Debug\ExceptionHandler;
+namespace App\Exceptions;
 
-/**
- * Bootstrap any application services.
- */
-public function boot(ExceptionHandler $exceptionHandler): void
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+
+class Handler extends ExceptionHandler
 {
-    $exceptionHandler->dontReportDuplicates();
+    /**
+     * Indicates that exception reporting should be deduplicated.
+     *
+     * @var bool
+     */
+    protected $deduplicateReporting = true;
+
+    // ...
 }
 ```
 


### PR DESCRIPTION
So much easier to just set the property in the exception handler, which is where you are probably looking for this feature. Keeps everything colocated.

## Before

<img width="736" alt="Screenshot 2023-09-14 at 1 11 32 pm" src="https://github.com/laravel/docs/assets/24803032/1f9fe470-0803-468a-a342-270a85b9655e">

## After

<img width="728" alt="Screenshot 2023-09-14 at 1 11 51 pm" src="https://github.com/laravel/docs/assets/24803032/ab0ce427-440b-4844-9f9d-659e599e2a29">
