### PR TITLE
Add PostgeSQL for Pulse

### DIFF
--- a/pulse.md
+++ b/pulse.md
@@ -28,7 +28,7 @@ For in-depth debugging of individual events, check out [Laravel Telescope](/docs
 ## Installation
 
 > **Warning**  
-> Pulse's first-party storage implementation currently requires a MySQL database. If you are using a different database engine, such as PostgreSQL, you will need a separate MySQL database for your Pulse data.
+> Pulse's first-party storage implementation currently requires a MySQL or PostgreSQL database. If you are using a different database engine, you will need a separate MySQL or PostgreSQL database for your Pulse data.
 
 Since Pulse is currently in beta, you may need to adjust your application's `composer.json` file to allow beta package releases to be installed:
 


### PR DESCRIPTION
I saw that @jessarcher added PostgreSQL support for Pulse, therefor this limitation can be updated. (Maybe it can even be removed? Not sure how it looks with MariaDB which is MySQL compatible and for not first party supported databases like MongoDB)
