### PR TITLE
Fix typo in Precognition docs

### DIFF
--- a/precognition.md
+++ b/precognition.md
@@ -418,7 +418,7 @@ Alpine.start();
 
 With the Laravel Precognition package installed and registered, you can now create a form object using Precognition's `$form` "magic", providing the HTTP method (`post`), the target URL (`/users`), and the initial form data.
 
-To enable live validation, you should bind the form's data to it's relevant input and then listen to each input's `change` event. In the `change` event handler, you should invoke the form's `validate` method, providing the input's name:
+To enable live validation, you should bind the form's data to its relevant input and then listen to each input's `change` event. In the `change` event handler, you should invoke the form's `validate` method, providing the input's name:
 
 ```html
 <form x-data="{


### PR DESCRIPTION
I found and fixed a typo in the Precognition docs.

`it's` vs `its`