### PR TITLE
Add missing Mailersend step

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -188,6 +188,14 @@ MAIL_FROM_NAME="App Name"
 MAILERSEND_API_KEY=your-api-key
 ```
 
+Add MailerSend as a Laravel Mailer in `config/mail.php` in `mailers` array:
+
+```php
+'mailersend' => [
+    'transport' => 'mailersend',
+],
+```
+
 To learn more about MailerSend, including how to use hosted templates, consult the [MailerSend driver documentation](https://github.com/mailersend/mailersend-laravel-driver#usage).
 
 <a name="failover-configuration"></a>

--- a/mail.md
+++ b/mail.md
@@ -188,7 +188,7 @@ MAIL_FROM_NAME="App Name"
 MAILERSEND_API_KEY=your-api-key
 ```
 
-Add MailerSend as a Laravel Mailer in `config/mail.php` in `mailers` array:
+Finally, add MailerSend to the `mailers` array in your application's `config/mail.php` configuration file:
 
 ```php
 'mailersend' => [


### PR DESCRIPTION
The documentation for Mailersend is currently missing a step in the Laravel documentation.

Currently following the documentation throws `InvalidArgumentException` "Mailer [mailersend] is not defined."

The documentation shouldn't miss a step.