### PR TITLE
[11.x] Hide X-powered-by in nginx config for deployment

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -80,6 +80,7 @@ server {
         fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
+        fastcgi_hide_header X-Powered-By;
     }
 
     location ~ /\.(?!well-known).* {


### PR DESCRIPTION
It is recommended in the OWASP guide to hide the `X-Powered-by` header in the web server config. 
https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-powered-by

That's why I've updated the nginx config given in the `Deployment` section to add a directive for this. 