### PR TITLE
modify-example-of-db-connection-name

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -333,7 +333,7 @@ By default, all Eloquent models will use the default database connection that is
          *
          * @var string
          */
-        protected $connection = 'sqlite';
+        protected $connection = 'mysql';
     }
 
 <a name="default-attribute-values"></a>


### PR DESCRIPTION
Before:

```bash
protected $connection = 'sqlite';
```

After:

```bash
protected $connection = 'mysql';
```
As 11.x using `sqlite` by default, I think, it is more convenient to use `mysql` or something else in this example (specify a different connection for a particular model).