### PR TITLE
Migrate --pretend can actually create schema unless protected $connection is included in the migration

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -151,6 +151,16 @@ If you would like to see the SQL statements that will be executed by the migrati
 php artisan migrate --pretend
 ```
 
+> **Note**
+> If your application has multiple database connections, for `--pretend` to work correctly you need to ensure that your migrations on the non-default database(s) have declared their `$connection` property as shown below
+
+```shell
+return new class extends Migration
+{
+    protected $connection = 'second-database';
+   ...
+```
+
 #### Isolating Migration Execution
 
 If you are deploying your application across multiple servers and running migrations as part of your deployment process, you likely do not want two servers attempting to migrate the database at the same time. To avoid this, you may use the `isolated` option when invoking the `migrate` command.


### PR DESCRIPTION
In [Issue 36596](https://github.com/laravel/framework/issues/36596) it was reported that the `php artisan migrate --pretend` command will create schema elements on non-default database connections if the migration doesn't contain a `protected $connection` declaration.

This PR seeks to improve the Laravel 10.x documentation to address this apparent bug with `php artisan migrate --pretend` discussed in that thread. 

@taylorotwell actually [said](https://github.com/laravel/framework/issues/36596#issuecomment-799444847), in part,

> I'll make sure we are documenting this.

This PR seeks to make good on that promise, and prevent others (like me) from missing this information for any project with multiple databases.

