### PR TITLE
[10.x] Include version requirement

### DIFF
--- a/pulse.md
+++ b/pulse.md
@@ -352,7 +352,7 @@ PULSE_DB_CONNECTION=pulse
 ### Redis Ingest
 
 > **Warning**  
-> The Redis Ingest requires Redis 6.2 or greater.
+> The Redis Ingest requires Redis 6.2 or greater and `phpredis` or `predis` as the application driver.
 
 By default, Pulse will store entries directly to the [configured database connection](#using-a-different-database) after the HTTP response has been sent to the client or a job has been processed; however, you may use Pulse's Redis ingest driver to send entries to a Redis stream instead. This can be enabled by configuring the `PULSE_INGEST_DRIVER` environment variable:
 

--- a/pulse.md
+++ b/pulse.md
@@ -351,6 +351,9 @@ PULSE_DB_CONNECTION=pulse
 <a name="ingest"></a>
 ### Redis Ingest
 
+> **Warning**  
+> The Redis Ingest requires Redis 6.2 or greater.
+
 By default, Pulse will store entries directly to the [configured database connection](#using-a-different-database) after the HTTP response has been sent to the client or a job has been processed; however, you may use Pulse's Redis ingest driver to send entries to a Redis stream instead. This can be enabled by configuring the `PULSE_INGEST_DRIVER` environment variable:
 
 ```

--- a/pulse.md
+++ b/pulse.md
@@ -352,7 +352,7 @@ PULSE_DB_CONNECTION=pulse
 ### Redis Ingest
 
 > **Warning**  
-> The Redis Ingest requires Redis 6.2 or greater and `phpredis` or `predis` as the application driver.
+> The Redis Ingest requires Redis 6.2 or greater and `phpredis` or `predis` as the application's configured Redis client driver.
 
 By default, Pulse will store entries directly to the [configured database connection](#using-a-different-database) after the HTTP response has been sent to the client or a job has been processed; however, you may use Pulse's Redis ingest driver to send entries to a Redis stream instead. This can be enabled by configuring the `PULSE_INGEST_DRIVER` environment variable:
 


### PR DESCRIPTION
We use a trimming strategy, `MINID`, that is only available in 6.2 or greater: https://redis.io/commands/xtrim/