### PR TITLE
update providers for L11

### DIFF
--- a/structure.md
+++ b/structure.md
@@ -172,7 +172,7 @@ This directory does not exist by default, but will be created for you if you exe
 
 The `Providers` directory contains all of the [service providers](/docs/{{version}}/providers) for your application. Service providers bootstrap your application by binding services in the service container, registering events, or performing any other tasks to prepare your application for incoming requests.
 
-In a fresh Laravel application, this directory will already contain several providers. You are free to add your own providers to this directory as needed.
+In a fresh Laravel application, this directory will already contain `AppServiceProvider`. You are free to add your own providers to this directory as needed.
 
 <a name="the-rules-directory"></a>
 #### The Rules Directory

--- a/structure.md
+++ b/structure.md
@@ -172,7 +172,7 @@ This directory does not exist by default, but will be created for you if you exe
 
 The `Providers` directory contains all of the [service providers](/docs/{{version}}/providers) for your application. Service providers bootstrap your application by binding services in the service container, registering events, or performing any other tasks to prepare your application for incoming requests.
 
-In a fresh Laravel application, this directory will already contain `AppServiceProvider`. You are free to add your own providers to this directory as needed.
+In a fresh Laravel application, this directory will already contain the `AppServiceProvider`. You are free to add your own providers to this directory as needed.
 
 <a name="the-rules-directory"></a>
 #### The Rules Directory


### PR DESCRIPTION
In fresh laravel 11 application, there is only one service provider in providers directory. It seems like docs is not updated for this specific thing.