### PR TITLE
[11.x] add 'SQLite3 Extension' in 'Server Requirements'

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -36,6 +36,7 @@ The Laravel framework has a few system requirements. You should ensure that your
 - OpenSSL PHP Extension
 - PCRE PHP Extension
 - PDO PHP Extension
+- SQLite3 PHP Extension
 - Session PHP Extension
 - Tokenizer PHP Extension
 - XML PHP Extension


### PR DESCRIPTION
In L11, SQLite3 is the default DB driver, so we should install it.