### PR TITLE
Update logging.md

### DIFF
--- a/logging.md
+++ b/logging.md
@@ -214,7 +214,9 @@ You may call any of these methods to log a message for the corresponding level. 
 <a name="contextual-information"></a>
 ### Contextual Information
 
-An array of contextual data may be passed to the log methods. This contextual data will be formatted and displayed with the log message:
+An array of contextual data may be passed to the log methods. This contextual data will be formatted and displayed with the log message.
+
+If you want Monolog to replace context placeholders in your message, as shown below, you can add `'replace_placeholders' => true` to the log channel configuration.  
 
     use Illuminate\Support\Facades\Log;
 


### PR DESCRIPTION
The context code example strongly implies that `{id}` in the message string will be replaced with the value from the context. But that is _not_ the case for log channels that use the default monolog driver.

I'm not sure if this is the right place to put it, but as far as I can tell, the `replace_placeholders` config setting isn't documented anywhere.