### PR TITLE
[10.x] Fix group link of PHPUnit in `Dusk`

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -255,7 +255,7 @@ If you had test failures the last time you ran the `dusk` command, you may save 
 php artisan dusk:fails
 ```
 
-The `dusk` command accepts any argument that is normally accepted by the PHPUnit test runner, such as allowing you to only run the tests for a given [group](https://phpunit.readthedocs.io/en/10.1/annotations.html#group):
+The `dusk` command accepts any argument that is normally accepted by the PHPUnit test runner, such as allowing you to only run the tests for a given [group](https://docs.phpunit.de/en/10.5/annotations.html#group):
 
 ```shell
 php artisan dusk --group=foo


### PR DESCRIPTION
The [https://docs.phpunit.de/en/10.1/annotations.html#group](https://docs.phpunit.de/en/10.1/annotations.html#group) is not found (404)