### PR TITLE
Fix list Markdown for Included Software and Optional Software in Homestead docs

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -56,6 +56,7 @@ Homestead runs on any Windows, macOS, or Linux system and includes Nginx, PHP, M
 </style>
 
 <div id="software-list" markdown="1">
+
 - Ubuntu 20.04
 - Git
 - PHP 8.1
@@ -82,6 +83,7 @@ Homestead runs on any Windows, macOS, or Linux system and includes Nginx, PHP, M
 - Xdebug
 - XHProf / Tideways / XHGui
 - wp-cli
+
 </div>
 
 <a name="optional-software"></a>
@@ -96,6 +98,7 @@ Homestead runs on any Windows, macOS, or Linux system and includes Nginx, PHP, M
 </style>
 
 <div id="software-list" markdown="1">
+
 - Apache
 - Blackfire
 - Cassandra
@@ -125,6 +128,7 @@ Homestead runs on any Windows, macOS, or Linux system and includes Nginx, PHP, M
 - TimescaleDB
 - Trader <small>(PHP extension)</small>
 - Webdriver & Laravel Dusk Utilities
+
 </div>
 
 <a name="installation-and-setup"></a>


### PR DESCRIPTION
The markdown for [Included Software](https://laravel.com/docs/8.x/homestead#included-software) and [Optional Software](https://laravel.com/docs/8.x/homestead#optional-software) is not properly rendered as list.

To fix, add extra lines between the HTML and Markdown items.

Before:

<img width="928" alt="image" src="https://github.com/laravel/docs/assets/8132015/95203b8a-6400-4529-999d-ec0d10f58fde">

After:

<img width="926" alt="image" src="https://github.com/laravel/docs/assets/8132015/59ad4c01-fe6b-4953-9e77-7cfcc04a18f3">

Notice that the list is okay in 10.x and other versions:

<img width="716" alt="image" src="https://github.com/laravel/docs/assets/8132015/bfbe1d15-7672-47ed-b199-7d5c22b7abee">
