### PR TITLE
Update octane.md

### DIFF
--- a/octane.md
+++ b/octane.md
@@ -128,7 +128,7 @@ services:
   frankenphp:
     build:
       context: .
-    entrypoint: php artisan octane:frankenphp --max-requests=1
+    entrypoint: php artisan octane:frankenphp --max-requests=1 --workers=1
     ports:
       - "8000:8000"
     volumes:

--- a/octane.md
+++ b/octane.md
@@ -128,7 +128,7 @@ services:
   frankenphp:
     build:
       context: .
-    entrypoint: php artisan octane:frankenphp --max-requests=1 --workers=1
+    entrypoint: php artisan octane:frankenphp --workers=1 --max-requests=1
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
`--max-requests=1` will not work because the number of workers will be bigger than 1 

> The number of maximum requests is per worker, and by default, FrankenPHP starts many workers (2 times the number of CPUs).

https://github.com/laravel/octane/issues/816#issuecomment-1898126577