### PR TITLE
Add API Throttling middleware in Routing

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -845,6 +845,19 @@ Rate limiters may be attached to routes or route groups using the `throttle` [mi
         });
     });
 
+<a name="api-throttling"></a>
+#### API Throttling
+
+You can specify manually `throttle:api` middleware or use a method that will do it for you in each `api` route. Add the `throttleApi` method in your application's `bootstrap/app.php` file:
+
+    ->withMiddleware(function (Middleware $middleware) {
+        $middleware->throttleApi();
+        // ...
+    })
+
+> [!WARNING]  
+> Before adding the method, you must specify a [definition](/docs/{{version}}/routing#defining-rate-limiters) `RateLimiter` for the `api` name.
+
 <a name="throttling-with-redis"></a>
 #### Throttling With Redis
 


### PR DESCRIPTION
I'd like to add a Throttling API section to Routing as is done with Redis to make it easier for beginners and not implement their own designs. I found this method myself by looking at how `getMiddlewareGroups()` works in `withMiddleware()` method. I don't know exactly how to describe it, but I made a base for creating this section. Please flesh it out as it should be or create a new PR.