### PR TITLE
[10.x] Folio: Customizing the key - Ability to use the minus sign

### DIFF
--- a/folio.md
+++ b/folio.md
@@ -187,6 +187,8 @@ Captured models can be accessed as variables within your Blade template. The mod
 
 Sometimes you may wish to resolve bound Eloquent models using a column other than `id`. To do so, you may specify the column in the page's filename. For example, a page with the filename `[Post:slug].blade.php` will attempt to resolve the bound model via the `slug` column instead of the `id` column.
 
+If your operating system does not support `:` in filenames as a separator, then you may use `-` instead. For example:  `[Post-slug].blade.php`
+
 #### Model Location
 
 By default, Folio will search for your model within your application's `app/Models` directory. However, if needed, you may specify the fully-qualified model class name in your template's filename:


### PR DESCRIPTION
Hi there!

As a Windows user, I am not able to use the `:`  character in a filename when customizing the routing key. I get a filesystem error when using PHPStorm with Windows.

I was able to use the `-` sign and it worked as expected. This pull request documents this for those whose operating system doesn't support `:` in filenames.