### PR TITLE
[10.x] clarify need for backed Enum

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1242,6 +1242,9 @@ The `Enum` rule is a class based rule that validates whether the field under val
         'status' => [Rule::enum(ServerStatus::class)],
     ]);
 
+> **Warning**  
+> You must use a backed Enum if you are passing an `int` or `string` value.
+
 <a name="rule-exclude"></a>
 #### exclude
 

--- a/validation.md
+++ b/validation.md
@@ -1243,7 +1243,7 @@ The `Enum` rule is a class based rule that validates whether the field under val
     ]);
 
 > **Warning**  
-> You must use a backed Enum if you are passing an `int` or `string` value.
+> You must use a backed Enum if you are validating an `int` or `string` value.
 
 <a name="rule-exclude"></a>
 #### exclude

--- a/validation.md
+++ b/validation.md
@@ -1233,7 +1233,7 @@ The field under validation must end with one of the given values.
 <a name="rule-enum"></a>
 #### enum
 
-The `Enum` rule is a class based rule that validates whether the field under validation contains a valid enum value. The `Enum` rule accepts the name of the enum as its only constructor argument:
+The `Enum` rule is a class based rule that validates whether the field under validation contains a valid enum value. The `Enum` rule accepts the name of the enum as its only constructor argument. When validating primitive values, a backed Enum should be provided to the `Enum` rule:
 
     use App\Enums\ServerStatus;
     use Illuminate\Validation\Rule;
@@ -1241,9 +1241,6 @@ The `Enum` rule is a class based rule that validates whether the field under val
     $request->validate([
         'status' => [Rule::enum(ServerStatus::class)],
     ]);
-
-> **Warning**  
-> You must use a backed Enum if you are validating an `int` or `string` value.
 
 <a name="rule-exclude"></a>
 #### exclude


### PR DESCRIPTION
the validation rule currently requires a backed Enum if the value being validated is a `string` or `int`.

I think it would be nice if the rule also handled pure Enums when passed a `string`, but that's a separate issue. I'm going to attempt a PR for that in `laravel/framework`, but until then this clarification in the docs should help.