### PR TITLE
add warning about Inline Authorization

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -245,7 +245,7 @@ Similar to the `before` method, if the `after` closure returns a non-null result
 <a name="inline-authorization"></a>
 ### Inline Authorization
 
-Occasionally, you may wish to determine if the currently authenticated user is authorized to perform a given action without writing a dedicated gate that corresponds to the action. Laravel allows you to perform these types of "inline" authorization checks via the `Gate::allowIf` and `Gate::denyIf` methods:
+Occasionally, you may wish to determine if the currently authenticated user is authorized to perform a given action without writing a dedicated gate that corresponds to the action. Laravel allows you to perform these types of "inline" authorization checks via the `Gate::allowIf` and `Gate::denyIf` methods. Inline authorization does not execute any defined ["before" or "after" authorization hooks](#intercepting-gate-checks):
 
 ```php
 use App\Models\User;
@@ -257,9 +257,6 @@ Gate::denyIf(fn (User $user) => $user->banned());
 ```
 
 If the action is not authorized or if no user is currently authenticated, Laravel will automatically throw an `Illuminate\Auth\Access\AuthorizationException` exception. Instances of `AuthorizationException` are automatically converted to a 403 HTTP response by Laravel's exception handler.
-
-> [!WARNING]  
-> Inline authorization **does not** execute your "before" and "after" checks.
 
 <a name="creating-policies"></a>
 ## Creating Policies

--- a/authorization.md
+++ b/authorization.md
@@ -258,6 +258,9 @@ Gate::denyIf(fn (User $user) => $user->banned());
 
 If the action is not authorized or if no user is currently authenticated, Laravel will automatically throw an `Illuminate\Auth\Access\AuthorizationException` exception. Instances of `AuthorizationException` are automatically converted to a 403 HTTP response by Laravel's exception handler.
 
+> [!WARNING]  
+> Inline authorization **does not** execute your "before" and "after" checks.
+
 <a name="creating-policies"></a>
 ## Creating Policies
 


### PR DESCRIPTION
Inline authorization does not execute your "before" and "after" checks, so we'll add a warning about it.

This has bitten me a couple times, so figured I'd make it explicit.