### PR TITLE
[10.x] Update homestead.md removing laravel/homestead-arm reference

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -188,7 +188,7 @@ The `provider` key in your `Homestead.yaml` file indicates which Vagrant provide
     provider: virtualbox
 
 > **Warning**  
-> If you are using Apple Silicon, you should add `box: laravel/homestead-arm` to your `Homestead.yaml` file. Apple Silicon requires the Parallels provider.
+> If you are using Apple Silicon the Parallels provider is required.
 
 <a name="configuring-shared-folders"></a>
 #### Configuring Shared Folders


### PR DESCRIPTION
Vagrant Cloud now supports specifying architecture on boxes so Apple Silicon users no longer need to specify the `laravel/homestead-arm` box.

Related links:

* https://github.com/laravel/homestead/issues/1901
* https://app.vagrantup.com/laravel/boxes/homestead/versions/13.0.0 (now contains the arm64 box)