### PR TITLE
Add section about streaming reads with the s3 driver

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -193,6 +193,12 @@ Typically, after updating the disk's credentials to match the credentials of the
 
     'endpoint' => env('AWS_ENDPOINT', 'https://minio:9000'),
 
+<a name="streaming-reads"></a>
+#### Streaming Reads
+When reading files from a disk using the `s3` driver, a temporary local copy is created behind the scenes to allow file seeking. If you need to stream large files and don't require the ability to rewind the stream, you can enable truly streamed reads with the `stream_reads` configuration option:
+
+    'stream_reads' => true,
+
 <a name="minio"></a>
 #### MinIO
 


### PR DESCRIPTION
This PR is the spiritual successor to https://github.com/laravel/docs/pull/8371.

The `s3` filesystem driver doesn't *really* stream reads by default, even when calling e.g. `readStream`. Instead, it copies the whole file to a temporary directory and then returns a stream to that temporary file. This is because streaming reads are disabled by default:

https://github.com/laravel/framework/blob/v10.34.2/src/Illuminate/Filesystem/FilesystemManager.php#L244

This was introduced in https://github.com/laravel/framework/pull/34001, but without an explicit reason. I also asked about this behavior here, but without luck: https://github.com/laravel/framework/discussions/49232.
I suspect that it was disabled by default because Flysystem changed the default behavior to using streams, and that could've broken backwards compatibility in Laravel 7.x, and it was never touched since then.