### PR TITLE
Remove canSelectAll example from multiselect

### DIFF
--- a/prompts.md
+++ b/prompts.md
@@ -421,16 +421,6 @@ $categories = multiselect(
 );
 ```
 
-You may allow the user to easily select all options via the `canSelectAll` argument:
-
-```php
-$categories = multiselect(
-    label: 'What categories should be assigned?',
-    options: Category::pluck('name', 'id'),
-    canSelectAll: true
-);
-```
-
 <a name="multiselect-required"></a>
 #### Requiring a Value
 


### PR DESCRIPTION
It looks like this parameter was reverted and replaced with a keyboard shortcut. See the PR here: https://github.com/laravel/prompts/pull/147

This option does not exist in the helper signature at all. Se: https://github.com/laravel/prompts/blob/main/src/helpers.php#L59
