### PR TITLE
Add concrete domain name directory to example code

### DIFF
--- a/events.md
+++ b/events.md
@@ -71,7 +71,7 @@ By default, Laravel will automatically find and register your event listeners by
 If you plan to store your listeners in a different directory or within multiple directories, you may instruct Laravel to scan those directories using the `withEvents` method in your application's `bootstrap/app.php` file:
 
     ->withEvents(discover: [
-        __DIR__.'/../app/Domain/Listeners',
+        __DIR__.'/../app/Domain/Orders/Listeners',
     ])
 
 The `event:list` command may be used to list all of the listeners registered within your application:


### PR DESCRIPTION
Added concrete domain name directory  for consistency with **other places.**

### Other Places

1. Subsequent  example on the same page
https://github.com/laravel/docs/blob/33d43e187d466be64edb49b63f135a268fd7fb2c/events.md?plain=1#L93-L94

2. `artisan.md` example 
https://github.com/laravel/docs/blob/33d43e187d466be64edb49b63f135a268fd7fb2c/artisan.md?plain=1#L660-L662
