### PR TITLE
[11.x] Removes `^11.0` from installation step

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -58,7 +58,7 @@ Before creating your first Laravel project, make sure that your local machine ha
 After you have installed PHP and Composer, you may create a new Laravel project via Composer's `create-project` command:
 
 ```nothing
-composer create-project laravel/laravel:^11.0 example-app
+composer create-project laravel/laravel example-app
 ```
 
 Or, you may create new Laravel projects by globally installing [the Laravel installer](https://github.com/laravel/installer) via Composer:


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/50959. As the `^` is not supported on Windows terminals.