### PR TITLE
Fix return value of `bearerToken` method

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -176,7 +176,7 @@ The `hasHeader` method may be used to determine if the request contains a given 
         // ...
     }
 
-For convenience, the `bearerToken` method may be used to retrieve a bearer token from the `Authorization` header. If no such header is present, an empty string will be returned:
+For convenience, the `bearerToken` method may be used to retrieve a bearer token from the `Authorization` header. If no such header is present, `null` will be returned:
 
     $token = $request->bearerToken();
 


### PR DESCRIPTION
I believe the `bearerToken()` method returns `null` instead of `an empty string` when the Authorization header is not present.

---

The implementation of the `bearerToken()` method is as follows:

https://github.com/laravel/framework/blob/6d136614966e6eb3dd853cdd5e0390a265d9c6e4/src/Illuminate/Http/Concerns/InteractsWithInput.php#L57-L68
```
    /**
     * Get the bearer token from the request headers.
     *
     * @return string|null
     */
    public function bearerToken()
    {
        $header = $this->header('Authorization', '');

        $position = strrpos($header, 'Bearer ');

        if ($position !== false) {
            $header = substr($header, $position + 7);

            return str_contains($header, ',') ? strstr($header, ',', true) : $header;
        }
    }
```