### PR TITLE
Change default collation to match default config in framework

### DIFF
--- a/database.md
+++ b/database.md
@@ -103,7 +103,7 @@ To see how read / write connections should be configured, let's look at this exa
         'password' => env('DB_PASSWORD', ''),
         'unix_socket' => env('DB_SOCKET', ''),
         'charset' => env('DB_CHARSET', 'utf8mb4'),
-        'collation' => env('DB_COLLATION', 'utf8mb4_0900_ai_ci'),
+        'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
         'prefix' => '',
         'prefix_indexes' => true,
         'strict' => true,


### PR DESCRIPTION
This MR fixes the doc to be consistency about the collation being used by the framework by default

The example given in laravel 11.x docs refers to the mysql default collation instead of the collation the laravel framework uses by default for mysql

**Docs**
https://laravel.com/docs/11.x/database#read-and-write-connections

**Database config from framework version 11**
https://github.com/laravel/framework/blob/11.x/config/database.php#L55

