### PR TITLE
[11.x] Add doc for new helper method `fluent()` with more explaining 

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -1660,32 +1660,41 @@ For the inverse of `blank`, see the [`filled`](#method-filled) method.
 <a name="method-fluent"></a>
 #### `fluent()` {.collection-method}
 
-The `fluent` function helps to working with multi-dimension arrays:
+The `fluent` function simplifies array manipulation by providing intuitive methods for working with multi-dimensional arrays. With features like method chaining and dot notation access, it can streamline complex operations, improve productivity, and enhance code readability. By abstracting common array tasks into clear, expressive syntax, `fluent()` promotes maintainability in code.
+
+##### Usage Examples:
 
     $data = [
-      'user' => [
-        'name' => 'Taylor Otwell',
-          'address' => [
-            'city' => 'Amsterdam',
-            'country' => 'Netherlands',
-          ]  
-      ],
-    'posts' => [
-        [
-          'title' => 'Post 1',                
+        'user' => [
+            'name' => 'Taylor Otwell',
+            'address' => [
+                'city' => 'Amsterdam',
+                'country' => 'Netherlands',
+            ]  
         ],
-        [
-          'title' => 'Post 2',               
+        'posts' => [
+            [
+                'title' => 'Post 1',                
+            ],
+            [
+                'title' => 'Post 2',               
+            ]
         ]
-      ]
     ];
 
+    // Retrieve nested array elements:
     fluent($data)->get('user.name'); 
-    // Taylor Otwell
+    // Output: Taylor Otwell
+
+    // Perform operations on nested arrays:
     fluent($data)->collect('posts')->pluck('title'); 
-    // ['Post 1', 'Post 2']
+    // Output: ['Post 1', 'Post 2']
+
+    // Apply scopes to retrieve specific nested data:
     fluent($data)->scope('user.address')->toJson();
-    // {"city":"Amsterdam","country":"Netherlands"}
+    // Output: {"city":"Amsterdam","country":"Netherlands"}
+
+For more options and methods available in the `Fluent` class, please refer to the [Fluent Class Documentation](https://laravel.com/api/11.x/Illuminate/Support/Fluent.html).
 
 <a name="method-broadcast"></a>
 #### `broadcast()` {.collection-method}

--- a/helpers.md
+++ b/helpers.md
@@ -169,6 +169,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [event](#method-event)
 [fake](#method-fake)
 [filled](#method-filled)
+[fluent](#method-fluent)
 [info](#method-info)
 [literal](#method-literal)
 [logger](#method-logger)
@@ -1655,6 +1656,36 @@ The `blank` function determines whether the given value is "blank":
     // false
 
 For the inverse of `blank`, see the [`filled`](#method-filled) method.
+
+<a name="method-fluent"></a>
+#### `fluent()` {.collection-method}
+
+The `fluent` function helps to working with multi-dimension arrays:
+
+    $data = [
+      'user' => [
+        'name' => 'Taylor Otwell',
+          'address' => [
+            'city' => 'Amsterdam',
+            'country' => 'Netherlands',
+          ]  
+      ],
+    'posts' => [
+        [
+          'title' => 'Post 1',                
+        ],
+        [
+          'title' => 'Post 2',               
+        ]
+      ]
+    ];
+
+    fluent($data)->get('user.name'); 
+    // Taylor Otwell
+    fluent($data)->collect('posts')->pluck('title'); 
+    // ['Post 1', 'Post 2']
+    fluent($data)->scope('user.address')->toJson();
+    // {"city":"Amsterdam","country":"Netherlands"}
 
 <a name="method-broadcast"></a>
 #### `broadcast()` {.collection-method}


### PR DESCRIPTION

This PR adds documentation for the `fluent()` helper method, which is introduced in the framework [#50848](https://github.com/laravel/framework/pull/50848). The `fluent()` method is designed to simplify working with multi-dimensional arrays by providing intuitive methods.

### Changes Made:

- Added documentation for the `fluent()` method with more explaining.
- Included usage examples demonstrating how to use `fluent()` for array manipulation
- Added a reference to the Fluent Class Documentation for further information on available options and methods

This documentation will help developers effectively understand and utilize the `fluent()` method for working with multi-dimensional arrays in their Laravel projects.
