### PR TITLE
There are no `info` command on prompts helper functions

### DIFF
--- a/prompts.md
+++ b/prompts.md
@@ -613,12 +613,12 @@ If the `options` closure returns an associative array, then the closure will rec
 <a name="informational-messages"></a>
 ### Informational Messages
 
-The `note`, `info`, `warning`, `error`, and `alert` functions may be used to display informational messages:
+The `intro`, `outro`, `note`, `warning`, `error`, and `alert` functions may be used to display informational messages:
 
 ```php
-use function Laravel\Prompts\info;
+use function Laravel\Prompts\note;
 
-info('Package installed successfully.');
+note('Package installed successfully.');
 ```
 
 <a name="tables"></a>


### PR DESCRIPTION
Removing `info` from the documentation and adding `intro`, and `outro` that was missing.

![CleanShot 2023-10-19 at 22 59 01@2x](https://github.com/laravel/docs/assets/23129218/13806a03-f340-423a-8edc-0b2f3f80d485)
