### PR TITLE
[10.x] Adding Missing Content of `Configuring Eloquent Strictness`

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -371,8 +371,10 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * Bootstrap any application services.
+ *
+ * @return void
  */
-public function boot(): void
+public function boot()
 {
     Model::preventLazyLoading(! $this->app->isProduction());
 }
@@ -382,6 +384,21 @@ Also, you may instruct Laravel to throw an exception when attempting to fill an 
 
 ```php
 Model::preventSilentlyDiscardingAttributes(! $this->app->isProduction());
+```
+
+Finally, you may instruct Eloquent to throw an exception if you attempt to access an attribute on a model when that attribute was not actually retrieved from the database or when the attribute does not exist. For example, this may occur when you forget to add an attribute to the `select` clause of an Eloquent query:
+
+```php
+Model::preventAccessingMissingAttributes(! $this->app->isProduction());
+```
+
+<a name="enabling-eloquent-strict-mode"></a>
+#### Enabling Eloquent "Strict Mode"
+
+For convenience, you may enable all three of the methods discussed above by simply invoking the `shouldBeStrict` method:
+
+```php
+Model::shouldBeStrict(! $this->app->isProduction());
 ```
 
 <a name="retrieving-models"></a>


### PR DESCRIPTION
I used `9.x` as a base to include the missing content in `10.x`