### PR TITLE
[10.x] Remove importing unused classes in one example of controllers.md

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -74,9 +74,6 @@ If a controller action is particularly complex, you might find it convenient to 
     <?php
 
     namespace App\Http\Controllers;
-    
-    use App\Models\User;
-    use Illuminate\Http\Response;
 
     class ProvisionServer extends Controller
     {


### PR DESCRIPTION
Hi,
These classes have not been used in the example of `Single Action Controllers`.