### PR TITLE
[10.x] Explain UTC behaviour when serialising dates

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -422,7 +422,7 @@ To specify the format that should be used when actually storing a model's dates 
 
 By default, the `date` and `datetime` casts will serialize dates to a UTC ISO-8601 date string (`YYYY-MM-DDTHH:MM:SS.uuuuuuZ`), regardless of the timezone specified in your application's `timezone` configuration option. You are strongly encouraged to always use this serialization format, as well as to store your application's dates in the UTC timezone by not changing your application's `timezone` configuration option from its default `UTC` value. Consistently using the UTC timezone throughout your application will provide the maximum level of interoperability with other date manipulation libraries written in PHP and JavaScript.
 
-If a custom format is applied to the `date` or `datetime` cast, such as `datetime:Y-m-d H:i:s`, the inner timezone of the Carbon instance will be used during date serialization. Typically, this will be the timezone specified in your application's `timezone` configuration option.
+If a custom format is applied to the `date` or `datetime` cast, such as `datetime:Y-m-d H:i:s`, the inner timezone of the Carbon instance will be used during date serialization. Typically, this will be the timezone specified in your application's `timezone` configuration option. But the displayed date string will still be shown in UTC as explained above.
 
 <a name="enum-casting"></a>
 ### Enum Casting


### PR DESCRIPTION
Currently, it's still not clear that dates will always be displayed as UTC when being serialised in Eloquent models. This extra sentence should make this crystal clear. See https://github.com/laravel/framework/issues/49899