### PR TITLE
Possible typo on queues.md

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1583,7 +1583,7 @@ Then, set the `queue.batching.driver` configuration option's value to `dynamodb`
 
 ```php
 'batching' => [
-    'driver' => env('QUEUE_FAILED_DRIVER', 'dynamodb'),
+    'driver' => env('QUEUE_BATCHING_DRIVER', 'dynamodb'),
     'key' => env('AWS_ACCESS_KEY_ID'),
     'secret' => env('AWS_SECRET_ACCESS_KEY'),
     'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),


### PR DESCRIPTION
I noticed a small typo when investigating Dynamodb for batches.

https://laravel.com/docs/11.x/queues#storing-batches-in-dynamodb

```
'batching' => [
    'driver' => env('QUEUE_FAILED_DRIVER', 'dynamodb'),
    'key' => env('AWS_ACCESS_KEY_ID'),
    'secret' => env('AWS_SECRET_ACCESS_KEY'),
    'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
    'table' => 'job_batches',
],
```
I think `QUEUE_FAILED_DRIVER` should be `QUEUE_BATCHING_DRIVER`


thanks 🚀 