### PR TITLE
added note that the db Artisan command does not work on windows

### DIFF
--- a/database.md
+++ b/database.md
@@ -381,6 +381,9 @@ If needed, you may specify a database connection name to connect to a database c
 php artisan db mysql
 ```
 
+> **Note**
+> The `db` Artisan command currently does not work on Windows.
+
 <a name="inspecting-your-databases"></a>
 ## Inspecting Your Databases
 


### PR DESCRIPTION
Currently when you run the `db` Artisan command on a windows computer the CLI throws a `Symfony\Component\Process\Exception\RuntimeException` stating that 'TTY mode is not supported on Windows platform.'

This PR will document this limitation in the docs.