### PR TITLE
Remove the `assertArraySubset' part

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -490,7 +490,7 @@ $this->assertTrue($response['created']);
 ```
 
 > [!NOTE]  
-> The `assertJson` method converts the response to an array and utilizes `PHPUnit::assertArraySubset` to verify that the given array exists within the JSON response returned by the application. So, if there are other properties in the JSON response, this test will still pass as long as the given fragment is present.
+> The `assertJson` method converts the response to an array to verify that the given array exists within the JSON response returned by the application. So, if there are other properties in the JSON response, this test will still pass as long as the given fragment is present.
 
 <a name="verifying-exact-match"></a>
 #### Asserting Exact JSON Matches
@@ -1122,7 +1122,7 @@ Assert that the response contains the given JSON data:
 
     $response->assertJson(array $data, $strict = false);
 
-The `assertJson` method converts the response to an array and utilizes `PHPUnit::assertArraySubset` to verify that the given array exists within the JSON response returned by the application. So, if there are other properties in the JSON response, this test will still pass as long as the given fragment is present.
+The `assertJson` method converts the response to an array to verify that the given array exists within the JSON response returned by the application. So, if there are other properties in the JSON response, this test will still pass as long as the given fragment is present.
 
 <a name="assert-json-count"></a>
 #### assertJsonCount


### PR DESCRIPTION
There's no more `assertArraySubset' in PHPUnit itself.
I think it's time to remove this part.

This is the Laravel version.
https://github.com/laravel/framework/blob/11.x/src/Illuminate/Testing/Assert.php