### PR TITLE
[10.x] Add `assertBatchCount()`, `assertNothingBatched()`

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -2132,7 +2132,11 @@ The `Bus` facade's `assertBatched` method may be used to assert that a [batch of
 You may use the `assertBatchCount` method to assert that a given number of batches were dispatched:
 
     Bus::assertBatchCount(3);
-    
+
+You may use `assertNothingBatched` to assert that no batches were dispatched:
+
+    Bus::assertNothingBatched();
+
 <a name="testing-job-batch-interaction"></a>
 #### Testing Job / Batch Interaction
 

--- a/queues.md
+++ b/queues.md
@@ -2129,6 +2129,10 @@ The `Bus` facade's `assertBatched` method may be used to assert that a [batch of
                $batch->jobs->count() === 10;
     });
 
+You may use the `assertBatchCount` method to assert that a given number of batches were dispatched:
+
+    Bus::assertBatchCount(3);
+    
 <a name="testing-job-batch-interaction"></a>
 #### Testing Job / Batch Interaction
 


### PR DESCRIPTION
This PR adds documentation for the [`assertBatchCount()`](https://github.com/laravel/framework/blob/3d37d781d4bd299e17e4c58c6a85963747ac4762/src/Illuminate/Support/Testing/Fakes/BusFake.php#L461-L472) and [`assertNothingDispatched()`](https://github.com/laravel/framework/blob/3d37d781d4bd299e17e4c58c6a85963747ac4762/src/Illuminate/Support/Testing/Fakes/BusFake.php#L474-L482) methods.

