### PR TITLE
[11.x] Document Paddle's bill for non-catalog items feature

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -48,11 +48,11 @@
     - [Crediting Transactions](#crediting-transactions)
 - [Transactions](#transactions)
     - [Past and Upcoming Payments](#past-and-upcoming-payments)
-- [Bill for Non-Catalog Items](#bill-non-catalog-items)
-    - [Bill Single Non-Catalog Item](#non-catalog-single-item)
-    - [Bill Multiple Non-Catalog Items](#non-catalog-multiple-items)
-    - [Subscribe to a Non-Catalog Item](#non-catalog-subscription)
-    - [Change Currency](#non-catalog-currency)
+- [Bill for Non-Catalog Items](#bill-for-non-catalog-items)
+    - [Bill Single Non-Catalog Item](#bill-single-non-catalog-item)
+    - [Bill Multiple Non-Catalog Items](#bill-multiple-non-catalog-items)
+    - [Subscribe to a Non-Catalog Item](#subscribe-to-a-non-catalog-item)
+    - [Change Currency](#change-currency)
 - [Testing](#testing)
 
 <a name="introduction"></a>
@@ -1404,7 +1404,7 @@ Next payment: {{ $nextPayment->amount() }} due on {{ $nextPayment->date()->forma
 ```
 
   
-<a name="bill-non-catalog-items"></a>
+<a name="bill-for-non-catalog-items"></a>
 ## Bill for Non-Catalog Items
 
 Sometimes you need to manage your product catalog outside of Paddle. With this option, you can create transactions for products and prices that are not in your paddle catalog.
@@ -1412,7 +1412,7 @@ Sometimes you need to manage your product catalog outside of Paddle. With this o
 > [!WARNING]  
 > All non-catalog actions will call Paddle's API and create an incomplete transaction on their end, beware of where you place this code as it might affect the performance of your app. 
 
-<a name="non-catalog-single-item"></a>
+<a name="bill-single-non-catalog-item"></a>
 ### Bill Single Non-Catalog Item
 
 You may create a single transaction for a non-catalog item by calling the `charge` method:
@@ -1437,7 +1437,7 @@ Route::get('/buy', function (Request $request) {
     return view('billing', ['checkout' => $checkout]);
 });
 ```
-<a name="non-catalog-multiple-items"></a>
+<a name="bill-multiple-non-catalog-items"></a>
 ### Bill Multiple Non-Catalog Items
 
 If you need to bill multiple items in a single transaction you should use `chargeMany` method, keep in mind that you need to construct each item's object as required by [Paddle](https://developer.paddle.com/api-reference/transactions/create-transaction#request-body)
@@ -1481,7 +1481,7 @@ Route::get('/buy', function (Request $request) {
 });
 ```
 
-<a name="non-catalog-subscription"></a>
+<a name="subscribe-to-a-non-catalog-item"></a>
 ### Subscribe to a Non-Catalog Item
 
 To subscribe a user to a non-catalog item you should call the method `newSubscription`:
@@ -1525,7 +1525,7 @@ Route::get('/buy', function (Request $request) {
 });
 ```
 
-<a name="non-catalog-currency"></a>
+<a name="change-currency"></a>
 ### Change Currency
 
 The default currency for non-catalog transactions is `USD`, you might change it by setting `CASHIER_CURRENCY` within your application's `.env` file:

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -1439,7 +1439,47 @@ Route::get('/buy', function (Request $request) {
 ```
 <a name="non-catalog-multiple-items"></a>
 ### Bill multiple non-catalog items
-WIP
+
+If you need to bill multiple items in a single transaction you should use `chargeMany` method, keep in mind that you need to construct each item's object as required by [Paddle](https://developer.paddle.com/api-reference/transactions/create-transaction#request-body)
+
+```php
+use Illuminate\Http\Request;
+
+Route::get('/buy', function (Request $request) {
+    $checkout = $user->chargeMany([
+        [
+            'price' => [
+                'description' => 'T-shirt',
+                'unit_price' => [
+                    'amount' => '1000',
+                    'currency_code' => config('cashier.currency'),
+                ],
+                'product' => [
+                    'name' => 'T-shirt',
+                    'tax_category' => 'standard',
+                ],
+            ],
+            'quantity' => 1,
+        ],
+        [
+            'price' => [
+                'description' => 'Jeans',
+                'unit_price' => [
+                    'amount' => '3500',
+                    'currency_code' => config('cashier.currency'),
+                ],
+                'product' => [
+                    'name' => 'Jeans',
+                    'tax_category' => 'standard',
+                ],
+            ],
+            'quantity' => 1,
+        ],
+    ]);
+
+    return view('billing', ['checkout' => $checkout]);
+});
+```
 
 <a name="non-catalog-subscription"></a>
 ### Subscribe to a non-catalog item

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -48,6 +48,10 @@
     - [Crediting Transactions](#crediting-transactions)
 - [Transactions](#transactions)
     - [Past and Upcoming Payments](#past-and-upcoming-payments)
+- [Bill for non-catalog items](#bill-non-catalog-items)
+    - [Bill single non-catalog item](#non-catalog-single-item)
+    - [Bill multiple non-catalog items](#non-catalog-multiple-items)
+    - [Subscribe to a non-catalog item](#non-catalog-subscription)
 - [Testing](#testing)
 
 <a name="introduction"></a>
@@ -1397,6 +1401,23 @@ Both of these methods will return an instance of `Laravel\Paddle\Payment`; howev
 ```blade
 Next payment: {{ $nextPayment->amount() }} due on {{ $nextPayment->date()->format('d/m/Y') }}
 ```
+
+<a name="bill-non-catalog-items"></a>
+## Bill for non-catalog items
+
+Sometimes you need to manage your product catalog outside of Paddle. With this option, you can create transactions for products and prices that are not in your paddle catalog.
+
+<a name="non-catalog-single-item"></a>
+### Bill single non-catalog item
+WIP
+
+<a name="non-catalog-multiple-items"></a>
+### Bill multiple non-catalog items
+WIP
+
+<a name="non-catalog-subscription"></a>
+### Subscribe to a non-catalog item
+WIP
 
 <a name="testing"></a>
 ## Testing

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -1531,7 +1531,7 @@ Route::get('/buy', function (Request $request) {
 The default currency for non-catalog transactions is `USD`, you might change it by setting `CASHIER_CURRENCY` within your application's `.env` file:
 
 ```ini
-CASHIER_CURRENCY=true
+CASHIER_CURRENCY=EUR
 ```
 
 You can find a list of supported currencies by Paddle on the following link: https://developer.paddle.com/concepts/sell/supported-currencies

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -52,6 +52,7 @@
     - [Bill single non-catalog item](#non-catalog-single-item)
     - [Bill multiple non-catalog items](#non-catalog-multiple-items)
     - [Subscribe to a non-catalog item](#non-catalog-subscription)
+    - [Change currency](#non-catalog-currency)
 - [Testing](#testing)
 
 <a name="introduction"></a>
@@ -1402,22 +1403,98 @@ Both of these methods will return an instance of `Laravel\Paddle\Payment`; howev
 Next payment: {{ $nextPayment->amount() }} due on {{ $nextPayment->date()->format('d/m/Y') }}
 ```
 
+  
 <a name="bill-non-catalog-items"></a>
 ## Bill for non-catalog items
 
 Sometimes you need to manage your product catalog outside of Paddle. With this option, you can create transactions for products and prices that are not in your paddle catalog.
 
+> [!WARNING]  
+> All non-catalog actions will call Paddle's API and create an incomplete transaction on their end, beware of where you place this code as it might affect the performance of your app. 
+
 <a name="non-catalog-single-item"></a>
 ### Bill single non-catalog item
-WIP
 
+You may create a single transaction for a non-catalog item by calling the `charge` method:
+```php
+use Illuminate\Http\Request;
+
+Route::get('/buy', function (Request $request) {
+    $checkout = $user->charge(1000, 'T-shirt');
+
+    return view('billing', ['checkout' => $checkout]);
+});
+```
+
+If you need to modify the quantity, you can pass a third parameter which will override the defaults and set the desired quantity like so:
+
+```php
+use Illuminate\Http\Request;
+
+Route::get('/buy', function (Request $request) {
+    $checkout = $user->charge(1000, 'T-shirt', ['quantity' => 3]);
+
+    return view('billing', ['checkout' => $checkout]);
+});
+```
 <a name="non-catalog-multiple-items"></a>
 ### Bill multiple non-catalog items
 WIP
 
 <a name="non-catalog-subscription"></a>
 ### Subscribe to a non-catalog item
-WIP
+
+To subscribe a user to a non-catalog item you should call the method `newSubscription`:
+
+```php
+use Illuminate\Http\Request;
+
+Route::get('/buy', function (Request $request) {
+    $checkout = $user->newSubscription(1000, 'Gym subscription')
+        ->checkout();
+
+    return view('billing', ['checkout' => $checkout]);
+});
+```
+
+The subscription default interval is monthly, if you need to set another type of interval you can chain either `yearly`,  `monthly`, `weekly`, `daily`, for example:
+
+```php
+use Illuminate\Http\Request;
+
+Route::get('/buy', function (Request $request) {
+    $checkout = $user->newSubscription(1000, 'Gym subscription')
+        ->yearly()
+        ->checkout();
+
+    return view('billing', ['checkout' => $checkout]);
+});
+```
+
+To set the number of seats you should chain the `quantity` method as follows:
+
+```php
+use Illuminate\Http\Request;
+
+Route::get('/buy', function (Request $request) {
+    $checkout = $user->newSubscription(1000, 'Gym subscription')
+        ->quantity(3)
+        ->checkout();
+
+    return view('billing', ['checkout' => $checkout]);
+});
+```
+
+<a name="non-catalog-currency"></a>
+### Change currency
+
+The default currency for non-catalog transactions is `USD`, you might change it by setting `CASHIER_CURRENCY` within your application's `.env` file:
+
+```ini
+CASHIER_CURRENCY=true
+```
+
+You can find a list of supported currencies by Paddle on the following link: https://developer.paddle.com/concepts/sell/supported-currencies
 
 <a name="testing"></a>
 ## Testing

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -48,11 +48,11 @@
     - [Crediting Transactions](#crediting-transactions)
 - [Transactions](#transactions)
     - [Past and Upcoming Payments](#past-and-upcoming-payments)
-- [Bill for non-catalog items](#bill-non-catalog-items)
-    - [Bill single non-catalog item](#non-catalog-single-item)
-    - [Bill multiple non-catalog items](#non-catalog-multiple-items)
-    - [Subscribe to a non-catalog item](#non-catalog-subscription)
-    - [Change currency](#non-catalog-currency)
+- [Bill for Non-Catalog Items](#bill-non-catalog-items)
+    - [Bill Single Non-Catalog Item](#non-catalog-single-item)
+    - [Bill Multiple Non-Catalog Items](#non-catalog-multiple-items)
+    - [Subscribe to a Non-Catalog Item](#non-catalog-subscription)
+    - [Change Currency](#non-catalog-currency)
 - [Testing](#testing)
 
 <a name="introduction"></a>
@@ -1405,7 +1405,7 @@ Next payment: {{ $nextPayment->amount() }} due on {{ $nextPayment->date()->forma
 
   
 <a name="bill-non-catalog-items"></a>
-## Bill for non-catalog items
+## Bill for Non-Catalog Items
 
 Sometimes you need to manage your product catalog outside of Paddle. With this option, you can create transactions for products and prices that are not in your paddle catalog.
 
@@ -1413,7 +1413,7 @@ Sometimes you need to manage your product catalog outside of Paddle. With this o
 > All non-catalog actions will call Paddle's API and create an incomplete transaction on their end, beware of where you place this code as it might affect the performance of your app. 
 
 <a name="non-catalog-single-item"></a>
-### Bill single non-catalog item
+### Bill Single Non-Catalog Item
 
 You may create a single transaction for a non-catalog item by calling the `charge` method:
 ```php
@@ -1438,7 +1438,7 @@ Route::get('/buy', function (Request $request) {
 });
 ```
 <a name="non-catalog-multiple-items"></a>
-### Bill multiple non-catalog items
+### Bill Multiple Non-Catalog Items
 
 If you need to bill multiple items in a single transaction you should use `chargeMany` method, keep in mind that you need to construct each item's object as required by [Paddle](https://developer.paddle.com/api-reference/transactions/create-transaction#request-body)
 
@@ -1482,7 +1482,7 @@ Route::get('/buy', function (Request $request) {
 ```
 
 <a name="non-catalog-subscription"></a>
-### Subscribe to a non-catalog item
+### Subscribe to a Non-Catalog Item
 
 To subscribe a user to a non-catalog item you should call the method `newSubscription`:
 
@@ -1526,7 +1526,7 @@ Route::get('/buy', function (Request $request) {
 ```
 
 <a name="non-catalog-currency"></a>
-### Change currency
+### Change Currency
 
 The default currency for non-catalog transactions is `USD`, you might change it by setting `CASHIER_CURRENCY` within your application's `.env` file:
 


### PR DESCRIPTION
Documentation for the newly added functionality of non-catalog items on Cashier paddle: https://github.com/laravel/cashier-paddle/pull/263