### PR TITLE
[10.x] Update the withDelay example to include the event, not the listener

### DIFF
--- a/events.md
+++ b/events.md
@@ -330,7 +330,7 @@ If you would like to define the listener's queue connection, queue name, or dela
     /**
      * Get the number of seconds before the job should be processed.
      */
-    public function withDelay(SendShipmentNotification $event): int
+    public function withDelay(OrderShipped $event): int
     {
         return $event->highPriority ? 0 : 60;
     }


### PR DESCRIPTION
The event that gets passed into the `withDelay` method is actually the Event `OrderShipped`, not the Listener `SendShipmentNotification`. Because of the way that the docs chunk up the examples, it's not clear that this is, in fact, the Listener. As such, when I went to add a delay to a Listener (following this example) I received a type error. This change updates the docs to show the actual event that will be passed to the `withDelay` method.