### PR TITLE
Installation Doc Change: Add Try Laravel section with Project Idx 

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -2,6 +2,7 @@
 
 - [Meet Laravel](#meet-laravel)
     - [Why Laravel?](#why-laravel)
+- [Try Laravel](#try-laravel)
 - [Creating a Laravel Project](#creating-a-laravel-project)
 - [Initial Configuration](#initial-configuration)
     - [Environment Based Configuration](#environment-based-configuration)
@@ -52,6 +53,11 @@ Need extreme scaling? Platforms like [Laravel Vapor](https://vapor.laravel.com) 
 #### A Community Framework
 
 Laravel combines the best packages in the PHP ecosystem to offer the most robust and developer friendly framework available. In addition, thousands of talented developers from around the world have [contributed to the framework](https://github.com/laravel/framework). Who knows, maybe you'll even become a Laravel contributor.
+
+<a name="try-laravel"></a>
+## Try Laravel
+
+Sign up for [Googles Project IDX](https://idx.google.com/) and start a new workspace using the Laravel starting template. 
 
 <a name="creating-a-laravel-project"></a>
 ## Creating a Laravel Project


### PR DESCRIPTION
## Why the changes
[Project IDX](https://idx.dev/) is an in-browser editor workspace made by google. Using the current laravel template 1 click allows you to run a laravel application on it right in your browser. I think this would be a great addition to the documentation to let someone try out Laravel, or even build an entire application. 

Example image of laravel workspace
![Screenshot from 2024-06-28 16-15-31](https://github.com/laravel/docs/assets/6562688/294bbfd4-9b34-4b32-810d-2722c2052f6f)

## What changed
Added Try Laravel section and link to project idx and instructions on what workspace to select. 