### PR TITLE
[11.x] Change deterministic header name

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -209,7 +209,7 @@ You may also use the `render` method to override the rendering behavior for buil
 <a name="rendering-exceptions-as-json"></a>
 #### Rendering Exceptions as JSON
 
-When rendering an exception, Laravel will automatically determine if the exception should be rendered as an HTML or JSON response based on the `Content-Type` header of the request. If you would like to customize how Laravel determines whether to render HTML or JSON exception responses, you may utilize the `shouldRenderJsonWhen` method:
+When rendering an exception, Laravel will automatically determine if the exception should be rendered as an HTML or JSON response based on the `Accept` header of the request. If you would like to customize how Laravel determines whether to render HTML or JSON exception responses, you may utilize the `shouldRenderJsonWhen` method:
 
     use Illuminate\Http\Request;
     use Throwable;


### PR DESCRIPTION
## Description

The current docs state:

> When rendering an exception, Laravel will automatically determine if the exception should be rendered as an HTML or JSON response based on the Content-Type header of the request.

Whilst building my latest API, I noticed that the `Content-Type` header doesn't determine if the exception should be rendered at HTML or JSON, but rather the `Accept` header.

In this PR, I'm simply updating the header name to reflect the reality I experienced.