### PR TITLE
[11.x] Document all Pennant events

### DIFF
--- a/pennant.md
+++ b/pennant.md
@@ -985,11 +985,15 @@ Once the driver has been registered, you may use the `redis` driver in your appl
 
 Pennant dispatches a variety of events that can be useful when tracking feature flags throughout your application.
 
-### `Laravel\Pennant\Events\RetrievingKnownFeature`
+### `Laravel\Pennant\Events\FeatureRetrieved`
 
 This event is dispatched the first time a known feature is retrieved during a request for a specific scope. This event can be useful to create and track metrics against the feature flags that are being used throughout your application.
 
-### `Laravel\Pennant\Events\RetrievingUnknownFeature`
+### `Laravel\Pennant\Events\FeatureResolved`
+
+This event is dispatched the first time a feature's value is resolved for a specific scope from it's definition or feature class resolver.
+
+### `Laravel\Pennant\Events\UnknownFeatureResolved`
 
 This event is dispatched the first time an unknown feature is retrieved during a request for a specific scope. This event can be useful if you have intended to remove a feature flag, but may have accidentally left some stray references to it throughout your application.
 
@@ -1002,7 +1006,7 @@ namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Event;
-use Laravel\Pennant\Events\RetrievingUnknownFeature;
+use Laravel\Pennant\Events\UnknownFeatureResolved;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -1011,13 +1015,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Event::listen(function (RetrievingUnknownFeature $event) {
+        Event::listen(function (UnknownFeatureResolved $event) {
             report("Resolving unknown feature [{$event->feature}].");
         });
     }
 }
 ```
 
-### `Laravel\Pennant\Events\DynamicallyDefiningFeature`
+### `Laravel\Pennant\Events\DynamicallyRegisteringFeatureClass`
 
 This event is dispatched when a class based feature is being dynamically checked for the first time during a request.

--- a/pennant.md
+++ b/pennant.md
@@ -1025,3 +1025,35 @@ class AppServiceProvider extends ServiceProvider
 ### `Laravel\Pennant\Events\DynamicallyRegisteringFeatureClass`
 
 This event is dispatched when a class based feature is being dynamically checked for the first time during a request.
+
+### `Laravel\Pennant\Events\UnexpectedNullScopeEncountered`
+
+This event is dispatched when a `null` scope is passed to a feature definition that [doesn't support null](#nullable-scope).
+
+This is handled gracefully and the feature will return false. If you want to opt out of this behaviour:
+
+```php
+use Laravel\Pennant\Events\UnexpectedNullScopeEncountered;
+
+Event::listen(UnexpectedNullScopeEncountered::class, fn () => abort(500));
+```
+
+### `Laravel\Pennant\Events\FeatureUpdated`
+
+This event is dispatched when updating a feature for a scope, usually through calling `activate` or `deactivate`.
+
+### `Laravel\Pennant\Events\FeatureUpdatedForAllScopes`
+
+This event is dispatched when updating a feature for all scopes, usually through calling `activateForEveryone` or `deactivateForEveryone`.
+
+### `Laravel\Pennant\Events\FeatureDeleted`
+
+This event is dispatched when deleting a feature for a scope, usually through calling `forget`.
+
+### `Laravel\Pennant\Events\FeaturesPurged`
+
+This event is dispatched when purging specific features.
+
+### `Laravel\Pennant\Events\AllFeaturesPurged`
+
+This event is dispatched when purging all features.

--- a/pennant.md
+++ b/pennant.md
@@ -987,7 +987,7 @@ Pennant dispatches a variety of events that can be useful when tracking feature 
 
 ### `Laravel\Pennant\Events\FeatureRetrieved`
 
-This event is dispatched whenever a [feature is checked](#checking-features). It may be useful for creating and tracking metrics against a feature flag's usage throughout your application.
+This event is dispatched whenever a [feature is checked](#checking-features). This event may be useful for creating and tracking metrics against a feature flag's usage throughout your application.
 
 ### `Laravel\Pennant\Events\FeatureResolved`
 
@@ -995,9 +995,7 @@ This event is dispatched the first time a feature's value is resolved for a spec
 
 ### `Laravel\Pennant\Events\UnknownFeatureResolved`
 
-This event is dispatched the first time an unknown feature is resolved for a specific scope. This event may be useful if you have intended to remove a feature flag, but have accidentally left stray references to it throughout your application.
-
-For example, you may find it useful to listen for this event and log an error when it occurs:
+This event is dispatched the first time an unknown feature is resolved for a specific scope. Listening to this event may be useful if you have intended to remove a feature flag but have accidentally left stray references to it throughout your application:
 
 ```php
 <?php
@@ -1031,7 +1029,7 @@ This event is dispatched when a [class based feature](#class-based-features) is 
 
 This event is dispatched when a `null` scope is passed to a feature definition that [doesn't support null](#nullable-scope).
 
-This is handled gracefully and the feature will return `false`. If you wanted to opt out of this default behaviour you could register a handler in the `boot` method of the `AppServiceProvider`:
+This situation is handled gracefully and the feature will return `false`. However, if you would like to opt out of this feature's default graceful behavior, you may register a listener for this event in the `boot` method of your application's `AppServiceProvider`:
 
 ```php
 use Illuminate\Support\Facades\Log;
@@ -1049,15 +1047,15 @@ public function boot(): void
 
 ### `Laravel\Pennant\Events\FeatureUpdated`
 
-This event is dispatched when updating a feature for a scope, usually through calling `activate` or `deactivate`.
+This event is dispatched when updating a feature for a scope, usually by calling `activate` or `deactivate`.
 
 ### `Laravel\Pennant\Events\FeatureUpdatedForAllScopes`
 
-This event is dispatched when updating a feature for all scopes, usually through calling `activateForEveryone` or `deactivateForEveryone`.
+This event is dispatched when updating a feature for all scopes, usually by calling `activateForEveryone` or `deactivateForEveryone`.
 
 ### `Laravel\Pennant\Events\FeatureDeleted`
 
-This event is dispatched when deleting a feature for a scope, usually through calling `forget`.
+This event is dispatched when deleting a feature for a scope, usually by calling `forget`.
 
 ### `Laravel\Pennant\Events\FeaturesPurged`
 


### PR DESCRIPTION
I was looking at the documentation for Pennant and noticed the events do not line up with the actual events in the package. I can see they were renamed and updated in this PR https://github.com/laravel/pennant/pull/21, but accidentally reverted in this commit https://github.com/laravel/docs/commit/075b0ceebac575e24c9c00958e3f662d43809c00.

I have correctly renamed the events to what they actually are while keeping the amendments that have been made to the docs since.

Whilst making this change, I thought it made sense to document the new events that have also been added. I'm not sure they all need descriptions as some of them are self-explanatory but have added them for now so they can be amended or removed.

I used the information in this PR https://github.com/laravel/pennant/pull/31 to help document the `UnexpectedNullScopeEncountered` event.

Technically this documentation also applies to versions prior to `11.x` but I'm not sure on the approach for updating older versions or if that is something that is done.

Hope this provides a good basis for updating the docs for Pennant's events.