### PR TITLE
Restore note about storage and bootstrap/cache folder permissions

### DIFF
--- a/structure.md
+++ b/structure.md
@@ -90,6 +90,9 @@ The `storage` directory contains your logs, compiled Blade templates, file based
 
 The `storage/app/public` directory may be used to store user-generated files, such as profile avatars, that should be publicly accessible. You should create a symbolic link at `public/storage` which points to this directory. You may create the link using the `php artisan storage:link` Artisan command.
 
+> [!WARNING]  
+> The web server process owner must be able to write inside of `bootstrap/cache` and `storage` in order for the framework to edit and create files in these folders. Please confirm the user your web server operates as (often `www-data` or `apache` but please check for sure). Avoid setting the permissions of these folders to `777` which allows write access to any user.
+
 <a name="the-tests-directory"></a>
 #### The Tests Directory
 


### PR DESCRIPTION
# Problem

The web server process owner must be able to write inside of the `storage` and `bootstrap/cache` folders in order for the framework to create files in those folders. In my experience using Laravel with many teams over the years, I often see environments where these folder permissions are set to `777` which is far less secure.

This is because it is not immediately obvious that these folders need to only be writable by the user acting on behalf of the web server. Unfortunately, it is common for devs/admins to not understand why the framework can't write the log files, for instance, until they open up the `storage` folder for too many people.

There was previously a note about this within this page or another. It was removed for some reason, but the fact that those folders need such access remains.

# Solution

Add a note about how the owner of the web server process must be able to write in `bootstrap/cache` and `storage` in order for the framework to make files there and to avoid opening up those folders too much.

# Notes

I'm not sure the best way to convey this info. The *!WARNING* tag might be appropriate as I have here, but I did not want the text to be too verbose nor sound too pushy. Also it would be great to provide more guidance to the reader about how to confirm the web server process owner, but that may be too much info in the doc. 

With `httpd`, this can be set with the `User` directive and discovered with a command like `apachectl -S`. I'm not sure the equivalent for `nginx` but I think the situation is similar. And then other web servers will have other configurations. If users do a search for "php find web server process owner" they will be on the right track.

I strongly feel this is important info that should be restored in the docs so that old and new users of Laravel will be very clear as to the only folders the framework expects to write to by default, which helps Laravel developers securely setup their deployment.