### PR TITLE
Added note re: fileinfo extension

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -61,6 +61,9 @@ After you have installed PHP and Composer, you may create a new Laravel project 
 composer create-project laravel/laravel example-app
 ```
 
+> **Note**
+> To use composer's create-project with Laravel, the fileinfo extension must be enabled in PHP. If it is not, you may enable it by uncommenting `extension=fileinfo` in your php.ini file.
+
 Once the project has been created, start Laravel's local development server using Laravel Artisan's `serve` command:
 
 ```nothing


### PR DESCRIPTION
I added a note for something that delayed me while learning Laravel, and, I felt, made the documentation less user-friendly than it could be.

That was that I hadn't enabled `extension=fileinfo` in my php.ini file, and so couldn't use composer's create-project command with laravel. 

If you simply install php in the normal way on windows, the fileinfo extension is not enabled by default and will prevent use of composer's `create-project` command with laravel.

In retrospect, now that I know what was wrong, the problem is clearly stated in the error message and it appears the workaround, ignoring ext fileinfo, seems to work. Nevertheless, it seems to me that, since any noob like me will instantly run into this problem when they install php, composer, and then attempt to create a laravel project, the laravel documentation could do the favor of giving the heads up so laravel instantly works out of the box without having to navigate an unexpected error message. 