### PR TITLE
Should bug fixes be targed to 10.x?

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -81,7 +81,7 @@ Informal discussion regarding bugs, new features, and implementation of existing
 <a name="which-branch"></a>
 ## Which Branch?
 
-**All** bug fixes should be sent to the latest version that supports bug fixes (currently `11.x`). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
+**All** bug fixes should be sent to the latest version that supports bug fixes (currently `10.x`). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
 
 **Minor** features that are **fully backward compatible** with the current release may be sent to the latest stable branch (currently `11.x`).
 


### PR DESCRIPTION
The support policy says that 10.x has bug fixes until August 6th, 2024: https://github.com/laravel/docs/blob/661689450c2cea25c4634da0dcbd3be9e990744d/releases.md?plain=1#L30