### PR TITLE
[11.x] Extend SQLite support to 3.26+

### DIFF
--- a/database.md
+++ b/database.md
@@ -22,7 +22,7 @@ Almost every modern web application interacts with a database. Laravel makes int
 - MariaDB 10.3+ ([Version Policy](https://mariadb.org/about/#maintenance-policy))
 - MySQL 5.7+ ([Version Policy](https://en.wikipedia.org/wiki/MySQL#Release_history))
 - PostgreSQL 10.0+ ([Version Policy](https://www.postgresql.org/support/versioning/))
-- SQLite 3.35.0+
+- SQLite 3.26.0+
 - SQL Server 2017+ ([Version Policy](https://docs.microsoft.com/en-us/lifecycle/products/?products=sql-server))
 
 </div>

--- a/upgrade.md
+++ b/upgrade.md
@@ -205,11 +205,11 @@ public function dump(...$args);
 ### Database
 
 <a name="sqlite-minimum-version"></a>
-#### SQLite 3.35.0+
+#### SQLite 3.26.0+
 
 **Likelihood Of Impact: High**
 
-If your application is utilizing an SQLite database, SQLite 3.35.0 or greater is required.
+If your application is utilizing an SQLite database, SQLite 3.26.0 or greater is required.
 
 <a name="eloquent-model-casts-method"></a>
 #### Eloquent Model `casts` Method


### PR DESCRIPTION
* laravel/framework#51373

Note: We may also fix this on 10.x docs, should be 3.16.0+ for SQLite, can be 10.3+ for MariaDB and 10.0+ for PostgreSQL.