### PR TITLE
Cursor pagination items warning

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -126,7 +126,7 @@ You may create a cursor based paginator instance via the `cursorPaginate` method
 Once you have retrieved a cursor paginator instance, you may [display the pagination results](#displaying-pagination-results) as you typically would when using the `paginate` and `simplePaginate` methods. For more information on the instance methods offered by the cursor paginator, please consult the [cursor paginator instance method documentation](#cursor-paginator-instance-methods).
 
 > **Warning**  
-> Your query must contain an "order by" clause in order to take advantage of cursor pagination. You must ensure that the columns you wish to order by are properties of the objects you wish to paginate. Non-unique column names (such as two `id` columns when performing a join) on the objects may cause cursor pagination to act unexpectedly. You may wish to use a column alias for this case, and you should reference the column alias in your "order by" clause.
+> Your query must contain an "order by" clause in order to take advantage of cursor pagination. In addition, the columns that the query are ordered by must belong to the table you are paginating.
 
 <a name="cursor-vs-offset-pagination"></a>
 #### Cursor vs. Offset Pagination

--- a/pagination.md
+++ b/pagination.md
@@ -126,7 +126,7 @@ You may create a cursor based paginator instance via the `cursorPaginate` method
 Once you have retrieved a cursor paginator instance, you may [display the pagination results](#displaying-pagination-results) as you typically would when using the `paginate` and `simplePaginate` methods. For more information on the instance methods offered by the cursor paginator, please consult the [cursor paginator instance method documentation](#cursor-paginator-instance-methods).
 
 > **Warning**  
-> Your query must contain an "order by" clause in order to take advantage of cursor pagination. You must also ensure that the "order by" parameter appears in the item you are paginating in order to properly generate a cursor. If you are sorting by a joined column that isn't included in the select, consider using a different pagination method.
+> Your query must contain an "order by" clause in order to take advantage of cursor pagination. You must ensure that the columns you wish to order by are properties of the objects you wish to paginate. Non-unique column names (such as two `id` columns when performing a join) on the objects may cause cursor pagination to act unexpectedly. You may wish to use a column alias for this case, and you should reference the column alias in your "order by" clause.
 
 <a name="cursor-vs-offset-pagination"></a>
 #### Cursor vs. Offset Pagination

--- a/pagination.md
+++ b/pagination.md
@@ -126,7 +126,7 @@ You may create a cursor based paginator instance via the `cursorPaginate` method
 Once you have retrieved a cursor paginator instance, you may [display the pagination results](#displaying-pagination-results) as you typically would when using the `paginate` and `simplePaginate` methods. For more information on the instance methods offered by the cursor paginator, please consult the [cursor paginator instance method documentation](#cursor-paginator-instance-methods).
 
 > **Warning**  
-> Your query must contain an "order by" clause in order to take advantage of cursor pagination.
+> Your query must contain an "order by" clause in order to take advantage of cursor pagination. You must also ensure that the "order by" parameter appears in the item you are paginating in order to properly generate a cursor. If you are sorting by a joined column that isn't included in the select, consider using a different pagination method.
 
 <a name="cursor-vs-offset-pagination"></a>
 #### Cursor vs. Offset Pagination


### PR DESCRIPTION
I'm not entirely sure this belongs to the existing warning, but I spent the last few hours trying to debug an issue that was reported and it's not obvious why this is a problem.

Say you have a database with two tables

**conversations**
| id  | created_at |
| ------------- | ------------- |
| 25  | 2023-01-01 00:00:00  |

**messages**
| id  | conversation_id | message | created_at |
| ------------- | ------------- | ------------- | ------------- |
| 98 | 25 | Hello! | 2023-11-29 13:45:12  |


And you want to build a cursor like this 
```php
$query = Conversation::query()
    ->select('conversations.*')
    ->join('messages', 'conversation.id', 'messages.conversation_id')
    ->orderBy('messages.created_at')
    ->orderBy('conversations.id');

$query->cursorPaginate()->nextCursor()->encode(); // <-- base64 string
```

Will build a cursor with
```php
[
    '_pointsToNextItems' => true,
    'conversations.id' => 25,
    'messages.created_at' => '2023-01-01 00:00:00', // <-- this should be 2023-11-29 13:45:12
]
```

But the value is actually the conversations.created_at value, not the messages.created_at value.