### PR TITLE
doc: bump actions/upload-artifact github action to v4

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -2198,13 +2198,13 @@ jobs:
         run: php artisan dusk
       - name: Upload Screenshots
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: screenshots
           path: tests/Browser/screenshots
       - name: Upload Console Logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: console
           path: tests/Browser/console


### PR DESCRIPTION
The @actions/upload-artifact github action version 2 is deprecated since *June 30, 2024*. Version 3 is also scheduled for deprecation on *November 30, 2024*.

The [action repository](https://github.com/actions/upload-artifact) recommands to update workflows to use v4 of the artifact actions.

The provided workflow **currently works**, however it displays a deprecation warning in its output.