### PR TITLE
table() expects an array, collection given

### DIFF
--- a/prompts.md
+++ b/prompts.md
@@ -805,7 +805,7 @@ use function Laravel\Prompts\table;
 
 table(
     ['Name', 'Email'],
-    User::all(['name', 'email'])
+    User::all(['name', 'email'])->toArray()
 );
 ```
 


### PR DESCRIPTION
Following the current docs about the `table()` helper results in a TypeError. Array is expected, Collection given.

![CleanShot 2024-06-10 at 08 32 01](https://github.com/laravel/docs/assets/1841317/5de61810-68f4-46a5-aaaf-1a84cfc4ac30)
