### PR TITLE
Remove references to config getters

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -202,14 +202,6 @@ To set configuration values at runtime, you may invoke the `Config` facade's `se
 
     config(['app.timezone' => 'America/Chicago']);
 
-To assist with static analysis, the `Config` facade also provides typed configuration retrieval methods. If the retrieved configuration value does not match the expected type, an exception will be thrown:
-
-    Config::string('config-key');
-    Config::integer('config-key');
-    Config::float('config-key');
-    Config::boolean('config-key');
-    Config::array('config-key');
-
 <a name="configuration-caching"></a>
 ## Configuration Caching
 


### PR DESCRIPTION
In `configuration` documentation for `10.x` there are references to typed getters that will be available in `11.x`.
This PR removes any references to them.
They are already there in `11.x` documentation.

See https://github.com/laravel/framework/pull/50140 for more info.