### PR TITLE
Corrected trivial typo in `assetReleased` to `assertReleased`

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -2411,7 +2411,7 @@ In addition, you may occasionally need to test an individual job's interaction w
 
 Sometimes, you may need to test that a queued job [releases itself back onto the queue](#manually-releasing-a-job). Or, you may need to test that the job deleted itself. You may test these queue interactions by instantiating the job and invoking the `withFakeQueueInteractions` method.
 
-Once the job's queue interactions have been faked, you may invoke the `handle` method on the job. After invoking the job, the `assetReleased`, `assertDeleted`, and `assertFailed` methods may be used to make assertions against the job's queue interactions:
+Once the job's queue interactions have been faked, you may invoke the `handle` method on the job. After invoking the job, the `assertReleased`, `assertDeleted`, and `assertFailed` methods may be used to make assertions against the job's queue interactions:
 
 ```php
 use App\Jobs\ProcessPodcast;


### PR DESCRIPTION
Added missing letter 'r'.