### PR TITLE
[11.x] Update Pint Documentation

### DIFF
--- a/pint.md
+++ b/pint.md
@@ -165,7 +165,7 @@ If you would like to exclude a file by providing an exact path to the file, you 
 <a name="running-tests-on-github-actions"></a>
 ### GitHub Actions
 
-To automate linting your project with Laravel Pint, you can configure [GitHub Actions](https://github.com/features/actions) to run Pint whenever new code is pushed to GitHub. First, be sure to grant "Read and write permissions" to workflows within GitHub at **Settings > Actions > General > Workflow permissions**. Then, create a `.github/workflows/lint.yml` file with the following content:
+To automate linting your project with Laravel Pint, you can configure [GitHub Actions](https://github.com/features/actions) to run Pint whenever new code is pushed to GitHub. Create a `.github/workflows/lint.yml` file with the following content:
 
 ```yaml
 name: Fix Code Style

--- a/pint.md
+++ b/pint.md
@@ -179,6 +179,9 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.3]
+    
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This pull request improves the GitHub Actions workflow by adding the necessary `permissions: contents: write` setting. Without this, the `stefanzweifel/git-auto-commit-action@v5` would get a "permission denied" error when trying to commit linted files back to the repository after running Laravel Pint. This change ensures the action can be committed successfully.

[GitHub Actions Permissions Documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)

