### PR TITLE
Change DATABASE_URL to DB_URL

### DIFF
--- a/database.md
+++ b/database.md
@@ -75,7 +75,7 @@ These URLs typically follow a standard schema convention:
 driver://username:password@host:port/database?options
 ```
 
-For convenience, Laravel supports these URLs as an alternative to configuring your database with multiple configuration options. If the `url` (or corresponding `DATABASE_URL` environment variable) configuration option is present, it will be used to extract the database connection and credential information.
+For convenience, Laravel supports these URLs as an alternative to configuring your database with multiple configuration options. If the `url` (or corresponding `DB_URL` environment variable) configuration option is present, it will be used to extract the database connection and credential information.
 
 <a name="read-and-write-connections"></a>
 ### Read and Write Connections


### PR DESCRIPTION
With Laravel 11, the var `DATABASE_URL` has changed. It is now `DB_URL` (see [config/database.php](https://github.com/laravel/laravel/blob/11.x/config/database.php))