### PR TITLE
scheduler docs- change new DeleteRecentUsers

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -48,7 +48,7 @@ If you prefer to reserve your `routes/console.php` file for command definitions 
     use Illuminate\Console\Scheduling\Schedule;
 
     ->withSchedule(function (Schedule $schedule) {
-        $schedule->call(new DeleteRecentUsers)->daily();
+        $schedule->call(DeleteRecentUsers::class)->daily();
     })
 
 If you would like to view an overview of your scheduled tasks and the next time they are scheduled to run, you may use the `schedule:list` Artisan command:


### PR DESCRIPTION
Hi everyone, 

So I was following the Laravel Scheduler documentation for setting up a Laravel 11 Scheduled Console Command with the documentation. https://laravel.com/docs/11.x/scheduling#introduction

The current documentation says that you can register a command in ```bootstrap/app.php``` to use this syntax:

```php
->withSchedule(function (Schedule $schedule) {
    $schedule->call(new DeleteRecentUsers)->daily();
})
```

which I did, my example here:
```php
->withSchedule(function (Schedule $schedule) {
      $schedule->call(new MyComamndName)
          ->timezone('America/New_York')
          ->weeklyOn(1, '12:00')
          ->emailOutputOnFailure(env("FAILURE_EMAIL")
); 
```
I then ran the command: ```php artisan schedule:list``` to check the command was good to go and received the following error.

```php
Invalid scheduled callback event. Must be a string or callable.

  at vendor/laravel/framework/src/Illuminate/Console/Scheduling/CallbackEvent.php:56
     52▕      */
     53▕     public function __construct(EventMutex $mutex, $callback, array $parameters = [], $timezone = null)
     54▕     {
     55▕         if (! is_string($callback) && ! Reflector::isCallable($callback)) {
  ➜  56▕             throw new InvalidArgumentException(
     57▕                 'Invalid scheduled callback event. Must be a string or callable.'
     58▕             );
     59▕         }
     60▕ 

      +1 vendor frames 

  2   bootstrap/app.php:30
      Illuminate\Console\Scheduling\Schedule::call()
      +6 vendor frames 

  9   artisan:13
      Illuminate\Foundation\Application::handleCommand()
```

The error said that the function was expecting a string, so I updated my function to run like this:
```php
->withSchedule(function (Schedule $schedule) {
        $schedule->call(MyComamndName::class)
            ->timezone('America/New_York')
            ->weeklyOn(1, '12:00')
            ->emailOutputOnFailure(env("FAILURE_EMAIL"));
    })
```

where they key difference is that I use this syntax: ```MyComamndName::class``` when referencing my MyComamndName. 

This fixed the error when running the ```php artisan schedule:list``` command and my cron job is good to go. So this leads me to believe that the documentation is incorrect for this example. I could be **totally wrong here**, but wanted to try to help out so I made this small change to the docs.

Thank you for reading.