### PR TITLE
Warning about DB::listen

### DIFF
--- a/database.md
+++ b/database.md
@@ -285,7 +285,8 @@ If you would like to specify a closure that is invoked for each SQL query execut
         }
     }
 
-Inside `DB::listen` you should not perform any `INSERT` operations otherwise the Eloquent `save` method will not work correctly when saving new models in the database.
+> **Warning**  
+> Inside `DB::listen` you should not perform any `INSERT` operations otherwise the Eloquent `save` method will not work correctly when saving new models in the database.
 
 <a name="monitoring-cumulative-query-time"></a>
 ### Monitoring Cumulative Query Time

--- a/database.md
+++ b/database.md
@@ -285,7 +285,7 @@ If you would like to specify a closure that is invoked for each SQL query execut
         }
     }
 
-Inside `DB::listen` you should not perform any `INSERT` operations otherwise the Eloquent `save` method will not work correctly when saving new models in the database
+Inside `DB::listen` you should not perform any `INSERT` operations otherwise the Eloquent `save` method will not work correctly when saving new models in the database.
 
 <a name="monitoring-cumulative-query-time"></a>
 ### Monitoring Cumulative Query Time

--- a/database.md
+++ b/database.md
@@ -285,6 +285,8 @@ If you would like to specify a closure that is invoked for each SQL query execut
         }
     }
 
+Inside `DB::listen` you should not perform any `INSERT` operations otherwise the Eloquent `save` method will not work correctly when saving new models in the database
+
 <a name="monitoring-cumulative-query-time"></a>
 ### Monitoring Cumulative Query Time
 


### PR DESCRIPTION
I noticed a limitation: inside `DB::listen` you cannot use data insertion into the database, because in this case the insertion from the Eloquent side breaks due to the fact that `LAST_INSERT_ID` returns the ID not for the original record, but for the one that is inserted inside `DB::listen`.

For example if you want to log slow queries:

```php
DB::listen(function (QueryExecuted $query) {
    if($query->time > 500) {
        SlowQuery::create([
            "sql" => $query->sql
        ]);
    }
});

$post = Post::create(...); // if this takes more than 500 ms
$post->getKey(); // ID will be from SlowQuery model, not from Post
```

Not so easy to detect this immediately.