### PR TITLE
Grammar updated for Database Transactions

### DIFF
--- a/database.md
+++ b/database.md
@@ -323,7 +323,7 @@ A common performance bottleneck of modern web applications is the amount of time
 <a name="database-transactions"></a>
 ## Database Transactions
 
-You may use the `transaction` method provided by the `DB` facade to run a set of operations within a database transaction. If an exception is thrown within the transaction closure, the transaction will automatically be rolled back and the exception is re-thrown. If the closure executes successfully, the transaction will automatically be committed. You don't need to worry about manually rolling back or committing while using the `transaction` method:
+You may use the `transaction` method provided by the `DB` facade to run a set of operations within a database transaction. If an exception is thrown within the transaction closure, the transaction will automatically be rolled back and the exception will be re-thrown out. If the closure executes successfully, the transaction will automatically be committed. You don't need to worry about manually rolling back or committing while using the `transaction` method:
 
     use Illuminate\Support\Facades\DB;
 


### PR DESCRIPTION
I have updated the sentence

"the transaction will automatically be rolled back and the exception is re-thrown." To "the transaction will automatically be rolled back and the exception  will be re-thrown out"