### PR TITLE
[11.x] Add `whereIn` example with enum class

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -323,6 +323,10 @@ For convenience, some commonly used regular expression patterns have helper meth
     Route::get('/category/{category}', function (string $category) {
         // ...
     })->whereIn('category', ['movie', 'song', 'painting']);
+    
+    Route::get('/category/{category}', function (string $category) {
+        // ...
+    })->whereIn('category', CategoryStatusEnum::cases());
 
 If the incoming request does not match the route pattern constraints, a 404 HTTP response will be returned.
 


### PR DESCRIPTION
I wrote `CategoryStatusEnum` so that the developer knows that it is an enum class.