### PR TITLE
Fix method name by Context Class -->  "hydrated" instead of "hydrating"

### DIFF
--- a/context.md
+++ b/context.md
@@ -10,7 +10,7 @@
 - [Hidden Context](#hidden-context)
 - [Events](#events)
     - [Dehydrating](#dehydrating)
-    - [Hydrating](#hydrating)
+    - [Hydrated](#hydrated)
 
 <a name="introduction"></a>
 ## Introduction
@@ -284,7 +284,7 @@ Context::forgetHidden(/* ... */);
 <a name="events"></a>
 ## Events
 
-Context dispatches two events that allow you to hook into the dehydrating and hydrating process of the context.
+Context dispatches two events that allow you to hook into the dehydrating and hydrated process of the context.
 
 To illustrate how these events may be used, imagine that in a middleware of your application you set the `app.locale` configuration value based on the incoming HTTP request's `Accept-Language` header. Context's events allow you to capture this value during the request and restore it on the queue, ensuring notifications sent on the queue have the correct `app.locale` value. We can use context's events and [hidden](#hidden-context) data to achieve this, which the following documentation will illustrate.
 
@@ -314,12 +314,12 @@ public function boot(): void
 > [!NOTE]
 > You should not use the `Context` facade within the `dehydrating` callback, as that will change the context of the current process. Ensure you only make changes to the repository passed to the callback.
 
-<a name="hydrating"></a>
-### Hydrating
+<a name="hydrated"></a>
+### Hydrated
 
-Whenever a queued job begins executing on the queue, any context that was shared with the job will be "hydrated" back into the current context. The `Context::hydrating` method allows you to register a closure that will be invoked during the hydration process.
+Whenever a queued job begins executing on the queue, any context that was shared with the job will be "hydrated" back into the current context. The `Context::hydrated` method allows you to register a closure that will be invoked during the hydration process.
 
-Typically, you should register `hydrating` callbacks within the `boot` method of your application's `AppServiceProvider` class:
+Typically, you should register `hydrated` callbacks within the `boot` method of your application's `AppServiceProvider` class:
 
 ```php
 use Illuminate\Log\Context\Repository;
@@ -331,7 +331,7 @@ use Illuminate\Support\Facades\Context;
  */
 public function boot(): void
 {
-    Context::hydrating(function (Repository $context) {
+    Context::hydrated(function (Repository $context) {
         if ($context->hasHidden('locale')) {
             Config::set('app.locale', $context->getHidden('locale'));
         }
@@ -340,4 +340,4 @@ public function boot(): void
 ```
 
 > [!NOTE]
-> You should not use the `Context` facade within the `hydrating` callback and instead ensure you only make changes to the repository passed to the callback.
+> You should not use the `Context` facade within the `hydrated` callback and instead ensure you only make changes to the repository passed to the callback.


### PR DESCRIPTION
Method "hydrating" don't exist. Correct name is "hydrated".