### PR TITLE
[10.x] `authorize` method may be removed if not used

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -458,7 +458,7 @@ Therefore, if your application is taking advantage of [route model binding](/doc
 
 If the `authorize` method returns `false`, an HTTP response with a 403 status code will automatically be returned and your controller method will not execute.
 
-If you plan to handle authorization logic for the request in another part of your application, you may simply return `true` from the `authorize` method:
+If you plan to handle authorization logic for the request in another part of your application, you may remove the `authorize` method completely, or simply return `true`:
 
     /**
      * Determine if the user is authorized to make this request.


### PR DESCRIPTION
both removing the `authorize()` method, and returning `true` will result in the same behavior, so adding a comment to explain this is an option.

https://github.com/laravel/framework/blob/10.x/src/Illuminate/Foundation/Http/FormRequest.php#L190

I would even go so far as to say we should *recommend* removing the method, as it's less code to run through, but this is probably good enough to start.