### PR TITLE
Need call('post') instead of post() when using UploadedFile::fake()

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -751,7 +751,7 @@ test('avatars can be uploaded', function () {
 
     $file = UploadedFile::fake()->image('avatar.jpg');
 
-    $response = $this->post('/avatar', [
+    $response = $this->call('post', '/avatar', files: [
         'avatar' => $file,
     ]);
 


### PR DESCRIPTION
`$this->post('/avatar', ['avatar' => $file])` does not populate the request's `$files` argument ([see the empty $files array here](https://github.com/laravel/framework/blob/6c0561caeb8265b7d17cabeea0ec7d4c5cca28aa/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php#L368)).

(therefore in the controller `$request->input('avatar')` returns the image, but `$request->file('avatar')` returns null)

To ensure `$request->file('avatar')` returns the image, we need to use `$this->call('post', '/avatar', files: ['avatar' => $file])` ([see here](https://github.com/laravel/framework/blob/6c0561caeb8265b7d17cabeea0ec7d4c5cca28aa/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php#L567)).

Alternatively for older PHP versions: `$this->call('post', '/avatar', [], [], ['avatar' => $file])`.