### PR TITLE
"extending controller" or "defining listener"

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -920,7 +920,7 @@ If you would like to add a subscription to a customer who already has a default 
 <a name="creating-subscriptions-from-the-stripe-dashboard"></a>
 #### Creating Subscriptions From the Stripe Dashboard
 
-You may also create subscriptions from the Stripe dashboard itself. When doing so, Cashier will sync newly added subscriptions and assign them a type of `default`. To customize the subscription type that is assigned to dashboard created subscriptions, [extend the `WebhookController`](#defining-webhook-event-handlers) and overwrite the `newSubscriptionType` method.
+You may also create subscriptions from the Stripe dashboard itself. When doing so, Cashier will sync newly added subscriptions and assign them a type of `default`. To customize the subscription type that is assigned to dashboard created subscriptions, [define webhook event handlers](#defining-webhook-event-handlers).
 
 In addition, you may only create one type of subscription via the Stripe dashboard. If your application offers multiple subscriptions that use different types, only one type of subscription may be added through the Stripe dashboard.
 


### PR DESCRIPTION
The docs mention extending a controller for webhooks but then show adding event listeners instead
There is no specific controller mentioned or demonstrated.. unlike the listeners.
I expect this to get rejected and closed.. there was no way to point to it in an issue and not sure the best way to handle.