### PR TITLE
[11.x] Adds documentation for Command::fail method

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -158,35 +158,18 @@ Let's take a look at an example command. Note that we are able to request any de
 > [!NOTE]  
 > For greater code reuse, it is good practice to keep your console commands light and let them defer to application services to accomplish their tasks. In the example above, note that we inject a service class to do the "heavy lifting" of sending the e-mails.
 
-<a name="force-fail"></a>
-#### Forcing Non-Zero Exit Codes
+<a name="exit-codes"></a>
+#### Exit Codes
 
-The `handle` method may optionally return an integer. This integer is used to indicate whether a command exited successfully (exit code: 0) or if it encountered an error (exit code 1..255) during execution. Some of these codes can be retrieved as constants on the command's class.
+If nothing is returned from the `handle` method and the command executes successfully, the command will exit with a `0` exit code, indicating success. However, the `handle` method may optionally return an integer to manually specify command's exit code:
 
-    $this->error('Something bad happened.');
-    return static::FAILED; // int(1)
+    $this->error('Something went wrong.');
 
-When splitting up a command's handler into smaller functions, you might run into situations where you'd prefer to have the command error out __before__ returning to the handler. In these cases you can use the `fail` convenience method.
+    return 1;
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(): void
-    {
-        $document = new Document;
-        $document->validate();
-        $this->deliverPdf($document);
-        $this->notifyOwner($document);
-    }
+If you would like to "fail" the command from another method within the command, you may utilize the `fail` method. The `fail` method will immediately terminate execution of the command and return an exit code of `1`:
 
-    protected function deliverPdf(Document $document): void
-    {
-        try {
-            $document->send($document->client);
-        } catch (Exception $e) {
-            $this->fail('Document failed to send.');
-        }
-    }
+    $this->fail('Something went wrong.');
 
 <a name="closure-commands"></a>
 ### Closure Commands

--- a/artisan.md
+++ b/artisan.md
@@ -158,6 +158,36 @@ Let's take a look at an example command. Note that we are able to request any de
 > [!NOTE]  
 > For greater code reuse, it is good practice to keep your console commands light and let them defer to application services to accomplish their tasks. In the example above, note that we inject a service class to do the "heavy lifting" of sending the e-mails.
 
+<a name="force-fail"></a>
+#### Forcing Non-Zero Exit Codes
+
+The `handle` method may optionally return an integer. This integer is used to indicate whether a command exited successfully (exit code: 0) or if it encountered an error (exit code 1..255) during execution. Some of these codes can be retrieved as constants on the command's class.
+
+    $this->error('Something bad happened.');
+    return static::FAILED; // int(1)
+
+When splitting up a command's handler into smaller functions, you might run into situations where you'd prefer to have the command error out __before__ returning to the handler. In these cases you can use the `fail` convenience method.
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $document = new Document;
+        $document->validate();
+        $this->deliverPdf($document);
+        $this->notifyOwner($document);
+    }
+
+    protected function deliverPdf(Document $document): void
+    {
+        try {
+            $document->send($document->client);
+        } catch (Exception $e) {
+            $this->fail('Document failed to send.');
+        }
+    }
+
 <a name="closure-commands"></a>
 ### Closure Commands
 


### PR DESCRIPTION
This adds a simple writeup and example for the new `Command::fail` method in [#51435](https://github.com/laravel/framework/pull/51435) to the `artisan` docs page.