### PR TITLE
Warning about order of background tasks

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -332,6 +332,8 @@ By default, multiple tasks scheduled at the same time will execute sequentially 
              ->daily()
              ->runInBackground();
 
+Note that the schedule() method of Kernel executes top-down, so all background tasks need to be declared toward the top, otherwise they may still run after long-running tasks.
+
 > **Warning**  
 > The `runInBackground` method may only be used when scheduling tasks via the `command` and `exec` methods.
 


### PR DESCRIPTION
I learned the hard way that tasks declared toward the top of the Kernel still execute before those at the bottom, so if there are any 'runInBackground' tasks that you expect to run asynchronously, that won't be the case unless they're at the top of the file.

Updating documentation so that others are aware.