### PR TITLE
[10.x] Remove warning about schema dumps and in-memory SQLite databases.

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -71,7 +71,7 @@ php artisan schema:dump --database=testing --prune
 You should commit your database schema file to source control so that other new developers on your team may quickly create your application's initial database structure.
 
 > [!WARNING]  
-> Migration squashing is only available for the MySQL, PostgreSQL, and SQLite databases and utilizes the database's command-line client. Schema dumps may not be restored to in-memory SQLite databases.
+> Migration squashing is only available for the MySQL, PostgreSQL, and SQLite databases and utilizes the database's command-line client.
 
 <a name="migration-structure"></a>
 ## Migration Structure


### PR DESCRIPTION
The docs have a warning in the "Squashing Migrations" section that schema dumps may not be restored to in-memory SQLite database. However, I believe this issue was resolved in PR [#45375](https://github.com/laravel/framework/pull/45375), which was released in v9.45.1.

To test this, I ran the following steps in a project that had existing migrations:

1. Place an sqlite schema at: `database/schema/sqlite-schema.dump`
```
CREATE TABLE IF NOT EXISTS "migrations" ("id" integer not null primary key autoincrement, "migration" varchar not null, "batch" integer not null);
```

2. Update the .env file with the following values:
```
DB_CONNECTION=sqlite
DB_DATABASE=:memory:
```

3. Run the migration (`php artisan migrate`) and see them all succeed.

According to a previous issue [#35162](https://github.com/laravel/framework/issues/35162), this normally would have failed with all the migration files stating "SQLSTATE[HY000]: General error: 1 no such table: migrations". However, it appears to be working fine now.