### PR TITLE
Bring Fortify::authenticateThrough() default pipeline definition up to date

### DIFF
--- a/fortify.md
+++ b/fortify.md
@@ -189,6 +189,7 @@ The example below contains the default pipeline definition that you may use as a
 
 ```php
 use Laravel\Fortify\Actions\AttemptToAuthenticate;
+use Laravel\Fortify\Actions\CanonicalizeUsername;
 use Laravel\Fortify\Actions\EnsureLoginIsNotThrottled;
 use Laravel\Fortify\Actions\PrepareAuthenticatedSession;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
@@ -198,6 +199,7 @@ use Illuminate\Http\Request;
 Fortify::authenticateThrough(function (Request $request) {
     return array_filter([
             config('fortify.limiters.login') ? null : EnsureLoginIsNotThrottled::class,
+            config('fortify.lowercase_usernames') ? CanonicalizeUsername::class : null,
             Features::enabled(Features::twoFactorAuthentication()) ? RedirectIfTwoFactorAuthenticatable::class : null,
             AttemptToAuthenticate::class,
             PrepareAuthenticatedSession::class,

--- a/fortify.md
+++ b/fortify.md
@@ -193,6 +193,7 @@ use Laravel\Fortify\Actions\CanonicalizeUsername;
 use Laravel\Fortify\Actions\EnsureLoginIsNotThrottled;
 use Laravel\Fortify\Actions\PrepareAuthenticatedSession;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
+use Laravel\Fortify\Features;
 use Laravel\Fortify\Fortify;
 use Illuminate\Http\Request;
 


### PR DESCRIPTION
Was working through a tutorial on how someone improved the Jetstream Invite process and discovered the `Fortify::authenticateThrough()` default pipeline documentation has been outdated since the addition of https://github.com/laravel/fortify/pull/485.