### PR TITLE
Remove array syntax from Events docs

### DIFF
--- a/events.md
+++ b/events.md
@@ -82,7 +82,7 @@ Typically, events should be registered via the `EventServiceProvider` `$listen` 
     {
         Event::listen(
             PodcastProcessed::class,
-            [SendPodcastNotification::class, 'handle']
+            SendPodcastNotification::class,
         );
 
         Event::listen(function (PodcastProcessed $event) {


### PR DESCRIPTION
By default, Laravel will use the `handle` method on an event. To remove confusion - when somebody would change the `handle` and now `make:listener` does not work anymore out of the box - it would be better to not have the customisation in the docs.