### PR TITLE
[10.x] Cashier Paddle quickstart docs

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -247,7 +247,7 @@ To accomplish this, you may provide an array of custom data to the `checkout` me
             'status' => 'incomplete',
         ]);
 
-        $checkout $request->user()->checkout($order->price_ids)
+        $checkout = $request->user()->checkout($order->price_ids)
             ->customData(['order_id' => $order->id]);
 
         return view('billing', ['checkout' => $checkout]);

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -192,6 +192,204 @@ After defining your model, you may instruct Cashier to use your custom model via
         Cashier::useTransactionModel(Transaction::class);
     }
 
+<a name="quickstart"></a>
+## Quickstart
+
+<a name="quickstart-selling-products"></a>
+### Selling Products
+
+> [!NOTE]  
+> Before utilizing Paddle Checkout, you should define Products with fixed prices in your Paddle dashboard. In addition, you should [configure Paddle's webhook handling](#handling-paddle-webhooks).
+
+Offering product and subscription billing via your application can be intimidating. However, thanks to Cashier and [Paddle's Checkout Overlay](https://www.paddle.com/billing/checkout), you can easily build modern, robust payment integrations.
+
+To charge customers for non-recurring, single-charge products, we'll utilize Cashier to charge customers with Paddle's Checkout Overlay, where they will provide their payment details and confirm their purchase. Once the payment has been made via the checkout overlay, the customer will be redirected to a success URL of your choosing within your application:
+
+    use Illuminate\Http\Request;
+
+    Route::get('/buy', function (Request $request) {
+        $checkout = $user->checkout('pri_deluxe_album')
+            ->returnTo(route('dashboard'));
+
+        return view('buy', ['checkout' => $checkout]);
+    })->name('checkout');
+
+Then place a clickable button in the `buy` view to invoke the Checkout Overlay:
+
+```html
+<x-paddle-button :checkout="$checkout" class="px-8 py-4">
+    Buy Product
+</x-paddle-button>
+```
+
+As you can see in the example above, we will utilize Cashier's provided `checkout` method to create a checkout object to present the customer the Paddle Checkout Overlay for a given "price identifier". When using Paddle, "prices" refer to [defined prices for specific products](https://developer.paddle.com/build/products/create-products-prices).
+
+If necessary, the `checkout` method will automatically create a customer in Paddle and connect that Paddle customer record to the corresponding user in your application's database. After completing the checkout session, the customer will be redirected to a dedicated success page where you can display an informational message to the customer.
+
+<a name="providing-meta-data-to-paddle-checkout"></a>
+#### Providing Meta Data to Paddle Checkout
+
+When selling products, it's common to keep track of completed orders and purchased products via `Cart` and `Order` models defined by your own application. When redirecting customers to Paddle's Checkout Overlay to complete a purchase, you may need to provide an existing order identifier so that you can associate the completed purchase with the corresponding order when the customer is redirected back to your application.
+
+To accomplish this, you may provide an array of custom data to the `checkout` method. Let's imagine that a pending `Order` is created within our application when a user begins the checkout process. Remember, the `Cart` and `Order` models in this example are illustrative and not provided by Cashier. You are free to implement these concepts based on the needs of your own application:
+    
+    use App\Models\Cart;
+    use App\Models\Order;
+    use Illuminate\Http\Request;
+    
+    Route::get('/cart/{cart}/checkout', function (Request $request, Cart $cart) {
+        $order = Order::create([
+            'cart_id' => $cart->id,
+            'price_ids' => $cart->price_ids,
+            'status' => 'incomplete',
+        ]);
+
+        $checkout $request->user()->checkout($order->price_ids)
+            ->customData(['order_id' => $order->id]);
+
+        return view('billing', ['checkout' => $checkout]);
+    })->name('checkout');
+
+As you can see in the example above, when a user begins the checkout process, we will provide all of the cart / order's associated Paddle price identifiers to the `checkout` method. Of course, your application is responsible for associating these items with the "shopping cart" or order as a customer adds them. We also provide the order's ID to the Paddle Checkout Overlay via the `customData` method.
+
+By default, Cashier doesn't store individual order information when selling products. However, you can easily listen to the webhooks dispatched by Paddle and raised via events by Cashier to store order information in your database.
+
+To get started, listen for the `TransactionCompleted` event dispatched by Cashier. Typically, you should register the event listener in the `boot` method of one of your application's service providers:
+
+    use App\Listeners\StoreOrder;
+    use Illuminate\Support\Facades\Event;
+    use Laravel\Paddle\Events\TransactionCompleted;
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        Event::listen(TransactionCompleted::class, StoreOrder::class);
+    }
+
+In this example, the `StoreOrder` listener might look like the following:
+
+    namespace App\Listeners;
+
+    use Laravel\Cashier\Cashier;
+    use Laravel\Cashier\Events\TransactionCompleted;
+
+    class StoreOrder
+    {
+        /**
+         * Handle the incoming Cashier webhook event.
+         */
+        public function handle(TransactionCompleted $event): void
+        {
+            // The custom data at the time of the purchase...
+            $data = $payload['data']['custom_data'];
+
+            // Store the customer's order...
+            $event->billable->orders()->create(...);
+        }
+    }
+
+Please refer to Paddle's documentation for more information on the [data contained by the `transaction.completed` event](https://developer.paddle.com/webhooks/transactions/transaction-completed).
+
+<a name="quickstart-selling-subscriptions"></a>
+### Selling Subscriptions
+
+> [!NOTE]  
+> Before utilizing Paddle Checkout, you should define Products with fixed prices in your Paddle dashboard. In addition, you should [configure Paddle's webhook handling](#handling-paddle-webhooks).
+
+Offering product and subscription billing via your application can be intimidating. However, thanks to Cashier and [Paddle's Checkout Overlay](https://www.paddle.com/billing/checkout), you can easily build modern, robust payment integrations.
+
+To learn how to sell subscriptions using Cashier and Paddle's Checkout Overlay, let's consider the simple scenario of a subscription service with a basic monthly (`price_basic_monthly`) and yearly (`price_basic_yearly`) plan. These two prices could be grouped under a "Basic" product (`pro_basic`) in our Paddle dashboard. In addition, our subscription service might offer an Expert plan as `pro_expert`.
+
+First, let's discover how a customer can subscribe to our services. Of course, you can imagine the customer might click a "subscribe" button for the Basic plan on our application's pricing page. This button will invoke a Paddle Checkout Overlay for their chosen plan:
+
+    use Illuminate\Http\Request;
+
+    Route::get('/subscribe', function (Request $request) {
+        $checkout = $user->checkout('price_basic_monthly')
+            ->returnTo(route('dashboard'));
+
+        return view('subscribe', ['checkout' => $checkout]);
+    })->name('subscribe');
+
+Then place a clickable button in the `subscribe` view to invoke the Checkout Overlay:
+
+```html
+<x-paddle-button :checkout="$checkout" class="px-8 py-4">
+    Subscribe
+</x-paddle-button>
+```
+
+As you can see in the example above, we will invoke the Paddle Checkout Overlay which will allow them to subscribe to our Basic plan. After a successful checkout, the customer will be redirected back to the URL we provided to the `subscribe` method. To know when their subscription has actually started (since some payment methods require a few seconds to process), we'll also need to [configure Cashier's webhook handling](#handling-paddle-webhooks).
+
+Now that customers can start subscriptions, we need to restrict certain portions of our application so that only subscribed users can access them. Of course, we can always determine a user's current subscription status via the `subscribed` method provided by Cashier's `Billable` trait:
+
+```blade
+@if ($user->subscribed())
+    <p>You are subscribed.</p>
+@endif
+```
+
+We can even easily determine if a user is subscribed to specific product or price:
+
+```blade
+@if ($user->subscribedToProduct('pro_basic'))
+    <p>You are subscribed to our Basic product.</p>
+@endif
+
+@if ($user->subscribedToPrice('price_basic_monthly'))
+    <p>You are subscribed to our monthly Basic plan.</p>
+@endif
+```
+
+<a name="quickstart-building-a-subscribed-middleware"></a>
+#### Building a Subscribed Middleware
+
+For convenience, you may wish to create a [middleware](/docs/{{version}}/middleware) which determines if the incoming request is from a subscribed user. Once this middleware has been defined, you may easily assign it to a route to prevent users that are not subscribed from accessing the route:
+
+    <?php
+
+    namespace App\Http\Middleware;
+
+    use Closure;
+    use Illuminate\Http\Request;
+    use Symfony\Component\HttpFoundation\Response;
+
+    class Subscribed
+    {
+        /**
+         * Handle an incoming request.
+         */
+        public function handle(Request $request, Closure $next): Response
+        {
+            if (! $request->user()?->subscribed()) {
+                // Redirect user to billing page and ask them to subscribe...
+                return redirect('/billing');
+            }
+
+            return $next($request);
+        }
+    }
+
+Once the middleware has been defined, you may assign it to a route:
+
+    use App\Http\Middleware\Subscribed;
+
+    Route::get('/dashboard', function () {
+        // ...
+    })->middleware([Subscribed::class]);
+
+<a name="quickstart-allowing-customers-to-manage-their-billing-plan"></a>
+#### Allowing Customers to Manage Their Billing Plan
+
+Of course, customers may want to change their subscription plan to another product or "tier". 
+
+WIP...
+
+> [!NOTE]  
+> As long as you have configured Cashier's webhook handling, Cashier will automatically keep your application's Cashier-related database tables in sync by inspecting the incoming webhooks from Paddle. So, for example, when you cancel a customer's subscription via Paddle's dashboard, Cashier will receive the corresponding webhook and mark the subscription as "cancelled" in your application's database.
+
 <a name="checkout-sessions"></a>
 ## Checkout Sessions
 

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -10,6 +10,9 @@
     - [Paddle JS](#paddle-js)
     - [Currency Configuration](#currency-configuration)
     - [Overriding Default Models](#overriding-default-models)
+- [Quickstart](#quickstart)
+    - [Selling Products](#quickstart-selling-products)
+    - [Selling Subscriptions](#quickstart-selling-subscriptions)
 - [Checkout Sessions](#checkout-sessions)
     - [Overlay Checkout](#overlay-checkout)
     - [Inline Checkout](#inline-checkout)
@@ -208,7 +211,7 @@ To charge customers for non-recurring, single-charge products, we'll utilize Cas
     use Illuminate\Http\Request;
 
     Route::get('/buy', function (Request $request) {
-        $checkout = $user->checkout('pri_deluxe_album')
+        $checkout = $request->user()->checkout('pri_deluxe_album')
             ->returnTo(route('dashboard'));
 
         return view('buy', ['checkout' => $checkout]);
@@ -307,7 +310,7 @@ First, let's discover how a customer can subscribe to our services. Of course, y
     use Illuminate\Http\Request;
 
     Route::get('/subscribe', function (Request $request) {
-        $checkout = $user->checkout('price_basic_monthly')
+        $checkout = $request->user()->checkout('price_basic_monthly')
             ->returnTo(route('dashboard'));
 
         return view('subscribe', ['checkout' => $checkout]);
@@ -383,9 +386,27 @@ Once the middleware has been defined, you may assign it to a route:
 <a name="quickstart-allowing-customers-to-manage-their-billing-plan"></a>
 #### Allowing Customers to Manage Their Billing Plan
 
-Of course, customers may want to change their subscription plan to another product or "tier". 
+Of course, customers may want to change their subscription plan to another product or "tier". In our example from above, we'd want to allow the customer to change their plan from a monthly subscription to a yearly subscription. For this you'll need to implement something like a button that leads to the below route:
 
-WIP...
+    use Illuminate\Http\Request;
+
+    Route::put('/subscription/{price}/swap', function (Request $request, $price) {
+        $user->subscription()->swap($price); // With "$price" being "price_basic_yearly" for this example.
+
+        return redirect()->route('dashboard');
+    })->name('subscription.swap');
+
+Besides swapping plans you'll also need to allow your customers to cancel their subscription. Like swapping plans, provide a button that leads to the following route:
+
+    use Illuminate\Http\Request;
+
+    Route::put('/subscription/cancel', function (Request $request, $price) {
+        $user->subscription()->cancel();
+
+        return redirect()->route('dashboard');
+    })->name('subscription.cancel');
+
+And now your subscription will get cancelled at the end of its billing period.
 
 > [!NOTE]  
 > As long as you have configured Cashier's webhook handling, Cashier will automatically keep your application's Cashier-related database tables in sync by inspecting the incoming webhooks from Paddle. So, for example, when you cancel a customer's subscription via Paddle's dashboard, Cashier will receive the corresponding webhook and mark the subscription as "cancelled" in your application's database.


### PR DESCRIPTION
I mostly took over the docs from the Cashier Stripe QuickStart and modified them to the Paddle equivalents. For the order/cart example I used an event listener as the same approach using the redirect parameter in Cashier Stripe isn't available with Paddle.