### PR TITLE
Redirect slash

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -963,7 +963,7 @@ The `subscribed` method also makes a great candidate for a [route middleware](/d
         {
             if ($request->user() && ! $request->user()->subscribed('default')) {
                 // This user is not a paying customer...
-                return redirect('billing');
+                return redirect('/billing');
             }
 
             return $next($request);

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -755,7 +755,7 @@ The `subscribed` method also makes a great candidate for a [route middleware](/d
         {
             if ($request->user() && ! $request->user()->subscribed()) {
                 // This user is not a paying customer...
-                return redirect('billing');
+                return redirect('/billing');
             }
 
             return $next($request);

--- a/middleware.md
+++ b/middleware.md
@@ -27,7 +27,7 @@ To create a new middleware, use the `make:middleware` Artisan command:
 php artisan make:middleware EnsureTokenIsValid
 ```
 
-This command will place a new `EnsureTokenIsValid` class within your `app/Http/Middleware` directory. In this middleware, we will only allow access to the route if the supplied `token` input matches a specified value. Otherwise, we will redirect the users back to the `home` URI:
+This command will place a new `EnsureTokenIsValid` class within your `app/Http/Middleware` directory. In this middleware, we will only allow access to the route if the supplied `token` input matches a specified value. Otherwise, we will redirect the users back to the `/home` URI:
 
     <?php
 
@@ -47,7 +47,7 @@ This command will place a new `EnsureTokenIsValid` class within your `app/Http/M
         public function handle(Request $request, Closure $next): Response
         {
             if ($request->input('token') !== 'my-secret-token') {
-                return redirect('home');
+                return redirect('/home');
             }
 
             return $next($request);

--- a/pennant.md
+++ b/pennant.md
@@ -524,7 +524,7 @@ You will notice that the closure we have defined is not expecting a `User`, but 
 
 ```php
 if (Feature::for($user->team)->active('billing-v2')) {
-    return redirect()->to('/billing/v2');
+    return redirect('/billing/v2');
 }
 
 // ...

--- a/requests.md
+++ b/requests.md
@@ -471,11 +471,11 @@ You may also use the `flashOnly` and `flashExcept` methods to flash a subset of 
 
 Since you often will want to flash input to the session and then redirect to the previous page, you may easily chain input flashing onto a redirect using the `withInput` method:
 
-    return redirect('form')->withInput();
+    return redirect('/form')->withInput();
 
     return redirect()->route('user.create')->withInput();
 
-    return redirect('form')->withInput(
+    return redirect('/form')->withInput(
         $request->except('password')
     );
 

--- a/responses.md
+++ b/responses.md
@@ -152,7 +152,7 @@ By default, thanks to the `Illuminate\Cookie\Middleware\EncryptCookies` middlewa
 Redirect responses are instances of the `Illuminate\Http\RedirectResponse` class, and contain the proper headers needed to redirect the user to another URL. There are several ways to generate a `RedirectResponse` instance. The simplest method is to use the global `redirect` helper:
 
     Route::get('/dashboard', function () {
-        return redirect('home/dashboard');
+        return redirect('/home/dashboard');
     });
 
 Sometimes you may wish to redirect the user to their previous location, such as when a submitted form is invalid. You may do so by using the global `back` helper function. Since this feature utilizes the [session](/docs/{{version}}/session), make sure the route calling the `back` function is using the `web` middleware group:
@@ -225,7 +225,7 @@ Redirecting to a new URL and [flashing data to the session](/docs/{{version}}/se
     Route::post('/user/profile', function () {
         // ...
 
-        return redirect('dashboard')->with('status', 'Profile updated!');
+        return redirect('/dashboard')->with('status', 'Profile updated!');
     });
 
 After the user is redirected, you may display the flashed message from the [session](/docs/{{version}}/session). For example, using [Blade syntax](/docs/{{version}}/blade):

--- a/validation.md
+++ b/validation.md
@@ -559,7 +559,7 @@ If you do not want to use the `validate` method on the request, you may create a
             ]);
 
             if ($validator->fails()) {
-                return redirect('post/create')
+                return redirect('/post/create')
                             ->withErrors($validator)
                             ->withInput();
             }
@@ -611,7 +611,7 @@ You may use the `validateWithBag` method to store the error messages in a [named
 
 If you have multiple forms on a single page, you may wish to name the `MessageBag` containing the validation errors, allowing you to retrieve the error messages for a specific form. To achieve this, pass a name as the second argument to `withErrors`:
 
-    return redirect('register')->withErrors($validator, 'login');
+    return redirect('/register')->withErrors($validator, 'login');
 
 You may then access the named `MessageBag` instance from the `$errors` variable:
 


### PR DESCRIPTION
I'd like to add a slash to all `redirect()` helper so that developers who are just joining realize that it's about the path, not the route. Some may confuse this with the `redirect()->route()` construct.

I also removed the `to()` method from the Pennant section.