### PR TITLE
[11.x] Adjusts installation docs

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -164,7 +164,13 @@ cd example-app
 ./vendor/bin/sail up
 ```
 
-Once the application's Docker containers have been started, you can access the application in your web browser at: http://localhost.
+Once the application's Docker containers have been started, you should run your application's [database migrations](/docs/{{version}}/migrations) in a separate terminal:
+
+```shell
+./vendor/bin/sail artisan migrate
+```
+
+Finally, you can access the application in your web browser at: http://localhost.
 
 > [!NOTE]  
 > To continue learning more about Laravel Sail, review its [complete documentation](/docs/{{version}}/sail).
@@ -195,7 +201,13 @@ cd example-app
 ./vendor/bin/sail up
 ```
 
-Once the application's Docker containers have been started, you can access the application in your web browser at: http://localhost.
+Once the application's Docker containers have been started, you should run your application's [database migrations](/docs/{{version}}/migrations) in a separate terminal:
+
+```shell
+./vendor/bin/sail artisan migrate
+```
+
+Finally, you can access the application in your web browser at: http://localhost.
 
 > [!NOTE]  
 > To continue learning more about Laravel Sail, review its [complete documentation](/docs/{{version}}/sail).
@@ -235,7 +247,13 @@ cd example-app
 ./vendor/bin/sail up
 ```
 
-Once the application's Docker containers have been started, you can access the application in your web browser at: http://localhost.
+Once the application's Docker containers have been started, you should run your application's [database migrations](/docs/{{version}}/migrations) in a separate terminal:
+
+```shell
+./vendor/bin/sail artisan migrate
+```
+
+Finally, you can access the application in your web browser at: http://localhost.
 
 > [!NOTE]  
 > To continue learning more about Laravel Sail, review its [complete documentation](/docs/{{version}}/sail).

--- a/installation.md
+++ b/installation.md
@@ -164,7 +164,7 @@ cd example-app
 ./vendor/bin/sail up
 ```
 
-Once the application's Docker containers have been started, you should run your application's [database migrations](/docs/{{version}}/migrations) in a separate terminal:
+Once the application's Docker containers have started, you should run your application's [database migrations](/docs/{{version}}/migrations):
 
 ```shell
 ./vendor/bin/sail artisan migrate
@@ -201,7 +201,7 @@ cd example-app
 ./vendor/bin/sail up
 ```
 
-Once the application's Docker containers have been started, you should run your application's [database migrations](/docs/{{version}}/migrations) in a separate terminal:
+Once the application's Docker containers have started, you should run your application's [database migrations](/docs/{{version}}/migrations):
 
 ```shell
 ./vendor/bin/sail artisan migrate
@@ -247,7 +247,7 @@ cd example-app
 ./vendor/bin/sail up
 ```
 
-Once the application's Docker containers have been started, you should run your application's [database migrations](/docs/{{version}}/migrations) in a separate terminal:
+Once the application's Docker containers have started, you should run your application's [database migrations](/docs/{{version}}/migrations):
 
 ```shell
 ./vendor/bin/sail artisan migrate


### PR DESCRIPTION
Because `database` is the session's driver by default, people need to run their database migrations when using the `curl -s "https://laravel.build/example-app" | bash` command.