### PR TITLE
Fixing method name and example code under Price Preview section

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -579,7 +579,7 @@ The currency will be determined based on the IP address of the request; however,
 
     use Laravel\Paddle\Cashier;
 
-    $prices = Cashier::productPrices(['pri_123', 'pri_456'], ['address' => [
+    $prices = Cashier::previewPrices(['pri_123', 'pri_456'], ['address' => [
         'country_code' => 'BE',
         'postal_code' => '1234',
     ]]);

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -599,7 +599,7 @@ You may also display the subtotal price and tax amount separately:
 ```blade
 <ul>
     @foreach ($prices as $price)
-        <li>{{ $price->product_title }} - {{ $price->subtotal() }} (+ {{ $price->tax() }} tax)</li>
+        <li>{{ $price->product['name'] }} - {{ $price->subtotal() }} (+ {{ $price->tax() }} tax)</li>
     @endforeach
 </ul>
 ```


### PR DESCRIPTION
Fixing the method name from `productPrices` to `previewPrices` and example code in **Price Preview** section.