### PR TITLE
Update matchAll to include first only matching group

### DIFF
--- a/strings.md
+++ b/strings.md
@@ -2031,7 +2031,7 @@ The `matchAll` method will return a collection containing the portions of a stri
 
     // collect(['bar', 'bar'])
 
-If you specify a matching group within the expression, Laravel will return a collection of only the first group's matches:
+If you specify a matching group within the expression, Laravel will return a collection of the first matching group's matches:
 
     use Illuminate\Support\Str;
 

--- a/strings.md
+++ b/strings.md
@@ -2031,7 +2031,7 @@ The `matchAll` method will return a collection containing the portions of a stri
 
     // collect(['bar', 'bar'])
 
-If you specify a matching group within the expression, Laravel will return a collection of that group's matches:
+If you specify a matching group within the expression, Laravel will return a collection of only the first group's matches:
 
     use Illuminate\Support\Str;
 


### PR DESCRIPTION
Currently the `->matchAll` returns only the matches for the first group. Added documentation to prevent people debugging their code for ages.