### PR TITLE
[11.x] Add missing slash to routes

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -106,7 +106,7 @@ php artisan make:controller ProvisionServer --invokable
 
 [Middleware](/docs/{{version}}/middleware) may be assigned to the controller's routes in your route files:
 
-    Route::get('profile', [UserController::class, 'show'])->middleware('auth');
+    Route::get('/profile', [UserController::class, 'show'])->middleware('auth');
 
 Or, you may find it convenient to specify middleware within your controller class. To do so, your controller should implement the `HasMiddleware` interface, which dictates that the controller should have a static `middleware` method. From this method, you may return an array of middleware that should be applied to the controller's actions:
 

--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -61,7 +61,7 @@ Alternatively, you may cast a model or collection to a string, which will automa
 
 Since models and collections are converted to JSON when cast to a string, you can return Eloquent objects directly from your application's routes or controllers. Laravel will automatically serialize your Eloquent models and collections to JSON when they are returned from routes or controllers:
 
-    Route::get('users', function () {
+    Route::get('/users', function () {
         return User::all();
     });
 

--- a/routing.md
+++ b/routing.md
@@ -479,7 +479,7 @@ If a group of routes all utilize the same [controller](/docs/{{version}}/control
 Route groups may also be used to handle subdomain routing. Subdomains may be assigned route parameters just like route URIs, allowing you to capture a portion of the subdomain for usage in your route or controller. The subdomain may be specified by calling the `domain` method before defining the group:
 
     Route::domain('{account}.example.com')->group(function () {
-        Route::get('user/{id}', function (string $account, string $id) {
+        Route::get('/user/{id}', function (string $account, string $id) {
             // ...
         });
     });


### PR DESCRIPTION
All routes in the documentation (except resources) have a slash. These three have been stripped of it for some reason.