### PR TITLE
11.x - Add Controller Middleware section to upgrading

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -208,7 +208,7 @@ public function dump(...$args);
 
 **Likelihood Of Impact: Medium**
 
-The `middleware` method which used to be called from your Controller's constructor has removed. If you are applying middelware within your controller you should update to use the new style for [controller middleware](/docs/{{version}}/controllers#controller-middleware):
+The `middleware` method which used to be called from your Controller's constructor has removed. If you are applying middleware within your controller you should remove `$this->middleware` from your constructor and migrate to use the new style for [controller middleware](/docs/{{version}}/controllers#controller-middleware):
 
 ```php
 <?php

--- a/upgrade.md
+++ b/upgrade.md
@@ -199,6 +199,43 @@ The `dump` method of the `Illuminate\Support\Enumerable` contract has been updat
 public function dump(...$args);
 ```
 
+<a name="controllers"></a>
+### Controllers
+
+<a name="controller-middleware"></a>
+#### Controller Middleware
+
+**Likelihood Of Impact: Medium**
+
+The `middleware` method which used to be called from your Controller's constructor has removed. If you are applying middelware within your controller you should update to use the new style for [controller middleware](/docs/{{version}}/controllers#controller-middleware):
+
+```php
+<?php
+ 
+namespace App\Http\Controllers;
+ 
+use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controllers\HasMiddleware;
+use Illuminate\Routing\Controllers\Middleware;
+ 
+class UserController extends Controller implements HasMiddleware
+{
+    /**
+     * Get the middleware that should be assigned to the controller.
+     */
+    public static function middleware(): array
+    {
+        return [
+            'auth',
+            new Middleware('log', only: ['index']),
+            new Middleware('subscribed', except: ['store']),
+        ];
+    }
+ 
+    // ...
+}
+```
+
 <a name="database"></a>
 ### Database
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -24,6 +24,7 @@
 - [Carbon 3](#carbon-3)
 - [Password Rehashing](#password-rehashing)
 - [Per-Second Rate Limiting](#per-second-rate-limiting)
+- [Controller Middleware](#controller-middleware)
 
 </div>
 


### PR DESCRIPTION
In Laravel 10.x the logic was `$this->middleware` for controllers, but this is causes a "Call to undefined method" exception in Laravel 11.x.

Added a section to upgrading docs to highlight this change with code example for new style and link to docs.