### PR TITLE
[11.x] Add `Publishing Migrations` section in packages

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -155,14 +155,20 @@ If your package contains [database migrations](/docs/{{version}}/migrations), yo
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
     }
 
+Once your package's migrations have been registered, they will automatically be run when the `php artisan migrate` command is executed. You do not need to export them to the application's `database/migrations` directory.
+
 <a name="publishing-migrations"></a>
 #### Publishing Migrations
 
 If you would like to make your views available, you may use the service provider's `publishesMigrations` method. The `publishesMigrations` method accepts an array of package migration paths and their desired publish locations:
 
+```php
+$this->publishesMigrations([
+    __DIR__.'/../database/migrations' => $this->app->databasePath('migrations'),
+], 'pennant-migrations');
+```
 
-
-Once your package's migrations have been registered, they will automatically be run when the `php artisan migrate` command is executed. You do not need to export them to the application's `database/migrations` directory.
+Now, when users of your package execute Laravel's vendor:publish Artisan command, your package's migrations will be copied to the specified publish location.
 
 <a name="language-files"></a>
 ### Language Files

--- a/packages.md
+++ b/packages.md
@@ -155,6 +155,13 @@ If your package contains [database migrations](/docs/{{version}}/migrations), yo
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
     }
 
+<a name="publishing-migrations"></a>
+#### Publishing Migrations
+
+If you would like to make your views available, you may use the service provider's `publishesMigrations` method. The `publishesMigrations` method accepts an array of package migration paths and their desired publish locations:
+
+
+
 Once your package's migrations have been registered, they will automatically be run when the `php artisan migrate` command is executed. You do not need to export them to the application's `database/migrations` directory.
 
 <a name="language-files"></a>

--- a/packages.md
+++ b/packages.md
@@ -160,7 +160,7 @@ Once your package's migrations have been registered, they will automatically be 
 <a name="publishing-migrations"></a>
 #### Publishing Migrations
 
-If you would like to make your views available, you may use the service provider's `publishesMigrations` method. The `publishesMigrations` method accepts an array of package migration paths and their desired publish locations:
+If you would like to make your migrations available, you may use the service provider's `publishesMigrations` method. The `publishesMigrations` method accepts an array of package migration paths and their desired publish locations:
 
 ```php
 $this->publishesMigrations([


### PR DESCRIPTION
In Laravel 11, we have a new method named `publishesMigrations`. I think is a good idea to add to the packages page.

> **_NOTE:_** I think the description can be better.