### PR TITLE
Add crucial note about folder permissions to deployment.md

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -100,6 +100,11 @@ frankenphp php-server -r public/
 
 To take advantage of more powerful features supported by FrankenPHP, such as its [Laravel Octane](/docs/{{version}}/octane) integration, HTTP/3, modern compression, or the ability to package Laravel applications as standalone binaries, please consult FrankenPHP's [Laravel documentation](https://frankenphp.dev/docs/laravel/).
 
+<a name="folder-permissions"></a>
+### Folder Permissions
+
+The framework will need to write to the folders `storage` and `bootstrap/cache`. Please make sure the web server process owner, the user the web server acts on behalf of, can write to these folders.
+
 <a name="optimization"></a>
 ## Optimization
 

--- a/deployment.md
+++ b/deployment.md
@@ -5,7 +5,7 @@
 - [Server Configuration](#server-configuration)
     - [Nginx](#nginx)
     - [FrankenPHP](#frankenphp)
-    - [Folder Permissions](#folder-permissions)
+    - [Directory Permissions](#directory-permissions)
 - [Optimization](#optimization)
     - [Caching Configuration](#optimizing-configuration-loading)
     - [Caching Events](#caching-events)
@@ -101,10 +101,10 @@ frankenphp php-server -r public/
 
 To take advantage of more powerful features supported by FrankenPHP, such as its [Laravel Octane](/docs/{{version}}/octane) integration, HTTP/3, modern compression, or the ability to package Laravel applications as standalone binaries, please consult FrankenPHP's [Laravel documentation](https://frankenphp.dev/docs/laravel/).
 
-<a name="folder-permissions"></a>
-### Folder Permissions
+<a name="directory-permissions"></a>
+### Directory Permissions
 
-The framework will need to write to the folders `storage` and `bootstrap/cache`. Please make sure the web server process owner, the user the web server acts on behalf of, can write to these folders.
+Laravel will need to write to the `bootstrap/cache` and `storage` directories, so you should ensure the web server process owner has permission to write to these directories.
 
 <a name="optimization"></a>
 ## Optimization

--- a/deployment.md
+++ b/deployment.md
@@ -5,6 +5,7 @@
 - [Server Configuration](#server-configuration)
     - [Nginx](#nginx)
     - [FrankenPHP](#frankenphp)
+    - [Folder Permissions](#folder-permissions)
 - [Optimization](#optimization)
     - [Caching Configuration](#optimizing-configuration-loading)
     - [Caching Events](#caching-events)


### PR DESCRIPTION
This PR is related to #9710. @taylorotwell expressed that he was not in disagreement with the veracity of this info, but did not think [structure.md](https://laravel.com/docs/11.x/structure) was a good place for this and was unsure if this was important enough to mention.

Please see #9710 for the **Problem**, **Solution**, and **Notes** sections that explain why these docs should inform devs there are two folders, `storage` and `bootstrap/cache`, that the framework needs to write into.

Also, take a look at [this guide on setting up permissions on a Linux web server](https://serverfault.com/questions/357108/what-permissions-should-my-website-files-folders-have-on-a-linux-webserver) that explains more about secure user and folder permissions in such an environment.

I've been working with this framework for some time. Over and over I see junior and senior devs set these folders to `777`. Enough is enough! 🙂