### PR TITLE
Clarify timeout value unit in `Http::timeout()` method

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -208,7 +208,7 @@ If you would like to quickly add a bearer token to the request's `Authorization`
 <a name="timeout"></a>
 ### Timeout
 
-The `timeout` method may be used to specify the maximum number of seconds to wait for a response. By default, the HTTP client will timeout after 30 seconds:
+The `timeout` method may be used to specify the maximum number of seconds to wait for a response. By default, the HTTP client will timeout after 30 seconds, In the example below, the timeout is set to 3 seconds:
 
     $response = Http::timeout(3)->get(/* ... */);
 


### PR DESCRIPTION
Updated the documentation for the `timeout` method in HTTP client to explicitly state that the timeout value is specified in seconds.