### PR TITLE
[11.x] Fix the class type in notifications.md

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -1492,7 +1492,7 @@ When a notification is sent, the `Illuminate\Notifications\Events\NotificationSe
         /**
          * Handle the given event.
          */
-        public function handle(NotificationSending $event): void
+        public function handle(NotificationSent $event): void
         {
             // ...
         }


### PR DESCRIPTION
Replace the class type with the intended one (see the class import above).