### PR TITLE
Add missing link for HTTP Redirects doc file

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -40,6 +40,7 @@
     - [File Storage](/docs/{{version}}/filesystem)
     - [Helpers](/docs/{{version}}/helpers)
     - [HTTP Client](/docs/{{version}}/http-client)
+    - [HTTP Redirects](/docs/{{version}}/redirects)
     - [Localization](/docs/{{version}}/localization)
     - [Mail](/docs/{{version}}/mail)
     - [Notifications](/docs/{{version}}/notifications)


### PR DESCRIPTION
Maybe it was excluded on purpose? `redirects.md` hasn't been updated since Feb 6, 2023.