### PR TITLE
[10.x] Added missing `toBase64` docs

### DIFF
--- a/strings.md
+++ b/strings.md
@@ -1150,11 +1150,13 @@ The `Str::title` method converts the given string to `Title Case`:
 <a name="method-str-to-base64"></a>
 #### `Str::toBase64()` {.collection-method}
 
-The `Str::toBase64()` method converts the given string to a base64:
+The `Str::toBase64` method converts the given string to Base64:
 
     use Illuminate\Support\Str;
 
     $base64 = Str::toBase64('Laravel');
+
+    // TGFyYXZlbA==
 
 <a name="method-str-to-html-string"></a>
 #### `Str::toHtmlString()` {.collection-method}

--- a/strings.md
+++ b/strings.md
@@ -2433,7 +2433,7 @@ The `title` method converts the given string to `Title Case`:
 <a name="method-fluent-str-to-base64"></a>
 #### `toBase64()` {.collection-method}
 
-The `toBase64()` method converts the given string to a base64:
+The `toBase64` method converts the given string to Base64:
 
     use Illuminate\Support\Str;
 

--- a/strings.md
+++ b/strings.md
@@ -95,6 +95,7 @@ Laravel includes a variety of functions for manipulating string values. Many of 
 [Str::swap](#method-str-swap)
 [Str::take](#method-take)
 [Str::title](#method-title-case)
+[Str::toBase64](#method-str-to-base64)
 [Str::toHtmlString](#method-str-to-html-string)
 [Str::ucfirst](#method-str-ucfirst)
 [Str::ucsplit](#method-str-ucsplit)
@@ -194,6 +195,7 @@ Laravel includes a variety of functions for manipulating string values. Many of 
 [tap](#method-fluent-str-tap)
 [test](#method-fluent-str-test)
 [title](#method-fluent-str-title)
+[toBase64](#method-fluent-str-to-base64)
 [trim](#method-fluent-str-trim)
 [ucfirst](#method-fluent-str-ucfirst)
 [ucsplit](#method-fluent-str-ucsplit)
@@ -1144,6 +1146,15 @@ The `Str::title` method converts the given string to `Title Case`:
     $converted = Str::title('a nice title uses the correct case');
 
     // A Nice Title Uses The Correct Case
+
+<a name="method-str-to-base64"></a>
+#### `Str::toBase64()` {.collection-method}
+
+The `Str::toBase64()` method converts the given string to a base64:
+
+    use Illuminate\Support\Str;
+
+    $base64 = Str::toBase64('Laravel');
 
 <a name="method-str-to-html-string"></a>
 #### `Str::toHtmlString()` {.collection-method}
@@ -2416,6 +2427,17 @@ The `title` method converts the given string to `Title Case`:
     $converted = Str::of('a nice title uses the correct case')->title();
 
     // A Nice Title Uses The Correct Case
+
+<a name="method-fluent-str-to-base64"></a>
+#### `toBase64()` {.collection-method}
+
+The `toBase64()` method converts the given string to a base64:
+
+    use Illuminate\Support\Str;
+
+    $base64 = Str::of('Laravel')->toBase64();
+
+    // TGFyYXZlbA==
 
 <a name="method-fluent-str-trim"></a>
 #### `trim` {.collection-method}


### PR DESCRIPTION
This PR adds documentation for `toBase64`. Feel free to update the description so it aligns with the quality of the rest of the docs.