### PR TITLE
[11.x] Precognition: Replace attribute `for` with `htmlFor` in React example

### DIFF
--- a/precognition.md
+++ b/precognition.md
@@ -247,7 +247,7 @@ export default function Form() {
 
     return (
         <form onSubmit={submit}>
-            <label for="name">Name</label>
+            <label htmlFor="name">Name</label>
             <input
                 id="name"
                 value={form.data.name}
@@ -256,7 +256,7 @@ export default function Form() {
             />
             {form.invalid('name') && <div>{form.errors.name}</div>}
 
-            <label for="email">Email</label>
+            <label htmlFor="email">Email</label>
             <input
                 id="email"
                 value={form.data.email}


### PR DESCRIPTION
The `for` attribute is not allowed in JSX syntax and should be replaced with `htmlFor`