### PR TITLE
Fix call to Model::increment()

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -313,7 +313,7 @@ If you need to customize the names of the columns used to store the timestamps, 
 
 If you would like to perform model operations without the model having its `updated_at` timestamp modified, you may operate on the model within a closure given to the `withoutTimestamps` method:
 
-    Model::withoutTimestamps(fn () => $post->increment(['reads']));
+    Model::withoutTimestamps(fn () => $post->increment('reads'));
 
 <a name="database-connections"></a>
 ### Database Connections


### PR DESCRIPTION
Fixes a code example where `\Illuminate\Database\Eloquent\Model::increment` is called with an array as its first argument. [The function expects a string](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Eloquent/Model.php#L926).