### PR TITLE
[Pennant] update section regarding class based feature naming

### DIFF
--- a/pennant.md
+++ b/pennant.md
@@ -118,6 +118,8 @@ php artisan pennant:feature NewApi
 
 When writing a feature class, you only need to define a `resolve` method, which will be invoked to resolve the feature's initial value for a given scope. Again, the scope will typically be the currently authenticated user:
 
+The class FQN is the name used to reference the feature, optionally a `$name` property can be used. This allows for using the same naming convention as when manually defining inline features.
+
 ```php
 <?php
 
@@ -127,6 +129,14 @@ use Illuminate\Support\Lottery;
 
 class NewApi
 {
+
+    /**
+     * Custom name for the feature.
+     *
+     * @var string
+     */
+     public $name = 'new-api';
+    
     /**
      * Resolve the feature's initial value.
      */
@@ -335,6 +345,16 @@ To make checking features in Blade a seamless experience, Pennant offers a `@fea
 
 ```blade
 @feature('site-redesign')
+    <!-- 'site-redesign' is active -->
+@else
+    <!-- 'site-redesign' is inactive -->
+@endfeature
+```
+
+When using class based features, then the FQN can also be used to check for the feature.
+
+```blade
+@feature(\App\Features\SiteRedesign::class)
     <!-- 'site-redesign' is active -->
 @else
     <!-- 'site-redesign' is inactive -->


### PR DESCRIPTION
I was working with a class based feature and was looking if I could change the name that was used.
Because I want to use the name in javascript, and the FQN was a bit hard to work with.

I came across this issue https://github.com/laravel/pennant/issues/67 and saw it was undocumented. Hence this pull request to add it to the docs.

## Changes
- update the class based feature section regarding using a property for naming the feature
- update the Blade directive section regarding using a class based feature FQN