### PR TITLE
update for setting request id in header  logging.md

### DIFF
--- a/logging.md
+++ b/logging.md
@@ -243,7 +243,11 @@ Occasionally, you may wish to specify some contextual information that should be
                 'request-id' => $requestId
             ]);
 
-            return $next($request)->header('Request-Id', $requestId);
+            $response = $next($request);
+
+            $response->headers->set('Request-Id', $requestId);
+
+            return $response;
         }
     }
 


### PR DESCRIPTION
minor update who we should set request id in header, this will fail for `BinaryFileResponse`.
We can be reproduced with Livewire package, the request to `livewire/livewire.js` will fail.