### PR TITLE
[10.x] Update helpers.md

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -888,6 +888,8 @@ The `Arr::toCssClasses` method conditionally compiles a CSS class string. The me
 The `Arr::toCssStyles` conditionally compiles a CSS style string. The method accepts an array of classes where the array key contains the class or classes you wish to add, while the value is a boolean expression. If the array element has a numeric key, it will always be included in the rendered class list:
 
 ```php
+use Illuminate\Support\Arr;
+
 $hasColor = true;
 
 $array = ['background-color: blue', 'color: blue' => $hasColor];


### PR DESCRIPTION
This pull request addresses a consistency issue in the Laravel documentation for array helpers. In the `Arr::toCssStyles()` method snippet, a namespace import was missing. This PR adds the necessary import statement, ensuring uniformity with other code blocks. The changes enhance readability and maintain a consistent coding style throughout the documentation.