### PR TITLE
[11.x] Sail troubleshooting docs

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -27,6 +27,7 @@
   - [Xdebug CLI Usage](#xdebug-cli-usage)
   - [Xdebug Browser Usage](#xdebug-browser-usage)
 - [Customization](#sail-customization)
+- [Troubleshooting](#troubleshooting)
 
 <a name="introduction"></a>
 ## Introduction
@@ -520,5 +521,15 @@ sail artisan sail:publish
 After running this command, the Dockerfiles and other configuration files used by Laravel Sail will be placed within a `docker` directory in your application's root directory. After customizing your Sail installation, you may wish to change the image name for the application container in your application's `docker-compose.yml` file. After doing so, rebuild your application's containers using the `build` command. Assigning a unique name to the application image is particularly important if you are using Sail to develop multiple Laravel applications on a single machine:
 
 ```shell
+sail build --no-cache
+```
+
+<a name="troubleshooting"></a>
+## Troubleshooting
+
+Sometimes it could be that you're stuck on an old version of Sail's runtime files or that containers contain old values instead of updates ones from newer Sail releases. If you want to completely start from scratch, run the below two commands to do so:
+
+```shell
+docker compose down -v
 sail build --no-cache
 ```


### PR DESCRIPTION
I've ran recently into the issue that I couldn't connect to mysql anymore through sail. Turned out the old container still contained the previous user/password from older Sail versions. I've had it a couple of times now that I had to completely start from scratch and @fideloper recently let me know about `docker compose down -v`. I feel like a section on how to completely start from scratch can help people who run into similar issues.