### PR TITLE
[11.x] Add Laravel Installer update instructions

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -94,17 +94,13 @@ In addition, you should review the upgrade guides for each of these packages to 
 - [Laravel Spark Stripe](#spark-stripe)
 - [Laravel Telescope](#telescope)
 
-Finally, you may remove the `doctrine/dbal` Composer dependency if you have previously added it to your application, as Laravel is no longer dependent on this package.
-
-#### Laravel Installer
-
-You should update the Laravel Installer to the latest version, to make sure you have all necessary installation options for the new Laravel 11 Application Structure.
-
-If you have the Laravel Installer globally installed via Composer you can simply run:
+If you have manually installed the Laravel installer, you should update the installer via Composer:
 
 ```bash
-composer require laravel/installer:^5.6
+composer global require laravel/installer:^5.6
 ```
+
+Finally, you may remove the `doctrine/dbal` Composer dependency if you have previously added it to your application, as Laravel is no longer dependent on this package.
 
 <a name="application-structure"></a>
 ### Application Structure

--- a/upgrade.md
+++ b/upgrade.md
@@ -96,6 +96,16 @@ In addition, you should review the upgrade guides for each of these packages to 
 
 Finally, you may remove the `doctrine/dbal` Composer dependency if you have previously added it to your application, as Laravel is no longer dependent on this package.
 
+#### Laravel Installer
+
+You should update the Laravel Installer to the latest version, to make sure you have all necessary installation options for the new Laravel 11 Application Structure.
+
+If you have the Laravel Installer globally installed via Composer you can simply run:
+
+```bash
+composer require laravel/installer:^5.6
+```
+
 <a name="application-structure"></a>
 ### Application Structure
 


### PR DESCRIPTION
If you are running an older version of the Laravel Installer, you will not have all the correct installation options for a new Laravel 11 Application.

Assuming there will be a 5.6 release tomorrow, otherwise another version number can be documented.

Kind of related PR: https://github.com/laravel/installer/pull/319