### PR TITLE
Add Intl Extension to Deployment

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -34,6 +34,7 @@ The Laravel framework has a few system requirements. You should ensure that your
 - Fileinfo PHP Extension
 - Filter PHP Extension
 - Hash PHP Extension
+- Intl Extension
 - Mbstring PHP Extension
 - OpenSSL PHP Extension
 - PCRE PHP Extension


### PR DESCRIPTION
This extension is required for the [Number](https://laravel.com/docs/11.x/helpers#numbers-method-list) methods and for Laravel Cashier (Stripe/Paddle) packages and it is also used for validation `dns` and `spoof` in [`email` rule](https://laravel.com/docs/11.x/validation#rule-email).