### PR TITLE
[11.x] Add "aws/aws-sdk-php" install step for DynamoDB cache setup

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -90,13 +90,13 @@ Before using the [DynamoDB](https://aws.amazon.com/dynamodb) cache driver, you m
 
 This table should also have a string partition key with a name that corresponds to the value of the `stores.dynamodb.attributes.key` configuration item within your application's `cache` configuration file. By default, the partition key should be named `key`.
 
-Next, install the AWS SDK so that your Laravel application can communicate with Amazon DynamoDB:
+Next, install the AWS SDK so that your Laravel application can communicate with DynamoDB:
 
 ```shell
 composer require aws/aws-sdk-php
 ```
 
-Then, set the `cache.default` configuration option's value to `dynamodb`. In addition, you should define the `key`, `secret`, and `region` configuration options within the `dynamodb` configuration array. These options will be used to authenticate with AWS:
+In addition, you should ensure that values are provided for the DynamoDB cache store configuration options. Typically these options, such as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, should be defined in your application's `.env` configuration file:
 
 ```php
 'dynamodb' => [

--- a/cache.md
+++ b/cache.md
@@ -90,6 +90,25 @@ Before using the [DynamoDB](https://aws.amazon.com/dynamodb) cache driver, you m
 
 This table should also have a string partition key with a name that corresponds to the value of the `stores.dynamodb.attributes.key` configuration item within your application's `cache` configuration file. By default, the partition key should be named `key`.
 
+Next, install the AWS SDK so that your Laravel application can communicate with Amazon DynamoDB:
+
+```shell
+composer require aws/aws-sdk-php
+```
+
+Then, set the `cache.default` configuration option's value to `dynamodb`. In addition, you should define the `key`, `secret`, and `region` configuration options within the `dynamodb` configuration array. These options will be used to authenticate with AWS:
+
+```php
+'dynamodb' => [
+    'driver' => 'dynamodb',
+    'key' => env('AWS_ACCESS_KEY_ID'),
+    'secret' => env('AWS_SECRET_ACCESS_KEY'),
+    'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
+    'table' => env('DYNAMODB_CACHE_TABLE', 'cache'),
+    'endpoint' => env('DYNAMODB_ENDPOINT'),
+],
+```
+
 <a name="cache-usage"></a>
 ## Cache Usage
 


### PR DESCRIPTION
Hey! This PR proposes a small change that explains to the reader that they need to install the `aws/aws-sdk-php` Composer package if wanting to use DynamoDB as their cache.

Without installing the SDK, it appears that an exception is thrown when we try and interact with the cache. I ran into this issue myself earlier today and couldn't see any mention in the cache docs of needing to install the package (apologies if it's there and I just missed it!).

The only mention of the SDK that I saw was in the queues section (https://laravel.com/docs/11.x/queues#dynamodb-configuration) but that's not until further in the docs so it might be confusing to newer developers.

So, I copied a small part over from the queues section and added it to the DynamoDB cache section. Although there is a slight bit of duplication, I'm hoping this should make it easier for readers to follow the cache set up step-by-step 🙂