### PR TITLE
Add documentation for charAt().

### DIFF
--- a/strings.md
+++ b/strings.md
@@ -41,6 +41,7 @@ Laravel includes a variety of functions for manipulating string values. Many of 
 [Str::between](#method-str-between)
 [Str::betweenFirst](#method-str-between-first)
 [Str::camel](#method-camel-case)
+[Str::charAt](#method-char-at)
 [Str::contains](#method-str-contains)
 [Str::containsAll](#method-str-contains-all)
 [Str::endsWith](#method-ends-with)
@@ -124,6 +125,7 @@ Laravel includes a variety of functions for manipulating string values. Many of 
 [between](#method-fluent-str-between)
 [betweenFirst](#method-fluent-str-between-first)
 [camel](#method-fluent-str-camel)
+[charAt](#method-fluent-str-char-at)
 [classBasename](#method-fluent-str-class-basename)
 [contains](#method-fluent-str-contains)
 [containsAll](#method-fluent-str-contains-all)
@@ -341,6 +343,18 @@ The `Str::camel` method converts the given string to `camelCase`:
     $converted = Str::camel('foo_bar');
 
     // fooBar
+
+<a name="method-char-at"></a>
+
+#### `Str::charAt()` {.collection-method}
+
+The `Str::charAt` method retrieves the the character at the specified index. If the index is out of bounds, `false` is returned:
+
+    use Illuminate\Support\Str;
+
+    $character = Str::charAt('This is my name', 6);
+
+    // s
 
 <a name="method-str-contains"></a>
 #### `Str::contains()` {.collection-method}
@@ -1395,6 +1409,17 @@ The `camel` method converts the given string to `camelCase`:
     $converted = Str::of('foo_bar')->camel();
 
     // fooBar
+
+<a name="method-fluent-str-char-at"></a>
+#### `charAt` {.collection-method}
+
+The `charAt` method retrieves the the character at the specified index. If the index is out of bounds, `false` is returned:
+
+    use Illuminate\Support\Str;
+
+    $character = Str::of('This is my name')->charAt(6);
+
+    // s
 
 <a name="method-fluent-str-class-basename"></a>
 #### `classBasename` {.collection-method}

--- a/strings.md
+++ b/strings.md
@@ -342,19 +342,19 @@ The `Str::camel` method converts the given string to `camelCase`:
 
     $converted = Str::camel('foo_bar');
 
-    // fooBar
+    // 'fooBar'
 
 <a name="method-char-at"></a>
 
 #### `Str::charAt()` {.collection-method}
 
-The `Str::charAt` method retrieves the the character at the specified index. If the index is out of bounds, `false` is returned:
+The `Str::charAt` method returns the character at the specified index. If the index is out of bounds, `false` is returned:
 
     use Illuminate\Support\Str;
 
-    $character = Str::charAt('This is my name', 6);
+    $character = Str::charAt('This is my name.', 6);
 
-    // s
+    // 's'
 
 <a name="method-str-contains"></a>
 #### `Str::contains()` {.collection-method}
@@ -1408,18 +1408,18 @@ The `camel` method converts the given string to `camelCase`:
 
     $converted = Str::of('foo_bar')->camel();
 
-    // fooBar
+    // 'fooBar'
 
 <a name="method-fluent-str-char-at"></a>
 #### `charAt` {.collection-method}
 
-The `charAt` method retrieves the the character at the specified index. If the index is out of bounds, `false` is returned:
+The `charAt` method returns the character at the specified index. If the index is out of bounds, `false` is returned:
 
     use Illuminate\Support\Str;
 
-    $character = Str::of('This is my name')->charAt(6);
+    $character = Str::of('This is my name.')->charAt(6);
 
-    // s
+    // 's'
 
 <a name="method-fluent-str-class-basename"></a>
 #### `classBasename` {.collection-method}
@@ -1430,7 +1430,7 @@ The `classBasename` method returns the class name of the given class with the cl
 
     $class = Str::of('Foo\Bar\Baz')->classBasename();
 
-    // Baz
+    // 'Baz'
 
 <a name="method-fluent-str-contains"></a>
 #### `contains` {.collection-method}


### PR DESCRIPTION
I've seen the `charAt()` method used quite a bit, and so I was surprised to see it's [not documented](https://twitter.com/jordankdalton/status/1724206892401020937). Hoping to remedy that (unless there's a reason not to). 

Thanks!