### PR TITLE
Don't suggest cache tags for Redis

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -130,11 +130,7 @@ The `registerPolicies` method of the `AuthServiceProvider` is now invoked automa
 
 **Likelihood Of Impact: Medium**
 
-Redis [cache tag](/docs/{{version}}/cache#cache-tags) support has been rewritten for better performance and storage efficiency. In previous releases of Laravel, stale cache tags would accumulate in the cache when using Redis as your application's cache driver.
-
-However, to properly prune stale cache tag entries, Laravel's new `cache:prune-stale-tags` Artisan command should be [scheduled](/docs/{{version}}/scheduling) in your application's `App\Console\Kernel` class:
-
-    $schedule->command('cache:prune-stale-tags')->hourly();
+Usage of `Cache::tags()` is only recommended for Memcached. If you are using Redis as your application's cache driver, you should consider moving to Memcached or using an alternative solution.
 
 ### Database
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -130,7 +130,7 @@ The `registerPolicies` method of the `AuthServiceProvider` is now invoked automa
 
 **Likelihood Of Impact: Medium**
 
-Usage of `Cache::tags()` is only recommended for Memcached. If you are using Redis as your application's cache driver, you should consider moving to Memcached or using an alternative solution.
+Usage of `Cache::tags()` is only recommended for applications using Memcached. If you are using Redis as your application's cache driver, you should consider moving to Memcached or using an alternative solution.
 
 ### Database
 


### PR DESCRIPTION
The upgrade guide indicates that Redis cache tags got a performance improvement. However based on discussions linked below, it appears that usage of redis cache tags is not recommended. The outdated guidance in the upgrade guide caused a series of significant bugs in our production application. This PR updates the docs to recommend against using cache tags until a suitable solution can be found.

- Discussion of the problem: https://github.com/laravel/framework/discussions/49159
- Evidence that redis cache tagging isn't coming back or getting fixed any time soon: https://github.com/laravel/framework/pull/48078#issuecomment-1716332925

The current upgrade guide still contains a broken link to the documentation on cache tagging (which was removed as a result of Taylor's comment in the second link there).

If there is another recommended way for implementing Redis cache tags, I'd be happy to write up docs for that, but I'm not seeing one in my quick perusal of the issues, PRs, and conversations in github.