### PR TITLE
[10.x] update `virtualAs` description to include all supported databases

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -973,7 +973,7 @@ Modifier  |  Description
 `->unsigned()`  |  Set INTEGER columns as UNSIGNED (MySQL).
 `->useCurrent()`  |  Set TIMESTAMP columns to use CURRENT_TIMESTAMP as default value.
 `->useCurrentOnUpdate()`  |  Set TIMESTAMP columns to use CURRENT_TIMESTAMP when a record is updated (MySQL).
-`->virtualAs($expression)`  |  Create a virtual generated column (MySQL/PostgreSQL/SQLite).
+`->virtualAs($expression)`  |  Create a virtual generated column (MySQL / PostgreSQL / SQLite).
 `->generatedAs($expression)`  |  Create an identity column with specified sequence options (PostgreSQL).
 `->always()`  |  Defines the precedence of sequence values over input for an identity column (PostgreSQL).
 `->isGeometry()`  |  Set spatial column type to `geometry` - the default type is `geography` (PostgreSQL).

--- a/migrations.md
+++ b/migrations.md
@@ -973,7 +973,7 @@ Modifier  |  Description
 `->unsigned()`  |  Set INTEGER columns as UNSIGNED (MySQL).
 `->useCurrent()`  |  Set TIMESTAMP columns to use CURRENT_TIMESTAMP as default value.
 `->useCurrentOnUpdate()`  |  Set TIMESTAMP columns to use CURRENT_TIMESTAMP when a record is updated (MySQL).
-`->virtualAs($expression)`  |  Create a virtual generated column (MySQL).
+`->virtualAs($expression)`  |  Create a virtual generated column (MySQL/PostgreSQL/SQLite).
 `->generatedAs($expression)`  |  Create an identity column with specified sequence options (PostgreSQL).
 `->always()`  |  Defines the precedence of sequence values over input for an identity column (PostgreSQL).
 `->isGeometry()`  |  Set spatial column type to `geometry` - the default type is `geography` (PostgreSQL).


### PR DESCRIPTION
While looking into the `virtualAs` modifier it looks like PostgreSQL & SQLite are missing from the description based on the [ColumnDefinition](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Schema/ColumnDefinition.php#L33) class doc block and [10.x virtualAs api docs](https://laravel.com/api/10.x/Illuminate/Database/Schema/ColumnDefinition.html#method_virtualAs). 

This also looks to be the case in 9.x & 8.x documentation. Can open subsequent PRs if welcomed. 