### PR TITLE
Remove outdated (?) warning about constraining eager loaded relationships

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1739,9 +1739,6 @@ In this example, Eloquent will only eager load posts where the post's `title` co
         $query->orderBy('created_at', 'desc');
     }])->get();
 
-> **Warning**  
-> The `limit` and `take` query builder methods may not be used when constraining eager loads.
-
 <a name="constraining-eager-loading-of-morph-to-relationships"></a>
 #### Constraining Eager Loading Of `morphTo` Relationships
 


### PR DESCRIPTION
The docs state that 

"The limit and take query builder methods may not be used when constraining eager loads."

However, in multiple tests, these methods did work.

Is the doc too ambiguous and I misunderstood it? Or is this warning outdated and needs to be removed?

I understood it to mean that the relationship that's being eager loaded can't be limited, i.e., all related rows will be returned, no matter what. However, when I use limit, it returns no more than the limit specified.

I can't open an issue in this repo, so I made a PR instead, removing this warning.

