### PR TITLE
[8.x] add redis compression level documentation

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -190,6 +190,7 @@ The phpredis extension may also be configured to use a variety serialization and
         'options' => [
             'serializer' => Redis::SERIALIZER_MSGPACK,
             'compression' => Redis::COMPRESSION_LZ4,
+            'compression_level' => 3,
         ],
 
         // Rest of Redis configuration...
@@ -198,6 +199,13 @@ The phpredis extension may also be configured to use a variety serialization and
 Currently supported serialization algorithms include: `Redis::SERIALIZER_NONE` (default), `Redis::SERIALIZER_PHP`, `Redis::SERIALIZER_JSON`, `Redis::SERIALIZER_IGBINARY`, and `Redis::SERIALIZER_MSGPACK`.
 
 Supported compression algorithms include: `Redis::COMPRESSION_NONE` (default), `Redis::COMPRESSION_LZF`, `Redis::COMPRESSION_ZSTD`, and `Redis::COMPRESSION_LZ4`.
+
+Compression level differs per algorithm.
+
+| Algorithm | Compression Levels |
+|-----------|--------------------|
+| LZ4 / LZF | 1 to 9             |
+| ZSTD      | -7 to 22           |
 
 <a name="interacting-with-redis"></a>
 ## Interacting With Redis


### PR DESCRIPTION
Since Laravel 8.x, the Redis compression level was able to be set within the [PhpRedis Connector](https://github.com/laravel/framework/commit/0dc2d8a8f3c0b1884cc16f76aa274653e2469eb6#diff-26ee5ddf302319f628deb577955caf1b93e85415b027eaf1b1550fa4594342c0) via the `compression_level` configuraiton value.

This PR adds this hidden functionality to the docs so developers do not have to dig through Laravel's Redis Connection logic to work out how to tweak the Redis Compression Level.

A table has been added to guide developers with common compression level values. However these values are not set in stone and can vary depending on the compression algorithm being used.

## LZ4 Compression Levels

The LZ4 compression library defines level 9 as the best compression

https://github.com/nemequ/liblzf/blob/fb25820c3c0aeafd127956ae6c115063b47e459a/lzf.c#L86

PhpRedis recommends compression levels from 1-9 and defaults to level 3

https://github.com/phpredis/phpredis?tab=readme-ov-file#session-compression

## ZSTD Compression Levels

Wikipedia defines the compression range of ZSTD as ranging from -7 to 22.

https://en.wikipedia.org/wiki/Zstd

# PRs for other Laravel Versions

https://github.com/laravel/docs/pull/9735
https://github.com/laravel/docs/pull/9736
https://github.com/laravel/docs/pull/9737
