### PR TITLE
Fix example

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -979,7 +979,7 @@ Alternatively, you may use the `limit` and `offset` methods. These methods are f
 
 Sometimes you may want certain query clauses to apply to a query based on another condition. For instance, you may only want to apply a `where` statement if a given input value is present on the incoming HTTP request. You may accomplish this using the `when` method:
 
-    $role = $request->string('role');
+    $role = $request->input('role');
 
     $users = DB::table('users')
                     ->when($role, function (Builder $query, string $role) {


### PR DESCRIPTION
The `Request::string` method returns a `Stringable` object. Objects always evaluate to `true`, so this example is broken because the `->when` `Closure` will always executed - even if the "role" input is an empty string.

Fixes https://github.com/laravel/framework/issues/52559