### PR TITLE
Added subnet to trustedProxies example to show it's supported

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -604,7 +604,7 @@ To solve this, you may enable the `Illuminate\Http\Middleware\TrustProxies` midd
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->trustProxies(at: [
             '192.168.1.1',
-            '192.168.1.2',
+            '10.0.0.0/8',
         ]);
     })
 


### PR DESCRIPTION
I noticed the documentation https://laravel.com/docs/11.x/requests#configuring-trusted-proxies does not mention anything about subnets. I went through the code of when trusted proxies is used and you are able to use subnets but it is not obvious. 

This also better mirrors the symfony docs that are referenced https://symfony.com/doc/7.0/deployment/proxies.html

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/ed016ada-ff97-48aa-98b5-ea4c937b972d">

I really hope this addition is added just to help clarify for people in the future. Let me know if I did anything wrong or you want me to make any changes to my PR