### PR TITLE
Properly terminate group/closure method call

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -608,7 +608,7 @@ Finally, you may reference the guard when assigning the authentication middlewar
 
     Route::middleware('auth:api')->group(function () {
         // ...
-    }
+    });
 
 <a name="adding-custom-user-providers"></a>
 ## Adding Custom User Providers


### PR DESCRIPTION
Avoids introducing a crash when one does copy 'n paste coding.