### PR TITLE
Modify-db-connection-name-example-for-multiple-connections

### DIFF
--- a/database.md
+++ b/database.md
@@ -253,7 +253,7 @@ If your application defines multiple connections in your `config/database.php` c
 
     use Illuminate\Support\Facades\DB;
 
-    $users = DB::connection('sqlite')->select(/* ... */);
+    $users = DB::connection('mysql')->select(/* ... */);
 
 You may access the raw, underlying PDO instance of a connection using the `getPdo` method on a connection instance:
 
@@ -424,7 +424,7 @@ In addition, you may use the following `Schema` methods to inspect your database
 
 If you would like to inspect a database connection that is not your application's default connection, you may use the `connection` method:
 
-    $columns = Schema::connection('sqlite')->getColumns('users');
+    $columns = Schema::connection('mysql')->getColumns('users');
 
 <a name="table-overview"></a>
 #### Table Overview

--- a/eloquent.md
+++ b/eloquent.md
@@ -333,7 +333,7 @@ By default, all Eloquent models will use the default database connection that is
          *
          * @var string
          */
-        protected $connection = 'sqlite';
+        protected $connection = 'mysql';
     }
 
 <a name="default-attribute-values"></a>

--- a/migrations.md
+++ b/migrations.md
@@ -286,7 +286,7 @@ You may determine the existence of a table, column, or index using the `hasTable
 
 If you want to perform a schema operation on a database connection that is not your application's default connection, use the `connection` method:
 
-    Schema::connection('sqlite')->create('users', function (Blueprint $table) {
+    Schema::connection('mysql')->create('users', function (Blueprint $table) {
         $table->id();
     });
 


### PR DESCRIPTION
In multiple db connections or not default db connection's example, I think, usages of `mysql` or other db name instead of `sqlite` will be easy to understand cause 11.x uses `sqlite` as default db.