### PR TITLE
[10.x] Re-add Laravel installer docs

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -61,6 +61,14 @@ After you have installed PHP and Composer, you may create a new Laravel project 
 composer create-project laravel/laravel example-app
 ```
 
+Or, you may create new Laravel projects by globally installing [the Laravel installer](https://github.com/laravel/installer) via Composer:
+
+```nothing
+composer global require laravel/installer
+
+laravel new example-app
+```
+
 Once the project has been created, start Laravel's local development server using Laravel Artisan's `serve` command:
 
 ```nothing


### PR DESCRIPTION
I feel like we should still have a mention of the installer in the docs as many people, including myself, still use it as their preferred way to start new projects with the framework.

Also see https://github.com/laravel/installer/issues/296