### PR TITLE
[10.x] Update all references of Builder to the contract on the Eloquent: Relationships page

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1264,7 +1264,7 @@ where user_id = ? and active = 1 or votes >= 100
 
 In most situations, you should use [logical groups](/docs/{{version}}/queries#logical-grouping) to group the conditional checks between parentheses:
 
-    use Illuminate\Database\Eloquent\Builder;
+    use Illuminate\Contracts\Database\Eloquent\Builder;
 
     $user->posts()
             ->where(function (Builder $query) {
@@ -1318,7 +1318,7 @@ Nested `has` statements may be constructed using "dot" notation. For example, yo
 
 If you need even more power, you may use the `whereHas` and `orWhereHas` methods to define additional query constraints on your `has` queries, such as inspecting the content of a comment:
 
-    use Illuminate\Database\Eloquent\Builder;
+    use Illuminate\Contracts\Database\Eloquent\Builder;
 
     // Retrieve posts with at least one comment containing words like code%...
     $posts = Post::whereHas('comments', function (Builder $query) {
@@ -1359,7 +1359,7 @@ When retrieving model records, you may wish to limit your results based on the a
 
 If you need even more power, you may use the `whereDoesntHave` and `orWhereDoesntHave` methods to add additional query constraints to your `doesntHave` queries, such as inspecting the content of a comment:
 
-    use Illuminate\Database\Eloquent\Builder;
+    use Illuminate\Contracts\Database\Eloquent\Builder;
 
     $posts = Post::whereDoesntHave('comments', function (Builder $query) {
         $query->where('content', 'like', 'code%');
@@ -1367,7 +1367,7 @@ If you need even more power, you may use the `whereDoesntHave` and `orWhereDoesn
 
 You may use "dot" notation to execute a query against a nested relationship. For example, the following query will retrieve all posts that do not have comments; however, posts that have comments from authors that are not banned will be included in the results:
 
-    use Illuminate\Database\Eloquent\Builder;
+    use Illuminate\Contracts\Database\Eloquent\Builder;
 
     $posts = Post::whereDoesntHave('comments.author', function (Builder $query) {
         $query->where('banned', 0);
@@ -1381,7 +1381,7 @@ To query the existence of "morph to" relationships, you may use the `whereHasMor
     use App\Models\Comment;
     use App\Models\Post;
     use App\Models\Video;
-    use Illuminate\Database\Eloquent\Builder;
+    use Illuminate\Contracts\Database\Eloquent\Builder;
 
     // Retrieve comments associated to posts or videos with a title like code%...
     $comments = Comment::whereHasMorph(
@@ -1403,7 +1403,7 @@ To query the existence of "morph to" relationships, you may use the `whereHasMor
 
 You may occasionally need to add query constraints based on the "type" of the related polymorphic model. The closure passed to the `whereHasMorph` method may receive a `$type` value as its second argument. This argument allows you to inspect the "type" of the query that is being built:
 
-    use Illuminate\Database\Eloquent\Builder;
+    use Illuminate\Contracts\Database\Eloquent\Builder;
 
     $comments = Comment::whereHasMorph(
         'commentable',
@@ -1420,7 +1420,7 @@ You may occasionally need to add query constraints based on the "type" of the re
 
 Instead of passing an array of possible polymorphic models, you may provide `*` as a wildcard value. This will instruct Laravel to retrieve all of the possible polymorphic types from the database. Laravel will execute an additional query in order to perform this operation:
 
-    use Illuminate\Database\Eloquent\Builder;
+    use Illuminate\Contracts\Database\Eloquent\Builder;
 
     $comments = Comment::whereHasMorph('commentable', '*', function (Builder $query) {
         $query->where('title', 'like', 'foo%');
@@ -1444,7 +1444,7 @@ Sometimes you may want to count the number of related models for a given relatio
 
 By passing an array to the `withCount` method, you may add the "counts" for multiple relations as well as add additional constraints to the queries:
 
-    use Illuminate\Database\Eloquent\Builder;
+    use Illuminate\Contracts\Database\Eloquent\Builder;
 
     $posts = Post::withCount(['votes', 'comments' => function (Builder $query) {
         $query->where('content', 'like', 'code%');
@@ -1455,7 +1455,7 @@ By passing an array to the `withCount` method, you may add the "counts" for mult
 
 You may also alias the relationship count result, allowing multiple counts on the same relationship:
 
-    use Illuminate\Database\Eloquent\Builder;
+    use Illuminate\Contracts\Database\Eloquent\Builder;
 
     $posts = Post::withCount([
         'comments',


### PR DESCRIPTION
Upgrading from v10.44.0 to v10.45.0, our code broke because we were using code similar to this:

```php
use Illuminate\Database\Eloquent\Builder;

public function posts(?string $tag = null): HasMany
{
    return $this->hasMany(Post::class)
        ->when($tag, fn (Builder $query, string $tag) => $query->where('tag', $tag));
}
```

This caused:

> Unknown error TypeError: App\\Models\\{closure}(): Argument #⁠1 ($query) must be of type Illuminate\\Database\\Query\\Builder, Illuminate\\Database\\Eloquent\\Relations\\HasMany given

It appears this PR was the cause: https://github.com/laravel/framework/pull/50124

Looking through the PR description, this is actually exactly the edge case we are experiencing:

> The only edge case I can think of is someone receiving the `Builder` instance inside these methods callbacks, but that was deprecated in favor of the `BuilderContract`, so its a far stretch.

I have resolved the issue locally by typing the received variable to this `BuilderContract`, but I was unaware of the existence of the _BuilderContract_ and that this should be used in favor of the direct `Builder` import.

Since the documentation about relationships almost exclusively, save one instance, refers directly to the `Builder` namespace, I wanted to submit this PR to guide future developers to using the `BuilderContract` instead.