### PR TITLE
Added upgrade note about `AuthenticationException::redirectTo()`

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -39,7 +39,6 @@
 - [The `Enumerable` Contract](#the-enumerable-contract)
 - [The `UserProvider` Contract](#the-user-provider-contract)
 - [The `Authenticatable` Contract](#the-authenticatable-contract)
-- [The `AuthenticationException` Class](#the-authentication-exception-class)
 
 </div>
 
@@ -161,13 +160,13 @@ The default `User` model included with Laravel receives this method automaticall
 
 #### The `AuthenticationException` Class
 
-**Likelihood Of Impact: Low**
+**Likelihood Of Impact: Very Low**
 
-The `redirectTo()` method of the `Illuminate\Auth\AuthenticationException` class now accepts a required `Request` instance as its first argument. If you are manually catching this exception and calling the `redirectTo` method, you should update your code to pass the `Request` instance as the first argument:
+The `redirectTo` method of the `Illuminate\Auth\AuthenticationException` class now requires an `Illuminate\Http\Request` instance as its first argument. If you are manually catching this exception and calling the `redirectTo` method, you should update your code accordingly:
 
 ```php
 if ($e instanceof AuthenticationException) {
-    $path = $e->redirectTo(request());
+    $path = $e->redirectTo($request);
 }
 ```
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -39,6 +39,7 @@
 - [The `Enumerable` Contract](#the-enumerable-contract)
 - [The `UserProvider` Contract](#the-user-provider-contract)
 - [The `Authenticatable` Contract](#the-authenticatable-contract)
+- [The `AuthenticationException` Class](#the-authentication-exception-class)
 
 </div>
 
@@ -155,6 +156,20 @@ public function getAuthPasswordName()
 ```
 
 The default `User` model included with Laravel receives this method automatically since the method is included within the `Illuminate\Auth\Authenticatable` trait.
+
+<a name="the-authentication-exception-class"></a>
+
+#### The `AuthenticationException` Class
+
+**Likelihood Of Impact: Low**
+
+The `redirectTo()` method of the `Illuminate\Auth\AuthenticationException` class now accepts a required `Request` instance as its first argument. If you are manually catching this exception and calling the `redirectTo` method, you should update your code to pass the `Request` instance as the first argument:
+
+```php
+if ($e instanceof AuthenticationException) {
+    $path = $e->redirectTo(request());
+}
+```
 
 <a name="cache"></a>
 ### Cache


### PR DESCRIPTION
The `redirectTo()` method on the `AuthenticationException` now requires a `Request` instance:

https://github.com/laravel/framework/commit/1d878ccac4ed1e2a0cc337bf32fac4e52f893dfb#diff-321608159b002b8e92d19ef7ab6f68f568f79b2a08877e074eb6479b70e5ceacR63-R72