### PR TITLE
Fix whitespaces

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -649,7 +649,7 @@ Sometimes, you may need more manual control over how a progress bar is advanced.
 
     $bar->finish();
 
-> [!NOTE]
+> [!NOTE]  
 > For more advanced options, check out the [Symfony Progress Bar component documentation](https://symfony.com/doc/7.0/components/console/helpers/progressbar.html).
 
 <a name="registering-commands"></a>

--- a/authentication.md
+++ b/authentication.md
@@ -280,8 +280,8 @@ For complex query conditions, you may provide a closure in your array of credent
     use Illuminate\Database\Eloquent\Builder;
 
     if (Auth::attempt([
-        'email' => $email, 
-        'password' => $password, 
+        'email' => $email,
+        'password' => $password,
         fn (Builder $query) => $query->has('activeSubscription'),
     ])) {
         // Authentication was successful...

--- a/billing.md
+++ b/billing.md
@@ -251,7 +251,7 @@ Offering product and subscription billing via your application can be intimidati
 To charge customers for non-recurring, single-charge products, we'll utilize Cashier to direct customers to Stripe Checkout, where they will provide their payment details and confirm their purchase. Once the payment has been made via Checkout, the customer will be redirected to a success URL of your choosing within your application:
 
     use Illuminate\Http\Request;
-    
+
     Route::get('/checkout', function (Request $request) {
         $stripePriceId = 'price_deluxe_album';
 
@@ -276,11 +276,11 @@ If necessary, the `checkout` method will automatically create a customer in Stri
 When selling products, it's common to keep track of completed orders and purchased products via `Cart` and `Order` models defined by your own application. When redirecting customers to Stripe Checkout to complete a purchase, you may need to provide an existing order identifier so that you can associate the completed purchase with the corresponding order when the customer is redirected back to your application.
 
 To accomplish this, you may provide an array of `metadata` to the `checkout` method. Let's imagine that a pending `Order` is created within our application when a user begins the checkout process. Remember, the `Cart` and `Order` models in this example are illustrative and not provided by Cashier. You are free to implement these concepts based on the needs of your own application:
-    
+
     use App\Models\Cart;
     use App\Models\Order;
     use Illuminate\Http\Request;
-    
+
     Route::get('/cart/{cart}/checkout', function (Request $request, Cart $cart) {
         $order = Order::create([
             'cart_id' => $cart->id,
@@ -340,7 +340,7 @@ To learn how to sell subscriptions using Cashier and Stripe Checkout, let's cons
 First, let's discover how a customer can subscribe to our services. Of course, you can imagine the customer might click a "subscribe" button for the Basic plan on our application's pricing page. This button or link should direct the user to a Laravel route which creates the Stripe Checkout session for their chosen plan:
 
     use Illuminate\Http\Request;
-    
+
     Route::get('/subscription-checkout', function (Request $request) {
         return $request->user()
             ->newSubscription('default', 'price_basic_monthly')
@@ -2215,7 +2215,7 @@ Some payment methods require additional data in order to confirm payments. For e
     $subscription->withPaymentConfirmationOptions([
         'mandate_data' => '...',
     ])->swap('price_xxx');
-    
+
 You may consult the [Stripe API documentation](https://stripe.com/docs/api/payment_intents/confirm) to review all of the options accepted when confirming payments.
 
 <a name="strong-customer-authentication"></a>

--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -201,7 +201,7 @@ After defining your model, you may instruct Cashier to use your custom model via
 <a name="quickstart-selling-products"></a>
 ### Selling Products
 
-> [!NOTE]
+> [!NOTE]  
 > Before utilizing Paddle Checkout, you should define Products with fixed prices in your Paddle dashboard. In addition, you should [configure Paddle's webhook handling](#handling-paddle-webhooks).
 
 Offering product and subscription billing via your application can be intimidating. However, thanks to Cashier and [Paddle's Checkout Overlay](https://www.paddle.com/billing/checkout), you can easily build modern, robust payment integrations.
@@ -235,11 +235,11 @@ In the `buy` view, we will include a button to display the Checkout Overlay. The
 When selling products, it's common to keep track of completed orders and purchased products via `Cart` and `Order` models defined by your own application. When redirecting customers to Paddle's Checkout Overlay to complete a purchase, you may need to provide an existing order identifier so that you can associate the completed purchase with the corresponding order when the customer is redirected back to your application.
 
 To accomplish this, you may provide an array of custom data to the `checkout` method. Let's imagine that a pending `Order` is created within our application when a user begins the checkout process. Remember, the `Cart` and `Order` models in this example are illustrative and not provided by Cashier. You are free to implement these concepts based on the needs of your own application:
-    
+
     use App\Models\Cart;
     use App\Models\Order;
     use Illuminate\Http\Request;
-    
+
     Route::get('/cart/{cart}/checkout', function (Request $request, Cart $cart) {
         $order = Order::create([
             'cart_id' => $cart->id,

--- a/collections.md
+++ b/collections.md
@@ -31,7 +31,7 @@ As mentioned above, the `collect` helper returns a new `Illuminate\Support\Colle
 
     $collection = collect([1, 2, 3]);
 
-> [!NOTE]
+> [!NOTE]  
 > The results of [Eloquent](/docs/{{version}}/eloquent) queries are always returned as `Collection` instances.
 
 <a name="extending-collections"></a>
@@ -432,7 +432,7 @@ The `collect` method is primarily useful for converting [lazy collections](#lazy
 
     // [1, 2, 3]
 
-> [!NOTE]
+> [!NOTE]  
 > The `collect` method is especially useful when you have an instance of `Enumerable` and need a non-lazy collection instance. Since `collect()` is part of the `Enumerable` contract, you can safely use it to get a `Collection` instance.
 
 <a name="method-combine"></a>
@@ -525,7 +525,7 @@ The `containsOneItem` method determines whether the collection contains a single
 
 This method has the same signature as the [`contains`](#method-contains) method; however, all values are compared using "strict" comparisons.
 
-> [!NOTE]
+> [!NOTE]  
 > This method's behavior is modified when using [Eloquent Collections](/docs/{{version}}/eloquent-collections#method-contains).
 
 <a name="method-count"></a>
@@ -636,7 +636,7 @@ The `diff` method compares the collection against another collection or a plain 
 
     // [1, 3, 5]
 
-> [!NOTE]
+> [!NOTE]  
 > This method's behavior is modified when using [Eloquent Collections](/docs/{{version}}/eloquent-collections#method-diff).
 
 <a name="method-diffassoc"></a>
@@ -856,7 +856,7 @@ Primitive types such as `string`, `int`, `float`, `bool`, and `array` may also b
 
     return $collection->ensure('int');
 
-> [!WARNING]
+> [!WARNING]  
 > The `ensure` method does not guarantee that elements of different types will not be added to the collection at a later time.
 
 <a name="method-every"></a>
@@ -895,7 +895,7 @@ The `except` method returns all items in the collection except for those with th
 
 For the inverse of `except`, see the [only](#method-only) method.
 
-> [!NOTE]
+> [!NOTE]  
 > This method's behavior is modified when using [Eloquent Collections](/docs/{{version}}/eloquent-collections#method-except).
 
 <a name="method-filter"></a>
@@ -1078,7 +1078,7 @@ The `forget` method removes an item from the collection by its key:
 
     // ['framework' => 'laravel']
 
-> [!WARNING]
+> [!WARNING]  
 > Unlike most other collection methods, `forget` does not return a new modified collection; it modifies the collection it is called on.
 
 <a name="method-forpage"></a>
@@ -1281,7 +1281,7 @@ The `intersect` method removes any values from the original collection that are 
 
     // [0 => 'Desk', 2 => 'Chair']
 
-> [!NOTE]
+> [!NOTE]  
 > This method's behavior is modified when using [Eloquent Collections](/docs/{{version}}/eloquent-collections#method-intersect).
 
 <a name="method-intersectAssoc"></a>
@@ -1470,7 +1470,7 @@ The `map` method iterates through the collection and passes each value to the gi
 
     // [2, 4, 6, 8, 10]
 
-> [!WARNING]
+> [!WARNING]  
 > Like most other collection methods, `map` returns a new collection instance; it does not modify the collection it is called on. If you want to transform the original collection, use the [`transform`](#method-transform) method.
 
 <a name="method-mapinto"></a>
@@ -1750,7 +1750,7 @@ The `only` method returns the items in the collection with the specified keys:
 
 For the inverse of `only`, see the [except](#method-except) method.
 
-> [!NOTE]
+> [!NOTE]  
 > This method's behavior is modified when using [Eloquent Collections](/docs/{{version}}/eloquent-collections#method-only).
 
 <a name="method-pad"></a>
@@ -2322,7 +2322,7 @@ You may also pass a simple value to the `skipUntil` method to skip all items unt
 
     // [3, 4]
 
-> [!WARNING]
+> [!WARNING]  
 > If the given value is not found or the callback never returns `true`, the `skipUntil` method will return an empty collection.
 
 <a name="method-skipwhile"></a>
@@ -2340,7 +2340,7 @@ The `skipWhile` method skips over items from the collection while the given call
 
     // [4]
 
-> [!WARNING]
+> [!WARNING]  
 > If the callback never returns `false`, the `skipWhile` method will return an empty collection.
 
 <a name="method-slice"></a>
@@ -2449,7 +2449,7 @@ The `sort` method sorts the collection. The sorted collection keeps the original
 
 If your sorting needs are more advanced, you may pass a callback to `sort` with your own algorithm. Refer to the PHP documentation on [`uasort`](https://secure.php.net/manual/en/function.uasort.php#refsect1-function.uasort-parameters), which is what the collection's `sort` method calls utilizes internally.
 
-> [!NOTE]
+> [!NOTE]  
 > If you need to sort a collection of nested arrays or objects, see the [`sortBy`](#method-sortby) and [`sortByDesc`](#method-sortbydesc) methods.
 
 <a name="method-sortby"></a>
@@ -2793,7 +2793,7 @@ You may also pass a simple value to the `takeUntil` method to get the items unti
 
     // [1, 2]
 
-> [!WARNING]
+> [!WARNING]  
 > If the given value is not found or the callback never returns `true`, the `takeUntil` method will return all items in the collection.
 
 <a name="method-takewhile"></a>
@@ -2811,7 +2811,7 @@ The `takeWhile` method returns items in the collection until the given callback 
 
     // [1, 2]
 
-> [!WARNING]
+> [!WARNING]  
 > If the callback never returns `false`, the `takeWhile` method will return all items in the collection.
 
 <a name="method-tap"></a>
@@ -2856,7 +2856,7 @@ The `toArray` method converts the collection into a plain PHP `array`. If the co
         ]
     */
 
-> [!WARNING]
+> [!WARNING]  
 > `toArray` also converts all of the collection's nested objects that are an instance of `Arrayable` to an array. If you want to get the raw array underlying the collection, use the [`all`](#method-all) method instead.
 
 <a name="method-tojson"></a>
@@ -2885,7 +2885,7 @@ The `transform` method iterates over the collection and calls the given callback
 
     // [2, 4, 6, 8, 10]
 
-> [!WARNING]
+> [!WARNING]  
 > Unlike most other collection methods, `transform` modifies the collection itself. If you wish to create a new collection instead, use the [`map`](#method-map) method.
 
 <a name="method-undot"></a>
@@ -2989,7 +2989,7 @@ Finally, you may also pass your own closure to the `unique` method to specify wh
 
 The `unique` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`uniqueStrict`](#method-uniquestrict) method to filter using "strict" comparisons.
 
-> [!NOTE]
+> [!NOTE]  
 > This method's behavior is modified when using [Eloquent Collections](/docs/{{version}}/eloquent-collections#method-unique).
 
 <a name="method-uniquestrict"></a>
@@ -3498,7 +3498,7 @@ Likewise, we can use the `sum` higher order message to gather the total number o
 <a name="lazy-collection-introduction"></a>
 ### Introduction
 
-> [!WARNING]
+> [!WARNING]  
 > Before learning more about Laravel's lazy collections, take some time to familiarize yourself with [PHP generators](https://www.php.net/manual/en/language.generators.overview.php).
 
 To supplement the already powerful `Collection` class, the `LazyCollection` class leverages PHP's [generators](https://www.php.net/manual/en/language.generators.overview.php) to allow you to work with very large datasets while keeping memory usage low.
@@ -3689,7 +3689,7 @@ Almost all methods available on the `Collection` class are also available on the
 
 </div>
 
-> [!WARNING]
+> [!WARNING]  
 > Methods that mutate the collection (such as `shift`, `pop`, `prepend` etc.) are **not** available on the `LazyCollection` class.
 
 <a name="lazy-collection-methods"></a>

--- a/configuration.md
+++ b/configuration.md
@@ -51,7 +51,7 @@ Laravel's default `.env` file contains some common configuration values that may
 
 If you are developing with a team, you may wish to continue including and updating the `.env.example` file with your application. By putting placeholder values in the example configuration file, other developers on your team can clearly see which environment variables are needed to run your application.
 
-> [!NOTE]
+> [!NOTE]  
 > Any variable in your `.env` file can be overridden by external environment variables such as server-level or system-level environment variables.
 
 <a name="environment-file-security"></a>

--- a/container.md
+++ b/container.md
@@ -231,7 +231,7 @@ Sometimes you may have two classes that utilize the same interface, but you wish
 Sometimes you may have a class that receives some injected classes, but also needs an injected primitive value such as an integer. You may easily use contextual binding to inject any value your class may need:
 
     use App\Http\Controllers\UserController;
-    
+
     $this->app->when(UserController::class)
               ->needs('$variableName')
               ->give($value);

--- a/context.md
+++ b/context.md
@@ -318,7 +318,7 @@ public function boot(): void
 }
 ```
 
-> [!NOTE]
+> [!NOTE]  
 > You should not use the `Context` facade within the `dehydrating` callback, as that will change the context of the current process. Ensure you only make changes to the repository passed to the callback.
 
 <a name="hydrated"></a>
@@ -346,5 +346,5 @@ public function boot(): void
 }
 ```
 
-> [!NOTE]
+> [!NOTE]  
 > You should not use the `Context` facade within the `hydrated` callback and instead ensure you only make changes to the repository passed to the callback.

--- a/controllers.md
+++ b/controllers.md
@@ -38,7 +38,7 @@ Let's take a look at an example of a basic controller. A controller may have any
     <?php
 
     namespace App\Http\Controllers;
-    
+
     use App\Models\User;
     use Illuminate\View\View;
 

--- a/database-testing.md
+++ b/database-testing.md
@@ -220,7 +220,7 @@ Assert that a table in the database does not contain records matching the given 
 The `assertSoftDeleted` method may be used to assert a given Eloquent model has been "soft deleted":
 
     $this->assertSoftDeleted($user);
-    
+
 <a name="assert-not-deleted"></a>
 #### assertNotSoftDeleted
 

--- a/database.md
+++ b/database.md
@@ -50,7 +50,7 @@ By default, foreign key constraints are enabled for SQLite connections. If you w
 DB_FOREIGN_KEYS=false
 ```
 
-> [!NOTE]
+> [!NOTE]  
 > If you use the [Laravel installer](/docs/{{version}}/installation#creating-a-laravel-project) to create your Laravel application and select SQLite as your database, Laravel will automatically create a `database/database.sqlite` file and run the default [database migrations](/docs/{{version}}/migrations) for you.
 
 <a name="mssql-configuration"></a>

--- a/dusk.md
+++ b/dusk.md
@@ -64,7 +64,7 @@ To get started, you should install [Google Chrome](https://www.google.com/chrome
 composer require laravel/dusk --dev
 ```
 
-> [!WARNING]
+> [!WARNING]  
 > If you are manually registering Dusk's service provider, you should **never** register it in your production environment, as doing so could lead to arbitrary users being able to authenticate with your application.
 
 After installing the Dusk package, execute the `dusk:install` Artisan command. The `dusk:install` command will create a `tests/Browser` directory, an example Dusk test, and install the Chrome Driver binary for your operating system:
@@ -75,7 +75,7 @@ php artisan dusk:install
 
 Next, set the `APP_URL` environment variable in your application's `.env` file. This value should match the URL you use to access your application in a browser.
 
-> [!NOTE]
+> [!NOTE]  
 > If you are using [Laravel Sail](/docs/{{version}}/sail) to manage your local development environment, please also consult the Sail documentation on [configuring and running Dusk tests](/docs/{{version}}/sail#laravel-dusk).
 
 <a name="managing-chromedriver-installations"></a>
@@ -97,7 +97,7 @@ php artisan dusk:chrome-driver --all
 php artisan dusk:chrome-driver --detect
 ```
 
-> [!WARNING]
+> [!WARNING]  
 > Dusk requires the `chromedriver` binaries to be executable. If you're having problems running Dusk, you should ensure the binaries are executable using the following command: `chmod -R 0755 vendor/laravel/dusk/bin/`.
 
 <a name="using-other-browsers"></a>
@@ -181,7 +181,7 @@ class ExampleTest extends DuskTestCase
 }
 ```
 
-> [!WARNING]
+> [!WARNING]  
 > SQLite in-memory databases may not be used when executing Dusk tests. Since the browser executes within its own process, it will not be able to access the in-memory databases of other processes.
 
 <a name="reset-truncation"></a>
@@ -220,7 +220,7 @@ class ExampleTest extends DuskTestCase
 
 By default, this trait will truncate all tables except the `migrations` table. If you would like to customize the tables that should be truncated, you may define a `$tablesToTruncate` property on your test class:
 
-> [!NOTE]
+> [!NOTE]  
 > If you are using Pest, you should define properties or methods on the base `DuskTestCase` class or on any class your test file extends.
 
     /**
@@ -287,7 +287,7 @@ The `dusk` command accepts any argument that is normally accepted by the Pest / 
 php artisan dusk --group=foo
 ```
 
-> [!NOTE]
+> [!NOTE]  
 > If you are using [Laravel Sail](/docs/{{version}}/sail) to manage your local development environment, please consult the Sail documentation on [configuring and running Dusk tests](/docs/{{version}}/sail#laravel-dusk).
 
 <a name="manually-starting-chromedriver"></a>
@@ -506,7 +506,7 @@ Often, you will be testing pages that require authentication. You can use Dusk's
               ->visit('/home');
     });
 
-> [!WARNING]
+> [!WARNING]  
 > After using the `loginAs` method, the user session will be maintained for all tests within the file.
 
 <a name="cookies"></a>
@@ -707,7 +707,7 @@ The `attach` method may be used to attach a file to a `file` input element. Like
 
     $browser->attach('photo', __DIR__.'/photos/mountains.png');
 
-> [!WARNING]
+> [!WARNING]  
 > The attach function requires the `Zip` PHP extension to be installed and enabled on your server.
 
 <a name="pressing-buttons"></a>
@@ -738,7 +738,7 @@ You may use the `seeLink` method to determine if a link with the given display t
         // ...
     }
 
-> [!WARNING]
+> [!WARNING]  
 > These methods interact with jQuery. If jQuery is not available on the page, Dusk will automatically inject it into the page so it is available for the test's duration.
 
 <a name="using-the-keyboard"></a>
@@ -752,7 +752,7 @@ Another valuable use case for the `keys` method is sending a "keyboard shortcut"
 
     $browser->keys('.app', ['{command}', 'j']);
 
-> [!NOTE]
+> [!NOTE]  
 > All modifier keys such as `{command}` are wrapped in `{}` characters, and match the constants defined in the `Facebook\WebDriver\WebDriverKeys` class, which can be [found on GitHub](https://github.com/php-webdriver/php-webdriver/blob/master/lib/WebDriverKeys.php).
 
 <a name="fluent-keyboard-interactions"></a>
@@ -2108,7 +2108,7 @@ class ExampleTest extends DuskTestCase
 <a name="continuous-integration"></a>
 ## Continuous Integration
 
-> [!WARNING]
+> [!WARNING]  
 > Most Dusk continuous integration configurations expect your Laravel application to be served using the built-in PHP development server on port 8000. Therefore, before continuing, you should ensure that your continuous integration environment has an `APP_URL` environment variable value of `http://127.0.0.1:8000`.
 
 <a name="running-tests-on-heroku-ci"></a>

--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -88,7 +88,7 @@ In addition, the `Illuminate\Database\Eloquent\Collection` class provides a supe
 The `append` method may be used to indicate that an attribute should be [appended](/docs/{{version}}/eloquent-serialization#appending-values-to-json) for every model in the collection. This method accepts an array of attributes or a single attribute:
 
     $users->append('team');
-    
+
     $users->append(['team', 'is_admin']);
 
 <a name="method-contains"></a>
@@ -151,7 +151,7 @@ The `load` method eager loads the given relationships for all models in the coll
     $users->load(['comments', 'posts']);
 
     $users->load('comments.author');
-    
+
     $users->load(['comments', 'posts' => fn ($query) => $query->where('active', 1)]);
 
 <a name="method-loadMissing"></a>
@@ -162,7 +162,7 @@ The `loadMissing` method eager loads the given relationships for all models in t
     $users->loadMissing(['comments', 'posts']);
 
     $users->loadMissing('comments.author');
-    
+
     $users->loadMissing(['comments', 'posts' => fn ($query) => $query->where('active', 1)]);
 
 <a name="method-modelKeys"></a>

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1941,7 +1941,7 @@ The `createQuietly` and `createManyQuietly` methods may be used to create a mode
     $user->posts()->createQuietly([
         'title' => 'Post title.',
     ]);
-    
+
     $user->posts()->createManyQuietly([
         ['title' => 'First post.'],
         ['title' => 'Second post.'],

--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -493,7 +493,7 @@ If you would like to customize the information included in the `links` or `meta`
 
         return $default;
     }
-    
+
 <a name="conditional-attributes"></a>
 ### Conditional Attributes
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -895,7 +895,7 @@ Eloquent's `upsert` method may be used to update or create records in a single, 
         ['departure' => 'Oakland', 'destination' => 'San Diego', 'price' => 99],
         ['departure' => 'Chicago', 'destination' => 'New York', 'price' => 150]
     ], uniqueBy: ['departure', 'destination'], update: ['price']);
-    
+
 > [!WARNING]  
 > All databases except SQL Server require the columns in the second argument of the `upsert` method to have a "primary" or "unique" index. In addition, the MariaDB and MySQL database drivers ignore the second argument of the `upsert` method and always use the "primary" and "unique" indexes of the table to detect existing records.
 
@@ -1510,7 +1510,7 @@ This command will place the new observer in your `app/Observers` directory. If t
         {
             // ...
         }
-        
+
         /**
          * Handle the User "restored" event.
          */

--- a/errors.md
+++ b/errors.md
@@ -410,6 +410,6 @@ php artisan vendor:publish --tag=laravel-errors
 <a name="fallback-http-error-pages"></a>
 #### Fallback HTTP Error Pages
 
-You may also define a "fallback" error page for a given series of HTTP status codes. This page will be rendered if there is not a corresponding page for the specific HTTP status code that occurred. To accomplish this, define a `4xx.blade.php` template and a `5xx.blade.php` template in your application's `resources/views/errors` directory. 
+You may also define a "fallback" error page for a given series of HTTP status codes. This page will be rendered if there is not a corresponding page for the specific HTTP status code that occurred. To accomplish this, define a `4xx.blade.php` template and a `5xx.blade.php` template in your application's `resources/views/errors` directory.
 
 When defining fallback error pages, the fallback pages will not affect `404`, `500`, and `503` error responses since Laravel has internal, dedicated pages for these status codes. To customize the pages rendered for these status codes, you should define a custom error page for each of them individually.

--- a/events.md
+++ b/events.md
@@ -234,7 +234,7 @@ Next, let's take a look at the listener for our example event. Event listeners r
         }
     }
 
-> [!NOTE]
+> [!NOTE]  
 > Your event listeners may also type-hint any dependencies they need on their constructors. All event listeners are resolved via the Laravel [service container](/docs/{{version}}/container), so dependencies will be injected automatically.
 
 <a name="stopping-the-propagation-of-an-event"></a>
@@ -404,7 +404,7 @@ If your queue connection's `after_commit` configuration option is set to `false`
         use InteractsWithQueue;
     }
 
-> [!NOTE]
+> [!NOTE]  
 > To learn more about working around these issues, please review the documentation regarding [queued jobs and database transactions](/docs/{{version}}/queues#jobs-and-database-transactions).
 
 <a name="handling-failed-jobs"></a>
@@ -519,7 +519,7 @@ If you would like to conditionally dispatch an event, you may use the `dispatchI
 
     OrderShipped::dispatchUnless($condition, $order);
 
-> [!NOTE]
+> [!NOTE]  
 > When testing, it can be helpful to assert that certain events were dispatched without actually triggering their listeners. Laravel's [built-in testing helpers](#testing) make it a cinch.
 
 <a name="dispatching-events-after-database-transactions"></a>

--- a/helpers.md
+++ b/helpers.md
@@ -1322,7 +1322,7 @@ $result = Number::pairs(25, 10);
 // [[1, 10], [11, 20], [21, 25]]
 
 $result = Number::pairs(25, 10, offset: 0);
- 
+
 // [[0, 10], [10, 20], [20, 25]]
 ```
 
@@ -2260,7 +2260,7 @@ Additional arguments may be passed to the `value` function. If the first argumen
     $result = value(function (string $name) {
         return $name;
     }, 'Taylor');
-    
+
     // 'Taylor'
 
 <a name="method-view"></a>

--- a/http-tests.md
+++ b/http-tests.md
@@ -95,7 +95,7 @@ class ExampleTest extends TestCase
 
 In general, each of your tests should only make one request to your application. Unexpected behavior may occur if multiple requests are executed within a single test method.
 
-> [!NOTE]
+> [!NOTE]  
 > For convenience, the CSRF middleware is automatically disabled when running tests.
 
 <a name="customizing-request-headers"></a>
@@ -480,7 +480,7 @@ expect($response['created'])->toBeTrue();
 $this->assertTrue($response['created']);
 ```
 
-> [!NOTE]
+> [!NOTE]  
 > The `assertJson` method converts the response to an array and utilizes `PHPUnit::assertArraySubset` to verify that the given array exists within the JSON response returned by the application. So, if there are other properties in the JSON response, this test will still pass as long as the given fragment is present.
 
 <a name="verifying-exact-match"></a>
@@ -1312,7 +1312,7 @@ Assert that the response has a moved permanently (301) HTTP status code:
 Assert that the response has the given URI value in the `Location` header:
 
     $response->assertLocation($uri);
-    
+
 <a name="assert-content"></a>
 #### assertContent
 

--- a/installation.md
+++ b/installation.md
@@ -82,7 +82,7 @@ php artisan serve
 
 Once you have started the Artisan development server, your application will be accessible in your web browser at [http://localhost:8000](http://localhost:8000). Next, you're ready to [start taking your next steps into the Laravel ecosystem](#next-steps). Of course, you may also want to [configure a database](#databases-and-migrations).
 
-> [!NOTE]
+> [!NOTE]  
 > If you would like a head start when developing your Laravel application, consider using one of our [starter kits](/docs/{{version}}/starter-kits). Laravel's starter kits provide backend and frontend authentication scaffolding for your new Laravel application.
 
 <a name="initial-configuration"></a>
@@ -99,7 +99,7 @@ Since many of Laravel's configuration option values may vary depending on whethe
 
 Your `.env` file should not be committed to your application's source control, since each developer / server using your application could require a different environment configuration. Furthermore, this would be a security risk in the event an intruder gains access to your source control repository, since any sensitive credentials would be exposed.
 
-> [!NOTE]
+> [!NOTE]  
 > For more information about the `.env` file and environment based configuration, check out the full [configuration documentation](/docs/{{version}}/configuration#environment-configuration).
 
 <a name="databases-and-migrations"></a>
@@ -126,7 +126,7 @@ If you choose to use a database other than SQLite, you will need to create the d
 php artisan migrate
 ```
 
-> [!NOTE]
+> [!NOTE]  
 > If you are developing on macOS or Windows and need to install MySQL, PostgreSQL, or Redis locally, consider using [Herd Pro](https://herd.laravel.com/#plans).
 
 <a name="directory-configuration"></a>
@@ -141,7 +141,7 @@ Laravel should always be served out of the root of the "web directory" configure
 
 Once you install Herd, you're ready to start developing with Laravel. Herd includes command line tools for `php`, `composer`, `laravel`, `expose`, `node`, `npm`, and `nvm`.
 
-> [!NOTE]
+> [!NOTE]  
 > [Herd Pro](https://herd.laravel.com/#plans) augments Herd with additional powerful features, such as the ability to create and manage local MySQL, Postgres, and Redis databases, as well as local mail viewing and log monitoring.
 
 <a name="herd-on-macos"></a>

--- a/localization.md
+++ b/localization.md
@@ -91,9 +91,9 @@ You may instruct Laravel's "pluralizer", which is used by Eloquent and other por
      */
     public function boot(): void
     {
-        Pluralizer::useLanguage('spanish');     
+        Pluralizer::useLanguage('spanish');
 
-        // ...     
+        // ...
     }
 
 > [!WARNING]  

--- a/logging.md
+++ b/logging.md
@@ -295,7 +295,7 @@ If you would like to share contextual information across _all_ logging channels,
         }
     }
 
-> [!NOTE]
+> [!NOTE]  
 > If you need to share log context while processing queued jobs, you may utilize [job middleware](/docs/{{version}}/queues#job-middleware).
 
 <a name="writing-to-specific-channels"></a>

--- a/migrations.md
+++ b/migrations.md
@@ -627,7 +627,7 @@ The `integer` method creates an `INTEGER` equivalent column:
 The `ipAddress` method creates a `VARCHAR` equivalent column:
 
     $table->ipAddress('visitor');
-    
+
 When using PostgreSQL, an `INET` column will be created.
 
 <a name="column-method-json"></a>

--- a/mocking.md
+++ b/mocking.md
@@ -240,7 +240,7 @@ You may also provide a closure to the various time travel methods. The closure w
     $this->travel(5)->days(function () {
         // Test something five days into the future...
     });
-    
+
     $this->travelTo(now()->subDays(10), function () {
         // Test something during a given moment...
     });

--- a/notifications.md
+++ b/notifications.md
@@ -1267,7 +1267,7 @@ To direct Slack notifications to the appropriate Slack team and channel, define 
 - A `SlackRoute` instance, which allows you to specify an OAuth token and channel name, e.g. `SlackRoute::make($this->slack_channel, $this->slack_token)`. This method should be used to send notifications to external workspaces.
 
 For instance, returning `#support-channel` from the `routeNotificationForSlack` method will send the notification to the `#support-channel` channel in the workspace associated with the Bot User OAuth token located in your application's `services.php` configuration file:
- 
+
     <?php
 
     namespace App\Models;

--- a/octane.md
+++ b/octane.md
@@ -150,7 +150,7 @@ If you plan to develop your application using [Laravel Sail](/docs/{{version}}/s
 ```shell
 ./vendor/bin/sail up
 
-./vendor/bin/sail composer require laravel/octane spiral/roadrunner-cli spiral/roadrunner-http 
+./vendor/bin/sail composer require laravel/octane spiral/roadrunner-cli spiral/roadrunner-http
 ```
 
 Next, you should start a Sail shell and use the `rr` executable to retrieve the latest Linux based build of the RoadRunner binary:

--- a/pagination.md
+++ b/pagination.md
@@ -150,7 +150,7 @@ However, cursor pagination has the following limitations:
 
 - Like `simplePaginate`, cursor pagination can only be used to display "Next" and "Previous" links and does not support generating links with page numbers.
 - It requires that the ordering is based on at least one unique column or a combination of columns that are unique. Columns with `null` values are not supported.
-- Query expressions in "order by" clauses are supported only if they are aliased and added to the "select" clause as well. 
+- Query expressions in "order by" clauses are supported only if they are aliased and added to the "select" clause as well.
 - Query expressions with parameters are not supported.
 
 <a name="manually-creating-a-paginator"></a>

--- a/pennant.md
+++ b/pennant.md
@@ -143,7 +143,8 @@ class NewApi
 }
 ```
 
-> [!NOTE] Feature classes are resolved via the [container](/docs/{{version}}/container), so you may inject dependencies into the feature class's constructor when needed.
+> [!NOTE]   
+> Feature classes are resolved via the [container](/docs/{{version}}/container), so you may inject dependencies into the feature class's constructor when needed.
 
 #### Customizing the Stored Feature Name
 
@@ -679,7 +680,8 @@ Pennant's included Blade directive also makes it easy to conditionally render co
 @endfeature
 ```
 
-> [!NOTE] When using rich values, it is important to know that a feature is considered "active" when it has any value other than `false`.
+> [!NOTE]   
+> When using rich values, it is important to know that a feature is considered "active" when it has any value other than `false`.
 
 When calling the [conditional `when`](#conditional-execution) method, the feature's rich value will be provided to the first closure:
 
@@ -847,7 +849,8 @@ Alternatively, you may deactivate the feature for all users:
 Feature::deactivateForEveryone('new-api');
 ```
 
-> [!NOTE] This will only update the resolved feature values that have been stored by Pennant's storage driver. You will also need to update the feature definition in your application.
+> [!NOTE]   
+> This will only update the resolved feature values that have been stored by Pennant's storage driver. You will also need to update the feature definition in your application.
 
 <a name="purging-features"></a>
 ### Purging Features

--- a/precognition.md
+++ b/precognition.md
@@ -314,7 +314,7 @@ If you are validating a subset of a form's inputs with Precognition, it can be u
 <input
     id="avatar"
     type="file"
-    onChange={(e) => 
+    onChange={(e) =>
         form.setData('avatar', e.target.value);
 
         form.forgetError('avatar');
@@ -526,7 +526,7 @@ In the user creation example discussed above, we are using Precognition to perfo
 Alternatively, if you would like to submit the form via XHR you may use the form's `submit` function, which returns an Axios request promise:
 
 ```html
-<form 
+<form
     x-data="{
         form: $form('post', '/register', {
             name: '',

--- a/pulse.md
+++ b/pulse.md
@@ -158,7 +158,7 @@ public function boot(): void
 }
 ```
 
-> [!NOTE]
+> [!NOTE]  
 > You may completely customize how the authenticated user is captured and retrieved by implementing the `Laravel\Pulse\Contracts\ResolvesUsers` contract and binding it in Laravel's [service container](/docs/{{version}}/container#binding-a-singleton).
 
 <a name="dashboard-cards"></a>
@@ -190,7 +190,7 @@ If you wish to view all usage metrics on screen at the same time, you may includ
 
 To learn how to customize how Pulse retrieves and displays user information, consult our documentation on [resolving users](#dashboard-resolving-users).
 
-> [!NOTE]
+> [!NOTE]  
 > If your application receives a lot of requests or dispatches a lot of jobs, you may wish to enable [sampling](#sampling). See the [user requests recorder](#user-requests-recorder), [user jobs recorder](#user-jobs-recorder), and [slow jobs recorder](#slow-jobs-recorder) documentation for more information.
 
 <a name="exceptions-card"></a>
@@ -251,7 +251,7 @@ Most Pulse recorders will automatically capture entries based on framework event
 php artisan pulse:check
 ```
 
-> [!NOTE]
+> [!NOTE]  
 > To keep the `pulse:check` process running permanently in the background, you should use a process monitor such as Supervisor to ensure that the command does not stop running.
 
 As the `pulse:check` command is a long-lived process, it will not see changes to your codebase without being restarted. You should gracefully restart the command by calling the `pulse:restart` command during your application's deployment process:
@@ -471,7 +471,7 @@ PULSE_DB_CONNECTION=pulse
 <a name="ingest"></a>
 ### Redis Ingest
 
-> [!WARNING]
+> [!WARNING]  
 > The Redis Ingest requires Redis 6.2 or greater and `phpredis` or `predis` as the application's configured Redis client driver.
 
 By default, Pulse will store entries directly to the [configured database connection](#using-a-different-database) after the HTTP response has been sent to the client or a job has been processed; however, you may use Pulse's Redis ingest driver to send entries to a Redis stream instead. This can be enabled by configuring the `PULSE_INGEST_DRIVER` environment variable:
@@ -492,7 +492,7 @@ When using the Redis ingest, you will need to run the `pulse:work` command to mo
 php artisan pulse:work
 ```
 
-> [!NOTE]
+> [!NOTE]  
 > To keep the `pulse:work` process running permanently in the background, you should use a process monitor such as Supervisor to ensure that the Pulse worker does not stop running.
 
 As the `pulse:work` command is a long-lived process, it will not see changes to your codebase without being restarted. You should gracefully restart the command by calling the `pulse:restart` command during your application's deployment process:
@@ -593,7 +593,7 @@ Once you have defined your Livewire component and template, the card may be incl
 </x-pulse>
 ```
 
-> [!NOTE]
+> [!NOTE]  
 > If your card is included in a package, you will need to register the component with Livewire using the `Livewire::component` method.
 
 <a name="custom-card-styling"></a>
@@ -707,7 +707,7 @@ The available aggregation methods are:
 * `min`
 * `sum`
 
-> [!NOTE]
+> [!NOTE]  
 > When building a card package that captures the currently authenticated user ID, you should use the `Pulse::resolveAuthenticatedUserId()` method, which respects any [user resolver customizations](#dashboard-resolving-users) made to the application.
 
 <a name="custom-card-data-retrieval"></a>

--- a/routing.md
+++ b/routing.md
@@ -323,7 +323,7 @@ For convenience, some commonly used regular expression patterns have helper meth
     Route::get('/category/{category}', function (string $category) {
         // ...
     })->whereIn('category', ['movie', 'song', 'painting']);
-    
+
     Route::get('/category/{category}', function (string $category) {
         // ...
     })->whereIn('category', CategoryEnum::cases());

--- a/scout.md
+++ b/scout.md
@@ -177,7 +177,7 @@ public function toSearchableArray()
 }
 ```
 
-You should also define your Typesense collection schemas in your application's `config/scout.php` file. A collection schema describes the data types of each field that is searchable via Typesense. For more information on all available schema options, please consult the [Typesense documentation](https://typesense.org/docs/latest/api/collections.html#schema-parameters). 
+You should also define your Typesense collection schemas in your application's `config/scout.php` file. A collection schema describes the data types of each field that is searchable via Typesense. For more information on all available schema options, please consult the [Typesense documentation](https://typesense.org/docs/latest/api/collections.html#schema-parameters).
 
 If you need to change your Typesense collection's schema after it has been defined, you may either run `scout:flush` and `scout:import`, which will delete all existing indexed data and recreate the schema. Or, you may use Typesense's API to modify the collection's schema without removing any indexed data.
 

--- a/seeding.md
+++ b/seeding.md
@@ -135,7 +135,7 @@ You may also seed your database using the `migrate:fresh` command in combination
 ```shell
 php artisan migrate:fresh --seed
 
-php artisan migrate:fresh --seed --seeder=UserSeeder 
+php artisan migrate:fresh --seed --seeder=UserSeeder
 ```
 
 <a name="forcing-seeding-production"></a>

--- a/strings.md
+++ b/strings.md
@@ -545,12 +545,12 @@ The `Str::inlineMarkdown` method converts GitHub flavored Markdown into inline H
 By default, Markdown supports raw HTML, which will expose Cross-Site Scripting (XSS) vulnerabilities when used with raw user input. As per the [CommonMark Security documentation](https://commonmark.thephpleague.com/security/), you may use the `html_input` option to either escape or strip raw HTML, and the `allow_unsafe_links` option to specify whether to allow unsafe links. If you need to allow some raw HTML, you should pass your compiled Markdown through an HTML Purifier:
 
     use Illuminate\Support\Str;
-    
+
     Str::inlineMarkdown('Inject: <script>alert("Hello XSS!");</script>', [
         'html_input' => 'strip',
         'allow_unsafe_links' => false,
     ]);
-    
+
     // Inject: alert(&quot;Hello XSS!&quot;);
 
 <a name="method-str-is"></a>
@@ -1326,7 +1326,7 @@ The `Str::ulid` method generates a ULID, which is a compact, time-ordered unique
     use Illuminate\Support\Str;
 
     return (string) Str::ulid();
-    
+
     // 01gd6r360bp37zj17nxb55yv40
 
 If you would like to retrieve a `Illuminate\Support\Carbon` date instance representing the date and time that a given ULID was created, you may use the `createFromId` method provided by Laravel's Carbon integration:

--- a/testing.md
+++ b/testing.md
@@ -46,7 +46,7 @@ If you would like to create a test within the `tests/Unit` directory, you may us
 php artisan make:test UserTest --unit
 ```
 
-> [!NOTE]
+> [!NOTE]  
 > Test stubs may be customized using [stub publishing](/docs/{{version}}/artisan#stub-customization).
 
 Once the test has been generated, you may define test as you normally would using Pest or PHPUnit. To run your tests, execute the `vendor/bin/pest`, `vendor/bin/phpunit`, or `php artisan test` command from your terminal:
@@ -78,7 +78,7 @@ class ExampleTest extends TestCase
 }
 ```
 
-> [!WARNING]
+> [!WARNING]  
 > If you define your own `setUp` / `tearDown` methods within a test class, be sure to call the respective `parent::setUp()` / `parent::tearDown()` methods on the parent class. Typically, you should invoke `parent::setUp()` at the start of your own `setUp` method, and `parent::tearDown()` at the end of your `tearDown` method.
 
 <a name="running-tests"></a>

--- a/upgrade.md
+++ b/upgrade.md
@@ -48,7 +48,7 @@
 <a name="estimated-upgrade-time-??-minutes"></a>
 #### Estimated Upgrade Time: 15 Minutes
 
-> [!NOTE]
+> [!NOTE]  
 > We attempt to document every possible breaking change. Since some of these breaking changes are in obscure parts of the framework only a portion of these changes may actually affect your application. Want to save time? You can use [Laravel Shift](https://laravelshift.com/) to help automate your application upgrades.
 
 <a name="updating-dependencies"></a>

--- a/vite.md
+++ b/vite.md
@@ -866,7 +866,7 @@ For example, the `vite-imagetools` plugin outputs URLs like the following while 
 <img src="/@imagetools/f0b2f404b13f052c604e632f2fb60381bf61a520">
 ```
 
-The `vite-imagetools` plugin is expecting that the output URL will be intercepted by Vite and the plugin may then handle all URLs that start with `/@imagetools`. If you are using plugins that are expecting this behaviour, you will need to manually correct the URLs. You can do this in your `vite.config.js` file by using the `transformOnServe` option. 
+The `vite-imagetools` plugin is expecting that the output URL will be intercepted by Vite and the plugin may then handle all URLs that start with `/@imagetools`. If you are using plugins that are expecting this behaviour, you will need to manually correct the URLs. You can do this in your `vite.config.js` file by using the `transformOnServe` option.
 
 In this particular example, we will prepend the dev server URL to all occurrences of `/@imagetools` within the generated code:
 


### PR DESCRIPTION
Sorry for the PR's spam. I just want to make the documentation format better.

P.S.: Spaces after `[!NOTE]` and `[!WARNING]` are added only in places where they are not. In the others they have already been added so that they can be moved to a new line (does not affect the website).