### PR TITLE
[10.x] Fix incorrect route in documentation example

### DIFF
--- a/processes.md
+++ b/processes.md
@@ -410,7 +410,7 @@ class ExampleTest extends TestCase
     {
         Process::fake();
 
-        $response = $this->get('/');
+        $response = $this->get('/import');
 
         // Simple process assertion...
         Process::assertRan('bash import.sh');


### PR DESCRIPTION
Updated the example code in the documentation from `$this->get('/');` to `$this->get('/import');` to ensure accuracy.