### PR TITLE
[11.x] Adds warning for Reverb URI

### DIFF
--- a/reverb.md
+++ b/reverb.md
@@ -258,7 +258,7 @@ server {
 ```
 
 > [!WARNING]  
-> Reverb listens for WebSocket connections at `/app` and handles API requests at `/apps`. You should ensure the web server handling Reverb requests can serve both of these URIs.
+> Reverb listens for WebSocket connections at `/app` and handles API requests at `/apps`. You should ensure the web server handling Reverb requests can serve both of these URIs. If you are using [Laravel Forge](https://forge.laravel.com) to manage your servers, your Reverb server will be correctly configured by default.
 
 Typically, web servers are configured to limit the number of allowed connections in order to prevent overloading the server. To increase the number of allowed connections on an Nginx web server to 10,000, the `worker_rlimit_nofile` and `worker_connections` values of the `nginx.conf` file should be updated:
 

--- a/reverb.md
+++ b/reverb.md
@@ -258,7 +258,7 @@ server {
 ```
 
 > [!WARNING]  
-> Reverb listens for WebSocket connections at the `/app` URI prefix and handles API requests, such as event broadcasts, at the `/apps` URI prefix. You should ensure the web server handling Reverb requests can accommodate both. 
+> Reverb listens for WebSocket connections at `/app` and handles API requests at `/apps`. You should ensure the web server handling Reverb requests can serve both of these URIs.
 
 Typically, web servers are configured to limit the number of allowed connections in order to prevent overloading the server. To increase the number of allowed connections on an Nginx web server to 10,000, the `worker_rlimit_nofile` and `worker_connections` values of the `nginx.conf` file should be updated:
 

--- a/reverb.md
+++ b/reverb.md
@@ -257,6 +257,9 @@ server {
 }
 ```
 
+> [!WARNING]  
+> Reverb listens for WebSocket connections at the `/app` URI prefix and handles API requests, such as event broadcasts, at the `/apps` URI prefix. You should ensure the web server handling Reverb requests can accommodate both. 
+
 Typically, web servers are configured to limit the number of allowed connections in order to prevent overloading the server. To increase the number of allowed connections on an Nginx web server to 10,000, the `worker_rlimit_nofile` and `worker_connections` values of the `nginx.conf` file should be updated:
 
 ```nginx


### PR DESCRIPTION
The docs recommend using `/` for the Nginx location block which will allow all Reverb routes to be handled.

However, we have seen several issues now where more granularity is required or where a different web server is being used and the server is being configured to respond on URIs prefixed with `/app` or `/apps` only. In this scenario, the Reverb server will be able to respond to only WebSocket connections or API requests (event broadcasing etc), but not both.