### PR TITLE
Update API docs links in routing.md

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -879,7 +879,7 @@ You may use the `current`, `currentRouteName`, and `currentRouteAction` methods 
     $name = Route::currentRouteName(); // string
     $action = Route::currentRouteAction(); // string
 
-You may refer to the API documentation for both the [underlying class of the Route facade](https://laravel.com/api/{{version}}/Illuminate/Routing/Router.html) and [Route instance](https://laravel.com/api/{{version}}/Illuminate/Routing/Route.html) to review all of the methods that are available on the router and route classes.
+You may refer to the API documentation for both the [underlying class of the Route facade](https://laravel.com/api/master/Illuminate/Routing/Router.html) and [Route instance](https://laravel.com/api/master/Illuminate/Routing/Route.html) to review all of the methods that are available on the router and route classes.
 
 <a name="cors"></a>
 ## Cross-Origin Resource Sharing (CORS)


### PR DESCRIPTION
The links to the API documentation are broken. Either the 11.x version has to be declared or the version should be replaced with `master` as in this PR (for now).