### PR TITLE
Fix Laravel Sail Shell Alias not passing arguments

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -96,16 +96,21 @@ By default, Sail commands are invoked using the `vendor/bin/sail` script that is
 However, instead of repeatedly typing `vendor/bin/sail` to execute Sail commands, you may wish to configure a shell alias that allows you to execute Sail's commands more easily:
 
 ```shell
-alias sail='[ -f sail ] && sh sail || sh vendor/bin/sail'
+alias sail='sh $([ -f sail ] && echo sail || echo vendor/bin/sail)'
 ```
 
 To make sure this is always available, you may add this to your shell configuration file in your home directory, such as `~/.zshrc` or `~/.bashrc`, and then restart your shell.
 
-Once the shell alias has been configured, you may execute Sail commands by simply typing `sail`. The remainder of this documentation's examples will assume that you have configured this alias:
+Once the shell alias has been configured, you may execute Sail commands by simply typing `sail`:
 
 ```shell
 sail up
 ```
+
+**The remainder of this documentation's examples will assume that you have configured this alias.**
+
+> [!INFO]  
+> In case you are using the shell alias, you can extend the functionality of the Laravel Sail script. To do so, simply create a `sail` script with your customizations at the root of your project and call `"vendor/bin/sail" "$@"` at the end of it.
 
 <a name="starting-and-stopping-sail"></a>
 ## Starting and Stopping Sail

--- a/sail.md
+++ b/sail.md
@@ -101,16 +101,11 @@ alias sail='sh $([ -f sail ] && echo sail || echo vendor/bin/sail)'
 
 To make sure this is always available, you may add this to your shell configuration file in your home directory, such as `~/.zshrc` or `~/.bashrc`, and then restart your shell.
 
-Once the shell alias has been configured, you may execute Sail commands by simply typing `sail`:
+Once the shell alias has been configured, you may execute Sail commands by simply typing `sail`. The remainder of this documentation's examples will assume that you have configured this alias:
 
 ```shell
 sail up
 ```
-
-**The remainder of this documentation's examples will assume that you have configured this alias.**
-
-> [!INFO]  
-> In case you are using the shell alias, you can extend the functionality of the Laravel Sail script. To do so, simply create a `sail` script with your customizations at the root of your project and call `"vendor/bin/sail" "$@"` at the end of it.
 
 <a name="starting-and-stopping-sail"></a>
 ## Starting and Stopping Sail


### PR DESCRIPTION
This is the shell alias described and recommended in the Laravel Sail documentation:
```shell
alias sail='[ -f sail ] && sh sail || sh vendor/bin/sail'
```
The alias is supposed to have the following functionality:
- Check if a file called `sail` does exist in the CWD / Laravel project directory.
  - In case it does exist, execute it
  - In case it does not exist, execute the `vendor/bin/sail` script provided by the package.
- Pass all arguments to either sail script being executed

This functionality allows developers to add a custom script to their Laravel projects to wrap around and customize Laravel Sail's behaivour.

However, due to how shell alias does work, arguments are only passed to the false-part of the if-condition - **`sh sail` will never receive any arguments**. This limitation arises because the alias simply resolves to its string definition so the arguments are being being *appended* to the resolved string.

To illustrate this, the command `sail artisan queue:work` will become the following command:
```shell
[ -f sail ] && sh sail || sh vendor/bin/sail artisan queue:work
```

This Pull Request will adjust the alias, to resolve the correct sail script **before** it is being executed. This way, the alias does not have to deal with any arguments but only resolve the sail script to be used.
In addition to this, i have added a notice that does explain how Laravel Sail can be extended.