### PR TITLE
Fix errors directory in URL Generation

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -187,7 +187,7 @@ The closure passed to the `render` method should return an instance of `Illumina
 
     ->withExceptions(function (Exceptions $exceptions) {
         $exceptions->render(function (InvalidOrderException $e, Request $request) {
-            return response()->view('errors.invalid-order', [], 500);
+            return response()->view('errors.invalid-order', status: 500);
         });
     })
 

--- a/urls.md
+++ b/urls.md
@@ -177,7 +177,7 @@ When someone visits a signed URL that has expired, they will receive a generic e
 
     ->withExceptions(function (Exceptions $exceptions) {
         $exceptions->render(function (InvalidSignatureException $e) {
-            return response()->view('errors.link-expired', [], 403);
+            return response()->view('errors.link-expired', status: 403);
         });
     })
 

--- a/urls.md
+++ b/urls.md
@@ -177,7 +177,7 @@ When someone visits a signed URL that has expired, they will receive a generic e
 
     ->withExceptions(function (Exceptions $exceptions) {
         $exceptions->render(function (InvalidSignatureException $e) {
-            return response()->view('error.link-expired', [], 403);
+            return response()->view('errors.link-expired', [], 403);
         });
     })
 


### PR DESCRIPTION
By default, Laravel use the `errors` directory, but the example specifies the error directory.

In addition, I used named arguments for the best look.