### PR TITLE
[11.x] add api middleware group for private broadcast channels

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -339,7 +339,7 @@ If your SPA needs to authenticate with [private / presence broadcast channels](/
         )
         ->withBroadcasting(
             __DIR__.'/../routes/channels.php',
-            ['prefix' => 'api', 'middleware' => ['auth:sanctum']],
+            ['prefix' => 'api', 'middleware' => ['auth:sanctum', 'api']],
         )
 
 Next, in order for Pusher's authorization requests to succeed, you will need to provide a custom Pusher `authorizer` when initializing [Laravel Echo](/docs/{{version}}/broadcasting#client-side-installation). This allows your application to configure Pusher to use the `axios` instance that is [properly configured for cross-domain requests](#cors-and-cookies):

--- a/sanctum.md
+++ b/sanctum.md
@@ -339,7 +339,7 @@ If your SPA needs to authenticate with [private / presence broadcast channels](/
         )
         ->withBroadcasting(
             __DIR__.'/../routes/channels.php',
-            ['prefix' => 'api', 'middleware' => ['auth:sanctum', 'api']],
+            ['prefix' => 'api', 'middleware' => ['api', 'auth:sanctum']],
         )
 
 Next, in order for Pusher's authorization requests to succeed, you will need to provide a custom Pusher `authorizer` when initializing [Laravel Echo](/docs/{{version}}/broadcasting#client-side-installation). This allows your application to configure Pusher to use the `axios` instance that is [properly configured for cross-domain requests](#cors-and-cookies):


### PR DESCRIPTION
I tried both Reverb and Pusher using Sanctum, both service are not able to authenticate if putting the `channels` in `auth:sanctum` group only. However, adding `api` or `web` will work. 

I think it's because the `withBroadcasting` method does not include `api` middleware group since `11.x`. 