### PR TITLE
[10.x] Scout Database Driver toSearchableArray keys warning

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -189,6 +189,10 @@ Some search engines such as Meilisearch will only perform filter operations (`>`
         ];
     }
 
+
+> **Warning**  
+> The database engine uses keys of the toSearchableArray to filter the searched columns. Original, not modified values, will be searched by the database driver.
+
 <a name="configuring-filterable-data-for-meilisearch"></a>
 #### Configuring Filterable Data & Index Settings (Meilisearch)
 


### PR DESCRIPTION
the toSearchableArray function allows changing of values to be searched using providers. The database driver does not respect these changes and instead only respects the keys returned as a filter for columns to search by (https://github.com/laravel/scout/blob/10.x/src/Engines/DatabaseEngine.php#L170).