### PR TITLE
Update blade docs to show how to conditionally check for $slot content

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -1203,6 +1203,26 @@ To interact with slot attributes, you may access the `attributes` property of th
 </div>
 ```
 
+<a name="default-slot-content"></a>
+#### Default Slot Content
+
+You may use `$slot->isEmpty()` to check that content for the slot exists, and if not, provide default content.
+
+```blade
+<!-- /resources/views/components/alert.blade.php -->
+ 
+<span class="alert-title">{{ $title }}</span>
+ 
+<div class="alert alert-danger">
+    @if($slot->isEmpty())
+        This is default content if $slot is empty.
+    @else
+        {{ $slot }}
+    @endif
+</div>
+
+```
+
 <a name="inline-component-views"></a>
 ### Inline Component Views
 

--- a/blade.md
+++ b/blade.md
@@ -1148,6 +1148,20 @@ You may define the content of the named slot using the `x-slot` tag. Any content
 </x-alert>
 ```
 
+You may invoke a slot's `isEmpty` method to determine if the slot contains content:
+
+```blade
+<span class="alert-title">{{ $title }}</span>
+
+<div class="alert alert-danger">
+    @if ($slot->isEmpty())
+        This is default content if the slot is empty.
+    @else
+        {{ $slot }}
+    @endif
+</div>
+```
+
 <a name="scoped-slots"></a>
 #### Scoped Slots
 
@@ -1201,26 +1215,6 @@ To interact with slot attributes, you may access the `attributes` property of th
         {{ $footer }}
     </footer>
 </div>
-```
-
-<a name="default-slot-content"></a>
-#### Default Slot Content
-
-You may use `$slot->isEmpty()` to check that content for the slot exists, and if not, provide default content.
-
-```blade
-<!-- /resources/views/components/alert.blade.php -->
- 
-<span class="alert-title">{{ $title }}</span>
- 
-<div class="alert alert-danger">
-    @if($slot->isEmpty())
-        This is default content if $slot is empty.
-    @else
-        {{ $slot }}
-    @endif
-</div>
-
 ```
 
 <a name="inline-component-views"></a>


### PR DESCRIPTION
This pull requests updates the $slot section of the blade component docs.

Folks might mistakenly expect `@if($slot)` to work to check if `$slot` content exists, like I did. It would be helpful to clarify with an example of `@if($slot->isEmpty())`.