### PR TITLE
Document `assertPathEndsWith()` and `assertPathContains()`

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1184,6 +1184,8 @@ Dusk provides a variety of assertions that you may make against your application
 [assertPortIs](#assert-port-is)
 [assertPortIsNot](#assert-port-is-not)
 [assertPathBeginsWith](#assert-path-begins-with)
+[assertPathEndsWith](#assert-path-ends-with)
+[assertPathContains](#assert-path-contains)
 [assertPathIs](#assert-path-is)
 [assertPathIsNot](#assert-path-is-not)
 [assertRouteIs](#assert-route-is)
@@ -1321,6 +1323,20 @@ Assert that the current URL port does not match the given port:
 Assert that the current URL path begins with the given path:
 
     $browser->assertPathBeginsWith('/home');
+
+<a name="assert-path-ends-with"></a>
+#### assertPathEndsWith
+
+Assert that the current URL path ends with the given path:
+
+    $browser->assertPathEndsWith('/home');
+
+<a name="assert-path-contains"></a>
+#### assertPathContains
+
+Assert that the current URL path contains the given path:
+
+    $browser->assertPathContains('/home');
 
 <a name="assert-path-is"></a>
 #### assertPathIs


### PR DESCRIPTION
Document the following Dusk PR:

- [`assertPathEndsWith()` and `assertPathContains()`](https://github.com/laravel/dusk/pull/1100)