### PR TITLE
[10.x] Remove the beta flag for reverb

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -87,7 +87,7 @@ You will also need to configure and run a [queue worker](/docs/{{version}}/queue
 You may install Reverb using the Composer package manager. Since Reverb is currently in beta, you will need to explicitly install the beta release:
 
 ```sh
-composer require laravel/reverb:@beta
+composer require laravel/reverb
 ```
 
 Once the package is installed, you may run Reverb's installation command to publish the configuration, update your applications's broadcasting configuration, and add Reverb's required environment variables:

--- a/broadcasting.md
+++ b/broadcasting.md
@@ -84,7 +84,7 @@ You will also need to configure and run a [queue worker](/docs/{{version}}/queue
 <a name="reverb"></a>
 ### Reverb
 
-You may install Reverb using the Composer package manager. Since Reverb is currently in beta, you will need to explicitly install the beta release:
+You may install Reverb using the Composer package manager:
 
 ```sh
 composer require laravel/reverb

--- a/reverb.md
+++ b/reverb.md
@@ -32,7 +32,7 @@
 You may use the Composer package manager to install Reverb into your Laravel project. Since Reverb is currently in beta, you will need to explicitly install the beta release:
 
 ```sh
-composer require laravel/reverb:@beta
+composer require laravel/reverb
 ```
 
 Once the package is installed, you may run Reverb's installation command to publish the configuration, add Reverb's required environment variables, and enable event broadcasting in your application:

--- a/reverb.md
+++ b/reverb.md
@@ -29,7 +29,7 @@
 > [!WARNING]  
 > Laravel Reverb requires PHP 8.2+ and Laravel 10.47+.
 
-You may use the Composer package manager to install Reverb into your Laravel project. Since Reverb is currently in beta, you will need to explicitly install the beta release:
+You may use the Composer package manager to install Reverb into your Laravel project:
 
 ```sh
 composer require laravel/reverb


### PR DESCRIPTION
Since Laravel Reverb is no longer in beta, and Laravel 10 still supported, we can remove the info message from the documentation.