### PR TITLE
[11.x] Remove dead `Defining Authorization Routes` link

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -19,7 +19,6 @@
     - [Broadcast Conditions](#broadcast-conditions)
     - [Broadcasting and Database Transactions](#broadcasting-and-database-transactions)
 - [Authorizing Channels](#authorizing-channels)
-    - [Defining Authorization Routes](#defining-authorization-routes)
     - [Defining Authorization Callbacks](#defining-authorization-callbacks)
     - [Defining Channel Classes](#defining-channel-classes)
 - [Broadcasting Events](#broadcasting-events)


### PR DESCRIPTION
This link doesn't take you anywhere and doesn't appear to exist on the page anymore.