### PR TITLE
Unique rule example with ignore options

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1788,6 +1788,8 @@ Occasionally, you may need to set a custom connection for database queries made 
 **Forcing A Unique Rule To Ignore A Given ID:**
 
 Sometimes, you may wish to ignore a given ID during unique validation. For example, consider an "update profile" screen that includes the user's name, email address, and location. You will probably want to verify that the email address is unique. However, if the user only changes the name field and not the email field, you do not want a validation error to be thrown because the user is already the owner of the email address in question.
+    
+    email' => 'unique:users,email_address,ignore_id,ignore_column_name
 
 To instruct the validator to ignore the user's ID, we'll use the `Rule` class to fluently define the rule. In this example, we'll also specify the validation rules as an array instead of using the `|` character to delimit the rules:
 


### PR DESCRIPTION
Enhanced "Unique" rule example in docs to include ignoring ID and column for more control.