### PR TITLE
Sail: Update Node versions

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -402,13 +402,13 @@ sail up
 <a name="sail-node-versions"></a>
 ## Node Versions
 
-Sail installs Node 18 by default. To change the Node version that is installed when building your images, you may update the `build.args` definition of the `laravel.test` service in your application's `docker-compose.yml` file:
+Sail installs Node 20 by default. To change the Node version that is installed when building your images, you may update the `build.args` definition of the `laravel.test` service in your application's `docker-compose.yml` file:
 
 ```yaml
 build:
     args:
         WWWGROUP: '${WWWGROUP}'
-        NODE_VERSION: '14'
+        NODE_VERSION: '18'
 ```
 
 After updating your application's `docker-compose.yml` file, you should rebuild your container images:


### PR DESCRIPTION
* Update default node version after https://github.com/laravel/sail/pull/628
* Bump example of alternate Node version