### PR TITLE
Fix some formatting in validation doc

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1672,7 +1672,7 @@ If you would like to construct a more complex condition for the `required_if` ru
     ]);
 
 <a name="rule-required-if-accepted"></a>
-#### required_if_accepted:_anotherfield,...
+#### required_if_accepted:_anotherfield_,...
 
 The field under validation must be present and not empty if the _anotherfield_ field is equal to `yes`, `on`, `1`, `"1"`, `true`, or `"true"`.
 


### PR DESCRIPTION
I thought there's missing closing underline char according to markdown format
![image](https://github.com/laravel/docs/assets/55620873/0d8e9590-816c-4a8a-98b3-8f41101e63a0)
