### PR TITLE
Correction for unique method in eloquent collections

### DIFF
--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -225,7 +225,7 @@ The `toQuery` method returns an Eloquent query builder instance containing a `wh
 <a name="method-unique"></a>
 #### `unique($key = null, $strict = false)` {.collection-method}
 
-The `unique` method returns all of the unique models in the collection. Any models of the same type with the same primary key as another model in the collection are removed:
+The `unique` method returns all of the unique models in the collection. Any models with the same primary key as another model in the collection are removed:
 
     $users = $users->unique();
 


### PR DESCRIPTION
The documentation for `Illuminate\Database\Eloquent\Collection::unique` currently states the following:
> Any models of the same type with the same primary key as another model in the collection are removed.

This is incorrect, as items with a different type but the same primary key are still removed, as indicated by the following code snippet (which will output 1 instead of 2):
```php
<?php

use Illuminate\Database\Eloquent\Collection;
use Illuminate\Database\Eloquent\Model;

class ModelA extends Model {protected $fillable = ['id'];}
class ModelB extends Model {protected $fillable = ['id'];}

echo (new Collection([
    new ModelA(['id' => 1]), 
    new ModelB(['id' => 1])]
))->unique()->count();
```
This can be very confusing when working with collections produced by `MorphTo` relations.

If the behavior itself needs to be modified instead, I'd be happy to create a PR as well but as that would create breaking changes for existing code, updating the documentation would be a good first step.