### PR TITLE
[10.x] Corrected trivial grammatical error on Processes page.

### DIFF
--- a/processes.md
+++ b/processes.md
@@ -392,7 +392,7 @@ Route::get('/import', function () {
 });
 ```
 
-When testing this route, we can instruct Laravel to return a fake, successful process result for every invoked process by calling the `fake` method on the `Process` facade with no arguments. In addition, we can even [assert](#available-assertions) that a given process was "ran":
+When testing this route, we can instruct Laravel to return a fake, successful process result for every invoked process by calling the `fake` method on the `Process` facade with no arguments. In addition, we can even [assert](#available-assertions) that a given process was "run":
 
 ```php
 <?php


### PR DESCRIPTION
Passive voice of the verb "to run" is "run" not "ran."