### PR TITLE
[10.x] Nullable `failed` method

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1897,7 +1897,7 @@ When a particular job fails, you may want to send an alert to your users or reve
         /**
          * Handle a job failure.
          */
-        public function failed(Throwable $exception): void
+        public function failed(?Throwable $exception): void
         {
             // Send user notification of failure, etc...
         }


### PR DESCRIPTION
The exception may be `null` if you call the `fail` method without passing a string or exception, as documented.

<img width="712" alt="Screen Shot 2024-03-04 at 9 02 43 am" src="https://github.com/laravel/docs/assets/24803032/c0830d61-b032-4400-9d5f-196d943e7fc7">

So having this nullable in the docs seems more sensible, as the two documented version do not currently work together. If this were typed with `Throwable` an exception would be thrown when the queue worker attempts to call the job's `failed` method.

```php
<?php

namespace App\Jobs;

use Illuminate\Bus\Queueable;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Foundation\Bus\Dispatchable;
use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Queue\SerializesModels;

class TestJob implements ShouldQueue
{
    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

    public function handle(): void
    {
        $this->fail();
    }

    public function failed($e)
    {
        dd($e); // null
    }
}
```