### PR TITLE
update Exceptions directory descriptions

### DIFF
--- a/structure.md
+++ b/structure.md
@@ -130,7 +130,7 @@ This directory does not exist by default, but will be created for you by the `ev
 <a name="the-exceptions-directory"></a>
 #### The Exceptions Directory
 
-The `Exceptions` directory contains your application's exception handler and is also a good place to place any exceptions thrown by your application. If you would like to customize how your exceptions are logged or rendered, you should modify the `Handler` class in this directory.
+The `Exceptions` directory contains all of the custom exceptions for your application. These exceptions may be generated using the `make:exception` command.
 
 <a name="the-http-directory"></a>
 #### The Http Directory


### PR DESCRIPTION
In Laravel 11 there is no Exceptions/Handler.php but not updated in Laravel 11 docs.