### PR TITLE
[10.x] pulse "publish assets" command shouldn't mention migration file

### DIFF
--- a/pulse.md
+++ b/pulse.md
@@ -44,7 +44,7 @@ Then, you may use the Composer package manager to install Pulse into your Larave
 composer require laravel/pulse
 ```
 
-Next, you should publish the Pulse configuration and migration files using the `vendor:publish` Artisan command:
+Next, you should publish the Pulse configuration and dashboard file using the `vendor:publish` Artisan command:
 
 ```shell
 php artisan vendor:publish --provider="Laravel\Pulse\PulseServiceProvider"


### PR DESCRIPTION
I guess it should not mention migration file but dashboard file instead

![Screenshot from 2023-12-20 16-37-37](https://github.com/laravel/docs/assets/2412608/5340b74d-b569-4d60-9840-699c07bcd87f)
