### PR TITLE
[10.x] Add dependency update for laravel/ui

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -76,6 +76,7 @@ You should update the following dependencies in your application's `composer.jso
 - `doctrine/dbal` to `^3.0`
 - `spatie/laravel-ignition` to `^2.0`
 - `laravel/passport` to `^11.0` ([Upgrade Guide](https://github.com/laravel/passport/blob/11.x/UPGRADE.md))
+- `laravel/ui` to `^4.0`
 
 </div>
 


### PR DESCRIPTION
I was in the process of upgrading an older Laravel project. The project uses Laravel UI. Upgrading from Laravel 9 to Laravel 10 required updating laravel/ui. According to the Laravel UI documentation, Laravel 10.x requires laravel/ui 4.x.

https://github.com/laravel/ui?tab=readme-ov-file#supported-versions

Here's the supported versions table for laravel/ui.

<img width="270" alt="image" src="https://github.com/laravel/docs/assets/19653787/a3c156b2-8691-467b-a833-5e8438884237">