### PR TITLE
Fix typo in `shouldQueue` method description

### DIFF
--- a/events.md
+++ b/events.md
@@ -328,7 +328,7 @@ If you would like to define the listener's queue connection, queue name, or dela
 <a name="conditionally-queueing-listeners"></a>
 #### Conditionally Queueing Listeners
 
-Sometimes, you may need to determine whether a listener should be queued based on some data that are only available at runtime. To accomplish this, a `shouldQueue` method may be added to a listener to determine whether the listener should be queued. If the `shouldQueue` method returns `false`, the listener will not be executed:
+Sometimes, you may need to determine whether a listener should be queued based on some data that are only available at runtime. To accomplish this, a `shouldQueue` method may be added to a listener to determine whether the listener should be queued. If the `shouldQueue` method returns `false`, the listener will not be queued:
 
     <?php
 


### PR DESCRIPTION
The description of the `shouldQueue` method in the Events documentation seems to have a typo. The last sentence states that if `shouldQueue` returns false, the listener will not be "executed", when I think it should say "queued". This commit replaces "executed" with "queued" in the last sentence.