### PR TITLE
Add the subscription_items table to the Cashier Migration section

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -97,7 +97,7 @@ composer require laravel/cashier
 <a name="database-migrations"></a>
 ### Database Migrations
 
-Cashier's service provider registers its own database migration directory, so remember to migrate your database after installing the package. The Cashier migrations will add several columns to your `users` table as well as create a new `subscriptions` table to hold all of your customer's subscriptions:
+Cashier's service provider registers its own database migration directory, so remember to migrate your database after installing the package. The Cashier migrations will add several columns to your `users` table. It will also create a new `subscriptions` table to hold all of your customer's subscriptions and a `subscription_items` table for subscriptions with multiple prices:
 
 ```shell
 php artisan migrate


### PR DESCRIPTION
This PR adds info about the subscription_items table to the Database Migration section.