### PR TITLE
Fixes grammar for queue/connection customization heading

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -933,7 +933,7 @@ When chaining jobs, you may use the `catch` method to specify a closure that sho
 > Since chain callbacks are serialized and executed at a later time by the Laravel queue, you should not use the `$this` variable within chain callbacks.
 
 <a name="customizing-the-queue-and-connection"></a>
-### Customizing The Queue a Connection
+### Customizing the Queue and Connection
 
 <a name="dispatching-to-a-particular-queue"></a>
 #### Dispatching to a Particular Queue


### PR DESCRIPTION
Fixes a minor grammatical error in the Queue docs.