### PR TITLE
Fix recipient name order in on-demand notification example

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -322,13 +322,13 @@ Sometimes you may need to send a notification to someone who is not stored as a 
 If you would like to provide the recipient's name when sending an on-demand notification to the `mail` route, you may provide an array that contains the email address as the key and the name as the value of the first element in the array:
 
     Notification::route('mail', [
-        'barrett@example.com' => 'Barrett Blair',
+        'Barrett Blair' => 'barrett@example.com',
     ])->notify(new InvoicePaid($invoice));
 
 Using the `routes` method, you may provide ad-hoc routing information for multiple notification channels at once:
 
     Notification::routes([
-        'mail' => ['barrett@example.com' => 'Barrett Blair'],
+        'mail' => ['Barrett Blair' => 'barrett@example.com'],
         'vonage' => '5555555555',
     ])->notify(new InvoicePaid($invoice));
 


### PR DESCRIPTION
The current documentation incorrectly states the order of the email address and recipient name in the arrays passed to the `Notification::route` and `Notification::routes` methods.

The `route` parameter expects the key in the array to be a name and the value to be an address. Otherwise, there will be an exception:
> Email address "Barrett Blair" does not comply with the addr-spec of RFC 2822.

I've tested it with Laravel 10.x but this example for `route` method in docs is available since v8.x, do we need multiple PRs for every branch then or ...?