### PR TITLE
Fix trustProxies usage in Sail configuration

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -460,9 +460,7 @@ sail share
 When sharing your site via the `share` command, you should configure your application's trusted proxies using the `trustProxies` middleware method in your application's `bootstrap/app.php` file. Otherwise, URL generation helpers such as `url` and `route` will be unable to determine the correct HTTP host that should be used during URL generation:
 
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->trustProxies(at: [
-            '*',
-        ]);
+        $middleware->trustProxies(at: '*');
     })
 
 If you would like to choose the subdomain for your shared site, you may provide the `subdomain` option when executing the `share` command:


### PR DESCRIPTION
The example doesn't work since the TrustProxies Middleware doesn't expect the wildcard (`*`)  to be in an array: 

https://github.com/laravel/framework/blob/0b85e157ca53d7002aead978d597e4a1ad37c944/src/Illuminate/Http/Middleware/TrustProxies.php#L70