### PR TITLE
[10.x] Update Horizon Documentation to reflect the allowed waits config values

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -373,7 +373,7 @@ If you would like to be notified when one of your queues has a long wait time, y
 <a name="configuring-notification-wait-time-thresholds"></a>
 #### Configuring Notification Wait Time Thresholds
 
-You may configure how many seconds are considered a "long wait" within your application's `config/horizon.php` configuration file. The default is 60 seconds. The `waits` configuration option within this file allows you to control the long wait threshold for each connection / queue combination:
+You may configure how many seconds are considered a "long wait" within your application's `config/horizon.php` configuration file. The `waits` configuration option within this file allows you to control the long wait threshold for each connection / queue combination. Any undefined connection / queue combinations will default to a long wait threshold of 60 seconds:
 
     'waits' => [
         'redis:critical' => 30,

--- a/horizon.md
+++ b/horizon.md
@@ -373,11 +373,12 @@ If you would like to be notified when one of your queues has a long wait time, y
 <a name="configuring-notification-wait-time-thresholds"></a>
 #### Configuring Notification Wait Time Thresholds
 
-You may configure how many seconds are considered a "long wait" within your application's `config/horizon.php` configuration file. The `waits` configuration option within this file allows you to control the long wait threshold for each connection / queue combination:
+You may configure how many seconds are considered a "long wait" within your application's `config/horizon.php` configuration file. The default is 60 seconds. The `waits` configuration option within this file allows you to control the long wait threshold for each connection / queue combination:
 
     'waits' => [
-        'redis:default' => 60,
-        'redis:critical,high' => 90,
+        'redis:critical' => 30,
+        'redis:default'  => 60,
+        'redis:batch'    => 120,
     ],
 
 <a name="metrics"></a>

--- a/horizon.md
+++ b/horizon.md
@@ -377,8 +377,8 @@ You may configure how many seconds are considered a "long wait" within your appl
 
     'waits' => [
         'redis:critical' => 30,
-        'redis:default'  => 60,
-        'redis:batch'    => 120,
+        'redis:default' => 60,
+        'redis:batch' => 120,
     ],
 
 <a name="metrics"></a>


### PR DESCRIPTION
After investigation into why our Horizon installs are still reporting long waits after 60 seconds when it's explicitly stated otherwise in the config, we did some further research. 

We have seen that the `waits` array in the Horizon config does not accept multiple queues passed with commas, as seen in the code itself (see link below).

https://github.com/laravel/horizon/blob/fd5c8957e08419455cce6efdfc8f2c38a812debd/src/Listeners/MonitorWaitTimes.php#L56

Due to this, the documentation seem to be outdated/incorrect and has been updated to reflect both the default wait, which is 60 seconds, and how it would look if you have multiple queues with different wait times to report on.