### PR TITLE
[11.x] Update FrankenPHP docs

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -4,6 +4,7 @@
 - [Server Requirements](#server-requirements)
 - [Server Configuration](#server-configuration)
     - [Nginx](#nginx)
+    - [FrankenPHP](#frankenphp)
 - [Optimization](#optimization)
     - [Caching Configuration](#optimizing-configuration-loading)
     - [Caching Events](#caching-events)
@@ -90,11 +91,13 @@ server {
 <a name="frankenphp"></a>
 ### FrankenPHP
 
-Serving your Laravel applications using FrankenPHP is as easy as running `frankenphp php-server -r public/`.
+[FrankenPHP](https://frankenphp.dev/) may also be used to serve your Laravel applications. FrankenPHP is a modern PHP application server written in Go. To serve a Laravel PHP application using FrankenPHP, you may simply invoke its `php-server` command:
 
-To take advantage of the more powerful features supported by FrankenPHP, such as [Octane](octane.md) integration,
-HTTP/3, modern compression or the ability to package Laravel applications as standalone binaries,
-[see the FrankenPHP documentation entry dedicated to Laravel](https://frankenphp.dev/docs/laravel/).
+```shell
+frankenphp php-server -r public/
+```
+
+To take advantage of more powerful features supported by FrankenPHP, such as its [Laravel Octane](/docs/{{version}}/octane) integration, HTTP/3, modern compression, or the ability to package Laravel applications as standalone binaries, please consult FrankenPHP's [Laravel documentation](https://frankenphp.dev/docs/laravel/).
 
 <a name="optimization"></a>
 ## Optimization

--- a/deployment.md
+++ b/deployment.md
@@ -87,6 +87,15 @@ server {
 }
 ```
 
+<a name="frankenphp"></a>
+### FrankenPHP
+
+Serving your Laravel applications using FrankenPHP is as easy as running `frankenphp php-server -r public/`.
+
+To take advantage of the more powerful features supported by FrankenPHP, such as [Octane](octane.md) integration,
+HTTP/3, modern compression or the ability to package Laravel applications as standalone binaries,
+[see the FrankenPHP documentation entry dedicated to Laravel](https://frankenphp.dev/docs/laravel/).
+
 <a name="optimization"></a>
 ## Optimization
 

--- a/octane.md
+++ b/octane.md
@@ -56,7 +56,7 @@ php artisan octane:install
 > [!WARNING]  
 > FrankenPHP's Octane integration is in beta and should be used with caution in production.
 
-[FrankenPHP](https://frankenphp.dev) is a PHP application server, written in Go, that supports modern web features like early hints, Brotli and Zstandard compression. When you install Octane and choose FrankenPHP as your server, Octane will automatically download and install the FrankenPHP binary for you.
+[FrankenPHP](https://frankenphp.dev) is a PHP application server, written in Go, that supports modern web features like early hints, Brotli, and Zstandard compression. When you install Octane and choose FrankenPHP as your server, Octane will automatically download and install the FrankenPHP binary for you.
 
 <a name="frankenphp-via-laravel-sail"></a>
 #### FrankenPHP via Laravel Sail

--- a/octane.md
+++ b/octane.md
@@ -56,7 +56,7 @@ php artisan octane:install
 > [!WARNING]  
 > FrankenPHP's Octane integration is in beta and should be used with caution in production.
 
-[FrankenPHP](https://frankenphp.dev) is a PHP application server, written in Go, that supports modern web features like early hints and Zstandard compression. When you install Octane and choose FrankenPHP as your server, Octane will automatically download and install the FrankenPHP binary for you.
+[FrankenPHP](https://frankenphp.dev) is a PHP application server, written in Go, that supports modern web features like early hints, Brotli and Zstandard compression. When you install Octane and choose FrankenPHP as your server, Octane will automatically download and install the FrankenPHP binary for you.
 
 <a name="frankenphp-via-laravel-sail"></a>
 #### FrankenPHP via Laravel Sail


### PR DESCRIPTION
Some tiny tweaks and a link to our updated documentation entry explaining how to package standard Laravel apps and Octane apps as standalone binaries.