### PR TITLE
Fix typo in Arr::take() examples

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -852,7 +852,7 @@ The `Arr::take` method returns a new array with the specified number of items:
 
     $array = [0, 1, 2, 3, 4, 5];
 
-    $chunk = Arr::take(3);
+    $chunk = Arr::take($array, 3);
 
     // [0, 1, 2]
 
@@ -860,7 +860,7 @@ You may also pass a negative integer to take the specified number of items from 
 
     $array = [0, 1, 2, 3, 4, 5];
 
-    $chunk = Arr::take(-2);
+    $chunk = Arr::take($array, -2);
 
     // [4, 5]
 


### PR DESCRIPTION
# Description 

This PR fixes a typo in the `Arr::take()` example docs. 
![image](https://github.com/laravel/docs/assets/9967336/fcd4c042-04da-411e-a0a6-4e89cd231147)
 