### PR TITLE
Update Laravel 11 documentation for broadcasting installation

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -67,7 +67,7 @@ Event broadcasting is accomplished by a server-side broadcasting driver that bro
 <a name="configuration"></a>
 ### Configuration
 
-All of your application's event broadcasting configuration is stored in the `config/broadcasting.php` configuration file. Laravel supports several broadcast drivers out of the box: [Laravel Reverb](/docs/{{version}}/reverb), [Pusher Channels](https://pusher.com/channels), [Ably](https://ably.com), and a `log` driver for local development and debugging. Additionally, a `null` driver is included which allows you to totally disable broadcasting during testing. A configuration example is included for each of these drivers in the `config/broadcasting.php` configuration file.
+All of your application's event broadcasting configuration is stored in the `config/broadcasting.php` configuration file. Don't worry if this directory does not exist in your application; it will be created when you run the `install:broadcasting` Artisan command. Laravel supports several broadcast drivers out of the box: [Laravel Reverb](/docs/{{version}}/reverb), [Pusher Channels](https://pusher.com/channels), [Ably](https://ably.com), and a `log` driver for local development and debugging. Additionally, a `null` driver is included which allows you to completely disable broadcasting during testing. A configuration example is included for each of these drivers in the `config/broadcasting.php` configuration file.
 
 <a name="installation"></a>
 #### Installation
@@ -78,7 +78,7 @@ By default, broadcasting is not enabled in new Laravel applications. You may ena
 php artisan install:broadcasting
 ```
 
-The `install:broadcasting` command will create a `routes/channels.php` file where you may register your application's broadcast authorization routes and callbacks.
+The `install:broadcasting` command will create a configuration file `config/broadcasting.php` where all of your application's event broadcasting configuration is stored, and a `routes/channels.php` file where you may register your application's broadcast authorization routes and callbacks.
 
 <a name="queue-configuration"></a>
 #### Queue Configuration


### PR DESCRIPTION
This pull request updates the documentation for Laravel 11 regarding the installation process for broadcasting. Previously, the documentation stated that the `config/broadcasting.php` file would be created automatically when installing a new Laravel app. However, in Laravel 11, this file is not created automatically, and we need to run the `install:broadcasting` command. Additionally, while the documentation mentioned that this command creates `routes/channels.php`, it actually creates two files: `routes/channels.php` and `config/broadcasting.php`.

These adjustments ensure that the documentation accurately reflects the behavior of Laravel 11 and provides clear guidance for users.