### PR TITLE
Update name of env var in cache.md

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -431,7 +431,7 @@ To register the custom cache driver with Laravel, we will use the `extend` metho
 
 The first argument passed to the `extend` method is the name of the driver. This will correspond to your `driver` option in the `config/cache.php` configuration file. The second argument is a closure that should return an `Illuminate\Cache\Repository` instance. The closure will be passed an `$app` instance, which is an instance of the [service container](/docs/{{version}}/container).
 
-Once your extension is registered, update the `CACHE_STORE` environment variable or `default` option within your application's `config/cache.php` configuration file to the name of your extension.
+Once your extension is registered, update the `CACHE_DRIVER` environment variable or `default` option within your application's `config/cache.php` configuration file to the name of your extension.
 
 <a name="events"></a>
 ## Events


### PR DESCRIPTION
It seems like the correct name for the environment variable to change the cache driver is `CACHE_DRIVER` instead of `CACHE_STORE`. This might also apply to some previous versions.