### PR TITLE
Update PHP Version Range and Correct Release Date for Laravel 10 

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -31,7 +31,7 @@ For all Laravel releases, bug fixes are provided for 18 months and security fixe
 | 7 | 7.2 - 8.0 | March 3rd, 2020 | October 6th, 2020 | March 3rd, 2021 |
 | 8 | 7.3 - 8.1 | September 8th, 2020 | July 26th, 2022 | January 24th, 2023 |
 | 9 | 8.0 - 8.1 | February 8th, 2022 | August 8th, 2023 | February 6th, 2024 |
-| 10 | 8.1 | February 7th, 2023 | August 6th, 2024 | February 4th, 2025 |
+| 10 | 8.1 - 8.3 | February 14th, 2023 | August 6th, 2024 | February 4th, 2025 |
 
 <div class="version-colors">
     <div class="end-of-life">


### PR DESCRIPTION
## Update PHP Version Range and Correct Release Date for Laravel 10

This pull request updates the PHP version compatibility and corrects the release date for Laravel 10 in the documentation.

### Changes Made:

- **PHP Version Compatibility:**
  - Updated from `8.1` to `8.1 - 8.3`
  
- **Release Date:**
  - Corrected from `February 7th, 2023` to `February 14th, 2023`

### Rationale:

The PHP version range has been expanded to include versions `8.2` and `8.3` for better accuracy and up-to-date information. Additionally, the release date for Laravel v10 was corrected to ensure the documentation reflects the accurate historical release information.

Thank you for reviewing these updates!
