### PR TITLE
[10.x] Adds instructions for accessing the Telescope dashboard

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -56,6 +56,8 @@ php artisan telescope:install
 php artisan migrate
 ```
 
+Finally, you may access the Telescope dashboard via the `/telescope` route.
+
 <a name="migration-customization"></a>
 #### Migration Customization
 


### PR DESCRIPTION
I couldn't easily locate the telescope dashboard route. The only mention of it is further down the page.