### PR TITLE
[11.x] Add note for `make:provider` command

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -32,7 +32,7 @@ The Artisan CLI can generate a new provider via the `make:provider` command:
 php artisan make:provider RiakServiceProvider
 ```
 
-After generating provider, your provider register automatically in `bootstrap/providers.php`.
+After generating the provider, your provider is registered automatically in `bootstrap/providers.php`.
 
 <a name="the-register-method"></a>
 ### The Register Method

--- a/providers.md
+++ b/providers.md
@@ -26,13 +26,11 @@ All user-defined service providers are registered in the `bootstrap/providers.ph
 
 All service providers extend the `Illuminate\Support\ServiceProvider` class. Most service providers contain a `register` and a `boot` method. Within the `register` method, you should **only bind things into the [service container](/docs/{{version}}/container)**. You should never attempt to register any event listeners, routes, or any other piece of functionality within the `register` method.
 
-The Artisan CLI can generate a new provider via the `make:provider` command:
+The Artisan CLI can generate a new provider via the `make:provider` command. Laravel will automatically register your new provider in your application's `bootstrap/providers.php` file:
 
 ```shell
 php artisan make:provider RiakServiceProvider
 ```
-
-After generating the provider, your provider is registered automatically in `bootstrap/providers.php`.
 
 <a name="the-register-method"></a>
 ### The Register Method

--- a/providers.md
+++ b/providers.md
@@ -32,6 +32,8 @@ The Artisan CLI can generate a new provider via the `make:provider` command:
 php artisan make:provider RiakServiceProvider
 ```
 
+After generating provider, your provider register automatically in `bootstrap/providers.php`.
+
 <a name="the-register-method"></a>
 ### The Register Method
 


### PR DESCRIPTION
When the user uses the `make:provider` command to create a provider, the provider is automatically registered in the `providers.php` file.