### PR TITLE
[10.x] Add dedicated section for resolving users in Pulse

### DIFF
--- a/pulse.md
+++ b/pulse.md
@@ -141,19 +141,28 @@ For cards that display information about your users, such as the Application Usa
 
 When rendering the dashboard, Pulse will resolve the `name` and `email` fields from the `User` model and display avatars using the Gravatar web service. However, you may customize the user resolution and display by invoking the `Pulse::users` method within your application's `App\Providers\AppServiceProvider` class.
 
-The `users` method accepts a closure which will receive the user IDs to be displayed and should return an array or collection containing the `id`, `name`, `extra`, and `avatar` for each user ID:
+The `users` method accepts a closure which will receive the user IDs to be displayed and should return an array or collection containing an `id`, `name`, `extra`, and `avatar` for each user ID:
 
 ```php
+use App\Models\User;
 use Laravel\Pulse\Facades\Pulse;
 
-Pulse::users(function ($ids) {
-    return User::findMany($ids)->map(fn ($user) => [
-        'id' => $user->id,
-        'name' => $user->name,
-        'extra' => $user->email,
-        'avatar' => $user->avatar_url,
-    ]);
-});
+/**
+ * Bootstrap any application services.
+ */
+public function boot(): void
+{
+    Pulse::users(function ($ids) {
+        return User::findMany($ids)->map(fn ($user) => [
+            'id' => $user->id,
+            'name' => $user->name,
+            'extra' => $user->email,
+            'avatar' => $user->avatar_url,
+        ]);
+    });
+
+    // ...
+}
 ```
 
 <a name="dashboard-cards"></a>
@@ -177,7 +186,7 @@ If you wish to view all usage metrics on screen at the same time, you may includ
 <livewire:pulse.usage type="jobs" />
 ```
 
-See the [resolving users](#dashboard-resolving-users) documentation to customize how Pulse retrieves and displays user information in the dashboard.
+To learn how to customize how Pulse retrieves and displays user information, consult our documentation on [resolving users](#dashboard-resolving-users).
 
 > **Note**
 > If your application receives a lot of requests or dispatches a lot of jobs, you may wish to enable [sampling](#sampling). See the [user requests recorder](#user-requests-recorder), [user jobs recorder](#user-jobs-recorder), and [slow jobs recorder](#slow-jobs-recorder) documentation for more information.

--- a/pulse.md
+++ b/pulse.md
@@ -6,6 +6,7 @@
 - [Dashboard](#dashboard)
     - [Authorization](#dashboard-authorization)
     - [Customization](#dashboard-customization)
+    - [Resolving Users](#dashboard-resolving-users)
     - [Cards](#dashboard-cards)
 - [Capturing Entries](#capturing-entries)
     - [Recorders](#recorders)
@@ -133,6 +134,28 @@ Most cards also accept an `expand` prop to show the full card instead of scrolli
 <livewire:pulse.slow-queries expand />
 ```
 
+<a name="dashboard-resolving-users"></a>
+### Resolving Users
+
+For cards that display information about your users, such as the Application Usage card, Pulse will only record the user's ID.
+
+When rendering the dashboard, Pulse will resolve the `name` and `email` fields from the `User` model and display avatars using the Gravatar web service. However, you may customize the user resolution and display by invoking the `Pulse::users` method within your application's `App\Providers\AppServiceProvider` class.
+
+The `users` method accepts a closure which will receive the user IDs to be displayed and should return an array or collection containing the `id`, `name`, `extra`, and `avatar` for each user ID:
+
+```php
+use Laravel\Pulse\Facades\Pulse;
+
+Pulse::users(function ($ids) {
+    return User::findMany($ids)->map(fn ($user) => [
+        'id' => $user->id,
+        'name' => $user->name,
+        'extra' => $user->email,
+        'avatar' => $user->avatar_url,
+    ]);
+});
+```
+
 <a name="dashboard-cards"></a>
 ### Cards
 
@@ -154,22 +177,7 @@ If you wish to view all usage metrics on screen at the same time, you may includ
 <livewire:pulse.usage type="jobs" />
 ```
 
-By default, Pulse will resolve the `name` and `email` fields from the `User` model and display avatars using the Gravatar web service. However, you may customize the user resolution and display by invoking the `Pulse::users` method within application's `App\Providers\AppServiceProvider` class.
-
-The `users` method accepts a closure which will receive the user IDs to be displayed and should return an array or collection containing the `id`, `name`, `extra`, and `avatar` for each user ID:
-
-```php
-use Laravel\Pulse\Facades\Pulse;
-
-Pulse::users(function ($ids) {
-    return User::findMany($ids)->map(fn ($user) => [
-        'id' => $user->id,
-        'name' => $user->name,
-        'extra' => $user->email,
-        'avatar' => $user->avatar_url,
-    ]);
-});
-```
+See the [resolving users](#dashboard-resolving-users) documentation to customize how Pulse retrieves and displays user information in the dashboard.
 
 > **Note**
 > If your application receives a lot of requests or dispatches a lot of jobs, you may wish to enable [sampling](#sampling). See the [user requests recorder](#user-requests-recorder), [user jobs recorder](#user-jobs-recorder), and [slow jobs recorder](#slow-jobs-recorder) documentation for more information.


### PR DESCRIPTION
The most commonly reported issue in Pulse relates to having a non-standard user model. This is currently documented under the Application Usage card, however, it may not be obvious to look there.

This PR moves the information about resolving users to a dedicated section to make it more discoverable and more likely to be encountered when initially configuring Pulse.