### PR TITLE
[9.x] Update upgrade guide (HandleCors)

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -103,6 +103,16 @@ In addition, return types were added to methods implementing PHP's `SessionHandl
 
 </div>
 
+#### Update *fruitcake/laravel-cors* HandleCors middleware
+
+Since Laravel 9.2, this Middleware is included in laravel/framework. You can use the provided middleware, which should be compatible with the Middleware and config provided in this package. See https://github.com/laravel/laravel/pull/5825/files for the changes.
+
+Steps to upgrade:
+ 1. Remove `"fruitcake/laravel-cors"` from your composer.json
+ 2. Replace `\Fruitcake\Cors\HandleCors::class,` with `\Illuminate\Http\Middleware\HandleCors::class,` in `app/Http/Kernel.php`
+
+See `https://github.com/fruitcake/php-cors` for advanced usage. The config stays the same.
+
 <a name="application"></a>
 ### Application
 


### PR DESCRIPTION
Everytime I am upgrading from 8.x, I need to google about the need of removing *fruitcake/laravel-cors* package from app's composer.json, because it is not able to update packages this way. Also, after successfull update, changing the _HandleCors_ middleware in Kernel.php is needed.

In this P.R., I have added a few lines that mentions this process and easy steps which will help users migrate from 8.x to 9.x without need of googling this issue.