### PR TITLE
[10.x] Add `--dev` flag at end of the command in Dusk

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -61,7 +61,7 @@
 To get started, you should install [Google Chrome](https://www.google.com/chrome) and add the `laravel/dusk` Composer dependency to your project:
 
 ```shell
-composer require --dev laravel/dusk
+composer require laravel/dusk --dev
 ```
 
 > [!WARNING]  


### PR DESCRIPTION
For all pages for installing packages, the `--dev` flag is the end of the `require` command but for Dusk, it is not the end.

https://laravel.com/docs/10.x/pint#installation
https://laravel.com/docs/10.x/envoy#installation
https://laravel.com/docs/10.x/telescope#local-only-installation
