### PR TITLE
added npm run build command to bundle the application assets, because…

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -182,7 +182,11 @@ window.Echo = new Echo({
 Once you have uncommented and adjusted the Echo configuration according to your needs, you may compile your application's assets:
 
 ```shell
+# run the Vite development server
 npm run dev
+
+# Build and bundle the assets
+npm run build
 ```
 
 > **Note**  

--- a/broadcasting.md
+++ b/broadcasting.md
@@ -182,10 +182,6 @@ window.Echo = new Echo({
 Once you have uncommented and adjusted the Echo configuration according to your needs, you may compile your application's assets:
 
 ```shell
-# run the Vite development server
-npm run dev
-
-# Build and bundle the assets
 npm run build
 ```
 


### PR DESCRIPTION
… npm run dev starts the development server, and when you are using php local development server (php artisan serve) for your local development. and you make any changes like create a object variable in resources/js/app.js file and import the js file in your views via vite (@vite([resources/js/app.js])). the object won't be accessible via views js script file. also it will throw an error that the laravel can't find the manifesto.json in public/build dir. so when using php artisan serve command you first have to run npm run build to reflect the js changes and create a build dir in public dir.