### PR TITLE
[11.x] Fixes incorrect reference to validate and replaces it with verify

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -584,7 +584,7 @@ Then, in your application's `config/sanctum.php` configuration file, you should 
     'middleware' => [
         'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
         'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
-        'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
+        'verify_csrf_token' => Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
     ],
 
 <a name="telescope"></a>


### PR DESCRIPTION
In the upgrade guide, validate should be replaced with verify for the Sanctum upgrade section.