### PR TITLE
[10.x] Assigning a validation message info in upgrade docs

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -252,6 +252,35 @@ The deprecated `Redirect::home` method has been removed. Instead, your applicati
 return Redirect::route('home');
 ```
 
+<a name="validation-closure-fail-return-arg"></a>
+#### Assigning a validation message to a different key via a closure
+
+**Likelihood Of Impact: Very Low**
+
+Previously you could assign a failure message to a different key using an array. Now you can provide the key as the first argument and the failure message as the second argument.
+
+For example:
+
+```php
+Validator::make([
+    'foo' => 'string',
+    'bar' => [function ($attribute, $value, $fail) {
+        $fail(['foo' => 'something has gone wrong']);
+    }],
+]);
+```
+
+should now be:
+
+```php
+Validator::make([
+    'foo' => 'string',
+    'bar' => [function ($attribute, $value, $fail) {
+        $fail('foo', 'something has gone wrong');
+    }],
+]);
+```
+
 ### Testing
 
 <a name="service-mocking"></a>


### PR DESCRIPTION
# Why

Found during a recent upgrade. Appears to be very obscure but a breaking change that others might come across when upgrading from 9 to 10.