### PR TITLE
[10.x] Add `laravel/prompts` to contributions page

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -42,6 +42,7 @@ The Laravel source code is managed on GitHub, and there are repositories for eac
 - [Laravel Passport](https://github.com/laravel/passport)
 - [Laravel Pennant](https://github.com/laravel/pennant)
 - [Laravel Pint](https://github.com/laravel/pint)
+- [Laravel Prompts](https://github.com/laravel/prompts)
 - [Laravel Sail](https://github.com/laravel/sail)
 - [Laravel Sanctum](https://github.com/laravel/sanctum)
 - [Laravel Scout](https://github.com/laravel/scout)


### PR DESCRIPTION
Add github link to `laravel/prompts`