### PR TITLE
[10.x] Remove importing Controller in queries.md

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -56,7 +56,6 @@ You may use the `table` method provided by the `DB` facade to begin a query. The
 
     namespace App\Http\Controllers;
 
-    use App\Http\Controllers\Controller;
     use Illuminate\Support\Facades\DB;
     use Illuminate\View\View;
 


### PR DESCRIPTION
Hi,
Importing Controller is unnecessary When `UserController` is located in the same namespace as `Controller`.