### PR TITLE
Make Carbon update impact Likelihood High

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -412,7 +412,7 @@ public function scalar($query, $bindings = [], $useReadPdo = true);
 <a name="carbon-3"></a>
 #### Carbon 3
 
-**Likelihood Of Impact: Medium**
+**Likelihood Of Impact: High**
 
 Laravel 11 supports both Carbon 2 and Carbon 3. Carbon is a date manipulation library utilized extensively by Laravel and packages throughout the ecosystem. If you upgrade to Carbon 3, be aware that `diffIn*` methods now return floating-point numbers and may return negative values to indicate time direction, which is a significant change from Carbon 2. Review Carbon's [change log](https://github.com/briannesbitt/Carbon/releases/tag/3.0.0) for detailed information on how to handle these and other changes.
 


### PR DESCRIPTION
In my opinion this is very significant change:

After changes this code broke our appllicaiton:

`return $time->diffInMinutes(now(), true) > 10;`


because `diffIn` methods returns float instead of integer

Hotfix:

`return ((int) $time->diffInMinutes(now(), true)) > 10;`


I was in process of upgrading Laravel from 6 up to 11 and this single change had "Medium" likelihood impact in docs but it was serious for our project and we spent lot of time looking for problem and we had problem with our tests. 

Please consider changing Likelihood to High to increase awareness of this problem. This small change may save lot of time for other developers.

https://github.com/briannesbitt/Carbon/issues/2986
https://laravel.com/docs/11.x/upgrade#carbon-3