### PR TITLE
Update helpers.md

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -90,12 +90,13 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 <div class="collection-method-list" markdown="1">
 
 [Number::abbreviate](#method-number-abbreviate)
-[Number::format](#method-number-format)
-[Number::percentage](#method-number-percentage)
+[Number::clamp](#method-number-clamp)
 [Number::currency](#method-number-currency)
 [Number::fileSize](#method-number-file-size)
 [Number::forHumans](#method-number-for-humans)
+[Number::format](#method-number-format)
 [Number::ordinal](#method-number-ordinal)
+[Number::percentage](#method-number-percentage)
 [Number::spell](#method-number-spell)
 [Number::useLocale](#method-number-use-locale)
 [Number::withLocale](#method-number-with-locale)
@@ -1145,51 +1146,28 @@ The `Number::abbreviate` method returns the human-readable format of the provide
 
     // 1.23M
 
-<a name="method-number-format"></a>
-#### `Number::format()` {.collection-method}
+<a name="method-number-clamp"></a>
+#### `Number::clamp()` {.collection-method}
 
-The `Number::format` method formats the given number into a locale specific string:
-
-    use Illuminate\Support\Number;
-
-    $number = Number::format(100000);
-
-    // 100,000
-
-    $number = Number::format(100000, precision: 2);
-
-    // 100,000.00
-
-    $number = Number::format(100000.123, maxPrecision: 2);
-
-    // 100,000.12
-
-    $number = Number::format(100000, locale: 'de');
-
-    // 100.000
-
-<a name="method-number-percentage"></a>
-#### `Number::percentage()` {.collection-method}
-
-The `Number::percentage` method returns the percentage representation of the given value as a string:
+The `Number::clamp` method ensures a given number stays within a specified range. If the number is lower than the minimum, it's set to the minimum; if higher than the maximum, it's set to the maximum. The method returns the clamped number:
 
     use Illuminate\Support\Number;
 
-    $percentage = Number::percentage(10);
+    $number = Number::clamp(105, min: 10, max: 100);
 
-    // 10%
+    // 100
 
-    $percentage = Number::percentage(10, precision: 2);
+    $number = Number::clamp(5, min: 10, max: 100);
 
-    // 10.00%
+    // 10
 
-    $percentage = Number::percentage(10.123, maxPrecision: 2);
+    $number = Number::clamp(10, min: 10, max: 100);
 
-    // 10.12%
+    // 10
 
-    $percentage = Number::percentage(10, precision: 2, locale: 'de');
+    $number = Number::clamp(20, min: 10, max: 100);
 
-    // 10,00%
+    // 20
 
 <a name="method-number-currency"></a>
 #### `Number::currency()` {.collection-method}
@@ -1248,6 +1226,29 @@ The `Number::forHumans` method returns the human-readable format of the provided
 
     // 1.23 million
 
+<a name="method-number-format"></a>
+#### `Number::format()` {.collection-method}
+
+The `Number::format` method formats the given number into a locale specific string:
+
+    use Illuminate\Support\Number;
+
+    $number = Number::format(100000);
+
+    // 100,000
+
+    $number = Number::format(100000, precision: 2);
+
+    // 100,000.00
+
+    $number = Number::format(100000.123, maxPrecision: 2);
+
+    // 100,000.12
+
+    $number = Number::format(100000, locale: 'de');
+
+    // 100.000
+
 <a name="method-number-ordinal"></a>
 #### `Number::ordinal()` {.collection-method}
 
@@ -1266,6 +1267,29 @@ The `Number::ordinal` method returns a number's ordinal representation:
     $number = Number::ordinal(21);
 
     // 21st
+
+<a name="method-number-percentage"></a>
+#### `Number::percentage()` {.collection-method}
+
+The `Number::percentage` method returns the percentage representation of the given value as a string:
+
+    use Illuminate\Support\Number;
+
+    $percentage = Number::percentage(10);
+
+    // 10%
+
+    $percentage = Number::percentage(10, precision: 2);
+
+    // 10.00%
+
+    $percentage = Number::percentage(10.123, maxPrecision: 2);
+
+    // 10.12%
+
+    $percentage = Number::percentage(10, precision: 2, locale: 'de');
+
+    // 10,00%
 
 <a name="method-number-spell"></a>
 #### `Number::spell()` {.collection-method}


### PR DESCRIPTION
Hi team,

This PR reorders `Number` helper methods for clarity and includes the missing Number::clamp method in the documentation.

Thanks!