### PR TITLE
[11.x] Specifies that `services` must be published

### DIFF
--- a/socialite.md
+++ b/socialite.md
@@ -29,6 +29,12 @@ To get started with Socialite, use the Composer package manager to add the packa
 composer require laravel/socialite
 ```
 
+Next, you should publish the `config/services.php` configuration file using the `config:publish` Artisan command:
+
+```shell
+php artisan config:publish services
+```
+
 <a name="upgrading-socialite"></a>
 ## Upgrading Socialite
 


### PR DESCRIPTION
This pull request specifies that `services` configuration file must be published for working with socialite in Laravel 11.