### PR TITLE
[11.x] Update caveat for Vite URL processing with absolute paths and dedicated CSS entrypoints.

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -411,7 +411,7 @@ createInertiaApp({
 <a name="url-processing"></a>
 ### URL Processing
 
-When using Vite and referencing assets in your application's HTML, CSS, or JS, there are a couple of caveats to consider. First, if you reference assets with an absolute path, Vite will not include the asset in the build; therefore, you should ensure that the asset is available in your public directory. Absolute paths should be avoided when using a [dedicated CSS entrypoint](#configuring-vite) because, during development, browsers will attempt to load absolute paths from the Vite development server where the CSS is hosted instead of from your public directory.
+When using Vite and referencing assets in your application's HTML, CSS, or JS, there are a couple of caveats to consider. First, if you reference assets with an absolute path, Vite will not include the asset in the build; therefore, you should ensure that the asset is available in your public directory. You should avoid using absolute paths when using a [dedicated CSS entrypoint](#configuring-vite) because, during development, browsers will try to load these paths from the Vite development server, where the CSS is hosted, rather than from your public directory.
 
 When referencing relative asset paths, you should remember that the paths are relative to the file where they are referenced. Any assets referenced via a relative path will be re-written, versioned, and bundled by Vite.
 

--- a/vite.md
+++ b/vite.md
@@ -411,7 +411,7 @@ createInertiaApp({
 <a name="url-processing"></a>
 ### URL Processing
 
-When using Vite and referencing assets in your application's HTML, CSS, or JS, there are a couple of caveats to consider. First, if you reference assets with an absolute path, Vite will not include the asset in the build; therefore, you should ensure that the asset is available in your public directory.
+When using Vite and referencing assets in your application's HTML, CSS, or JS, there are a couple of caveats to consider. First, if you reference assets with an absolute path, Vite will not include the asset in the build; therefore, you should ensure that the asset is available in your public directory. Absolute paths should be avoided when using a [dedicated CSS entrypoint](#configuring-vite) because, during development, browsers will attempt to load absolute paths from the Vite development server where the CSS is hosted instead of from your public directory.
 
 When referencing relative asset paths, you should remember that the paths are relative to the file where they are referenced. Any assets referenced via a relative path will be re-written, versioned, and bundled by Vite.
 


### PR DESCRIPTION
This PR addresses a Vite issue that occurs during local development when absolute paths are used with a dedicated CSS entrypoint.

Resolves https://github.com/laravel/vite-plugin/issues/302