### PR TITLE
[11.x] add clarification on component slot escaping

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -1496,9 +1496,6 @@ For example, imagine we are building a "todo" list application. We might define 
 </html>
 ```
 
-> [!NOTE]  
-> The `$slot` variable is not escaped, so you may pass HTML to it without using the `{!! !!}` syntax. Any content within the slot variable will follow the appropriate behavior of however it was echoed.
-
 <a name="applying-the-layout-component"></a>
 #### Applying the Layout Component
 

--- a/blade.md
+++ b/blade.md
@@ -1496,6 +1496,9 @@ For example, imagine we are building a "todo" list application. We might define 
 </html>
 ```
 
+> [!NOTE]  
+> The `$slot` variable is not escaped, so you may pass HTML to it without using the `{!! !!}` syntax. Any content within the slot variable will follow the appropriate behavior of however it was echoed.
+
 <a name="applying-the-layout-component"></a>
 #### Applying the Layout Component
 
@@ -1506,7 +1509,7 @@ Once the `layout` component has been defined, we may create a Blade view that ut
 
 <x-layout>
     @foreach ($tasks as $task)
-        {{ $task }}
+        <div>{{ $task }}</div>
     @endforeach
 </x-layout>
 ```
@@ -1522,7 +1525,7 @@ Remember, content that is injected into a component will be supplied to the defa
     </x-slot>
 
     @foreach ($tasks as $task)
-        {{ $task }}
+        <div>{{ $task }}</div>
     @endforeach
 </x-layout>
 ```


### PR DESCRIPTION
this was a little confusing to me when I first saw it, so wanted to add some clarification.

it is likely, especially when using a component for your layout, that the `$slot` variable will contain HTML.  however, the docs show the `{{ $slot }}` escaped version. although I'm not exactly sure where this happens in the code, it seems that a slot is treated specially, and does not escape content.  All code inside the slot appears to respect any escaped or unescaped content.

I've also added a wrapping `<div>` around each task to more closely reflect a real world use, and to further drive home the `$slot` will handle any HTML content it is provided.