### PR TITLE
Fix broken link to PHPUnit docs

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -255,7 +255,7 @@ If you had test failures the last time you ran the `dusk` command, you may save 
 php artisan dusk:fails
 ```
 
-The `dusk` command accepts any argument that is normally accepted by the PHPUnit test runner, such as allowing you to only run the tests for a given [group](https://phpunit.readthedocs.io/en/10.1/annotations.html#group):
+The `dusk` command accepts any argument that is normally accepted by the PHPUnit test runner, such as allowing you to only run the tests for a given [group](https://phpunit.readthedocs.io/en/11.0/annotations.html#group):
 
 ```shell
 php artisan dusk --group=foo


### PR DESCRIPTION
Though, since there's no way of linking to 'latest' (I just looked into that possibility) it may be better to remove the link as it'll break again soon enough.