### PR TITLE
Update required SQLite version

### DIFF
--- a/database.md
+++ b/database.md
@@ -22,7 +22,7 @@ Almost every modern web application interacts with a database. Laravel makes int
 - MariaDB 10.3+ ([Version Policy](https://mariadb.org/about/#maintenance-policy))
 - MySQL 5.7+ ([Version Policy](https://en.wikipedia.org/wiki/MySQL#Release_history))
 - PostgreSQL 10.0+ ([Version Policy](https://www.postgresql.org/support/versioning/))
-- SQLite 3.26.0+
+- SQLite 3.35.0+
 - SQL Server 2017+ ([Version Policy](https://docs.microsoft.com/en-us/lifecycle/products/?products=sql-server))
 
 </div>


### PR DESCRIPTION
Laravel 11 does not work correctly if older SQLite3 is installed.

As documented in [master](https://laravel.com/docs/master/database#introduction), v3.35.0+ works well. 