### PR TITLE
Update horizon.md

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -185,23 +185,7 @@ Alternatively, the job you wish to silence can implement the `Laravel\Horizon\Co
 <a name="upgrading-horizon"></a>
 ## Upgrading Horizon
 
-When upgrading to a new major version of Horizon, it's important that you carefully review [the upgrade guide](https://github.com/laravel/horizon/blob/master/UPGRADE.md). In addition, when upgrading to any new Horizon version, you should re-publish Horizon's assets:
-
-```shell
-php artisan horizon:publish
-```
-
-To keep the assets up-to-date and avoid issues in future updates, you may add the `vendor:publish --tag=laravel-assets` command to the `post-update-cmd` scripts in your application's `composer.json` file:
-
-```json
-{
-    "scripts": {
-        "post-update-cmd": [
-            "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
-        ]
-    }
-}
-```
+When upgrading to a new major version of Horizon, it's important that you carefully review [the upgrade guide](https://github.com/laravel/horizon/blob/master/UPGRADE.md).
 
 <a name="running-horizon"></a>
 ## Running Horizon


### PR DESCRIPTION
In pull request #1438, @timacdonald and @taylorotwell  simplified the asset management process, making the command php artisan horizon:publish unnecessary. Therefore, it should be removed from the documentation.