### PR TITLE
update: heroku CI chrome buildpack

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -2121,7 +2121,7 @@ To run Dusk tests on [Heroku CI](https://www.heroku.com/continuous-integration),
         "test": {
           "buildpacks": [
             { "url": "heroku/php" },
-            { "url": "https://github.com/heroku/heroku-buildpack-google-chrome" }
+            { "url": "https://github.com/heroku/heroku-buildpack-chrome-for-testing" }
           ],
           "scripts": {
             "test-setup": "cp .env.testing .env",


### PR DESCRIPTION
Update Heroku Chrome Buildpack
---

The previous buildpack for chrome 
https://github.com/heroku/heroku-buildpack-google-chrome was deprecated and heroku recommends using the new chrome for testing buildpack.

