### PR TITLE
Describe the purpose and function of `queue:work --memory`

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1710,6 +1710,15 @@ The `--max-jobs` option may be used to instruct the worker to process the given 
 php artisan queue:work --max-jobs=1000
 ```
 
+<a name="handling-memory-leaks"></a>
+#### Handling Memory Leaks
+
+The `--memory` option specifies the amount of memory in megabytes that an idle queue worker may use before stopping. This acts as a failsafe if your jobs leak memory and continually drive up memory usage. The default value of 128 may be modified if your application generally uses a lot of memory while idle:
+
+```shell
+php artisan queue:work --memory=256
+```
+
 <a name="processing-all-queued-jobs-then-exiting"></a>
 #### Processing All Queued Jobs and Then Exiting
 


### PR DESCRIPTION
The implementation of `--memory` is actually really clever. I found it to be very useful to prevent potential memory leaks. However, its description does not fully describe what it does.

My first interpretation of its function was that it sets a limit on the amount of memory that individual jobs may use. Thus, I set it to a value that equals [the PHP INI setting `memory_limit`](https://www.php.net/manual/de/ini.core.php#ini.memory-limit). This setting essentially made the option useless, as the worker now kept running until it was right at the cusp of using up all memory. Subsequently, the next job to start processing would fail.

I found that it is probably best to just leave the default, unless your queue worker uses a lot of memory while idle. If this were the case, the queue worker would always stop after processing a single job, causing unnecessary restarts. For most applications, 128MB should be sufficient.

In conclusion, I think it is valuable to describe this option in more detail. Even though most users will not have to modify it, there is potential for misunderstanding is purpose, leading to a misconfiguration that actually makes your queue worker less reliable.

I also updated the description of the option in https://github.com/laravel/framework/pull/51873.