### PR TITLE
Fix URL in Eloquent: Mutators & Casting page

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -267,7 +267,7 @@ If you need to add a new, temporary cast at runtime, you may use the `mergeCasts
 <a name="stringable-casting"></a>
 #### Stringable Casting
 
-You may use the `Illuminate\Database\Eloquent\Casts\AsStringable` cast class to cast a model attribute to a [fluent `Illuminate\Support\Stringable` object](/docs/{{version}}/helpers#fluent-strings-method-list):
+You may use the `Illuminate\Database\Eloquent\Casts\AsStringable` cast class to cast a model attribute to a [fluent `Illuminate\Support\Stringable` object](/docs/{{version}}/strings#fluent-strings-method-list):
 
     <?php
 


### PR DESCRIPTION
Fixed the URL to the Strings page from the Helpers page as the string methods are moved to their own page from the Helpers page.