### PR TITLE
[10.x] Add warning for `trashed` event in Eloquent

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1460,6 +1460,9 @@ Instead of using custom event classes, you may register closures that execute wh
         }
     }
 
+> [!WARNING]  
+> When you want to use the `trashed` event in your model, you must use `softDeleted` event.
+
 If needed, you may utilize [queueable anonymous event listeners](/docs/{{version}}/events#queuable-anonymous-event-listeners) when registering model events. This will instruct Laravel to execute the model event listener in the background using your application's [queue](/docs/{{version}}/queues):
 
     use function Illuminate\Events\queueable;


### PR DESCRIPTION
Many developers don't know that when they want to use the `trashed` event, they need to use the `softDeleted` event.

https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/SoftDeletes.php#L171