### PR TITLE
Localization: Add section about handling missing translation strings.

### DIFF
--- a/localization.md
+++ b/localization.md
@@ -8,9 +8,9 @@
     - [Using Short Keys](#using-short-keys)
     - [Using Translation Strings As Keys](#using-translation-strings-as-keys)
 - [Retrieving Translation Strings](#retrieving-translation-strings)
-    - [Handling Missing Translation Strings](#handling-missing-translation-strings)
     - [Replacing Parameters In Translation Strings](#replacing-parameters-in-translation-strings)
     - [Pluralization](#pluralization)
+    - [Handling Missing Translation Strings](#handling-missing-translation-strings)
 - [Overriding Package Language Files](#overriding-package-language-files)
 
 <a name="introduction"></a>
@@ -165,19 +165,6 @@ If you are using the [Blade templating engine](/docs/{{version}}/blade), you may
 
     {{ __('messages.welcome') }}
 
-<a name="handling-missing-translation-strings">
-### Handling Missing Translation Strings
-
-The behavior when a translation string is missing can be customized using the `handleMissingTranslationKeyUsing` method in any service provider. You should pass a closure which can receive up to four parameters and returns the translation string to use.
-
-    use Illuminate\Translation\Translator;
-    use Log;
-
-    Translator::handleMissingTranslationKeyUsing(function ($key, $replace, $locale, $fallback) {
-        Log::error("Missing translation key [$key] detected.");
-        return $key;
-    });
-
 <a name="replacing-parameters-in-translation-strings"></a>
 ### Replacing Parameters In Translation Strings
 
@@ -246,6 +233,27 @@ You may also define placeholder attributes in pluralization strings. These place
 If you would like to display the integer value that was passed to the `trans_choice` function, you may use the built-in `:count` placeholder:
 
     'apples' => '{0} There are none|{1} There is one|[2,*] There are :count',
+
+<a name="handling-missing-translation-strings"></a>
+### Handling Missing Translation Strings
+
+Typically, when attempting to translate a string that does not have a corresponding key in your language files, Laravel will return the translation string key.
+
+You may customize or intercept this behavior using the `handleMissingKeysUsing` method. Typically, you should invoke this method in the `boot` method of your application's `AppServiceProvider`:
+
+    use Illuminate\Support\Facades\Lang;
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        Lang::handleMissingKeysUsing(function (string $key, array $replacements, string $locale) {
+            info("Missing translation key [$key] detected.");
+
+            return $key;
+        });
+    }
 
 <a name="overriding-package-language-files"></a>
 ## Overriding Package Language Files

--- a/localization.md
+++ b/localization.md
@@ -8,6 +8,7 @@
     - [Using Short Keys](#using-short-keys)
     - [Using Translation Strings As Keys](#using-translation-strings-as-keys)
 - [Retrieving Translation Strings](#retrieving-translation-strings)
+    - [Handling Missing Translation Strings](#handling-missing-translation-strings)
     - [Replacing Parameters In Translation Strings](#replacing-parameters-in-translation-strings)
     - [Pluralization](#pluralization)
 - [Overriding Package Language Files](#overriding-package-language-files)
@@ -163,6 +164,19 @@ Again, if the translation string does not exist, the `__` function will return t
 If you are using the [Blade templating engine](/docs/{{version}}/blade), you may use the `{{ }}` echo syntax to display the translation string:
 
     {{ __('messages.welcome') }}
+
+<a name="handling-missing-translation-strings">
+### Handling Missing Translation Strings
+
+The behavior when a translation string is missing can be customized using the `handleMissingTranslationKeyUsing` method in any service provider. You should pass a closure which can receive up to four parameters and returns the translation string to use.
+
+    use Illuminate\Translation\Translator;
+    use Log;
+
+    Translator::handleMissingTranslationKeyUsing(function ($key, $replace, $locale, $fallback) {
+        Log::error("Missing translation key [$key] detected.");
+        return $key;
+    });
 
 <a name="replacing-parameters-in-translation-strings"></a>
 ### Replacing Parameters In Translation Strings


### PR DESCRIPTION
This PR adds a section to the localization docs describing how to use the `handleMissingTranslationKeyUsing` method.

I've tried to keep the wording as simple as possible but provide detail in the code example. Let me know if there are any suggested improvements.

The relevant feature was originally merged in https://github.com/laravel/framework/pull/49040