### PR TITLE
[5.4] Use classes instead of IDs

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -137,17 +137,17 @@ For the remainder of this documentation, we'll discuss each method available on 
 ## Method Listing
 
 <style>
-    #collection-method code {
+    .collection-method code {
         font-size: 14px;
     }
 
-    #collection-method:not(.first-collection-method) {
+    .collection-method:not(.first-collection-method) {
         margin-top: 50px;
     }
 </style>
 
 <a name="method-all"></a>
-#### `all()` {#collection-method .first-collection-method}
+#### `all()` {.collection-method .first-collection-method}
 
 The `all` method returns the underlying array represented by the collection:
 
@@ -156,12 +156,12 @@ The `all` method returns the underlying array represented by the collection:
     // [1, 2, 3]
 
 <a name="method-average"></a>
-#### `average()` {#collection-method}
+#### `average()` {.collection-method}
 
 Alias for the [`avg`](#method-avg) method.
 
 <a name="method-avg"></a>
-#### `avg()` {#collection-method}
+#### `avg()` {.collection-method}
 
 The `avg` method returns the [average value](https://en.wikipedia.org/wiki/Average) of a given key:
 
@@ -174,7 +174,7 @@ The `avg` method returns the [average value](https://en.wikipedia.org/wiki/Avera
     // 2
 
 <a name="method-chunk"></a>
-#### `chunk()` {#collection-method}
+#### `chunk()` {.collection-method}
 
 The `chunk` method breaks the collection into multiple, smaller collections of a given size:
 
@@ -197,7 +197,7 @@ This method is especially useful in [views](/docs/{{version}}/views) when workin
     @endforeach
 
 <a name="method-collapse"></a>
-#### `collapse()` {#collection-method}
+#### `collapse()` {.collection-method}
 
 The `collapse` method collapses a collection of arrays into a single, flat collection:
 
@@ -210,7 +210,7 @@ The `collapse` method collapses a collection of arrays into a single, flat colle
     // [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 <a name="method-combine"></a>
-#### `combine()` {#collection-method}
+#### `combine()` {.collection-method}
 
 The `combine` method combines the keys of the collection with the values of another array or collection:
 
@@ -223,7 +223,7 @@ The `combine` method combines the keys of the collection with the values of anot
     // ['name' => 'George', 'age' => 29]
 
 <a name="method-concat"></a>
-#### `concat()` {#collection-method}
+#### `concat()` {.collection-method}
  
 The `concat` method appends the given `array` or collection values onto the end of the collection, ignoring any existing keys in the given items:
  
@@ -236,7 +236,7 @@ The `concat` method appends the given `array` or collection values onto the end 
     // ['John Doe', 'Jane Doe', 'Johnny Doe'] 
 
 <a name="method-contains"></a>
-#### `contains()` {#collection-method}
+#### `contains()` {.collection-method}
 
 The `contains` method determines whether the collection contains a given item:
 
@@ -274,12 +274,12 @@ Finally, you may also pass a callback to the `contains` method to perform your o
 The `contains` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`containsStrict`](#method-containsstrict) method to filter using "strict" comparisons.
 
 <a name="method-containsstrict"></a>
-#### `containsStrict()` {#collection-method}
+#### `containsStrict()` {.collection-method}
 
 This method has the same signature as the [`contains`](#method-contains) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-count"></a>
-#### `count()` {#collection-method}
+#### `count()` {.collection-method}
 
 The `count` method returns the total number of items in the collection:
 
@@ -290,7 +290,7 @@ The `count` method returns the total number of items in the collection:
     // 4
 
 <a name="method-diff"></a>
-#### `diff()` {#collection-method}
+#### `diff()` {.collection-method}
 
 The `diff` method compares the collection against another collection or a plain PHP `array` based on its values. This method will return the values in the original collection that are not present in the given collection:
 
@@ -303,7 +303,7 @@ The `diff` method compares the collection against another collection or a plain 
     // [1, 3, 5]
 
 <a name="method-diffassoc"></a>
-#### `diffAssoc()` {#collection-method}
+#### `diffAssoc()` {.collection-method}
 
 The `diffAssoc` method compares the collection against another collection or a plain PHP `array` based on its keys and values. This method will return the key / value pairs in the original collection that are not present in the given collection:
 
@@ -325,7 +325,7 @@ The `diffAssoc` method compares the collection against another collection or a p
     // ['color' => 'orange', 'remain' => 6]
 
 <a name="method-diffkeys"></a>
-#### `diffKeys()` {#collection-method}
+#### `diffKeys()` {.collection-method}
 
 The `diffKeys` method compares the collection against another collection or a plain PHP `array` based on its keys. This method will return the key / value pairs in the original collection that are not present in the given collection:
 
@@ -349,7 +349,7 @@ The `diffKeys` method compares the collection against another collection or a pl
     // ['one' => 10, 'three' => 30, 'five' => 50]
 
 <a name="method-each"></a>
-#### `each()` {#collection-method}
+#### `each()` {.collection-method}
 
 The `each` method iterates over the items in the collection and passes each item to a callback:
 
@@ -366,7 +366,7 @@ If you would like to stop iterating through the items, you may return `false` fr
     });
 
 <a name="method-every"></a>
-#### `every()` {#collection-method}
+#### `every()` {.collection-method}
 
 The `every` method may be used to verify that all elements of a collection pass a given truth test:
 
@@ -377,7 +377,7 @@ The `every` method may be used to verify that all elements of a collection pass 
     // false
 
 <a name="method-except"></a>
-#### `except()` {#collection-method}
+#### `except()` {.collection-method}
 
 The `except` method returns all items in the collection except for those with the specified keys:
 
@@ -392,7 +392,7 @@ The `except` method returns all items in the collection except for those with th
 For the inverse of `except`, see the [only](#method-only) method.
 
 <a name="method-filter"></a>
-#### `filter()` {#collection-method}
+#### `filter()` {.collection-method}
 
 The `filter` method filters the collection using the given callback, keeping only those items that pass a given truth test:
 
@@ -417,7 +417,7 @@ If no callback is supplied, all entries of the collection that are equivalent to
 For the inverse of `filter`, see the [reject](#method-reject) method.
 
 <a name="method-first"></a>
-#### `first()` {#collection-method}
+#### `first()` {.collection-method}
 
 The `first` method returns the first element in the collection that passes a given truth test:
 
@@ -434,7 +434,7 @@ You may also call the `first` method with no arguments to get the first element 
     // 1
 
 <a name="method-flatmap"></a>
-#### `flatMap()` {#collection-method}
+#### `flatMap()` {.collection-method}
 
 The `flatMap` method iterates through the collection and passes each value to the given callback. The callback is free to modify the item and return it, thus forming a new collection of modified items. Then, the array is flattened by a level:
 
@@ -453,7 +453,7 @@ The `flatMap` method iterates through the collection and passes each value to th
     // ['name' => 'SALLY', 'school' => 'ARKANSAS', 'age' => '28'];
 
 <a name="method-flatten"></a>
-#### `flatten()` {#collection-method}
+#### `flatten()` {.collection-method}
 
 The `flatten` method flattens a multi-dimensional collection into a single dimension:
 
@@ -490,7 +490,7 @@ You may optionally pass the function a "depth" argument:
 In this example, calling `flatten` without providing the depth would have also flattened the nested arrays, resulting in `['iPhone 6S', 'Apple', 'Galaxy S7', 'Samsung']`. Providing a depth allows you to restrict the levels of nested arrays that will be flattened.
 
 <a name="method-flip"></a>
-#### `flip()` {#collection-method}
+#### `flip()` {.collection-method}
 
 The `flip` method swaps the collection's keys with their corresponding values:
 
@@ -503,7 +503,7 @@ The `flip` method swaps the collection's keys with their corresponding values:
     // ['taylor' => 'name', 'laravel' => 'framework']
 
 <a name="method-forget"></a>
-#### `forget()` {#collection-method}
+#### `forget()` {.collection-method}
 
 The `forget` method removes an item from the collection by its key:
 
@@ -518,7 +518,7 @@ The `forget` method removes an item from the collection by its key:
 > {note} Unlike most other collection methods, `forget` does not return a new modified collection; it modifies the collection it is called on.
 
 <a name="method-forpage"></a>
-#### `forPage()` {#collection-method}
+#### `forPage()` {.collection-method}
 
 The `forPage` method returns a new collection containing the items that would be present on a given page number. The method accepts the page number as its first argument and the number of items to show per page as its second argument:
 
@@ -531,7 +531,7 @@ The `forPage` method returns a new collection containing the items that would be
     // [4, 5, 6]
 
 <a name="method-get"></a>
-#### `get()` {#collection-method}
+#### `get()` {.collection-method}
 
 The `get` method returns the item at a given key. If the key does not exist, `null` is returned:
 
@@ -558,7 +558,7 @@ You may even pass a callback as the default value. The result of the callback wi
     // default-value
 
 <a name="method-groupby"></a>
-#### `groupBy()` {#collection-method}
+#### `groupBy()` {.collection-method}
 
 The `groupBy` method groups the collection's items by a given key:
 
@@ -605,7 +605,7 @@ In addition to passing a string `key`, you may also pass a callback. The callbac
     */
 
 <a name="method-has"></a>
-#### `has()` {#collection-method}
+#### `has()` {.collection-method}
 
 The `has` method determines if a given key exists in the collection:
 
@@ -616,7 +616,7 @@ The `has` method determines if a given key exists in the collection:
     // true
 
 <a name="method-implode"></a>
-#### `implode()` {#collection-method}
+#### `implode()` {.collection-method}
 
 The `implode` method joins the items in a collection. Its arguments depend on the type of items in the collection. If the collection contains arrays or objects, you should pass the key of the attributes you wish to join, and the "glue" string you wish to place between the values:
 
@@ -636,7 +636,7 @@ If the collection contains simple strings or numeric values, simply pass the "gl
     // '1-2-3-4-5'
 
 <a name="method-intersect"></a>
-#### `intersect()` {#collection-method}
+#### `intersect()` {.collection-method}
 
 The `intersect` method removes any values from the original collection that are not present in the given `array` or collection. The resulting collection will preserve the original collection's keys:
 
@@ -649,7 +649,7 @@ The `intersect` method removes any values from the original collection that are 
     // [0 => 'Desk', 2 => 'Chair']
 
 <a name="method-intersectkey"></a>
-#### `intersectKey()` {#collection-method}
+#### `intersectKey()` {.collection-method}
 
 The `intersectKey` method removes any keys from the original collection that are not present in the given `array` or collection:
 
@@ -666,7 +666,7 @@ The `intersectKey` method removes any keys from the original collection that are
     // ['type' => 'screen', 'year' => 2009]
 
 <a name="method-isempty"></a>
-#### `isEmpty()` {#collection-method}
+#### `isEmpty()` {.collection-method}
 
 The `isEmpty` method returns `true` if the collection is empty; otherwise, `false` is returned:
 
@@ -675,7 +675,7 @@ The `isEmpty` method returns `true` if the collection is empty; otherwise, `fals
     // true
 
 <a name="method-isnotempty"></a>
-#### `isNotEmpty()` {#collection-method}
+#### `isNotEmpty()` {.collection-method}
 
 The `isNotEmpty` method returns `true` if the collection is not empty; otherwise, `false` is returned:
 
@@ -684,7 +684,7 @@ The `isNotEmpty` method returns `true` if the collection is not empty; otherwise
     // false
 
 <a name="method-keyby"></a>
-#### `keyBy()` {#collection-method}
+#### `keyBy()` {.collection-method}
 
 The `keyBy` method keys the collection by the given key. If multiple items have the same key, only the last one will appear in the new collection:
 
@@ -720,7 +720,7 @@ You may also pass a callback to the method. The callback should return the value
     */
 
 <a name="method-keys"></a>
-#### `keys()` {#collection-method}
+#### `keys()` {.collection-method}
 
 The `keys` method returns all of the collection's keys:
 
@@ -736,7 +736,7 @@ The `keys` method returns all of the collection's keys:
     // ['prod-100', 'prod-200']
 
 <a name="method-last"></a>
-#### `last()` {#collection-method}
+#### `last()` {.collection-method}
 
 The `last` method returns the last element in the collection that passes a given truth test:
 
@@ -753,7 +753,7 @@ You may also call the `last` method with no arguments to get the last element in
     // 4
 
 <a name="method-map"></a>
-#### `map()` {#collection-method}
+#### `map()` {.collection-method}
 
 The `map` method iterates through the collection and passes each value to the given callback. The callback is free to modify the item and return it, thus forming a new collection of modified items:
 
@@ -770,7 +770,7 @@ The `map` method iterates through the collection and passes each value to the gi
 > {note} Like most other collection methods, `map` returns a new collection instance; it does not modify the collection it is called on. If you want to transform the original collection, use the [`transform`](#method-transform) method.
 
 <a name="method-mapwithkeys"></a>
-#### `mapWithKeys()` {#collection-method}
+#### `mapWithKeys()` {.collection-method}
 
 The `mapWithKeys` method iterates through the collection and passes each value to the given callback. The callback should return an associative array containing a single key / value pair:
 
@@ -801,7 +801,7 @@ The `mapWithKeys` method iterates through the collection and passes each value t
     */
 
 <a name="method-max"></a>
-#### `max()` {#collection-method}
+#### `max()` {.collection-method}
 
 The `max` method returns the maximum value of a given key:
 
@@ -814,7 +814,7 @@ The `max` method returns the maximum value of a given key:
     // 5
 
 <a name="method-median"></a>
-#### `median()` {#collection-method}
+#### `median()` {.collection-method}
 
 The `median` method returns the [median value](https://en.wikipedia.org/wiki/Median) of a given key:
 
@@ -827,7 +827,7 @@ The `median` method returns the [median value](https://en.wikipedia.org/wiki/Med
     // 1.5
 
 <a name="method-merge"></a>
-#### `merge()` {#collection-method}
+#### `merge()` {.collection-method}
 
 The `merge` method merges the given array or collection with the original collection. If a string key in the given items matches a string key in the original collection, the given items's value will overwrite the value in the original collection:
 
@@ -850,7 +850,7 @@ If the given items's keys are numeric, the values will be appended to the end of
     // ['Desk', 'Chair', 'Bookcase', 'Door']
 
 <a name="method-min"></a>
-#### `min()` {#collection-method}
+#### `min()` {.collection-method}
 
 The `min` method returns the minimum value of a given key:
 
@@ -863,7 +863,7 @@ The `min` method returns the minimum value of a given key:
     // 1
 
 <a name="method-mode"></a>
-#### `mode()` {#collection-method}
+#### `mode()` {.collection-method}
 
 The `mode` method returns the [mode value](https://en.wikipedia.org/wiki/Mode_(statistics)) of a given key:
 
@@ -876,7 +876,7 @@ The `mode` method returns the [mode value](https://en.wikipedia.org/wiki/Mode_(s
     // [1]
 
 <a name="method-nth"></a>
-#### `nth()` {#collection-method}
+#### `nth()` {.collection-method}
 
 The `nth` method creates a new collection consisting of every n-th element:
 
@@ -893,7 +893,7 @@ You may optionally pass an offset as the second argument:
     // ['b', 'f']
 
 <a name="method-only"></a>
-#### `only()` {#collection-method}
+#### `only()` {.collection-method}
 
 The `only` method returns the items in the collection with the specified keys:
 
@@ -908,7 +908,7 @@ The `only` method returns the items in the collection with the specified keys:
 For the inverse of `only`, see the [except](#method-except) method.
 
 <a name="method-partition"></a>
-#### `partition()` {#collection-method}
+#### `partition()` {.collection-method}
 
 The `partition` method may be combined with the `list` PHP function to separate elements that pass a given truth test from those that do not:
 
@@ -919,7 +919,7 @@ The `partition` method may be combined with the `list` PHP function to separate 
     });
 
 <a name="method-pipe"></a>
-#### `pipe()` {#collection-method}
+#### `pipe()` {.collection-method}
 
 The `pipe` method passes the collection to the given callback and returns the result:
 
@@ -932,7 +932,7 @@ The `pipe` method passes the collection to the given callback and returns the re
     // 6
 
 <a name="method-pluck"></a>
-#### `pluck()` {#collection-method}
+#### `pluck()` {.collection-method}
 
 The `pluck` method retrieves all of the values for a given key:
 
@@ -956,7 +956,7 @@ You may also specify how you wish the resulting collection to be keyed:
     // ['prod-100' => 'Desk', 'prod-200' => 'Chair']
 
 <a name="method-pop"></a>
-#### `pop()` {#collection-method}
+#### `pop()` {.collection-method}
 
 The `pop` method removes and returns the last item from the collection:
 
@@ -971,7 +971,7 @@ The `pop` method removes and returns the last item from the collection:
     // [1, 2, 3, 4]
 
 <a name="method-prepend"></a>
-#### `prepend()` {#collection-method}
+#### `prepend()` {.collection-method}
 
 The `prepend` method adds an item to the beginning of the collection:
 
@@ -994,7 +994,7 @@ You may also pass a second argument to set the key of the prepended item:
     // ['zero' => 0, 'one' => 1, 'two' => 2]
 
 <a name="method-pull"></a>
-#### `pull()` {#collection-method}
+#### `pull()` {.collection-method}
 
 The `pull` method removes and returns an item from the collection by its key:
 
@@ -1009,7 +1009,7 @@ The `pull` method removes and returns an item from the collection by its key:
     // ['product_id' => 'prod-100']
 
 <a name="method-push"></a>
-#### `push()` {#collection-method}
+#### `push()` {.collection-method}
 
 The `push` method appends an item to the end of the collection:
 
@@ -1022,7 +1022,7 @@ The `push` method appends an item to the end of the collection:
     // [1, 2, 3, 4, 5]
 
 <a name="method-put"></a>
-#### `put()` {#collection-method}
+#### `put()` {.collection-method}
 
 The `put` method sets the given key and value in the collection:
 
@@ -1035,7 +1035,7 @@ The `put` method sets the given key and value in the collection:
     // ['product_id' => 1, 'name' => 'Desk', 'price' => 100]
 
 <a name="method-random"></a>
-#### `random()` {#collection-method}
+#### `random()` {.collection-method}
 
 The `random` method returns a random item from the collection:
 
@@ -1056,7 +1056,7 @@ You may optionally pass an integer to `random` to specify how many items you wou
 If the Collection has fewer items than requested, the method will throw an `InvalidArgumentException`.
 
 <a name="method-reduce"></a>
-#### `reduce()` {#collection-method}
+#### `reduce()` {.collection-method}
 
 The `reduce` method reduces the collection to a single value, passing the result of each iteration into the subsequent iteration:
 
@@ -1077,7 +1077,7 @@ The value for `$carry` on the first iteration is `null`; however, you may specif
     // 10
 
 <a name="method-reject"></a>
-#### `reject()` {#collection-method}
+#### `reject()` {.collection-method}
 
 The `reject` method filters the collection using the given callback. The callback should return `true` if the item should be removed from the resulting collection:
 
@@ -1094,7 +1094,7 @@ The `reject` method filters the collection using the given callback. The callbac
 For the inverse of the `reject` method, see the [`filter`](#method-filter) method.
 
 <a name="method-reverse"></a>
-#### `reverse()` {#collection-method}
+#### `reverse()` {.collection-method}
 
 The `reverse` method reverses the order of the collection's items:
 
@@ -1107,7 +1107,7 @@ The `reverse` method reverses the order of the collection's items:
     // [5, 4, 3, 2, 1]
 
 <a name="method-search"></a>
-#### `search()` {#collection-method}
+#### `search()` {.collection-method}
 
 The `search` method searches the collection for the given value and returns its key if found. If the item is not found, `false` is returned.
 
@@ -1132,7 +1132,7 @@ Alternatively, you may pass in your own callback to search for the first item th
     // 2
 
 <a name="method-shift"></a>
-#### `shift()` {#collection-method}
+#### `shift()` {.collection-method}
 
 The `shift` method removes and returns the first item from the collection:
 
@@ -1147,7 +1147,7 @@ The `shift` method removes and returns the first item from the collection:
     // [2, 3, 4, 5]
 
 <a name="method-shuffle"></a>
-#### `shuffle()` {#collection-method}
+#### `shuffle()` {.collection-method}
 
 The `shuffle` method randomly shuffles the items in the collection:
 
@@ -1160,7 +1160,7 @@ The `shuffle` method randomly shuffles the items in the collection:
     // [3, 2, 5, 1, 4] - (generated randomly)
 
 <a name="method-slice"></a>
-#### `slice()` {#collection-method}
+#### `slice()` {.collection-method}
 
 The `slice` method returns a slice of the collection starting at the given index:
 
@@ -1183,7 +1183,7 @@ If you would like to limit the size of the returned slice, pass the desired size
 The returned slice will preserve keys by default. If you do not wish to preserve the original keys, you can use the [`values`](#method-values) method to reindex them.
 
 <a name="method-sort"></a>
-#### `sort()` {#collection-method}
+#### `sort()` {.collection-method}
 
 The `sort` method sorts the collection. The sorted collection keeps the original array keys, so in this example we'll use the [`values`](#method-values) method to reset the keys to consecutively numbered indexes:
 
@@ -1200,7 +1200,7 @@ If your sorting needs are more advanced, you may pass a callback to `sort` with 
 > {tip} If you need to sort a collection of nested arrays or objects, see the [`sortBy`](#method-sortby) and [`sortByDesc`](#method-sortbydesc) methods.
 
 <a name="method-sortby"></a>
-#### `sortBy()` {#collection-method}
+#### `sortBy()` {.collection-method}
 
 The `sortBy` method sorts the collection by the given key. The sorted collection keeps the original array keys, so in this example we'll use the [`values`](#method-values) method to reset the keys to consecutively numbered indexes:
 
@@ -1245,12 +1245,12 @@ You can also pass your own callback to determine how to sort the collection valu
     */
 
 <a name="method-sortbydesc"></a>
-#### `sortByDesc()` {#collection-method}
+#### `sortByDesc()` {.collection-method}
 
 This method has the same signature as the [`sortBy`](#method-sortby) method, but will sort the collection in the opposite order.
 
 <a name="method-splice"></a>
-#### `splice()` {#collection-method}
+#### `splice()` {.collection-method}
 
 The `splice` method removes and returns a slice of items starting at the specified index:
 
@@ -1295,7 +1295,7 @@ In addition, you can pass a third argument containing the new items to replace t
     // [1, 2, 10, 11, 4, 5]
 
 <a name="method-split"></a>
-#### `split()` {#collection-method}
+#### `split()` {.collection-method}
 
 The `split` method breaks a collection into the given number of groups:
 
@@ -1308,7 +1308,7 @@ The `split` method breaks a collection into the given number of groups:
     // [[1, 2], [3, 4], [5]]
 
 <a name="method-sum"></a>
-#### `sum()` {#collection-method}
+#### `sum()` {.collection-method}
 
 The `sum` method returns the sum of all items in the collection:
 
@@ -1342,7 +1342,7 @@ In addition, you may pass your own callback to determine which values of the col
     // 6
 
 <a name="method-take"></a>
-#### `take()` {#collection-method}
+#### `take()` {.collection-method}
 
 The `take` method returns a new collection with the specified number of items:
 
@@ -1365,7 +1365,7 @@ You may also pass a negative integer to take the specified amount of items from 
     // [4, 5]
 
 <a name="method-tap"></a>
-#### `tap()` {#collection-method}
+#### `tap()` {.collection-method}
 
 The `tap` method passes the collection to the given callback, allowing you to "tap" into the collection at a specific point and do something with the items while not affecting the collection itself:
 
@@ -1379,7 +1379,7 @@ The `tap` method passes the collection to the given callback, allowing you to "t
     // 1
 
 <a name="method-times"></a>
-#### `times()` {#collection-method}
+#### `times()` {.collection-method}
 
 The static `times` method creates a new collection by invoking the callback a given amount of times:
 
@@ -1408,7 +1408,7 @@ This method can be useful when combined with factories to create [Eloquent](/doc
     */
 
 <a name="method-toarray"></a>
-#### `toArray()` {#collection-method}
+#### `toArray()` {.collection-method}
 
 The `toArray` method converts the collection into a plain PHP `array`. If the collection's values are [Eloquent](/docs/{{version}}/eloquent) models, the models will also be converted to arrays:
 
@@ -1425,7 +1425,7 @@ The `toArray` method converts the collection into a plain PHP `array`. If the co
 > {note} `toArray` also converts all of the collection's nested objects to an array. If you want to get the raw underlying array, use the [`all`](#method-all) method instead.
 
 <a name="method-tojson"></a>
-#### `toJson()` {#collection-method}
+#### `toJson()` {.collection-method}
 
 The `toJson` method converts the collection into a JSON serialized string:
 
@@ -1436,7 +1436,7 @@ The `toJson` method converts the collection into a JSON serialized string:
     // '{"name":"Desk", "price":200}'
 
 <a name="method-transform"></a>
-#### `transform()` {#collection-method}
+#### `transform()` {.collection-method}
 
 The `transform` method iterates over the collection and calls the given callback with each item in the collection. The items in the collection will be replaced by the values returned by the callback:
 
@@ -1453,7 +1453,7 @@ The `transform` method iterates over the collection and calls the given callback
 > {note} Unlike most other collection methods, `transform` modifies the collection itself. If you wish to create a new collection instead, use the [`map`](#method-map) method.
 
 <a name="method-union"></a>
-#### `union()` {#collection-method}
+#### `union()` {.collection-method}
 
 The `union` method adds the given array to the collection. If the given array contains keys that are already in the original collection, the original collection's values will be preferred:
 
@@ -1466,7 +1466,7 @@ The `union` method adds the given array to the collection. If the given array co
     // [1 => ['a'], 2 => ['b'], 3 => ['c']]
 
 <a name="method-unique"></a>
-#### `unique()` {#collection-method}
+#### `unique()` {.collection-method}
 
 The `unique` method returns all of the unique items in the collection. The returned collection keeps the original array keys, so in this example we'll use the [`values`](#method-values) method to reset the keys to consecutively numbered indexes:
 
@@ -1519,12 +1519,12 @@ You may also pass your own callback to determine item uniqueness:
 The `unique` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`uniqueStrict`](#method-uniquestrict) method to filter using "strict" comparisons.
 
 <a name="method-uniquestrict"></a>
-#### `uniqueStrict()` {#collection-method}
+#### `uniqueStrict()` {.collection-method}
 
 This method has the same signature as the [`unique`](#method-unique) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-values"></a>
-#### `values()` {#collection-method}
+#### `values()` {.collection-method}
 
 The `values` method returns a new collection with the keys reset to consecutive integers:
 
@@ -1545,7 +1545,7 @@ The `values` method returns a new collection with the keys reset to consecutive 
     */
 
 <a name="method-when"></a>
-#### `when()` {#collection-method}
+#### `when()` {.collection-method}
 
 The `when` method will execute the given callback when the first argument given to the method evaluates to `true`:
 
@@ -1560,7 +1560,7 @@ The `when` method will execute the given callback when the first argument given 
     // [1, 2, 3, 4]
 
 <a name="method-where"></a>
-#### `where()` {#collection-method}
+#### `where()` {.collection-method}
 
 The `where` method filters the collection by a given key / value pair:
 
@@ -1585,12 +1585,12 @@ The `where` method filters the collection by a given key / value pair:
 The `where` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`whereStrict`](#method-wherestrict) method to filter using "strict" comparisons.
 
 <a name="method-wherestrict"></a>
-#### `whereStrict()` {#collection-method}
+#### `whereStrict()` {.collection-method}
 
 This method has the same signature as the [`where`](#method-where) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-wherein"></a>
-#### `whereIn()` {#collection-method}
+#### `whereIn()` {.collection-method}
 
 The `whereIn` method filters the collection by a given key / value contained within the given array:
 
@@ -1615,12 +1615,12 @@ The `whereIn` method filters the collection by a given key / value contained wit
 The `whereIn` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`whereInStrict`](#method-whereinstrict) method to filter using "strict" comparisons.
 
 <a name="method-whereinstrict"></a>
-#### `whereInStrict()` {#collection-method}
+#### `whereInStrict()` {.collection-method}
 
 This method has the same signature as the [`whereIn`](#method-wherein) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-wherenotin"></a>
-#### `whereNotIn()` {#collection-method}
+#### `whereNotIn()` {.collection-method}
 
 The `whereNotIn` method filters the collection by a given key / value not contained within the given array:
 
@@ -1645,12 +1645,12 @@ The `whereNotIn` method filters the collection by a given key / value not contai
 The `whereNotIn` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`whereNotInStrict`](#method-wherenotinstrict) method to filter using "strict" comparisons.
 
 <a name="method-wherenotinstrict"></a>
-#### `whereNotInStrict()` {#collection-method}
+#### `whereNotInStrict()` {.collection-method}
 
 This method has the same signature as the [`whereNotIn`](#method-wherenotin) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-zip"></a>
-#### `zip()` {#collection-method}
+#### `zip()` {.collection-method}
 
 The `zip` method merges together the values of the given array with the values of the original collection at the corresponding index:
 

--- a/helpers.md
+++ b/helpers.md
@@ -143,11 +143,11 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 ## Method Listing
 
 <style>
-    #collection-method code {
+    .collection-method code {
         font-size: 14px;
     }
 
-    #collection-method:not(.first-collection-method) {
+    .collection-method:not(.first-collection-method) {
         margin-top: 50px;
     }
 </style>
@@ -156,7 +156,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 ## Arrays
 
 <a name="method-array-add"></a>
-#### `array_add()` {#collection-method .first-collection-method}
+#### `array_add()` {.collection-method .first-collection-method}
 
 The `array_add` function adds a given key / value pair to the array if the given key doesn't already exist in the array:
 
@@ -165,7 +165,7 @@ The `array_add` function adds a given key / value pair to the array if the given
     // ['name' => 'Desk', 'price' => 100]
 
 <a name="method-array-collapse"></a>
-#### `array_collapse()` {#collection-method}
+#### `array_collapse()` {.collection-method}
 
 The `array_collapse` function collapses an array of arrays into a single array:
 
@@ -174,7 +174,7 @@ The `array_collapse` function collapses an array of arrays into a single array:
     // [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 <a name="method-array-divide"></a>
-#### `array_divide()` {#collection-method}
+#### `array_divide()` {.collection-method}
 
 The `array_divide` function returns two arrays, one containing the keys, and the other containing the values of the original array:
 
@@ -185,7 +185,7 @@ The `array_divide` function returns two arrays, one containing the keys, and the
     // $values: ['Desk']
 
 <a name="method-array-dot"></a>
-#### `array_dot()` {#collection-method}
+#### `array_dot()` {.collection-method}
 
 The `array_dot` function flattens a multi-dimensional array into a single level array that uses "dot" notation to indicate depth:
 
@@ -194,7 +194,7 @@ The `array_dot` function flattens a multi-dimensional array into a single level 
     // ['foo.bar' => 'baz'];
 
 <a name="method-array-except"></a>
-#### `array_except()` {#collection-method}
+#### `array_except()` {.collection-method}
 
 The `array_except` function removes the given key / value pairs from the array:
 
@@ -205,7 +205,7 @@ The `array_except` function removes the given key / value pairs from the array:
     // ['name' => 'Desk']
 
 <a name="method-array-first"></a>
-#### `array_first()` {#collection-method}
+#### `array_first()` {.collection-method}
 
 The `array_first` function returns the first element of an array passing a given truth test:
 
@@ -222,7 +222,7 @@ A default value may also be passed as the third parameter to the method. This va
     $value = array_first($array, $callback, $default);
 
 <a name="method-array-flatten"></a>
-#### `array_flatten()` {#collection-method}
+#### `array_flatten()` {.collection-method}
 
 The `array_flatten` function will flatten a multi-dimensional array into a single level.
 
@@ -233,7 +233,7 @@ The `array_flatten` function will flatten a multi-dimensional array into a singl
     // ['Joe', 'PHP', 'Ruby'];
 
 <a name="method-array-forget"></a>
-#### `array_forget()` {#collection-method}
+#### `array_forget()` {.collection-method}
 
 The `array_forget` function removes a given key / value pair from a deeply nested array using "dot" notation:
 
@@ -244,7 +244,7 @@ The `array_forget` function removes a given key / value pair from a deeply neste
     // ['products' => []]
 
 <a name="method-array-get"></a>
-#### `array_get()` {#collection-method}
+#### `array_get()` {.collection-method}
 
 The `array_get` function retrieves a value from a deeply nested array using "dot" notation:
 
@@ -259,7 +259,7 @@ The `array_get` function also accepts a default value, which will be returned if
     $value = array_get($array, 'names.john', 'default');
 
 <a name="method-array-has"></a>
-#### `array_has()` {#collection-method}
+#### `array_has()` {.collection-method}
 
 The `array_has` function checks that a given item or items exists in an array using "dot" notation:
 
@@ -274,7 +274,7 @@ The `array_has` function checks that a given item or items exists in an array us
     // false
 
 <a name="method-array-last"></a>
-#### `array_last()` {#collection-method}
+#### `array_last()` {.collection-method}
 
 The `array_last` function returns the last element of an array passing a given truth test:
 
@@ -287,7 +287,7 @@ The `array_last` function returns the last element of an array passing a given t
     // 300
 
 <a name="method-array-only"></a>
-#### `array_only()` {#collection-method}
+#### `array_only()` {.collection-method}
 
 The `array_only` function will return only the specified key / value pairs from the given array:
 
@@ -298,7 +298,7 @@ The `array_only` function will return only the specified key / value pairs from 
     // ['name' => 'Desk', 'price' => 100]
 
 <a name="method-array-pluck"></a>
-#### `array_pluck()` {#collection-method}
+#### `array_pluck()` {.collection-method}
 
 The `array_pluck` function will pluck a list of the given key / value pairs from the array:
 
@@ -318,7 +318,7 @@ You may also specify how you wish the resulting list to be keyed:
     // [1 => 'Taylor', 2 => 'Abigail'];
 
 <a name="method-array-prepend"></a>
-#### `array_prepend()` {#collection-method}
+#### `array_prepend()` {.collection-method}
 
 The `array_prepend` function will push an item onto the beginning of an array:
 
@@ -329,7 +329,7 @@ The `array_prepend` function will push an item onto the beginning of an array:
     // $array: ['zero', 'one', 'two', 'three', 'four']
 
 <a name="method-array-pull"></a>
-#### `array_pull()` {#collection-method}
+#### `array_pull()` {.collection-method}
 
 The `array_pull` function returns and removes a key / value pair from the array:
 
@@ -342,7 +342,7 @@ The `array_pull` function returns and removes a key / value pair from the array:
     // $array: ['price' => 100]
 
 <a name="method-array-set"></a>
-#### `array_set()` {#collection-method}
+#### `array_set()` {.collection-method}
 
 The `array_set` function sets a value within a deeply nested array using "dot" notation:
 
@@ -353,7 +353,7 @@ The `array_set` function sets a value within a deeply nested array using "dot" n
     // ['products' => ['desk' => ['price' => 200]]]
 
 <a name="method-array-sort"></a>
-#### `array_sort()` {#collection-method}
+#### `array_sort()` {.collection-method}
 
 The `array_sort` function sorts the array by the results of the given Closure:
 
@@ -374,7 +374,7 @@ The `array_sort` function sorts the array by the results of the given Closure:
     */
 
 <a name="method-array-sort-recursive"></a>
-#### `array_sort_recursive()` {#collection-method}
+#### `array_sort_recursive()` {.collection-method}
 
 The `array_sort_recursive` function recursively sorts the array using the `sort` function:
 
@@ -409,7 +409,7 @@ The `array_sort_recursive` function recursively sorts the array using the `sort`
     */
 
 <a name="method-array-where"></a>
-#### `array_where()` {#collection-method}
+#### `array_where()` {.collection-method}
 
 The `array_where` function filters the array using the given Closure:
 
@@ -422,7 +422,7 @@ The `array_where` function filters the array using the given Closure:
     // [1 => 200, 3 => 400]
 
 <a name="method-array-wrap"></a>
-#### `array_wrap()` {#collection-method}
+#### `array_wrap()` {.collection-method}
 
 The `array_wrap` function will wrap the given value in an array. If the given value is already an array it will not be changed:
 
@@ -433,7 +433,7 @@ The `array_wrap` function will wrap the given value in an array. If the given va
     // [0 => 'Laravel']
 
 <a name="method-head"></a>
-#### `head()` {#collection-method}
+#### `head()` {.collection-method}
 
 The `head` function returns the first element in the given array:
 
@@ -444,7 +444,7 @@ The `head` function returns the first element in the given array:
     // 100
 
 <a name="method-last"></a>
-#### `last()` {#collection-method}
+#### `last()` {.collection-method}
 
 The `last` function returns the last element in the given array:
 
@@ -458,7 +458,7 @@ The `last` function returns the last element in the given array:
 ## Paths
 
 <a name="method-app-path"></a>
-#### `app_path()` {#collection-method}
+#### `app_path()` {.collection-method}
 
 The `app_path` function returns the fully qualified path to the `app` directory. You may also use the `app_path` function to generate a fully qualified path to a file relative to the application directory:
 
@@ -467,7 +467,7 @@ The `app_path` function returns the fully qualified path to the `app` directory.
     $path = app_path('Http/Controllers/Controller.php');
 
 <a name="method-base-path"></a>
-#### `base_path()` {#collection-method}
+#### `base_path()` {.collection-method}
 
 The `base_path` function returns the fully qualified path to the project root. You may also use the `base_path` function to generate a fully qualified path to a given file relative to the project root directory:
 
@@ -476,35 +476,35 @@ The `base_path` function returns the fully qualified path to the project root. Y
     $path = base_path('vendor/bin');
 
 <a name="method-config-path"></a>
-#### `config_path()` {#collection-method}
+#### `config_path()` {.collection-method}
 
 The `config_path` function returns the fully qualified path to the application configuration directory:
 
     $path = config_path();
 
 <a name="method-database-path"></a>
-#### `database_path()` {#collection-method}
+#### `database_path()` {.collection-method}
 
 The `database_path` function returns the fully qualified path to the application's database directory:
 
     $path = database_path();
 
 <a name="method-mix"></a>
-#### `mix()` {#collection-method}
+#### `mix()` {.collection-method}
 
 The `mix` function gets the path to a [versioned Mix file](/docs/{{version}}/mix):
 
     mix($file);
 
 <a name="method-public-path"></a>
-#### `public_path()` {#collection-method}
+#### `public_path()` {.collection-method}
 
 The `public_path` function returns the fully qualified path to the `public` directory:
 
     $path = public_path();
 
 <a name="method-resource-path"></a>
-#### `resource_path()` {#collection-method}
+#### `resource_path()` {.collection-method}
 
 The `resource_path` function returns the fully qualified path to the `resources` directory. You may also use the `resource_path` function to generate a fully qualified path to a given file relative to the resources directory:
 
@@ -513,7 +513,7 @@ The `resource_path` function returns the fully qualified path to the `resources`
     $path = resource_path('assets/sass/app.scss');
 
 <a name="method-storage-path"></a>
-#### `storage_path()` {#collection-method}
+#### `storage_path()` {.collection-method}
 
 The `storage_path` function returns the fully qualified path to the `storage` directory. You may also use the `storage_path` function to generate a fully qualified path to a given file relative to the storage directory:
 
@@ -525,7 +525,7 @@ The `storage_path` function returns the fully qualified path to the `storage` di
 ## Strings
 
 <a name="method-camel-case"></a>
-#### `camel_case()` {#collection-method}
+#### `camel_case()` {.collection-method}
 
 The `camel_case` function converts the given string to `camelCase`:
 
@@ -534,7 +534,7 @@ The `camel_case` function converts the given string to `camelCase`:
     // fooBar
 
 <a name="method-class-basename"></a>
-#### `class_basename()` {#collection-method}
+#### `class_basename()` {.collection-method}
 
 The `class_basename` returns the class name of the given class with the class' namespace removed:
 
@@ -543,7 +543,7 @@ The `class_basename` returns the class name of the given class with the class' n
     // Baz
 
 <a name="method-e"></a>
-#### `e()` {#collection-method}
+#### `e()` {.collection-method}
 
 The `e` function runs PHP's `htmlspecialchars` function with the `double_encode` option set to `false`:
 
@@ -552,7 +552,7 @@ The `e` function runs PHP's `htmlspecialchars` function with the `double_encode`
     // &lt;html&gt;foo&lt;/html&gt;
 
 <a name="method-ends-with"></a>
-#### `ends_with()` {#collection-method}
+#### `ends_with()` {.collection-method}
 
 The `ends_with` function determines if the given string ends with the given value:
 
@@ -561,7 +561,7 @@ The `ends_with` function determines if the given string ends with the given valu
     // true
 
 <a name="method-kebab-case"></a>
-#### `kebab_case()` {#collection-method}
+#### `kebab_case()` {.collection-method}
 
 The `kebab_case` function converts the given string to `kebab-case`:
 
@@ -571,7 +571,7 @@ The `kebab_case` function converts the given string to `kebab-case`:
 
 
 <a name="method-snake-case"></a>
-#### `snake_case()` {#collection-method}
+#### `snake_case()` {.collection-method}
 
 The `snake_case` function converts the given string to `snake_case`:
 
@@ -580,7 +580,7 @@ The `snake_case` function converts the given string to `snake_case`:
     // foo_bar
 
 <a name="method-str-limit"></a>
-#### `str_limit()` {#collection-method}
+#### `str_limit()` {.collection-method}
 
 The `str_limit` function limits the number of characters in a string. The function accepts a string as its first argument and the maximum number of resulting characters as its second argument:
 
@@ -589,7 +589,7 @@ The `str_limit` function limits the number of characters in a string. The functi
     // The PHP...
 
 <a name="method-starts-with"></a>
-#### `starts_with()` {#collection-method}
+#### `starts_with()` {.collection-method}
 
 The `starts_with` function determines if the given string begins with the given value:
 
@@ -598,7 +598,7 @@ The `starts_with` function determines if the given string begins with the given 
     // true
 
 <a name="method-str-after"></a>
-#### `str_after()` {#collection-method}
+#### `str_after()` {.collection-method}
 
 The `str_after` function returns everything after the given value in a string:
 
@@ -607,7 +607,7 @@ The `str_after` function returns everything after the given value in a string:
     // ' a test'
 
 <a name="method-str-contains"></a>
-#### `str_contains()` {#collection-method}
+#### `str_contains()` {.collection-method}
 
 The `str_contains` function determines if the given string contains the given value:
 
@@ -622,7 +622,7 @@ You may also pass an array of values to determine if the given string contains a
     // true
 
 <a name="method-str-finish"></a>
-#### `str_finish()` {#collection-method}
+#### `str_finish()` {.collection-method}
 
 The `str_finish` function adds a single instance of the given value to a string if it does not already end with it:
 
@@ -632,7 +632,7 @@ The `str_finish` function adds a single instance of the given value to a string 
     // this/string/
 
 <a name="method-str-is"></a>
-#### `str_is()` {#collection-method}
+#### `str_is()` {.collection-method}
 
 The `str_is` function determines if a given string matches a given pattern. Asterisks may be used to indicate wildcards:
 
@@ -645,7 +645,7 @@ The `str_is` function determines if a given string matches a given pattern. Aste
     // false
 
 <a name="method-str-plural"></a>
-#### `str_plural()` {#collection-method}
+#### `str_plural()` {.collection-method}
 
 The `str_plural` function converts a string to its plural form. This function currently only supports the English language:
 
@@ -668,14 +668,14 @@ You may provide an integer as a second argument to the function to retrieve the 
     // child
 
 <a name="method-str-random"></a>
-#### `str_random()` {#collection-method}
+#### `str_random()` {.collection-method}
 
 The `str_random` function generates a random string of the specified length. This function uses PHP's `random_bytes` function:
 
     $string = str_random(40);
 
 <a name="method-str-singular"></a>
-#### `str_singular()` {#collection-method}
+#### `str_singular()` {.collection-method}
 
 The `str_singular` function converts a string to its singular form. This function currently only supports the English language:
 
@@ -684,7 +684,7 @@ The `str_singular` function converts a string to its singular form. This functio
     // car
 
 <a name="method-str-slug"></a>
-#### `str_slug()` {#collection-method}
+#### `str_slug()` {.collection-method}
 
 The `str_slug` function generates a URL friendly "slug" from the given string:
 
@@ -693,7 +693,7 @@ The `str_slug` function generates a URL friendly "slug" from the given string:
     // laravel-5-framework
 
 <a name="method-studly-case"></a>
-#### `studly_case()` {#collection-method}
+#### `studly_case()` {.collection-method}
 
 The `studly_case` function converts the given string to `StudlyCase`:
 
@@ -702,7 +702,7 @@ The `studly_case` function converts the given string to `StudlyCase`:
     // FooBar
 
 <a name="method-title-case"></a>
-#### `title_case()` {#collection-method}
+#### `title_case()` {.collection-method}
 
 The `title_case` function converts the given string to `Title Case`:
 
@@ -711,14 +711,14 @@ The `title_case` function converts the given string to `Title Case`:
     // A Nice Title Uses The Correct Case
 
 <a name="method-trans"></a>
-#### `trans()` {#collection-method}
+#### `trans()` {.collection-method}
 
 The `trans` function translates the given language line using your [localization files](/docs/{{version}}/localization):
 
     echo trans('validation.required'):
 
 <a name="method-trans-choice"></a>
-#### `trans_choice()` {#collection-method}
+#### `trans_choice()` {.collection-method}
 
 The `trans_choice` function translates the given language line with inflection:
 
@@ -728,7 +728,7 @@ The `trans_choice` function translates the given language line with inflection:
 ## URLs
 
 <a name="method-action"></a>
-#### `action()` {#collection-method}
+#### `action()` {.collection-method}
 
 The `action` function generates a URL for the given controller action. You do not need to pass the full namespace to the controller. Instead, pass the controller class name relative to the `App\Http\Controllers` namespace:
 
@@ -739,21 +739,21 @@ If the method accepts route parameters, you may pass them as the second argument
     $url = action('UserController@profile', ['id' => 1]);
 
 <a name="method-asset"></a>
-#### `asset()` {#collection-method}
+#### `asset()` {.collection-method}
 
 Generate a URL for an asset using the current scheme of the request (HTTP or HTTPS):
 
     $url = asset('img/photo.jpg');
 
 <a name="method-secure-asset"></a>
-#### `secure_asset()` {#collection-method}
+#### `secure_asset()` {.collection-method}
 
 Generate a URL for an asset using HTTPS:
 
     echo secure_asset('foo/bar.zip');
 
 <a name="method-route"></a>
-#### `route()` {#collection-method}
+#### `route()` {.collection-method}
 
 The `route` function generates a URL for the given named route:
 
@@ -768,7 +768,7 @@ By default, the `route` function generates an absolute URL. If you wish to gener
     $url = route('routeName', ['id' => 1], false);
 
 <a name="method-secure-url"></a>
-#### `secure_url()` {#collection-method}
+#### `secure_url()` {.collection-method}
 
 The `secure_url` function generates a fully qualified HTTPS URL to the given path:
 
@@ -777,7 +777,7 @@ The `secure_url` function generates a fully qualified HTTPS URL to the given pat
     echo secure_url('user/profile', [1]);
 
 <a name="method-url"></a>
-#### `url()` {#collection-method}
+#### `url()` {.collection-method}
 
 The `url` function generates a fully qualified URL to the given path:
 
@@ -795,7 +795,7 @@ If no path is provided, a `Illuminate\Routing\UrlGenerator` instance is returned
 ## Miscellaneous
 
 <a name="method-abort"></a>
-#### `abort()` {#collection-method}
+#### `abort()` {.collection-method}
 
 The `abort` function throws a HTTP exception which will be rendered by the exception handler:
 
@@ -806,42 +806,42 @@ You may also provide the exception's response text:
     abort(401, 'Unauthorized.');
 
 <a name="method-abort-if"></a>
-#### `abort_if()` {#collection-method}
+#### `abort_if()` {.collection-method}
 
 The `abort_if` function throws an HTTP exception if a given boolean expression evaluates to `true`:
 
     abort_if(! Auth::user()->isAdmin(), 403);
 
 <a name="method-abort-unless"></a>
-#### `abort_unless()` {#collection-method}
+#### `abort_unless()` {.collection-method}
 
 The `abort_unless` function throws an HTTP exception if a given boolean expression evaluates to `false`:
 
     abort_unless(Auth::user()->isAdmin(), 403);
 
 <a name="method-auth"></a>
-#### `auth()` {#collection-method}
+#### `auth()` {.collection-method}
 
 The `auth` function returns an authenticator instance. You may use it instead of the `Auth` facade for convenience:
 
     $user = auth()->user();
 
 <a name="method-back"></a>
-#### `back()` {#collection-method}
+#### `back()` {.collection-method}
 
 The `back()` function generates a redirect response to the user's previous location:
 
     return back();
 
 <a name="method-bcrypt"></a>
-#### `bcrypt()` {#collection-method}
+#### `bcrypt()` {.collection-method}
 
 The `bcrypt` function hashes the given value using Bcrypt. You may use it as an alternative to the `Hash` facade:
 
     $password = bcrypt('my-secret-password');
 
 <a name="method-cache"></a>
-#### `cache()` {#collection-method}
+#### `cache()` {.collection-method}
 
 The `cache` function may be used to get values from the cache. If the given key does not exist in the cache, an optional default value will be returned:
 
@@ -856,14 +856,14 @@ You may add items to the cache by passing an array of key / value pairs to the f
     cache(['key' => 'value'], Carbon::now()->addSeconds(10));
 
 <a name="method-collect"></a>
-#### `collect()` {#collection-method}
+#### `collect()` {.collection-method}
 
 The `collect` function creates a [collection](/docs/{{version}}/collections) instance from the given array:
 
     $collection = collect(['taylor', 'abigail']);
 
 <a name="method-config"></a>
-#### `config()` {#collection-method}
+#### `config()` {.collection-method}
 
 The `config` function gets the value of a configuration variable. The configuration values may be accessed using "dot" syntax, which includes the name of the file and the option you wish to access. A default value may be specified and is returned if the configuration option does not exist:
 
@@ -876,21 +876,21 @@ The `config` helper may also be used to set configuration variables at runtime b
     config(['app.debug' => true]);
 
 <a name="method-csrf-field"></a>
-#### `csrf_field()` {#collection-method}
+#### `csrf_field()` {.collection-method}
 
 The `csrf_field` function generates an HTML `hidden` input field containing the value of the CSRF token. For example, using [Blade syntax](/docs/{{version}}/blade):
 
     {{ csrf_field() }}
 
 <a name="method-csrf-token"></a>
-#### `csrf_token()` {#collection-method}
+#### `csrf_token()` {.collection-method}
 
 The `csrf_token` function retrieves the value of the current CSRF token:
 
     $token = csrf_token();
 
 <a name="method-dd"></a>
-#### `dd()` {#collection-method}
+#### `dd()` {.collection-method}
 
 The `dd` function dumps the given variables and ends execution of the script:
 
@@ -903,14 +903,14 @@ If you do not want to halt the execution of your script, use the `dump` function
     dump($value);
 
 <a name="method-dispatch"></a>
-#### `dispatch()` {#collection-method}
+#### `dispatch()` {.collection-method}
 
 The `dispatch` function pushes a new job onto the Laravel [job queue](/docs/{{version}}/queues):
 
     dispatch(new App\Jobs\SendEmails);
 
 <a name="method-env"></a>
-#### `env()` {#collection-method}
+#### `env()` {.collection-method}
 
 The `env` function gets the value of an environment variable or returns a default value:
 
@@ -920,21 +920,21 @@ The `env` function gets the value of an environment variable or returns a defaul
     $env = env('APP_ENV', 'production');
 
 <a name="method-event"></a>
-#### `event()` {#collection-method}
+#### `event()` {.collection-method}
 
 The `event` function dispatches the given [event](/docs/{{version}}/events) to its listeners:
 
     event(new UserRegistered($user));
 
 <a name="method-factory"></a>
-#### `factory()` {#collection-method}
+#### `factory()` {.collection-method}
 
 The `factory` function creates a model factory builder for a given class, name, and amount. It can be used while [testing](/docs/{{version}}/database-testing#writing-factories) or [seeding](/docs/{{version}}/seeding#using-model-factories):
 
     $user = factory(App\User::class)->make();
 
 <a name="method-info"></a>
-#### `info()` {#collection-method}
+#### `info()` {.collection-method}
 
 The `info` function will write information to the log:
 
@@ -945,7 +945,7 @@ An array of contextual data may also be passed to the function:
     info('User login attempt failed.', ['id' => $user->id]);
 
 <a name="method-logger"></a>
-#### `logger()` {#collection-method}
+#### `logger()` {.collection-method}
 
 The `logger` function can be used to write a `debug` level message to the log:
 
@@ -960,7 +960,7 @@ A [logger](/docs/{{version}}/errors#logging) instance will be returned if no val
     logger()->error('You are not allowed here.');
 
 <a name="method-method-field"></a>
-#### `method_field()` {#collection-method}
+#### `method_field()` {.collection-method}
 
 The `method_field` function generates an HTML `hidden` input field containing the spoofed value of the form's HTTP verb. For example, using [Blade syntax](/docs/{{version}}/blade):
 
@@ -969,7 +969,7 @@ The `method_field` function generates an HTML `hidden` input field containing th
     </form>
 
 <a name="method-old"></a>
-#### `old()` {#collection-method}
+#### `old()` {.collection-method}
 
 The `old` function [retrieves](/docs/{{version}}/requests#retrieving-input) an old input value flashed into the session:
 
@@ -978,7 +978,7 @@ The `old` function [retrieves](/docs/{{version}}/requests#retrieving-input) an o
     $value = old('value', 'default');
 
 <a name="method-redirect"></a>
-#### `redirect()` {#collection-method}
+#### `redirect()` {.collection-method}
 
 The `redirect` function returns a redirect HTTP response, or returns the redirector instance if called with no arguments:
 
@@ -987,7 +987,7 @@ The `redirect` function returns a redirect HTTP response, or returns the redirec
     return redirect()->route('route.name');
 
 <a name="method-request"></a>
-#### `request()` {#collection-method}
+#### `request()` {.collection-method}
 
 The `request` function returns the current [request](/docs/{{version}}/requests) instance or obtains an input item:
 
@@ -996,7 +996,7 @@ The `request` function returns the current [request](/docs/{{version}}/requests)
     $value = request('key', $default = null)
 
 <a name="method-response"></a>
-#### `response()` {#collection-method}
+#### `response()` {.collection-method}
 
 The `response` function creates a [response](/docs/{{version}}/responses) instance or obtains an instance of the response factory:
 
@@ -1005,7 +1005,7 @@ The `response` function creates a [response](/docs/{{version}}/responses) instan
     return response()->json(['foo' => 'bar'], 200, $headers);
 
 <a name="method-retry"></a>
-#### `retry()` {#collection-method}
+#### `retry()` {.collection-method}
 
 The `retry` function attempts to execute the given callback until the given maximum attempt threshold is met. If the callback does not throw an exception, it's return value will be returned. If the callback throws an exception, it will automatically be retried. If the maximum attempt count is exceeded, the exception will be thrown:
 
@@ -1014,7 +1014,7 @@ The `retry` function attempts to execute the given callback until the given maxi
     }, 100);
 
 <a name="method-session"></a>
-#### `session()` {#collection-method}
+#### `session()` {.collection-method}
 
 The `session` function may be used to get or set session values:
 
@@ -1031,7 +1031,7 @@ The session store will be returned if no value is passed to the function:
     session()->put('key', $value);
 
 <a name="method-value"></a>
-#### `value()` {#collection-method}
+#### `value()` {.collection-method}
 
 The `value` function's behavior will simply return the value it is given. However, if you pass a `Closure` to the function, the `Closure` will be executed then its result will be returned:
 
@@ -1040,7 +1040,7 @@ The `value` function's behavior will simply return the value it is given. Howeve
     });
 
 <a name="method-view"></a>
-#### `view()` {#collection-method}
+#### `view()` {.collection-method}
 
 The `view` function retrieves a [view](/docs/{{version}}/views) instance:
 


### PR DESCRIPTION
Collection and helper function heading tags are currently broken for several older versions of the docs. This PR targets `5.4`.

On server render, the heading tags all contain the same literal `id="collection-method" attribute; IDs are meant to be unique.

```html
<h4 id="collection-method"><code>random()</code></h4>
```

When the JavaScript kicks in, the ID attribute is updated its corresponding `<a name="...">` link, however the intended styling is then broken because it targets the `id` attribute, e.g., `#collection-method { ... }`.

This PR updates the `5.1` branch to use classes instead of IDs, which means that it:

- Matches the later documentation versions
- Gets the intended styling applied
- Has no flash of styled / unstyled content