### PR TITLE
[Upgrade Doc] Adds dispatch helper info to L10 upgrades

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -30,7 +30,7 @@
 ## Low Impact Changes
 
 <div class="content-list" markdown="1">
-    
+
 - [Closure Validation Rule Messages](#closure-validation-rule-messages)
 - [Form Request `after` Method](#form-request-after-method)
 - [Public Path Binding](#public-path-binding)

--- a/upgrade.md
+++ b/upgrade.md
@@ -30,7 +30,7 @@
 ## Low Impact Changes
 
 <div class="content-list" markdown="1">
-
+    
 - [Closure Validation Rule Messages](#closure-validation-rule-messages)
 - [Form Request `after` Method](#form-request-after-method)
 - [Public Path Binding](#public-path-binding)
@@ -218,6 +218,13 @@ If you are using third-party logging services such as BugSnag or Rollbar, you ma
 **Likelihood Of Impact: Low**
 
 The deprecated `Bus::dispatchNow` and `dispatch_now` methods have been removed. Instead, your application should use the `Bus::dispatchSync` and `dispatch_sync` methods, respectively.
+
+<a name="dispatch-return"></a>
+#### The `dispatch()` Helper return value
+
+**Likelihood Of Impact: Low**
+
+Using `dispatch()` with a class that does not implement `\Illuminate\Contracts\Queue` would return the result of the class' `handle` method. This will now instead return an `Illuminate\Foundation\Bus\PendingBatch` instance. Instead, you should use `dispatch_sync()` to replicate this behavior. This is the same for the use of the `dispatch()` method via the `Illuminate\Foundation\Bus\DispatchesJobs` trait.
 
 ### Routing
 


### PR DESCRIPTION
# Why

This appears to be missing. I found it when doing an upgrade. It might catch a few people out if they were ever creating Job classes without the `ShouldQueue` interface to return a value.