### PR TITLE
[10.x] Remove importing Controller from one example in session.md

### DIFF
--- a/session.md
+++ b/session.md
@@ -90,7 +90,6 @@ There are two primary ways of working with session data in Laravel: the global `
 
     namespace App\Http\Controllers;
 
-    use App\Http\Controllers\Controller;
     use Illuminate\Http\Request;
     use Illuminate\View\View;
 


### PR DESCRIPTION
Hi,
Importing Controller is unnecessary When `UserController` is located in the same namespace as `Controller`.