### PR TITLE
[10.x] Add new Axios v1.6.2 `withXSRFToken` option to documentation

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -289,6 +289,12 @@ In addition, you should enable the `withCredentials` option on your application'
 axios.defaults.withCredentials = true;
 ```
 
+In later versions of Axios, you must also enable the `withXSRFToken` option for XSRF tokens to be sent to separate subdomains:
+
+```js
+axios.defaults.withXSRFToken = true;
+```
+
 Finally, you should ensure your application's session cookie domain configuration supports any subdomain of your root domain. You may accomplish this by prefixing the domain with a leading `.` within your application's `config/session.php` configuration file:
 
     'domain' => '.domain.com',

--- a/sanctum.md
+++ b/sanctum.md
@@ -283,15 +283,10 @@ If you are having trouble authenticating with your application from a SPA that e
 
 You should ensure that your application's CORS configuration is returning the `Access-Control-Allow-Credentials` header with a value of `True`. This may be accomplished by setting the `supports_credentials` option within your application's `config/cors.php` configuration file to `true`.
 
-In addition, you should enable the `withCredentials` option on your application's global `axios` instance. Typically, this should be performed in your `resources/js/bootstrap.js` file. If you are not using Axios to make HTTP requests from your frontend, you should perform the equivalent configuration on your own HTTP client:
+In addition, you should enable the `withCredentials` and `withXSRFToken` options on your application's global `axios` instance. Typically, this should be performed in your `resources/js/bootstrap.js` file. If you are not using Axios to make HTTP requests from your frontend, you should perform the equivalent configuration on your own HTTP client:
 
 ```js
 axios.defaults.withCredentials = true;
-```
-
-In later versions of Axios, you must also enable the `withXSRFToken` option for XSRF tokens to be sent to separate subdomains:
-
-```js
 axios.defaults.withXSRFToken = true;
 ```
 


### PR DESCRIPTION
In later versions of Axios ([v1.6.0](https://github.com/axios/axios/releases/tag/v1.6.0)) the `withCredentials` credentials option has had a breaking change in regards to automatically forwarding XSRF tokens to third party domains / subdomains. In response to this breaking change, Axios has [re-added the functionality back in](https://github.com/axios/axios/releases/tag/v1.6.2) via a `withXSRFToken` option. Here are the issue links (in oldest to latest order):

CVE Issue: https://github.com/axios/axios/issues/6006
CVE Fix: https://github.com/axios/axios/pull/6028
XSRFToken Option Addition: https://github.com/axios/axios/pull/6046

From the new option's PR:

```
📢 This PR added 'withXSRFToken' option as a replacement for old withCredentials behaviour. 
You should now use withXSRFToken along with withCredential to get the old behavior.
This functionality is considered as a fix
```