### PR TITLE
Added section about using auth in global scopes

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1261,6 +1261,37 @@ Eloquent also allows you to define global scopes using closures, which is partic
         }
     }
 
+<a name="using-auth"></a>
+#### Using Auth in Global Scopes
+
+Trying to access the authenticated user in a global scope will fail if you use methods such as `Auth::check()` or `Auth::user()`. For example, the following code will not work:
+
+    use Illuminate\Database\Eloquent\Builder;
+    use Illuminate\Database\Eloquent\Model;
+    use Illuminate\Support\Facades\Auth;
+    
+    class YearScope implements Scope
+    {
+        public function apply(Builder $builder, Model $model): void
+        {
+            $builder->where('year', Auth::user()->graduation_year);
+        }
+    }
+
+If you would like to access a property of the authenticated user, you first need to check for an authenticated user using `Auth::hasUser()`, `Auth::check()` or `Auth::user()`:
+
+    class YearScope implements Scope
+    {
+        public function apply(Builder $builder, Model $model): void
+        {
+            if (Auth::hasUser()) {
+                $builder->where('year', Auth::user()->graduation_year);
+            }
+        }
+    }
+
+You may also use [auth helpers](/docs/{{version}}/helpers#method-auth).
+
 <a name="removing-global-scopes"></a>
 #### Removing Global Scopes
 


### PR DESCRIPTION
It has not been previously documented that auth is not accessible in global scopes if used without first being checked. This commit adds the missing detail. 

**Many developers have run into this issue but it is still not documented:**
1. https://github.com/laravel/framework/issues/22316
2. https://www.reddit.com/r/laravel/comments/f4ni65/laravel_authhasuser_always_false_in_global_scope/
3. https://laravel.io/forum/06-30-2016-global-scope-auth
4. https://stackoverflow.com/questions/68256830/laravel-how-to-use-auth-user-inside-the-global-scope