### PR TITLE
Update instructions to install the beta release of the pulse package without downgrading application's minimum-stability setting

### DIFF
--- a/pulse.md
+++ b/pulse.md
@@ -35,17 +35,10 @@ For in-depth debugging of individual events, check out [Laravel Telescope](/docs
 > [!WARNING]  
 > Pulse's first-party storage implementation currently requires a MySQL, MariaDB, or PostgreSQL database. If you are using a different database engine, you will need a separate MySQL, MariaDB, or PostgreSQL database for your Pulse data.
 
-Since Pulse is currently in beta, you may need to adjust your application's `composer.json` file to allow beta package releases to be installed:
-
-```json
-"minimum-stability": "beta",
-"prefer-stable": true
-```
-
-Then, you may use the Composer package manager to install Pulse into your Laravel project:
+Since Pulse is currently in beta, you will need to explicitly install the beta release:
 
 ```sh
-composer require laravel/pulse
+composer require laravel/pulse:@beta
 ```
 
 Next, you should publish the Pulse configuration and migration files using the `vendor:publish` Artisan command:


### PR DESCRIPTION
Now it uses the same wording and method as [Laravel Reverb](https://laravel.com/docs/11.x/broadcasting#reverb) to install the beta package.