### PR TITLE
[11.x] Add example for `updateOrInsert` method in queries

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -1026,25 +1026,19 @@ The `updateOrInsert` method will attempt to locate a matching database record us
             ['votes' => '2']
         );
 
-Also, you allow to pass closure to check is record exists or not and return the correct value:
+You may provide a closure to the `updateOrInsert` method to customize the attributes that are updated or inserted into the database based on the existence of a matching record:
 
 ```php
 DB::table('users')->updateOrInsert(
-  ['user_id' => $user_id],
-  function ($exists) use ($data) {
-    if ($exists) {
-      return [
+    ['user_id' => $user_id],
+    fn ($exists) => $exists ? [
         'name' => $data['name'],
         'email' => $data['email'],
-      ];
-    }
-
-    return [
-      'name' => $data['name'],
-      'email' => $data['email'],
-      'optional_column' => $data['optional_column'],
-    ];
-  }
+    ] : [
+        'name' => $data['name'],
+        'email' => $data['email'],
+        'marketable' => true,
+    ],
 );
 ```
 

--- a/queries.md
+++ b/queries.md
@@ -1029,7 +1029,23 @@ The `updateOrInsert` method will attempt to locate a matching database record us
 Also, you allow to pass closure to check is record exists or not and return the correct value:
 
 ```php
+DB::table('users')->updateOrInsert(
+  ['user_id' => $user_id],
+  function ($exists) use ($data) {
+    if ($exists) {
+      return [
+        'name' => $data['name'],
+        'email' => $data['email'],
+      ];
+    }
 
+    return [
+      'name' => $data['name'],
+      'email' => $data['email'],
+      'optional_column' => $data['optional_column'],
+    ];
+  }
+);
 ```
 
 <a name="updating-json-columns"></a>

--- a/queries.md
+++ b/queries.md
@@ -1026,6 +1026,12 @@ The `updateOrInsert` method will attempt to locate a matching database record us
             ['votes' => '2']
         );
 
+Also, you allow to pass closure to check is record exists or not and return the correct value:
+
+```php
+
+```
+
 <a name="updating-json-columns"></a>
 ### Updating JSON Columns
 


### PR DESCRIPTION
In the new version of Laravel, we can pass Closure to the `updateOrInsert` method.