### PR TITLE
[10.x] add redis compression level documentation

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -192,6 +192,7 @@ The PhpRedis extension may also be configured to use a variety of serializers an
         'options' => [
             'serializer' => Redis::SERIALIZER_MSGPACK,
             'compression' => Redis::COMPRESSION_LZ4,
+            'compression_level' => 3,
         ],
 
         // Rest of Redis configuration...
@@ -200,6 +201,13 @@ The PhpRedis extension may also be configured to use a variety of serializers an
 Currently supported serializers include: `Redis::SERIALIZER_NONE` (default), `Redis::SERIALIZER_PHP`, `Redis::SERIALIZER_JSON`, `Redis::SERIALIZER_IGBINARY`, and `Redis::SERIALIZER_MSGPACK`.
 
 Supported compression algorithms include: `Redis::COMPRESSION_NONE` (default), `Redis::COMPRESSION_LZF`, `Redis::COMPRESSION_ZSTD`, and `Redis::COMPRESSION_LZ4`.
+
+Compression level differs per algorithm.
+
+| Algorithm | Compression Levels |
+|-----------|--------------------|
+| LZ4 / LZF | 1 to 9             |
+| ZSTD      | -7 to 22           |
 
 <a name="interacting-with-redis"></a>
 ## Interacting With Redis


### PR DESCRIPTION
Compression Level Docs for Laravel 10.x

See: https://github.com/laravel/docs/pull/9734