### PR TITLE
Change Carbon/Dates Likelihood Of Impact to High

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -412,7 +412,7 @@ public function scalar($query, $bindings = [], $useReadPdo = true);
 <a name="carbon-3"></a>
 #### Carbon 3
 
-**Likelihood Of Impact: Medium**
+**Likelihood Of Impact: High**
 
 Laravel 11 supports both Carbon 2 and Carbon 3. Carbon is a date manipulation library utilized extensively by Laravel and packages throughout the ecosystem. If you upgrade to Carbon 3, be aware that `diffIn*` methods now return floating-point numbers and may return negative values to indicate time direction, which is a significant change from Carbon 2. Review Carbon's [change log](https://github.com/briannesbitt/Carbon/releases/tag/3.0.0) for detailed information on how to handle these and other changes.
 


### PR DESCRIPTION
Hi. I'm reopening [pull request #9678](https://github.com/laravel/docs/pull/9678) due to significance of this, please reconsider this:

In my opinion this is very significant change:

After changes this code broke our appllicaiton:

`return $time->diffInMinutes(now(), true) > 10;`

because `diffIn` methods returns float instead of integer

Hotfix:

`return ((int) $time->diffInMinutes(now(), true)) > 10;`

I was in process of upgrading Laravel from 6 up to 11 and this single change had "Medium" likelihood impact in docs but it was serious for our project and we spent lot of time looking for problem and we had problem with our tests. 

Please consider changing Likelihood to High to increase awareness of this problem. This small change may save lot of time for other developers.

https://github.com/briannesbitt/Carbon/issues/2986
https://laravel.com/docs/11.x/upgrade#carbon-3

@taylorotwell Laravel codebase is in fact affected by this:

This code makes no sense:

https://github.com/illuminate/cache/blob/master/Repository.php#L554

Duration is always > 0

Please reconsider changing it to high. It may affect many people. Changing single word in docs can save lot of time for hundreds of teams as it would save our time. I readed Laravel Upgrade 11 notes carefuly but due to high time pressure in our projects I had to rush things and I didn't put enough weight to parts of documentation with Likelikehood impact scored "Medium". Such simple change of  wording "Medium" to  "High" could put developers on alert at least. It can save some frustration. And time.

![getSeconds](https://github.com/laravel/docs/assets/33749856/c5957a51-b587-43e6-96ee-b2dd28d34803)

The more i think about it gets worse. Dates function are crucial to applications. it's very difficult to detect such problems because we are dealing with time. They may surface up after long time.

Security, caching, sessions and more.

I had bad experience with floating-point problems but this seems far much worse.

Carbon 2: `diffInSeconds() returns 0`

Carbon 3: `diffInSeconds() returns 0.00001`

So if `$duration = now()->diffInSeconds($someTimestamps)`

So every statement in every application with `$duration > 0` will break.

Example above (from Laravel codebase) it might be trivial but might cause huge loss of time for many users. Impact might be huge and cause lot of stress to many dev teams