### PR TITLE
Revert "[11.x] Bump supported database versions"

### DIFF
--- a/database.md
+++ b/database.md
@@ -22,7 +22,7 @@ Almost every modern web application interacts with a database. Laravel makes int
 - MariaDB 10.3+ ([Version Policy](https://mariadb.org/about/#maintenance-policy))
 - MySQL 5.7+ ([Version Policy](https://en.wikipedia.org/wiki/MySQL#Release_history))
 - PostgreSQL 10.0+ ([Version Policy](https://www.postgresql.org/support/versioning/))
-- SQLite 3.8.8+
+- SQLite 3.35.0+
 - SQL Server 2017+ ([Version Policy](https://docs.microsoft.com/en-us/lifecycle/products/?products=sql-server))
 
 </div>

--- a/database.md
+++ b/database.md
@@ -19,10 +19,10 @@ Almost every modern web application interacts with a database. Laravel makes int
 
 <div class="content-list" markdown="1">
 
-- MariaDB 10.11+ ([Version Policy](https://mariadb.org/about/#maintenance-policy))
-- MySQL 8.0+ ([Version Policy](https://en.wikipedia.org/wiki/MySQL#Release_history))
-- PostgreSQL 12.0+ ([Version Policy](https://www.postgresql.org/support/versioning/))
-- SQLite 3.35.0+
+- MariaDB 10.3+ ([Version Policy](https://mariadb.org/about/#maintenance-policy))
+- MySQL 5.7+ ([Version Policy](https://en.wikipedia.org/wiki/MySQL#Release_history))
+- PostgreSQL 10.0+ ([Version Policy](https://www.postgresql.org/support/versioning/))
+- SQLite 3.8.8+
 - SQL Server 2017+ ([Version Policy](https://docs.microsoft.com/en-us/lifecycle/products/?products=sql-server))
 
 </div>


### PR DESCRIPTION
Reverts laravel/docs#9017. It is much too soon to do this, and this will only stop people upgrading to Laravel 11. The effort for us to continue supporting these older databases is very low and just because their OSS versions are EOL, it doesn't mean there aren't OSs providing security backports or other support plans, etc.

---

Is there a good reason to not support postgres 9.6 on Laravel 10, too? Would we consider lowering the min version in the Laravel 10 docs for postgres back to 9.6?