### PR TITLE
[11.x] Make spatial types consistent

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -575,7 +575,7 @@ The `foreignUuid` method creates a `UUID` equivalent column:
 
 The `geography` method creates a `GEOGRAPHY` equivalent column with the given spatial type and SRID (Spatial Reference System Identifier):
 
-    $table->geography('coordinates', $subtype = 'point', $srid = 4326);
+    $table->geography('coordinates', subtype: 'point', srid: 4326);
 
 > [!NOTE]  
 > Support for spatial types depends on your database driver. Please refer to your database's documentation. If your application is utilizing a PostgreSQL database, you must install the [PostGIS](https://postgis.net) extension before the `geography` method may be used.
@@ -585,7 +585,7 @@ The `geography` method creates a `GEOGRAPHY` equivalent column with the given sp
 
 The `geometry` method creates a `GEOMETRY` equivalent column with the given spatial type and SRID (Spatial Reference System Identifier):
 
-    $table->geometry('positions', $subtype = 'point', $srid = 0);
+    $table->geometry('positions', subtype: 'point', srid: 0);
 
 > [!NOTE]  
 > Support for spatial types depends on your database driver. Please refer to your database's documentation. If your application is utilizing a PostgreSQL database, you must install the [PostGIS](https://postgis.net) extension before the `geometry` method may be used.

--- a/migrations.md
+++ b/migrations.md
@@ -410,7 +410,7 @@ The schema builder blueprint offers a variety of methods that correspond to the 
 [foreignIdFor](#column-method-foreignIdFor)
 [foreignUlid](#column-method-foreignUlid)
 [foreignUuid](#column-method-foreignUuid)
-[geometryCollection](#column-method-geometryCollection)
+[geography](#column-method-geography)
 [geometry](#column-method-geometry)
 [id](#column-method-id)
 [increments](#column-method-increments)
@@ -418,22 +418,16 @@ The schema builder blueprint offers a variety of methods that correspond to the 
 [ipAddress](#column-method-ipAddress)
 [json](#column-method-json)
 [jsonb](#column-method-jsonb)
-[lineString](#column-method-lineString)
 [longText](#column-method-longText)
 [macAddress](#column-method-macAddress)
 [mediumIncrements](#column-method-mediumIncrements)
 [mediumInteger](#column-method-mediumInteger)
 [mediumText](#column-method-mediumText)
 [morphs](#column-method-morphs)
-[multiLineString](#column-method-multiLineString)
-[multiPoint](#column-method-multiPoint)
-[multiPolygon](#column-method-multiPolygon)
 [nullableMorphs](#column-method-nullableMorphs)
 [nullableTimestamps](#column-method-nullableTimestamps)
 [nullableUlidMorphs](#column-method-nullableUlidMorphs)
 [nullableUuidMorphs](#column-method-nullableUuidMorphs)
-[point](#column-method-point)
-[polygon](#column-method-polygon)
 [rememberToken](#column-method-rememberToken)
 [set](#column-method-set)
 [smallIncrements](#column-method-smallIncrements)
@@ -546,7 +540,7 @@ The `enum` method creates a `ENUM` equivalent column with the given valid values
 
 The `float` method creates a `FLOAT` equivalent column with the given precision:
 
-    $table->float('amount', 53);
+    $table->float('amount', $precision = 53);
 
 <a name="column-method-foreignId"></a>
 #### `foreignId()` {.collection-method}
@@ -576,19 +570,25 @@ The `foreignUuid` method creates a `UUID` equivalent column:
 
     $table->foreignUuid('user_id');
 
-<a name="column-method-geometryCollection"></a>
-#### `geometryCollection()` {.collection-method}
+<a name="column-method-geography"></a>
+#### `geography()` {.collection-method}
 
-The `geometryCollection` method creates a `GEOMETRYCOLLECTION` equivalent column:
+The `geography` method creates a `GEOGRAPHY` equivalent column with the given spatial type and SRID (Spatial Reference System Identifier):
 
-    $table->geometryCollection('positions');
+    $table->geography('positions', $subtype = 'point', $srid = 4326);
+
+> [!NOTE]  
+> Support for spatial types depends on your database driver. Please refer to your database's documentation. If your application is utilizing a PostgreSQL database, you must install the [PostGIS](https://postgis.net) extension before the `geography` method may be used.
 
 <a name="column-method-geometry"></a>
 #### `geometry()` {.collection-method}
 
-The `geometry` method creates a `GEOMETRY` equivalent column:
+The `geometry` method creates a `GEOMETRY` equivalent column with the given spatial type and SRID (Spatial Reference System Identifier):
 
-    $table->geometry('positions');
+    $table->geometry('positions', $subtype = 'point', $srid = 0);
+
+> [!NOTE]  
+> Support for spatial types depends on your database driver. Please refer to your database's documentation. If your application is utilizing a PostgreSQL database, you must install the [PostGIS](https://postgis.net) extension before the `geometry` method may be used.
 
 <a name="column-method-id"></a>
 #### `id()` {.collection-method}
@@ -634,13 +634,6 @@ The `jsonb` method creates a `JSONB` equivalent column:
 
     $table->jsonb('options');
 
-<a name="column-method-lineString"></a>
-#### `lineString()` {.collection-method}
-
-The `lineString` method creates a `LINESTRING` equivalent column:
-
-    $table->lineString('positions');
-
 <a name="column-method-longText"></a>
 #### `longText()` {.collection-method}
 
@@ -685,27 +678,6 @@ This method is intended to be used when defining the columns necessary for a pol
 
     $table->morphs('taggable');
 
-<a name="column-method-multiLineString"></a>
-#### `multiLineString()` {.collection-method}
-
-The `multiLineString` method creates a `MULTILINESTRING` equivalent column:
-
-    $table->multiLineString('positions');
-
-<a name="column-method-multiPoint"></a>
-#### `multiPoint()` {.collection-method}
-
-The `multiPoint` method creates a `MULTIPOINT` equivalent column:
-
-    $table->multiPoint('positions');
-
-<a name="column-method-multiPolygon"></a>
-#### `multiPolygon()` {.collection-method}
-
-The `multiPolygon` method creates a `MULTIPOLYGON` equivalent column:
-
-    $table->multiPolygon('positions');
-
 <a name="column-method-nullableTimestamps"></a>
 #### `nullableTimestamps()` {.collection-method}
 
@@ -733,20 +705,6 @@ The method is similar to the [ulidMorphs](#column-method-ulidMorphs) method; how
 The method is similar to the [uuidMorphs](#column-method-uuidMorphs) method; however, the columns that are created will be "nullable":
 
     $table->nullableUuidMorphs('taggable');
-
-<a name="column-method-point"></a>
-#### `point()` {.collection-method}
-
-The `point` method creates a `POINT` equivalent column:
-
-    $table->point('position');
-
-<a name="column-method-polygon"></a>
-#### `polygon()` {.collection-method}
-
-The `polygon` method creates a `POLYGON` equivalent column:
-
-    $table->polygon('position');
 
 <a name="column-method-rememberToken"></a>
 #### `rememberToken()` {.collection-method}
@@ -974,7 +932,6 @@ Modifier  |  Description
 `->virtualAs($expression)`  |  Create a virtual generated column (MySQL / PostgreSQL / SQLite).
 `->generatedAs($expression)`  |  Create an identity column with specified sequence options (PostgreSQL).
 `->always()`  |  Defines the precedence of sequence values over input for an identity column (PostgreSQL).
-`->isGeometry()`  |  Set spatial column type to `geometry` - the default type is `geography` (PostgreSQL).
 
 <a name="default-expressions"></a>
 #### Default Expressions

--- a/migrations.md
+++ b/migrations.md
@@ -575,7 +575,7 @@ The `foreignUuid` method creates a `UUID` equivalent column:
 
 The `geography` method creates a `GEOGRAPHY` equivalent column with the given spatial type and SRID (Spatial Reference System Identifier):
 
-    $table->geography('positions', $subtype = 'point', $srid = 4326);
+    $table->geography('coordinates', $subtype = 'point', $srid = 4326);
 
 > [!NOTE]  
 > Support for spatial types depends on your database driver. Please refer to your database's documentation. If your application is utilizing a PostgreSQL database, you must install the [PostGIS](https://postgis.net) extension before the `geography` method may be used.

--- a/upgrade.md
+++ b/upgrade.md
@@ -66,7 +66,7 @@ public function dump(...$args);
 <a name="database"></a>
 ### Database
 
-<a name="the-enumerable-contract"></a>
+<a name="spatial-types"></a>
 #### Spatial Types
 
 **Likelihood Of Impact: Low**

--- a/upgrade.md
+++ b/upgrade.md
@@ -62,3 +62,27 @@ The `dump` method of the `Illuminate\Support\Enumerable` contract has been updat
 ```php
 public function dump(...$args);
 ```
+
+<a name="database"></a>
+### Database
+
+<a name="the-enumerable-contract"></a>
+#### Spatial Types
+
+**Likelihood Of Impact: Low**
+
+The spatial column types of database migrations have been rewritten to make these types consistent across all databases, Therefore, you may remove `point`, `lineString`, `polygon`, `geometryCollection`, `multiPoint`, `multiLineString`, `multiPolygon`, and `multiPolygonZ` methods from your migrations and use `geometry` or `geography` methods instead:
+
+```php
+$table->geometry('shapes');
+$table->geography('coordinates');
+```
+
+To explicitly restrict the type or the spatial reference system identifier for values stored in the column on MySQL and PostgreSQL, you may pass the `subtype` and `srid` to the method:
+
+```php
+$table->geometry('dimension', subtype: 'polygon', srid: 0);
+$table->geography('latitude', subtype: 'point', srid: 4326);
+```
+
+The `->isGeometry()` and `->projection()` column modifiers of the PostgreSQL grammar have been removed accordingly. 

--- a/upgrade.md
+++ b/upgrade.md
@@ -18,6 +18,7 @@
 <div class="content-list" markdown="1">
 
 - [The `Enumerable` Contract](#the-enumerable-contract)
+- [Spatial Types](#spatial-types)
 
 </div>
 
@@ -71,14 +72,12 @@ public function dump(...$args);
 
 **Likelihood Of Impact: Low**
 
-The spatial column types of database migrations have been rewritten to make these types consistent across all databases, Therefore, you may remove `point`, `lineString`, `polygon`, `geometryCollection`, `multiPoint`, `multiLineString`, `multiPolygon`, and `multiPolygonZ` methods from your migrations and use `geometry` or `geography` methods instead:
+The spatial column types of database migrations have been rewritten to be consistent across all databases. Therefore, you may remove `point`, `lineString`, `polygon`, `geometryCollection`, `multiPoint`, `multiLineString`, `multiPolygon`, and `multiPolygonZ` methods from your migrations and use `geometry` or `geography` methods instead:
 
 ```php
 $table->geometry('shapes');
 $table->geography('coordinates');
 ```
-
-The `->isGeometry()` and `->projection()` column modifiers of the PostgreSQL grammar have been removed accordingly.
 
 To explicitly restrict the type or the spatial reference system identifier for values stored in the column on MySQL and PostgreSQL, you may pass the `subtype` and `srid` to the method:
 
@@ -86,3 +85,5 @@ To explicitly restrict the type or the spatial reference system identifier for v
 $table->geometry('dimension', subtype: 'polygon', srid: 0);
 $table->geography('latitude', subtype: 'point', srid: 4326);
 ```
+
+The `isGeometry` and `projection` column modifiers of the PostgreSQL grammar have been removed accordingly.

--- a/upgrade.md
+++ b/upgrade.md
@@ -78,11 +78,11 @@ $table->geometry('shapes');
 $table->geography('coordinates');
 ```
 
+The `->isGeometry()` and `->projection()` column modifiers of the PostgreSQL grammar have been removed accordingly.
+
 To explicitly restrict the type or the spatial reference system identifier for values stored in the column on MySQL and PostgreSQL, you may pass the `subtype` and `srid` to the method:
 
 ```php
 $table->geometry('dimension', subtype: 'polygon', srid: 0);
 $table->geography('latitude', subtype: 'point', srid: 4326);
 ```
-
-The `->isGeometry()` and `->projection()` column modifiers of the PostgreSQL grammar have been removed accordingly. 


### PR DESCRIPTION
* laravel/framework#49634

## References
* MySQL: https://dev.mysql.com/doc/refman/8.0/en/spatial-type-overview.html
* PostgreSQL (on PostGIS)
  * Geometry type: https://postgis.net/docs/manual-3.4/using_postgis_dbmanagement.html#Create_Spatial_Table
  * Geography type: https://postgis.net/docs/manual-3.4/using_postgis_dbmanagement.html#PostGIS_Geography
* SQL Server: 
  * Geometry type: https://learn.microsoft.com/en-us/sql/t-sql/spatial-geometry/spatial-types-geometry-transact-sql?view=sql-server-ver16
  * Geography type: https://learn.microsoft.com/en-us/sql/t-sql/spatial-geography/spatial-types-geography?view=sql-server-ver16
* SQLite (on SpatiaLite): https://www.gaia-gis.it/fossil/libspatialite/home