### PR TITLE
[11.x] Fixes Cashier stripe package name - just cashier not cashier-stripe

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -68,7 +68,7 @@ You should update the following dependencies in your application's `composer.jso
 
 - `laravel/framework` to `^11.0`
 - `nunomaduro/collision` to `^8.1`
-- `laravel/cashier-stripe` to `^15.0` (If installed)
+- `laravel/cashier` to `^15.0` (If installed)
 - `laravel/passport` to `^12.0` (If installed)
 - `laravel/sanctum` to `^4.0` (If installed)
 - `laravel/spark-stripe` to `^5.0` (If installed)


### PR DESCRIPTION
Cashier Stripe package is not named cashier-stripe, just cashier. This was a bit confusing when upgrading.