### PR TITLE
Add mixed hash verification information to hashing

### DIFF
--- a/hashing.md
+++ b/hashing.md
@@ -6,6 +6,7 @@
     - [Hashing Passwords](#hashing-passwords)
     - [Verifying That a Password Matches a Hash](#verifying-that-a-password-matches-a-hash)
     - [Determining if a Password Needs to be Rehashed](#determining-if-a-password-needs-to-be-rehashed)
+- [Mixed Hashes](#mixed-hashes)
 
 <a name="introduction"></a>
 ## Introduction
@@ -98,3 +99,43 @@ The `needsRehash` method provided by the `Hash` facade allows you to determine i
     if (Hash::needsRehash($hashed)) {
         $hashed = Hash::make('plain-text');
     }
+
+<a name="mixed-hashes"></a>
+## Supporting Mixed Hashes
+
+To prevent hash algorithm manipulation, Laravel's `Hash::check()` method will first verify the given hash was generated using the application's selected hashing algorithm before it checks if the plain-text password matches the given hashed password. If the algorithms are different, a `RuntimeException` exception will be thrown, halting the password hash check.
+
+For example, if your application is configured with `bcrypt` as the default hashing driver, and passing an `argon` hash to `Hash::check()` will trigger the exception:
+
+    $hashedPassword = '$argon2i$v=19$m=65536,t=4,p=1$Q2pBM0JmSUN6ZTVhRndXOA$VB6kqxNvqiKKYcqrS8vB8jZK51MbfUagjRgyIyzmRJk';
+    
+    try {
+        if (Hash::check("password", $hashedPassword)) {
+            return "Password matches";
+        } else {
+            return "Password doesn't match";
+        }
+    } catch (RuntimeException $e) {
+        return "Password algorithm doesn't match.";
+    }
+
+This is the expected behavior for most applications, where the hashing algorithm is not expected to change, and different algorithms can be an indication of some form of attack. However, if you need to support multiple hashing algorithms, such as when migrating from one algorithm to another, you can override this behaviour by setting `HASH_VERIFY=false` in your `.env` file or by passing `false` to either (or both of) the `bcrypt.verify` and `argon.verify` options in your application's `config/hashing.php` configuration file:
+
+
+    // .env
+    HASH_VERIFY=false
+
+or
+
+    // config/hashing.php
+    'bcrypt' => [
+        // ...
+        'verify' => false,
+    ],
+    
+    'argon' => [
+        // ...
+        'verify' => false,
+    ],
+
+With hash verification disabled, Laravel will check any valid password hash using PHP's `password_verify` function, regardless of the hashing algorithm used to generate the hash. Preventing the `RuntimeException` when different algorithms are encountered.


### PR DESCRIPTION
Second attempt to document the new `HASH_VERIFY` env var - this time actually explaining what happens when verification fails. 

https://github.com/laravel/docs/pull/9538#event-12272329009