### PR TITLE
Fix trustProxies usage in Sail configuration (2)

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -460,9 +460,7 @@ sail share
 When sharing your site via the `share` command, you should configure your application's trusted proxies using the `trustProxies` middleware method in your application's `bootstrap/app.php` file. Otherwise, URL generation helpers such as `url` and `route` will be unable to determine the correct HTTP host that should be used during URL generation:
 
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->trustProxies(at: [
-            '*',
-        ]);
+        $middleware->trustProxies(at: '*');
     })
 
 If you would like to choose the subdomain for your shared site, you may provide the `subdomain` option when executing the `share` command:


### PR DESCRIPTION
Reopening #9823 as the usage is wrongly documented in the Sail documentation and wont work: https://laravel.com/docs/11.x/sail#sharing-your-site

I believe the previous PR has been overlooked too fast with the comment:
> That named argument doesn't even accept a string in its type hint.  

As I commented in the earlier PR: It does accept a string and using the wildcard in an array syntax won't work as expected: https://github.com/laravel/docs/pull/9823#issuecomment-2291888940

_There was an another PR about the documentation of `trustHosts(at: callback)` at the same time. The confusion is comprehensible since they both are very similar but doesn't share the same argument signature. `trustHosts()` doesn't accept a string, but this PR is about `trustProxies()`_

It's worth noting that the **HTTP Requests** documentation uses the correct syntax using a string: https://laravel.com/docs/11.x/requests#trusting-all-proxies