### PR TITLE
[10.x] Added missing middleware in middlewarePriority array

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -238,6 +238,7 @@ Rarely, you may need your middleware to execute in a specific order but not have
     protected $middlewarePriority = [
         \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
         \Illuminate\Cookie\Middleware\EncryptCookies::class,
+        \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,


### PR DESCRIPTION
In Laravel 10 this middleware was added in the middlewarePriority property but it was not reported in the documentation https://github.com/laravel/framework/pull/46130