### PR TITLE
Add `/docs/{{version}}/` prefix to URL

### DIFF
--- a/rate-limiting.md
+++ b/rate-limiting.md
@@ -12,7 +12,7 @@
 Laravel includes a simple to use rate limiting abstraction which, in conjunction with your application's [cache](cache), provides an easy way to limit any action during a specified window of time.
 
 > [!NOTE]  
-> If you are interested in rate limiting incoming HTTP requests, please consult the [rate limiter middleware documentation](routing#rate-limiting).
+> If you are interested in rate limiting incoming HTTP requests, please consult the [rate limiter middleware documentation](/docs/{{version}}/routing#rate-limiting).
 
 <a name="cache-configuration"></a>
 ### Cache Configuration


### PR DESCRIPTION
This link lacks a version prefix (but still works).

Fun fact: this typo has been around since 8.x.