### PR TITLE
Remove unnecessary import statements

### DIFF
--- a/container.md
+++ b/container.md
@@ -29,9 +29,7 @@ Let's look at a simple example:
 
     namespace App\Http\Controllers;
 
-    use App\Http\Controllers\Controller;
     use App\Repositories\UserRepository;
-    use App\Models\User;
     use Illuminate\View\View;
 
     class UserController extends Controller


### PR DESCRIPTION
I removed two unnecessary imports from the `UserController` class example.

1. `App\Http\Controllers\Controller`: This import is redundant because the `UserController` class is in the same namespace.
2. `App\Models\User`: This import is unused in the current example.

