### PR TITLE
Add that sanctum requires origin or referer header

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -251,7 +251,7 @@ Sanctum also exists to provide a simple method of authenticating single page app
 For this feature, Sanctum does not use tokens of any kind. Instead, Sanctum uses Laravel's built-in cookie based session authentication services. This approach to authentication provides the benefits of CSRF protection, session authentication, as well as protects against leakage of the authentication credentials via XSS.
 
 > **Warning**  
-> In order to authenticate, your SPA and API must share the same top-level domain. However, they may be placed on different subdomains. Additionally, you should ensure that you send the `Accept: application/json` header with your request.
+> In order to authenticate, your SPA and API must share the same top-level domain. However, they may be placed on different subdomains. Additionally, you should ensure that you send the `Accept: application/json` header and either the `Referer` or `Origin` header with your request.
 
 
 <a name="spa-configuration"></a>


### PR DESCRIPTION
According to the issues below, sanctum requires the referer or origin header:
https://github.com/laravel/sanctum/issues/203
https://github.com/laravel/sanctum/issues/218

I think it would be better to write that in the manual.