### PR TITLE
[10.x] Add `type` method in migrations

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -1258,6 +1258,15 @@ Any additional [column modifiers](#column-modifiers) must be called before the `
           ->nullable()
           ->constrained();
 
+Sometimes you need to specify the foreign key type, so can use `type` method:
+
+```php
+$table->foreignId('user_id')
+    ->type('tinyInteger')
+    ->constrained('users')
+    ->cascadeOnDelete();
+```
+
 <a name="dropping-foreign-keys"></a>
 #### Dropping Foreign Keys
 

--- a/migrations.md
+++ b/migrations.md
@@ -1258,7 +1258,7 @@ Any additional [column modifiers](#column-modifiers) must be called before the `
           ->nullable()
           ->constrained();
 
-Sometimes you need to specify the foreign key type, so can use `type` method:
+Sometimes you need to specify the foreign key type, so you can use the `type` method:
 
 ```php
 $table->foreignId('user_id')


### PR DESCRIPTION
Add the `type` method for foreign keys in migrations.