### PR TITLE
[10.x] Highlight diff in Real-Time Facades code examples

### DIFF
--- a/facades.md
+++ b/facades.md
@@ -203,11 +203,13 @@ Injecting a publisher implementation into the method allows us to easily test th
         /**
          * Publish the podcast.
          */
-        public function publish(): void
+        public function publish(Publisher $publisher): void // [tl! remove]
+        public function publish(): void // [tl! add]
         {
             $this->update(['publishing' => now()]);
 
-            Publisher::publish($this);
+            $publisher->publish($this); // [tl! remove]
+            Publisher::publish($this); // [tl! add]
         }
     }
 


### PR DESCRIPTION
This will highlight the difference between the first and the second code examples in the [Real-Time Facades section](https://laravel.com/docs/10.x/facades#real-time-facades), that actually two more things in the `publish` method has also changed.

Before            |  After
:-------------------------:|:-------------------------:
![](https://github.com/laravel/docs/assets/13885653/4e9c5a6b-d6f4-487b-9707-7a0092e76416)  |  ![](https://github.com/laravel/docs/assets/13885653/22c44f4e-2910-46a9-9c93-f8642664d9d8)
