### PR TITLE
Improve wording on the `whereJsonContains` method and SQLite support

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -491,7 +491,7 @@ Laravel also supports querying JSON column types on databases that provide suppo
                     ->where('preferences->dining->meal', 'salad')
                     ->get();
 
-You may use `whereJsonContains` to query JSON arrays. This feature is not supported by the SQLite grammar yet:
+You may use `whereJsonContains` to query JSON arrays. This method is not supported by SQLite:
 
     $users = DB::table('users')
                     ->whereJsonContains('options->languages', 'en')

--- a/queries.md
+++ b/queries.md
@@ -491,7 +491,7 @@ Laravel also supports querying JSON column types on databases that provide suppo
                     ->where('preferences->dining->meal', 'salad')
                     ->get();
 
-You may use `whereJsonContains` to query JSON arrays. This feature is not supported by SQLite database versions less than 3.39.0:
+You may use `whereJsonContains` to query JSON arrays. This feature is not supported by the SQLite grammar yet:
 
     $users = DB::table('users')
                     ->whereJsonContains('options->languages', 'en')


### PR DESCRIPTION
I find the wording "This feature [whereJsonContains] is not supported by SQLite database versions less than 3.39.0" misleading. This wording suggests that the `whereJsonContains` method can be used by merely using a compatible version of SQLite, which is not true; while SQLite does support JSON functions since version 3.39.0 (as already stated in the previous paragraph), the SQLite Grammar does not support the `whereJsonContains` clause regardless of the version of SQLite.