### PR TITLE
Updates Vite docs - `detectTls` -> `valetTls`

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -144,7 +144,7 @@ export default defineConfig({
     plugins: [
         laravel({
             // ...
-            detectTls: 'my-app.test', // [tl! add]
+            valetTls: 'my-app.test', // [tl! add]
         }),
     ],
 });


### PR DESCRIPTION
The `PluginConfig` now uses `valetTls` to Utilize the valet TLS certificates.