### PR TITLE
Fix notification custom queue connection example

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -197,14 +197,29 @@ Alternatively, you may define a `withDelay` method on the notification class its
 <a name="customizing-the-notification-queue-connection"></a>
 #### Customizing The Notification Queue Connection
 
-By default, queued notifications will be queued using your application's default queue connection. If you would like to specify a different connection that should be used for a particular notification, you may define a `$connection` property on the notification class:
+By default, queued notifications will be queued using your application's default queue connection. If you would like to specify a different connection that should be used for a particular notification, you may call the `onConnection` method from your notification's constructor:
 
-    /**
-     * The name of the queue connection to use when queueing the notification.
-     *
-     * @var string
-     */
-    public $connection = 'redis';
+
+    <?php
+
+    namespace App\Notifications;
+
+    use Illuminate\Bus\Queueable;
+    use Illuminate\Contracts\Queue\ShouldQueue;
+    use Illuminate\Notifications\Notification;
+
+    class InvoicePaid extends Notification implements ShouldQueue
+    {
+        use Queueable;
+
+        /**
+         * Create a new notification instance.
+         */
+        public function __construct()
+        {
+            $this->onConnection('redis');
+        }
+    }
 
 Or, if you would like to specify a specific queue connection that should be used for each notification channel supported by the notification, you may define a `viaConnections` method on your notification. This method should return an array of channel name / queue connection name pairs:
 


### PR DESCRIPTION
If we follow the current example, we get this error:

```
Fatal error: App\Notifications\InvoicePaid and Illuminate\Bus\Queueable define the same property ($connection)
in the composition of App\Notifications\InvoicePaid. However, the definition differs and is considered incompatible.
```

To override a Trait's property, we need to create a parent class and it gets complicated. So it's best to use the `onConnection` method.

That's actually what the Queue documentation already suggests (see [Dispatching To A Particular Connection](https://laravel.com/docs/10.x/queues#dispatching-to-a-particular-connection)).