### PR TITLE
Add entry for `Str::of` to list of available methods for strings

### DIFF
--- a/strings.md
+++ b/strings.md
@@ -61,6 +61,7 @@ Laravel includes a variety of functions for manipulating string values. Many of 
 [Str::lower](#method-str-lower)
 [Str::markdown](#method-str-markdown)
 [Str::mask](#method-str-mask)
+[Str::of](#method-str)
 [Str::orderedUuid](#method-str-ordered-uuid)
 [Str::padBoth](#method-str-padboth)
 [Str::padLeft](#method-str-padleft)


### PR DESCRIPTION
There does not appear to be a direct description of the `Str::of` function. It appears under [`str()`](https://github.com/laravel/docs/blob/a2cf776692b78089c6e06464fd2bcfad31604f85/strings.md?plain=1#L1188).

I am not sure whether a separate description for `Str::of` is necessary or not as the description for `str()` is clear. However, a link in the available methods sections might help people find this description faster.