### PR TITLE
Add Note for Laravel Installer when using with Valet

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -72,6 +72,9 @@ composer global require laravel/installer
 laravel new example-app
 ```
 
+> [!NOTE]
+> When you are using [Laravel Valet](https://laravel.com/docs/11.x/valet), [the Laravel installer](https://github.com/laravel/installer) will check the TLD you are using. During this process, it will prompt you to enter your user password. To avoid this, run `valet trust`.
+
 Once the project has been created, start Laravel's local development server using Laravel Artisan's `serve` command:
 
 ```nothing


### PR DESCRIPTION
Related to this issue: https://github.com/laravel/installer/issues/347

Since the Laravel Installer added the TLD check feature in version 5.8.0, it starts asking for the user password every time you run `laravel new myproject`. This confuses some users because the installer suddenly asks for the user password without explaining the reason. Adding this note will address that issue.