### PR TITLE
Expand `forget()` example to include removing multiple keys at once

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1074,10 +1074,12 @@ The `forget` method removes an item from the collection by its key:
 
     // Forget a single key...
     $collection->forget('name');
+
     // ['framework' => 'laravel']
 
     // Forget multiple keys...
     $collection->forget(['name', 'framework']);
+
     // []
 
 > [!WARNING]  

--- a/collections.md
+++ b/collections.md
@@ -1072,11 +1072,13 @@ The `forget` method removes an item from the collection by its key:
 
     $collection = collect(['name' => 'taylor', 'framework' => 'laravel']);
 
+    // Forget a single key...
     $collection->forget('name');
-
-    $collection->all();
-
     // ['framework' => 'laravel']
+
+    // Forget multiple keys...
+    $collection->forget(['name', 'framework']);
+    // []
 
 > [!WARNING]  
 > Unlike most other collection methods, `forget` does not return a new modified collection; it modifies the collection it is called on.


### PR DESCRIPTION
- Code formatting copied from `session.md`. However, I realise `$collection->all();` is no longer present which other collection examples use.

https://github.com/laravel/docs/blob/696cad17f80605f1cf2ff68c97f60873500c55ca/session.md?plain=1#L223-L227