### PR TITLE
Replace raw password hash with `bcrypt()` helper

### DIFF
--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -42,7 +42,7 @@ To see an example of how to write a factory, take a look at the `database/factor
                 'name' => fake()->name(),
                 'email' => fake()->unique()->safeEmail(),
                 'email_verified_at' => now(),
-                'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+                'password' => bcrypt('password'),
                 'remember_token' => Str::random(10),
             ];
         }


### PR DESCRIPTION
In the Eloquent: Factories docs, a raw password hash is used in an UserFactory example. The actual password is added after the line in the form of a comment.

In my opinion, it would be better and more expressive to use the `bcrypt()` helper here. Added bonus: this would also generate an unique salt.