### PR TITLE
Removing semicolon from `view` example of Pulse page

### DIFF
--- a/pulse.md
+++ b/pulse.md
@@ -721,7 +721,7 @@ class TopSellers extends Card
     public function render()
     {
         return view('livewire.pulse.top-sellers', [
-            'topSellers' => $this->aggregate('user_sale', ['sum', 'count']);
+            'topSellers' => $this->aggregate('user_sale', ['sum', 'count'])
         ]);
     }
 }


### PR DESCRIPTION
This PR removes a `;` from a `view` example that will generate an error when the dev tries to copy the example code thinking about reproducing the steps in the documents, including because Pulse is something "new" that a lot of people are studying and reproducing.