### PR TITLE
Added a line about jetstream upgrade to the upgrade docs

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -70,11 +70,11 @@ You should update the following dependencies in your application's `composer.jso
 - `nunomaduro/collision` to `^8.1`
 - `laravel/breeze` to `^2.0` (If installed)
 - `laravel/cashier` to `^15.0` (If installed)
+- `laravel/jetstream` to `^5.0` (If installed)
 - `laravel/passport` to `^12.0` (If installed)
 - `laravel/sanctum` to `^4.0` (If installed)
 - `laravel/spark-stripe` to `^5.0` (If installed)
 - `laravel/telescope` to `^5.0` (If installed)
-- `laravel/jetstream` to `^5.0` (If installed)
 - `inertiajs/inertia-laravel` to `^1.0` (If installed)
 
 </div>

--- a/upgrade.md
+++ b/upgrade.md
@@ -74,6 +74,7 @@ You should update the following dependencies in your application's `composer.jso
 - `laravel/sanctum` to `^4.0` (If installed)
 - `laravel/spark-stripe` to `^5.0` (If installed)
 - `laravel/telescope` to `^5.0` (If installed)
+- `laravel/jetstream` to `^5.0` (If installed)
 - `inertiajs/inertia-laravel` to `^1.0` (If installed)
 
 </div>


### PR DESCRIPTION
When i upgraded my Laravel project that had Jetstream from 10 to 11, I had to do this change, and maybe others would find this useful too.