### PR TITLE
Clarify exclusions for fallback HTTP error pages

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -410,6 +410,6 @@ php artisan vendor:publish --tag=laravel-errors
 <a name="fallback-http-error-pages"></a>
 #### Fallback HTTP Error Pages
 
-You may also define a "fallback" error page for a given series of HTTP status codes. This page will be rendered if there is not a corresponding page for the specific HTTP status code that occurred. To accomplish this, define a `4xx.blade.php` template and a `5xx.blade.php` template in your application's `resources/views/errors` directory.
+You may also define a "fallback" error page for a given series of HTTP status codes. This page will be rendered if there is not a corresponding page for the specific HTTP status code that occurred. To accomplish this, define a `4xx.blade.php` template and a `5xx.blade.php` template in your application's `resources/views/errors` directory. 
 
-You must always create custom pages for `404`, `500` and `503` though, because Laravel has dedicated pages for these status codes that override the fallback pages.
+When defining fallback error pages, the fallback pages will not affect `404`, `500`, and `503` error responses since Laravel has internal, dedicated pages for these status codes. To customize the pages rendered for these status codes, you should define a custom error page for each of them individually.

--- a/errors.md
+++ b/errors.md
@@ -411,3 +411,5 @@ php artisan vendor:publish --tag=laravel-errors
 #### Fallback HTTP Error Pages
 
 You may also define a "fallback" error page for a given series of HTTP status codes. This page will be rendered if there is not a corresponding page for the specific HTTP status code that occurred. To accomplish this, define a `4xx.blade.php` template and a `5xx.blade.php` template in your application's `resources/views/errors` directory.
+
+You must always create custom pages for `404`, `500` and `503` though, because Laravel has dedicated pages for these status codes that override the fallback pages.


### PR DESCRIPTION
Since the documentation has caused confusion in a few places:

- https://github.com/laravel/framework/issues/46865
- https://github.com/laravel/framework/pull/46877