### PR TITLE
[11.x] Write documentation for notification middleware

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -250,7 +250,7 @@ If you would like to specify a specific queue that should be used for each notif
         ];
     }
 
-<a name="notification-middleware"></a>
+<a name="queued-notification-middleware"></a>
 #### Queued Notification Middleware
 
 Queued notifications may define middleware [just like queued jobs](/docs/{{version}}/queues#job-middleware). To get started, define a `middleware` method on your notification class. The `middleware` method will receive `$notifiable` and `$channel` variables, which allow you to customize the returned middleware based on the notification's destination:

--- a/notifications.md
+++ b/notifications.md
@@ -200,7 +200,7 @@ Queued notifications allow middleware to be used in the same way as (Jobs)[/docs
 
 In the following example, we use notification middleware to make sure that rate limits only apply to non-admin users, after which the rate limit of the corresponding channel is applied.
 
-```php
+
     public function middleware($notifiable, $channel)
     {
         if ($notifiable instance of User && $notifiable->isAdmin()) {
@@ -217,8 +217,6 @@ In the following example, we use notification middleware to make sure that rate 
         
         return $middleware;
     }
-```
-
 
 <a name="customizing-the-notification-queue-connection"></a>
 #### Customizing the Notification Queue Connection

--- a/notifications.md
+++ b/notifications.md
@@ -196,7 +196,7 @@ Alternatively, you may define a `withDelay` method on the notification class its
 
 <a name="notification-middleware"></a>
 ### Notification Middleware
-Queued notifications allow middleware to be used in the same way as (Jobs)[/docs/{{version}}/queues#job-middleware] do. Adding middleware to your queued notification reduces boilerplate code and makes it easy to reuse shared logic between notifications. The `middleware` method has access to the `$notifiable` and `$channel` objects, which enables you to customize your middleware based on the type of notification being sent.
+Queued notifications allow middleware to be used in the same way as (Jobs)[/docs/{{version}}/queues#job-middleware] do. Adding middleware to your queued notification reduces boilerplate code and makes it easy to reuse shared logic between notifications. The `middleware` method has access to the `$notifiable` and `$channel` variables, which allows you to customize your middleware based on the type and destination of the notification.
 
 In the following example, we use notification middleware to make sure that rate limits only apply to non-admin users, after which the rate limit of the corresponding channel is applied.
 

--- a/notifications.md
+++ b/notifications.md
@@ -194,6 +194,32 @@ Alternatively, you may define a `withDelay` method on the notification class its
         ];
     }
 
+<a name="notification-middleware"></a>
+### Notification Middleware
+Queued notifications allow middleware to be used in the same way as (Jobs)[/docs/{{version}}/queues#job-middleware] do. Adding middleware to your queued notification reduces boilerplate code and makes it easy to reuse shared logic between notifications. The `middleware` method has access to the `$notifiable` and `$channel` objects, which enables you to customize your middleware based on the type of notification being sent.
+
+In the following example, we use notification middleware to make sure that rate limits only apply to non-admin users, after which the rate limit of the corresponding channel is applied.
+
+```php
+    public function middleware($notifiable, $channel)
+    {
+        if ($notifiable instance of User && $notifiable->isAdmin()) {
+            return [];
+        }
+
+        $middleware = match ($channel) {
+            'email' => [new RateLimited('postmark')],
+            'sms' => [new Ratelimited('twilio')],
+            'slack' => [new Ratelimited('slack')],
+            default => [],
+        }
+        
+        
+        return $middleware;
+    }
+```
+
+
 <a name="customizing-the-notification-queue-connection"></a>
 #### Customizing the Notification Queue Connection
 

--- a/notifications.md
+++ b/notifications.md
@@ -200,7 +200,6 @@ Queued notifications allow middleware to be used in the same way as (Jobs)[/docs
 
 In the following example, we use notification middleware to make sure that rate limits only apply to non-admin users, after which the rate limit of the corresponding channel is applied.
 
-
     public function middleware($notifiable, $channel)
     {
         if ($notifiable instance of User && $notifiable->isAdmin()) {


### PR DESCRIPTION
After submitting a [PR](https://github.com/laravel/framework/pull/51174) to implement support for notification middleware, it turned out that Laravel already [has this functionality](https://github.com/laravel/framework/pull/44767), albeit undocumented.

This PR adds documentation for notification middleware.