### PR TITLE
[10.x] Fix security vulnerability in Cashier Stripe quickstart example

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -309,7 +309,17 @@ Next, let's build the Checkout success route. This is the route that users will 
     Route::get('/checkout/success', function (Request $request) {
         $sessionId = $request->get('session_id');
 
-        $orderId = Cashier::stripe()->checkout->sessions->retrieve($sessionId)['metadata']['order_id'] ?? null;
+        if ($sessionId === null) {
+            return;
+        }
+
+        $session = Cashier::stripe()->checkout->sessions->retrieve($sessionId);
+
+        if ($session->payment_status !== 'paid') {
+            return;
+        }
+
+        $orderId = $session['metadata']['order_id'] ?? null;
 
         $order = Order::findOrFail($orderId);
 


### PR DESCRIPTION
Currently the payment status is not checked.
This means the user can start a Stripe checkout session, get the session ID from the URL, and manually construct the checkout success route, marking the order as paid without paying.