### PR TITLE
[10.x] Removed redundant entry for password rule

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -934,7 +934,6 @@ Below is a list of all available validation rules and their function:
 [Not Regex](#rule-not-regex)
 [Nullable](#rule-nullable)
 [Numeric](#rule-numeric)
-[Password](#rule-password)
 [Present](#rule-present)
 [Present If](#rule-present-if)
 [Present Unless](#rule-present-unless)
@@ -1563,14 +1562,6 @@ The field under validation may be `null`.
 #### numeric
 
 The field under validation must be [numeric](https://www.php.net/manual/en/function.is-numeric.php).
-
-<a name="rule-password"></a>
-#### password
-
-The field under validation must match the authenticated user's password.
-
-> [!WARNING]  
-> This rule was renamed to `current_password` with the intention of removing it in Laravel 9. Please use the [Current Password](#rule-current-password) rule instead.
 
 <a name="rule-present"></a>
 #### present


### PR DESCRIPTION
In the Section for [Available Validation Rules](https://laravel.com/docs/10.x/validation#available-validation-rules) on the validation site, there is an entry for the `password` rule, which is marked to have been renamed and removed in Laravel 9. I think enough time has passed for the entry to be removed completely as to not cause confusion with the intended way to verify passwords, which is described on the bottom of the page.