### PR TITLE
[10.x] Remove importing Controller from two examples in validation.md

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -69,7 +69,6 @@ Next, let's take a look at a simple controller that handles incoming requests to
 
     namespace App\Http\Controllers;
 
-    use App\Http\Controllers\Controller;
     use Illuminate\Http\RedirectResponse;
     use Illuminate\Http\Request;
     use Illuminate\View\View;
@@ -543,7 +542,6 @@ If you do not want to use the `validate` method on the request, you may create a
 
     namespace App\Http\Controllers;
 
-    use App\Http\Controllers\Controller;
     use Illuminate\Http\RedirectResponse;
     use Illuminate\Http\Request;
     use Illuminate\Support\Facades\Validator;


### PR DESCRIPTION
Hi,
Importing Controller is unnecessary When `PostController` is located in the same namespace as `Controller`.