### PR TITLE
[5.6] Use classes instead of IDs

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -175,17 +175,17 @@ For the remainder of this documentation, we'll discuss each method available on 
 ## Method Listing
 
 <style>
-    #collection-method code {
+    .collection-method code {
         font-size: 14px;
     }
 
-    #collection-method:not(.first-collection-method) {
+    .collection-method:not(.first-collection-method) {
         margin-top: 50px;
     }
 </style>
 
 <a name="method-all"></a>
-#### `all()` {#collection-method .first-collection-method}
+#### `all()` {.collection-method .first-collection-method}
 
 The `all` method returns the underlying array represented by the collection:
 
@@ -194,12 +194,12 @@ The `all` method returns the underlying array represented by the collection:
     // [1, 2, 3]
 
 <a name="method-average"></a>
-#### `average()` {#collection-method}
+#### `average()` {.collection-method}
 
 Alias for the [`avg`](#method-avg) method.
 
 <a name="method-avg"></a>
-#### `avg()` {#collection-method}
+#### `avg()` {.collection-method}
 
 The `avg` method returns the [average value](https://en.wikipedia.org/wiki/Average) of a given key:
 
@@ -212,7 +212,7 @@ The `avg` method returns the [average value](https://en.wikipedia.org/wiki/Avera
     // 2
 
 <a name="method-chunk"></a>
-#### `chunk()` {#collection-method}
+#### `chunk()` {.collection-method}
 
 The `chunk` method breaks the collection into multiple, smaller collections of a given size:
 
@@ -235,7 +235,7 @@ This method is especially useful in [views](/docs/{{version}}/views) when workin
     @endforeach
 
 <a name="method-collapse"></a>
-#### `collapse()` {#collection-method}
+#### `collapse()` {.collection-method}
 
 The `collapse` method collapses a collection of arrays into a single, flat collection:
 
@@ -248,7 +248,7 @@ The `collapse` method collapses a collection of arrays into a single, flat colle
     // [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 <a name="method-combine"></a>
-#### `combine()` {#collection-method}
+#### `combine()` {.collection-method}
 
 The `combine` method combines the keys of the collection with the values of another array or collection:
 
@@ -261,7 +261,7 @@ The `combine` method combines the keys of the collection with the values of anot
     // ['name' => 'George', 'age' => 29]
 
 <a name="method-concat"></a>
-#### `concat()` {#collection-method}
+#### `concat()` {.collection-method}
 
 The `concat` method appends the given `array` or collection values onto the end of the collection:
 
@@ -274,7 +274,7 @@ The `concat` method appends the given `array` or collection values onto the end 
     // ['John Doe', 'Jane Doe', 'Johnny Doe']
 
 <a name="method-contains"></a>
-#### `contains()` {#collection-method}
+#### `contains()` {.collection-method}
 
 The `contains` method determines whether the collection contains a given item:
 
@@ -312,12 +312,12 @@ Finally, you may also pass a callback to the `contains` method to perform your o
 The `contains` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`containsStrict`](#method-containsstrict) method to filter using "strict" comparisons.
 
 <a name="method-containsstrict"></a>
-#### `containsStrict()` {#collection-method}
+#### `containsStrict()` {.collection-method}
 
 This method has the same signature as the [`contains`](#method-contains) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-count"></a>
-#### `count()` {#collection-method}
+#### `count()` {.collection-method}
 
 The `count` method returns the total number of items in the collection:
 
@@ -328,7 +328,7 @@ The `count` method returns the total number of items in the collection:
     // 4
 
 <a name="method-crossjoin"></a>
-#### `crossJoin()` {#collection-method}
+#### `crossJoin()` {.collection-method}
 
 The `crossJoin` method cross joins the collection's values among the given arrays or collections, returning a Cartesian product with all possible permutations:
 
@@ -367,7 +367,7 @@ The `crossJoin` method cross joins the collection's values among the given array
     */
 
 <a name="method-dd"></a>
-#### `dd()` {#collection-method}
+#### `dd()` {.collection-method}
 
 The `dd` method dumps the collection's items and ends execution of the script:
 
@@ -387,7 +387,7 @@ The `dd` method dumps the collection's items and ends execution of the script:
 If you do not want to stop executing the script, use the [`dump`](#method-dump) method instead.
 
 <a name="method-diff"></a>
-#### `diff()` {#collection-method}
+#### `diff()` {.collection-method}
 
 The `diff` method compares the collection against another collection or a plain PHP `array` based on its values. This method will return the values in the original collection that are not present in the given collection:
 
@@ -400,7 +400,7 @@ The `diff` method compares the collection against another collection or a plain 
     // [1, 3, 5]
 
 <a name="method-diffassoc"></a>
-#### `diffAssoc()` {#collection-method}
+#### `diffAssoc()` {.collection-method}
 
 The `diffAssoc` method compares the collection against another collection or a plain PHP `array` based on its keys and values. This method will return the key / value pairs in the original collection that are not present in the given collection:
 
@@ -422,7 +422,7 @@ The `diffAssoc` method compares the collection against another collection or a p
     // ['color' => 'orange', 'remain' => 6]
 
 <a name="method-diffkeys"></a>
-#### `diffKeys()` {#collection-method}
+#### `diffKeys()` {.collection-method}
 
 The `diffKeys` method compares the collection against another collection or a plain PHP `array` based on its keys. This method will return the key / value pairs in the original collection that are not present in the given collection:
 
@@ -446,7 +446,7 @@ The `diffKeys` method compares the collection against another collection or a pl
     // ['one' => 10, 'three' => 30, 'five' => 50]
 
 <a name="method-dump"></a>
-#### `dump()` {#collection-method}
+#### `dump()` {.collection-method}
 
 The `dump` method dumps the collection's items:
 
@@ -466,7 +466,7 @@ The `dump` method dumps the collection's items:
 If you want to stop executing the script after dumping the collection, use the [`dd`](#method-dd) method instead.
 
 <a name="method-each"></a>
-#### `each()` {#collection-method}
+#### `each()` {.collection-method}
 
 The `each` method iterates over the items in the collection and passes each item to a callback:
 
@@ -483,7 +483,7 @@ If you would like to stop iterating through the items, you may return `false` fr
     });
 
 <a name="method-eachspread"></a>
-#### `eachSpread()` {#collection-method}
+#### `eachSpread()` {.collection-method}
 
 The `eachSpread` method iterates over the collection's items, passing each nested item value into the given callback:
 
@@ -500,7 +500,7 @@ You may stop iterating through the items by returning `false` from the callback:
     });
 
 <a name="method-every"></a>
-#### `every()` {#collection-method}
+#### `every()` {.collection-method}
 
 The `every` method may be used to verify that all elements of a collection pass a given truth test:
 
@@ -511,7 +511,7 @@ The `every` method may be used to verify that all elements of a collection pass 
     // false
 
 <a name="method-except"></a>
-#### `except()` {#collection-method}
+#### `except()` {.collection-method}
 
 The `except` method returns all items in the collection except for those with the specified keys:
 
@@ -526,7 +526,7 @@ The `except` method returns all items in the collection except for those with th
 For the inverse of `except`, see the [only](#method-only) method.
 
 <a name="method-filter"></a>
-#### `filter()` {#collection-method}
+#### `filter()` {.collection-method}
 
 The `filter` method filters the collection using the given callback, keeping only those items that pass a given truth test:
 
@@ -551,7 +551,7 @@ If no callback is supplied, all entries of the collection that are equivalent to
 For the inverse of `filter`, see the [reject](#method-reject) method.
 
 <a name="method-first"></a>
-#### `first()` {#collection-method}
+#### `first()` {.collection-method}
 
 The `first` method returns the first element in the collection that passes a given truth test:
 
@@ -568,7 +568,7 @@ You may also call the `first` method with no arguments to get the first element 
     // 1
 
 <a name="method-first-where"></a>
-#### `firstWhere()` {#collection-method}
+#### `firstWhere()` {.collection-method}
 
 The `firstWhere` method returns the first element in the collection with the given key / value pair:
 
@@ -590,7 +590,7 @@ You may also call the `firstWhere` method with an operator:
     // ['name' => 'Diego', 'age' => 23]
 
 <a name="method-flatmap"></a>
-#### `flatMap()` {#collection-method}
+#### `flatMap()` {.collection-method}
 
 The `flatMap` method iterates through the collection and passes each value to the given callback. The callback is free to modify the item and return it, thus forming a new collection of modified items. Then, the array is flattened by a level:
 
@@ -609,7 +609,7 @@ The `flatMap` method iterates through the collection and passes each value to th
     // ['name' => 'SALLY', 'school' => 'ARKANSAS', 'age' => '28'];
 
 <a name="method-flatten"></a>
-#### `flatten()` {#collection-method}
+#### `flatten()` {.collection-method}
 
 The `flatten` method flattens a multi-dimensional collection into a single dimension:
 
@@ -646,7 +646,7 @@ You may optionally pass the function a "depth" argument:
 In this example, calling `flatten` without providing the depth would have also flattened the nested arrays, resulting in `['iPhone 6S', 'Apple', 'Galaxy S7', 'Samsung']`. Providing a depth allows you to restrict the levels of nested arrays that will be flattened.
 
 <a name="method-flip"></a>
-#### `flip()` {#collection-method}
+#### `flip()` {.collection-method}
 
 The `flip` method swaps the collection's keys with their corresponding values:
 
@@ -659,7 +659,7 @@ The `flip` method swaps the collection's keys with their corresponding values:
     // ['taylor' => 'name', 'laravel' => 'framework']
 
 <a name="method-forget"></a>
-#### `forget()` {#collection-method}
+#### `forget()` {.collection-method}
 
 The `forget` method removes an item from the collection by its key:
 
@@ -674,7 +674,7 @@ The `forget` method removes an item from the collection by its key:
 > {note} Unlike most other collection methods, `forget` does not return a new modified collection; it modifies the collection it is called on.
 
 <a name="method-forpage"></a>
-#### `forPage()` {#collection-method}
+#### `forPage()` {.collection-method}
 
 The `forPage` method returns a new collection containing the items that would be present on a given page number. The method accepts the page number as its first argument and the number of items to show per page as its second argument:
 
@@ -687,7 +687,7 @@ The `forPage` method returns a new collection containing the items that would be
     // [4, 5, 6]
 
 <a name="method-get"></a>
-#### `get()` {#collection-method}
+#### `get()` {.collection-method}
 
 The `get` method returns the item at a given key. If the key does not exist, `null` is returned:
 
@@ -714,7 +714,7 @@ You may even pass a callback as the default value. The result of the callback wi
     // default-value
 
 <a name="method-groupby"></a>
-#### `groupBy()` {#collection-method}
+#### `groupBy()` {.collection-method}
 
 The `groupBy` method groups the collection's items by a given key:
 
@@ -802,7 +802,7 @@ Multiple grouping criteria may be passed as an array. Each array element will be
     */
 
 <a name="method-has"></a>
-#### `has()` {#collection-method}
+#### `has()` {.collection-method}
 
 The `has` method determines if a given key exists in the collection:
 
@@ -813,7 +813,7 @@ The `has` method determines if a given key exists in the collection:
     // true
 
 <a name="method-implode"></a>
-#### `implode()` {#collection-method}
+#### `implode()` {.collection-method}
 
 The `implode` method joins the items in a collection. Its arguments depend on the type of items in the collection. If the collection contains arrays or objects, you should pass the key of the attributes you wish to join, and the "glue" string you wish to place between the values:
 
@@ -833,7 +833,7 @@ If the collection contains simple strings or numeric values, pass the "glue" as 
     // '1-2-3-4-5'
 
 <a name="method-intersect"></a>
-#### `intersect()` {#collection-method}
+#### `intersect()` {.collection-method}
 
 The `intersect` method removes any values from the original collection that are not present in the given `array` or collection. The resulting collection will preserve the original collection's keys:
 
@@ -846,7 +846,7 @@ The `intersect` method removes any values from the original collection that are 
     // [0 => 'Desk', 2 => 'Chair']
 
 <a name="method-intersectbykeys"></a>
-#### `intersectByKeys()` {#collection-method}
+#### `intersectByKeys()` {.collection-method}
 
 The `intersectByKeys` method removes any keys from the original collection that are not present in the given `array` or collection:
 
@@ -863,7 +863,7 @@ The `intersectByKeys` method removes any keys from the original collection that 
     // ['type' => 'screen', 'year' => 2009]
 
 <a name="method-isempty"></a>
-#### `isEmpty()` {#collection-method}
+#### `isEmpty()` {.collection-method}
 
 The `isEmpty` method returns `true` if the collection is empty; otherwise, `false` is returned:
 
@@ -872,7 +872,7 @@ The `isEmpty` method returns `true` if the collection is empty; otherwise, `fals
     // true
 
 <a name="method-isnotempty"></a>
-#### `isNotEmpty()` {#collection-method}
+#### `isNotEmpty()` {.collection-method}
 
 The `isNotEmpty` method returns `true` if the collection is not empty; otherwise, `false` is returned:
 
@@ -881,7 +881,7 @@ The `isNotEmpty` method returns `true` if the collection is not empty; otherwise
     // false
 
 <a name="method-keyby"></a>
-#### `keyBy()` {#collection-method}
+#### `keyBy()` {.collection-method}
 
 The `keyBy` method keys the collection by the given key. If multiple items have the same key, only the last one will appear in the new collection:
 
@@ -917,7 +917,7 @@ You may also pass a callback to the method. The callback should return the value
     */
 
 <a name="method-keys"></a>
-#### `keys()` {#collection-method}
+#### `keys()` {.collection-method}
 
 The `keys` method returns all of the collection's keys:
 
@@ -933,7 +933,7 @@ The `keys` method returns all of the collection's keys:
     // ['prod-100', 'prod-200']
 
 <a name="method-last"></a>
-#### `last()` {#collection-method}
+#### `last()` {.collection-method}
 
 The `last` method returns the last element in the collection that passes a given truth test:
 
@@ -950,17 +950,17 @@ You may also call the `last` method with no arguments to get the last element in
     // 4
 
 <a name="method-macro"></a>
-#### `macro()` {#collection-method}
+#### `macro()` {.collection-method}
 
 The static `macro` method allows you to add methods to the `Collection` class at run time. Refer to the documentation on [extending collections](#extending-collections) for more information.
 
 <a name="method-make"></a>
-#### `make()` {#collection-method}
+#### `make()` {.collection-method}
 
 The static `make` method creates a new collection instance. See the [Creating Collections](#creating-collections) section.
 
 <a name="method-map"></a>
-#### `map()` {#collection-method}
+#### `map()` {.collection-method}
 
 The `map` method iterates through the collection and passes each value to the given callback. The callback is free to modify the item and return it, thus forming a new collection of modified items:
 
@@ -977,7 +977,7 @@ The `map` method iterates through the collection and passes each value to the gi
 > {note} Like most other collection methods, `map` returns a new collection instance; it does not modify the collection it is called on. If you want to transform the original collection, use the [`transform`](#method-transform) method.
 
 <a name="method-mapinto"></a>
-#### `mapInto()` {#collection-method}
+#### `mapInto()` {.collection-method}
 
 The `mapInto()` method iterates over the collection, creating a new instance of the given class by passing the value into the constructor:
 
@@ -1004,7 +1004,7 @@ The `mapInto()` method iterates over the collection, creating a new instance of 
     // [Currency('USD'), Currency('EUR'), Currency('GBP')]
 
 <a name="method-mapspread"></a>
-#### `mapSpread()` {#collection-method}
+#### `mapSpread()` {.collection-method}
 
 The `mapSpread` method iterates over the collection's items, passing each nested item value into the given callback. The callback is free to modify the item and return it, thus forming a new collection of modified items:
 
@@ -1021,7 +1021,7 @@ The `mapSpread` method iterates over the collection's items, passing each nested
     // [1, 5, 9, 13, 17]
 
 <a name="method-maptogroups"></a>
-#### `mapToGroups()` {#collection-method}
+#### `mapToGroups()` {.collection-method}
 
 The `mapToGroups` method groups the collection's items by the given callback. The callback should return an associative array containing a single key / value pair, thus forming a new collection of grouped values:
 
@@ -1058,7 +1058,7 @@ The `mapToGroups` method groups the collection's items by the given callback. Th
     // ['John Doe', 'Jane Doe']
 
 <a name="method-mapwithkeys"></a>
-#### `mapWithKeys()` {#collection-method}
+#### `mapWithKeys()` {.collection-method}
 
 The `mapWithKeys` method iterates through the collection and passes each value to the given callback. The callback should return an associative array containing a single key / value pair:
 
@@ -1089,7 +1089,7 @@ The `mapWithKeys` method iterates through the collection and passes each value t
     */
 
 <a name="method-max"></a>
-#### `max()` {#collection-method}
+#### `max()` {.collection-method}
 
 The `max` method returns the maximum value of a given key:
 
@@ -1102,7 +1102,7 @@ The `max` method returns the maximum value of a given key:
     // 5
 
 <a name="method-median"></a>
-#### `median()` {#collection-method}
+#### `median()` {.collection-method}
 
 The `median` method returns the [median value](https://en.wikipedia.org/wiki/Median) of a given key:
 
@@ -1115,7 +1115,7 @@ The `median` method returns the [median value](https://en.wikipedia.org/wiki/Med
     // 1.5
 
 <a name="method-merge"></a>
-#### `merge()` {#collection-method}
+#### `merge()` {.collection-method}
 
 The `merge` method merges the given array or collection with the original collection. If a string key in the given items matches a string key in the original collection, the given items's value will overwrite the value in the original collection:
 
@@ -1138,7 +1138,7 @@ If the given items's keys are numeric, the values will be appended to the end of
     // ['Desk', 'Chair', 'Bookcase', 'Door']
 
 <a name="method-min"></a>
-#### `min()` {#collection-method}
+#### `min()` {.collection-method}
 
 The `min` method returns the minimum value of a given key:
 
@@ -1151,7 +1151,7 @@ The `min` method returns the minimum value of a given key:
     // 1
 
 <a name="method-mode"></a>
-#### `mode()` {#collection-method}
+#### `mode()` {.collection-method}
 
 The `mode` method returns the [mode value](https://en.wikipedia.org/wiki/Mode_(statistics)) of a given key:
 
@@ -1164,7 +1164,7 @@ The `mode` method returns the [mode value](https://en.wikipedia.org/wiki/Mode_(s
     // [1]
 
 <a name="method-nth"></a>
-#### `nth()` {#collection-method}
+#### `nth()` {.collection-method}
 
 The `nth` method creates a new collection consisting of every n-th element:
 
@@ -1181,7 +1181,7 @@ You may optionally pass an offset as the second argument:
     // ['b', 'f']
 
 <a name="method-only"></a>
-#### `only()` {#collection-method}
+#### `only()` {.collection-method}
 
 The `only` method returns the items in the collection with the specified keys:
 
@@ -1196,7 +1196,7 @@ The `only` method returns the items in the collection with the specified keys:
 For the inverse of `only`, see the [except](#method-except) method.
 
 <a name="method-pad"></a>
-#### `pad()` {#collection-method}
+#### `pad()` {.collection-method}
 
 The `pad` method will fill the array with the given value until the array reaches the specified size. This method behaves like the [array_pad](https://secure.php.net/manual/en/function.array-pad.php) PHP function.
 
@@ -1217,7 +1217,7 @@ To pad to the left, you should specify a negative size. No padding will take pla
     // [0, 0, 'A', 'B', 'C']
 
 <a name="method-partition"></a>
-#### `partition()` {#collection-method}
+#### `partition()` {.collection-method}
 
 The `partition` method may be combined with the `list` PHP function to separate elements that pass a given truth test from those that do not:
 
@@ -1236,7 +1236,7 @@ The `partition` method may be combined with the `list` PHP function to separate 
     // [3, 4, 5, 6]
 
 <a name="method-pipe"></a>
-#### `pipe()` {#collection-method}
+#### `pipe()` {.collection-method}
 
 The `pipe` method passes the collection to the given callback and returns the result:
 
@@ -1249,7 +1249,7 @@ The `pipe` method passes the collection to the given callback and returns the re
     // 6
 
 <a name="method-pluck"></a>
-#### `pluck()` {#collection-method}
+#### `pluck()` {.collection-method}
 
 The `pluck` method retrieves all of the values for a given key:
 
@@ -1288,7 +1288,7 @@ If duplicate keys exist, the last matching element will be inserted into the plu
     // ['Tesla' => 'black', 'Pagani' => 'orange']
 
 <a name="method-pop"></a>
-#### `pop()` {#collection-method}
+#### `pop()` {.collection-method}
 
 The `pop` method removes and returns the last item from the collection:
 
@@ -1303,7 +1303,7 @@ The `pop` method removes and returns the last item from the collection:
     // [1, 2, 3, 4]
 
 <a name="method-prepend"></a>
-#### `prepend()` {#collection-method}
+#### `prepend()` {.collection-method}
 
 The `prepend` method adds an item to the beginning of the collection:
 
@@ -1326,7 +1326,7 @@ You may also pass a second argument to set the key of the prepended item:
     // ['zero' => 0, 'one' => 1, 'two' => 2]
 
 <a name="method-pull"></a>
-#### `pull()` {#collection-method}
+#### `pull()` {.collection-method}
 
 The `pull` method removes and returns an item from the collection by its key:
 
@@ -1341,7 +1341,7 @@ The `pull` method removes and returns an item from the collection by its key:
     // ['product_id' => 'prod-100']
 
 <a name="method-push"></a>
-#### `push()` {#collection-method}
+#### `push()` {.collection-method}
 
 The `push` method appends an item to the end of the collection:
 
@@ -1354,7 +1354,7 @@ The `push` method appends an item to the end of the collection:
     // [1, 2, 3, 4, 5]
 
 <a name="method-put"></a>
-#### `put()` {#collection-method}
+#### `put()` {.collection-method}
 
 The `put` method sets the given key and value in the collection:
 
@@ -1367,7 +1367,7 @@ The `put` method sets the given key and value in the collection:
     // ['product_id' => 1, 'name' => 'Desk', 'price' => 100]
 
 <a name="method-random"></a>
-#### `random()` {#collection-method}
+#### `random()` {.collection-method}
 
 The `random` method returns a random item from the collection:
 
@@ -1388,7 +1388,7 @@ You may optionally pass an integer to `random` to specify how many items you wou
 If the Collection has fewer items than requested, the method will throw an `InvalidArgumentException`.
 
 <a name="method-reduce"></a>
-#### `reduce()` {#collection-method}
+#### `reduce()` {.collection-method}
 
 The `reduce` method reduces the collection to a single value, passing the result of each iteration into the subsequent iteration:
 
@@ -1409,7 +1409,7 @@ The value for `$carry` on the first iteration is `null`; however, you may specif
     // 10
 
 <a name="method-reject"></a>
-#### `reject()` {#collection-method}
+#### `reject()` {.collection-method}
 
 The `reject` method filters the collection using the given callback. The callback should return `true` if the item should be removed from the resulting collection:
 
@@ -1426,7 +1426,7 @@ The `reject` method filters the collection using the given callback. The callbac
 For the inverse of the `reject` method, see the [`filter`](#method-filter) method.
 
 <a name="method-reverse"></a>
-#### `reverse()` {#collection-method}
+#### `reverse()` {.collection-method}
 
 The `reverse` method reverses the order of the collection's items, preserving the original keys:
 
@@ -1447,7 +1447,7 @@ The `reverse` method reverses the order of the collection's items, preserving th
     */
 
 <a name="method-search"></a>
-#### `search()` {#collection-method}
+#### `search()` {.collection-method}
 
 The `search` method searches the collection for the given value and returns its key if found. If the item is not found, `false` is returned.
 
@@ -1472,7 +1472,7 @@ Alternatively, you may pass in your own callback to search for the first item th
     // 2
 
 <a name="method-shift"></a>
-#### `shift()` {#collection-method}
+#### `shift()` {.collection-method}
 
 The `shift` method removes and returns the first item from the collection:
 
@@ -1487,7 +1487,7 @@ The `shift` method removes and returns the first item from the collection:
     // [2, 3, 4, 5]
 
 <a name="method-shuffle"></a>
-#### `shuffle()` {#collection-method}
+#### `shuffle()` {.collection-method}
 
 The `shuffle` method randomly shuffles the items in the collection:
 
@@ -1500,7 +1500,7 @@ The `shuffle` method randomly shuffles the items in the collection:
     // [3, 2, 5, 1, 4] - (generated randomly)
 
 <a name="method-slice"></a>
-#### `slice()` {#collection-method}
+#### `slice()` {.collection-method}
 
 The `slice` method returns a slice of the collection starting at the given index:
 
@@ -1523,7 +1523,7 @@ If you would like to limit the size of the returned slice, pass the desired size
 The returned slice will preserve keys by default. If you do not wish to preserve the original keys, you can use the [`values`](#method-values) method to reindex them.
 
 <a name="method-sort"></a>
-#### `sort()` {#collection-method}
+#### `sort()` {.collection-method}
 
 The `sort` method sorts the collection. The sorted collection keeps the original array keys, so in this example we'll use the [`values`](#method-values) method to reset the keys to consecutively numbered indexes:
 
@@ -1540,7 +1540,7 @@ If your sorting needs are more advanced, you may pass a callback to `sort` with 
 > {tip} If you need to sort a collection of nested arrays or objects, see the [`sortBy`](#method-sortby) and [`sortByDesc`](#method-sortbydesc) methods.
 
 <a name="method-sortby"></a>
-#### `sortBy()` {#collection-method}
+#### `sortBy()` {.collection-method}
 
 The `sortBy` method sorts the collection by the given key. The sorted collection keeps the original array keys, so in this example we'll use the [`values`](#method-values) method to reset the keys to consecutively numbered indexes:
 
@@ -1585,12 +1585,12 @@ You can also pass your own callback to determine how to sort the collection valu
     */
 
 <a name="method-sortbydesc"></a>
-#### `sortByDesc()` {#collection-method}
+#### `sortByDesc()` {.collection-method}
 
 This method has the same signature as the [`sortBy`](#method-sortby) method, but will sort the collection in the opposite order.
 
 <a name="method-sortkeys"></a>
-#### `sortKeys()` {#collection-method}
+#### `sortKeys()` {.collection-method}
 
 The `sortKeys` method sorts the collection by the keys of the underlying associative array:
 
@@ -1613,12 +1613,12 @@ The `sortKeys` method sorts the collection by the keys of the underlying associa
     */
 
 <a name="method-sortkeysdesc"></a>
-#### `sortKeysDesc()` {#collection-method}
+#### `sortKeysDesc()` {.collection-method}
 
 This method has the same signature as the [`sortKeys`](#method-sortkeys) method, but will sort the collection in the opposite order.
 
 <a name="method-splice"></a>
-#### `splice()` {#collection-method}
+#### `splice()` {.collection-method}
 
 The `splice` method removes and returns a slice of items starting at the specified index:
 
@@ -1663,7 +1663,7 @@ In addition, you can pass a third argument containing the new items to replace t
     // [1, 2, 10, 11, 4, 5]
 
 <a name="method-split"></a>
-#### `split()` {#collection-method}
+#### `split()` {.collection-method}
 
 The `split` method breaks a collection into the given number of groups:
 
@@ -1676,7 +1676,7 @@ The `split` method breaks a collection into the given number of groups:
     // [[1, 2], [3, 4], [5]]
 
 <a name="method-sum"></a>
-#### `sum()` {#collection-method}
+#### `sum()` {.collection-method}
 
 The `sum` method returns the sum of all items in the collection:
 
@@ -1710,7 +1710,7 @@ In addition, you may pass your own callback to determine which values of the col
     // 6
 
 <a name="method-take"></a>
-#### `take()` {#collection-method}
+#### `take()` {.collection-method}
 
 The `take` method returns a new collection with the specified number of items:
 
@@ -1733,7 +1733,7 @@ You may also pass a negative integer to take the specified amount of items from 
     // [4, 5]
 
 <a name="method-tap"></a>
-#### `tap()` {#collection-method}
+#### `tap()` {.collection-method}
 
 The `tap` method passes the collection to the given callback, allowing you to "tap" into the collection at a specific point and do something with the items while not affecting the collection itself:
 
@@ -1747,7 +1747,7 @@ The `tap` method passes the collection to the given callback, allowing you to "t
     // 1
 
 <a name="method-times"></a>
-#### `times()` {#collection-method}
+#### `times()` {.collection-method}
 
 The static `times` method creates a new collection by invoking the callback a given amount of times:
 
@@ -1776,7 +1776,7 @@ This method can be useful when combined with factories to create [Eloquent](/doc
     */
 
 <a name="method-toarray"></a>
-#### `toArray()` {#collection-method}
+#### `toArray()` {.collection-method}
 
 The `toArray` method converts the collection into a plain PHP `array`. If the collection's values are [Eloquent](/docs/{{version}}/eloquent) models, the models will also be converted to arrays:
 
@@ -1793,7 +1793,7 @@ The `toArray` method converts the collection into a plain PHP `array`. If the co
 > {note} `toArray` also converts all of the collection's nested objects to an array. If you want to get the raw underlying array, use the [`all`](#method-all) method instead.
 
 <a name="method-tojson"></a>
-#### `toJson()` {#collection-method}
+#### `toJson()` {.collection-method}
 
 The `toJson` method converts the collection into a JSON serialized string:
 
@@ -1804,7 +1804,7 @@ The `toJson` method converts the collection into a JSON serialized string:
     // '{"name":"Desk", "price":200}'
 
 <a name="method-transform"></a>
-#### `transform()` {#collection-method}
+#### `transform()` {.collection-method}
 
 The `transform` method iterates over the collection and calls the given callback with each item in the collection. The items in the collection will be replaced by the values returned by the callback:
 
@@ -1821,7 +1821,7 @@ The `transform` method iterates over the collection and calls the given callback
 > {note} Unlike most other collection methods, `transform` modifies the collection itself. If you wish to create a new collection instead, use the [`map`](#method-map) method.
 
 <a name="method-union"></a>
-#### `union()` {#collection-method}
+#### `union()` {.collection-method}
 
 The `union` method adds the given array to the collection. If the given array contains keys that are already in the original collection, the original collection's values will be preferred:
 
@@ -1834,7 +1834,7 @@ The `union` method adds the given array to the collection. If the given array co
     // [1 => ['a'], 2 => ['b'], 3 => ['c']]
 
 <a name="method-unique"></a>
-#### `unique()` {#collection-method}
+#### `unique()` {.collection-method}
 
 The `unique` method returns all of the unique items in the collection. The returned collection keeps the original array keys, so in this example we'll use the [`values`](#method-values) method to reset the keys to consecutively numbered indexes:
 
@@ -1887,12 +1887,12 @@ You may also pass your own callback to determine item uniqueness:
 The `unique` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`uniqueStrict`](#method-uniquestrict) method to filter using "strict" comparisons.
 
 <a name="method-uniquestrict"></a>
-#### `uniqueStrict()` {#collection-method}
+#### `uniqueStrict()` {.collection-method}
 
 This method has the same signature as the [`unique`](#method-unique) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-unless"></a>
-#### `unless()` {#collection-method}
+#### `unless()` {.collection-method}
 
 The `unless` method will execute the given callback unless the first argument given to the method evaluates to `true`:
 
@@ -1913,7 +1913,7 @@ The `unless` method will execute the given callback unless the first argument gi
 For the inverse of `unless`, see the [`when`](#method-when) method.
 
 <a name="method-unwrap"></a>
-#### `unwrap()` {#collection-method}
+#### `unwrap()` {.collection-method}
 
 The static `unwrap` method returns the collection's underlying items from the given value when applicable:
 
@@ -1930,7 +1930,7 @@ The static `unwrap` method returns the collection's underlying items from the gi
     // 'John Doe'
 
 <a name="method-values"></a>
-#### `values()` {#collection-method}
+#### `values()` {.collection-method}
 
 The `values` method returns a new collection with the keys reset to consecutive integers:
 
@@ -1951,7 +1951,7 @@ The `values` method returns a new collection with the keys reset to consecutive 
     */
 
 <a name="method-when"></a>
-#### `when()` {#collection-method}
+#### `when()` {.collection-method}
 
 The `when` method will execute the given callback when the first argument given to the method evaluates to `true`:
 
@@ -1972,7 +1972,7 @@ The `when` method will execute the given callback when the first argument given 
 For the inverse of `when`, see the [`unless`](#method-unless) method.
 
 <a name="method-where"></a>
-#### `where()` {#collection-method}
+#### `where()` {.collection-method}
 
 The `where` method filters the collection by a given key / value pair:
 
@@ -1997,12 +1997,12 @@ The `where` method filters the collection by a given key / value pair:
 The `where` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`whereStrict`](#method-wherestrict) method to filter using "strict" comparisons.
 
 <a name="method-wherestrict"></a>
-#### `whereStrict()` {#collection-method}
+#### `whereStrict()` {.collection-method}
 
 This method has the same signature as the [`where`](#method-where) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-wherein"></a>
-#### `whereIn()` {#collection-method}
+#### `whereIn()` {.collection-method}
 
 The `whereIn` method filters the collection by a given key / value contained within the given array:
 
@@ -2027,12 +2027,12 @@ The `whereIn` method filters the collection by a given key / value contained wit
 The `whereIn` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`whereInStrict`](#method-whereinstrict) method to filter using "strict" comparisons.
 
 <a name="method-whereinstrict"></a>
-#### `whereInStrict()` {#collection-method}
+#### `whereInStrict()` {.collection-method}
 
 This method has the same signature as the [`whereIn`](#method-wherein) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-whereinstanceof"></a>
-#### `whereInstanceOf()` {#collection-method}
+#### `whereInstanceOf()` {.collection-method}
 
 The `whereInstanceOf` method filters the collection by a given class type:
 
@@ -2045,7 +2045,7 @@ The `whereInstanceOf` method filters the collection by a given class type:
     return $collection->whereInstanceOf(User::class);
 
 <a name="method-wherenotin"></a>
-#### `whereNotIn()` {#collection-method}
+#### `whereNotIn()` {.collection-method}
 
 The `whereNotIn` method filters the collection by a given key / value not contained within the given array:
 
@@ -2070,12 +2070,12 @@ The `whereNotIn` method filters the collection by a given key / value not contai
 The `whereNotIn` method uses "loose" comparisons when checking item values, meaning a string with an integer value will be considered equal to an integer of the same value. Use the [`whereNotInStrict`](#method-wherenotinstrict) method to filter using "strict" comparisons.
 
 <a name="method-wherenotinstrict"></a>
-#### `whereNotInStrict()` {#collection-method}
+#### `whereNotInStrict()` {.collection-method}
 
 This method has the same signature as the [`whereNotIn`](#method-wherenotin) method; however, all values are compared using "strict" comparisons.
 
 <a name="method-wrap"></a>
-#### `wrap()` {#collection-method}
+#### `wrap()` {.collection-method}
 
 The static `wrap` method wraps the given value in a collection when applicable:
 
@@ -2098,7 +2098,7 @@ The static `wrap` method wraps the given value in a collection when applicable:
     // ['John Doe']
 
 <a name="method-zip"></a>
-#### `zip()` {#collection-method}
+#### `zip()` {.collection-method}
 
 The `zip` method merges together the values of the given array with the values of the original collection at the corresponding index:
 

--- a/helpers.md
+++ b/helpers.md
@@ -180,11 +180,11 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 ## Method Listing
 
 <style>
-    #collection-method code {
+    .collection-method code {
         font-size: 14px;
     }
 
-    #collection-method:not(.first-collection-method) {
+    .collection-method:not(.first-collection-method) {
         margin-top: 50px;
     }
 </style>
@@ -193,7 +193,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 ## Arrays & Objects
 
 <a name="method-array-add"></a>
-#### `array_add()` {#collection-method .first-collection-method}
+#### `array_add()` {.collection-method .first-collection-method}
 
 The `array_add` function adds a given key / value pair to an array if the given key doesn't already exist in the array:
 
@@ -202,7 +202,7 @@ The `array_add` function adds a given key / value pair to an array if the given 
     // ['name' => 'Desk', 'price' => 100]
 
 <a name="method-array-collapse"></a>
-#### `array_collapse()` {#collection-method}
+#### `array_collapse()` {.collection-method}
 
 The `array_collapse` function collapses an array of arrays into a single array:
 
@@ -211,7 +211,7 @@ The `array_collapse` function collapses an array of arrays into a single array:
     // [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 <a name="method-array-divide"></a>
-#### `array_divide()` {#collection-method}
+#### `array_divide()` {.collection-method}
 
 The `array_divide` function returns two arrays, one containing the keys, and the other containing the values of the given array:
 
@@ -222,7 +222,7 @@ The `array_divide` function returns two arrays, one containing the keys, and the
     // $values: ['Desk']
 
 <a name="method-array-dot"></a>
-#### `array_dot()` {#collection-method}
+#### `array_dot()` {.collection-method}
 
 The `array_dot` function flattens a multi-dimensional array into a single level array that uses "dot" notation to indicate depth:
 
@@ -233,7 +233,7 @@ The `array_dot` function flattens a multi-dimensional array into a single level 
     // ['products.desk.price' => 100]
 
 <a name="method-array-except"></a>
-#### `array_except()` {#collection-method}
+#### `array_except()` {.collection-method}
 
 The `array_except` function removes the given key / value pairs from an array:
 
@@ -244,7 +244,7 @@ The `array_except` function removes the given key / value pairs from an array:
     // ['name' => 'Desk']
 
 <a name="method-array-first"></a>
-#### `array_first()` {#collection-method}
+#### `array_first()` {.collection-method}
 
 The `array_first` function returns the first element of an array passing a given truth test:
 
@@ -261,7 +261,7 @@ A default value may also be passed as the third parameter to the method. This va
     $first = array_first($array, $callback, $default);
 
 <a name="method-array-flatten"></a>
-#### `array_flatten()` {#collection-method}
+#### `array_flatten()` {.collection-method}
 
 The `array_flatten` function flattens a multi-dimensional array into a single level array:
 
@@ -272,7 +272,7 @@ The `array_flatten` function flattens a multi-dimensional array into a single le
     // ['Joe', 'PHP', 'Ruby']
 
 <a name="method-array-forget"></a>
-#### `array_forget()` {#collection-method}
+#### `array_forget()` {.collection-method}
 
 The `array_forget` function removes a given key / value pair from a deeply nested array using "dot" notation:
 
@@ -283,7 +283,7 @@ The `array_forget` function removes a given key / value pair from a deeply neste
     // ['products' => []]
 
 <a name="method-array-get"></a>
-#### `array_get()` {#collection-method}
+#### `array_get()` {.collection-method}
 
 The `array_get` function retrieves a value from a deeply nested array using "dot" notation:
 
@@ -300,7 +300,7 @@ The `array_get` function also accepts a default value, which will be returned if
     // 0
 
 <a name="method-array-has"></a>
-#### `array_has()` {#collection-method}
+#### `array_has()` {.collection-method}
 
 The `array_has` function checks whether a given item or items exists in an array using "dot" notation:
 
@@ -315,7 +315,7 @@ The `array_has` function checks whether a given item or items exists in an array
     // false
 
 <a name="method-array-last"></a>
-#### `array_last()` {#collection-method}
+#### `array_last()` {.collection-method}
 
 The `array_last` function returns the last element of an array passing a given truth test:
 
@@ -332,7 +332,7 @@ A default value may be passed as the third argument to the method. This value wi
     $last = array_last($array, $callback, $default);
 
 <a name="method-array-only"></a>
-#### `array_only()` {#collection-method}
+#### `array_only()` {.collection-method}
 
 The `array_only` function returns only the specified key / value pairs from the given array:
 
@@ -343,7 +343,7 @@ The `array_only` function returns only the specified key / value pairs from the 
     // ['name' => 'Desk', 'price' => 100]
 
 <a name="method-array-pluck"></a>
-#### `array_pluck()` {#collection-method}
+#### `array_pluck()` {.collection-method}
 
 The `array_pluck` function retrieves all of the values for a given key from an array:
 
@@ -363,7 +363,7 @@ You may also specify how you wish the resulting list to be keyed:
     // [1 => 'Taylor', 2 => 'Abigail']
 
 <a name="method-array-prepend"></a>
-#### `array_prepend()` {#collection-method}
+#### `array_prepend()` {.collection-method}
 
 The `array_prepend` function will push an item onto the beginning of an array:
 
@@ -382,7 +382,7 @@ If needed, you may specify the key that should be used for the value:
     // ['name' => 'Desk', 'price' => 100]
 
 <a name="method-array-pull"></a>
-#### `array_pull()` {#collection-method}
+#### `array_pull()` {.collection-method}
 
 The `array_pull` function returns and removes a key / value pair from an array:
 
@@ -399,7 +399,7 @@ A default value may be passed as the third argument to the method. This value wi
     $value = array_pull($array, $key, $default);
 
 <a name="method-array-random"></a>
-#### `array_random()` {#collection-method}
+#### `array_random()` {.collection-method}
 
 The `array_random` function returns a random value from an array:
 
@@ -416,7 +416,7 @@ You may also specify the number of items to return as an optional second argumen
     // [2, 5] - (retrieved randomly)
 
 <a name="method-array-set"></a>
-#### `array_set()` {#collection-method}
+#### `array_set()` {.collection-method}
 
 The `array_set` function sets a value within a deeply nested array using "dot" notation:
 
@@ -427,7 +427,7 @@ The `array_set` function sets a value within a deeply nested array using "dot" n
     // ['products' => ['desk' => ['price' => 200]]]
 
 <a name="method-array-sort"></a>
-#### `array_sort()` {#collection-method}
+#### `array_sort()` {.collection-method}
 
 The `array_sort` function sorts an array by its values:
 
@@ -458,7 +458,7 @@ You may also sort the array by the results of the given Closure:
     */
 
 <a name="method-array-sort-recursive"></a>
-#### `array_sort_recursive()` {#collection-method}
+#### `array_sort_recursive()` {.collection-method}
 
 The `array_sort_recursive` function recursively sorts an array using the `sort` function:
 
@@ -477,7 +477,7 @@ The `array_sort_recursive` function recursively sorts an array using the `sort` 
     */
 
 <a name="method-array-where"></a>
-#### `array_where()` {#collection-method}
+#### `array_where()` {.collection-method}
 
 The `array_where` function filters an array using the given Closure:
 
@@ -490,7 +490,7 @@ The `array_where` function filters an array using the given Closure:
     // [1 => '200', 3 => '400']
 
 <a name="method-array-wrap"></a>
-#### `array_wrap()` {#collection-method}
+#### `array_wrap()` {.collection-method}
 
 The `array_wrap` function wraps the given value in an array. If the given value is already an array it will not be changed:
 
@@ -509,7 +509,7 @@ If the given value is null, an empty array will be returned:
     // []
 
 <a name="method-data-fill"></a>
-#### `data_fill()` {#collection-method}
+#### `data_fill()` {.collection-method}
 
 The `data_fill` function sets a missing value within a nested array or object using "dot" notation:
 
@@ -544,7 +544,7 @@ This function also accepts asterisks as wildcards and will fill the target accor
     */
 
 <a name="method-data-get"></a>
-#### `data_get()` {#collection-method}
+#### `data_get()` {.collection-method}
 
 The `data_get` function retrieves a value from a nested array or object using "dot" notation:
 
@@ -561,7 +561,7 @@ The `data_get` function also accepts a default value, which will be returned if 
     // 0
 
 <a name="method-data-set"></a>
-#### `data_set()` {#collection-method}
+#### `data_set()` {.collection-method}
 
 The `data_set` function sets a value within a nested array or object using "dot" notation:
 
@@ -600,7 +600,7 @@ By default, any existing values are overwritten. If you wish to only set a value
     // ['products' => ['desk' => ['price' => 100]]]
 
 <a name="method-head"></a>
-#### `head()` {#collection-method}
+#### `head()` {.collection-method}
 
 The `head` function returns the first element in the given array:
 
@@ -611,7 +611,7 @@ The `head` function returns the first element in the given array:
     // 100
 
 <a name="method-last"></a>
-#### `last()` {#collection-method}
+#### `last()` {.collection-method}
 
 The `last` function returns the last element in the given array:
 
@@ -625,7 +625,7 @@ The `last` function returns the last element in the given array:
 ## Paths
 
 <a name="method-app-path"></a>
-#### `app_path()` {#collection-method}
+#### `app_path()` {.collection-method}
 
 The `app_path` function returns the fully qualified path to the `app` directory. You may also use the `app_path` function to generate a fully qualified path to a file relative to the application directory:
 
@@ -634,7 +634,7 @@ The `app_path` function returns the fully qualified path to the `app` directory.
     $path = app_path('Http/Controllers/Controller.php');
 
 <a name="method-base-path"></a>
-#### `base_path()` {#collection-method}
+#### `base_path()` {.collection-method}
 
 The `base_path` function returns the fully qualified path to the project root. You may also use the `base_path` function to generate a fully qualified path to a given file relative to the project root directory:
 
@@ -643,7 +643,7 @@ The `base_path` function returns the fully qualified path to the project root. Y
     $path = base_path('vendor/bin');
 
 <a name="method-config-path"></a>
-#### `config_path()` {#collection-method}
+#### `config_path()` {.collection-method}
 
 The `config_path` function returns the fully qualified path to the `config` directory. You may also use the `config_path` function to generate a fully qualified path to a given file within the application's configuration directory:
 
@@ -652,7 +652,7 @@ The `config_path` function returns the fully qualified path to the `config` dire
     $path = config_path('app.php');
 
 <a name="method-database-path"></a>
-#### `database_path()` {#collection-method}
+#### `database_path()` {.collection-method}
 
 The `database_path` function returns the fully qualified path to the `database` directory. You may also use the `database_path` function to generate a fully qualified path to a given file within the database directory:
 
@@ -661,14 +661,14 @@ The `database_path` function returns the fully qualified path to the `database` 
     $path = database_path('factories/UserFactory.php');
 
 <a name="method-mix"></a>
-#### `mix()` {#collection-method}
+#### `mix()` {.collection-method}
 
 The `mix` function returns the path to a [versioned Mix file](/docs/{{version}}/mix):
 
     $path = mix('css/app.css');
 
 <a name="method-public-path"></a>
-#### `public_path()` {#collection-method}
+#### `public_path()` {.collection-method}
 
 The `public_path` function returns the fully qualified path to the `public` directory. You may also use the `public_path` function to generate a fully qualified path to a given file within the public directory:
 
@@ -677,7 +677,7 @@ The `public_path` function returns the fully qualified path to the `public` dire
     $path = public_path('css/app.css');
 
 <a name="method-resource-path"></a>
-#### `resource_path()` {#collection-method}
+#### `resource_path()` {.collection-method}
 
 The `resource_path` function returns the fully qualified path to the `resources` directory. You may also use the `resource_path` function to generate a fully qualified path to a given file within the resources directory:
 
@@ -686,7 +686,7 @@ The `resource_path` function returns the fully qualified path to the `resources`
     $path = resource_path('assets/sass/app.scss');
 
 <a name="method-storage-path"></a>
-#### `storage_path()` {#collection-method}
+#### `storage_path()` {.collection-method}
 
 The `storage_path` function returns the fully qualified path to the `storage` directory. You may also use the `storage_path` function to generate a fully qualified path to a given file within the storage directory:
 
@@ -698,7 +698,7 @@ The `storage_path` function returns the fully qualified path to the `storage` di
 ## Strings
 
 <a name="method-__"></a>
-#### `__()` {#collection-method}
+#### `__()` {.collection-method}
 
 The `__` function translates the given translation string or translation key using your [localization files](/docs/{{version}}/localization):
 
@@ -709,7 +709,7 @@ The `__` function translates the given translation string or translation key usi
 If the specified translation string or key does not exist, the `__` function will return the given value. So, using the example above, the `__` function would return `messages.welcome` if that translation key does not exist.
 
 <a name="method-camel-case"></a>
-#### `camel_case()` {#collection-method}
+#### `camel_case()` {.collection-method}
 
 The `camel_case` function converts the given string to `camelCase`:
 
@@ -718,7 +718,7 @@ The `camel_case` function converts the given string to `camelCase`:
     // fooBar
 
 <a name="method-class-basename"></a>
-#### `class_basename()` {#collection-method}
+#### `class_basename()` {.collection-method}
 
 The `class_basename` returns the class name of the given class with the class' namespace removed:
 
@@ -727,7 +727,7 @@ The `class_basename` returns the class name of the given class with the class' n
     // Baz
 
 <a name="method-e"></a>
-#### `e()` {#collection-method}
+#### `e()` {.collection-method}
 
 The `e` function runs PHP's `htmlspecialchars` function with the `double_encode` option set to `true` by default:
 
@@ -736,7 +736,7 @@ The `e` function runs PHP's `htmlspecialchars` function with the `double_encode`
     // &lt;html&gt;foo&lt;/html&gt;
 
 <a name="method-ends-with"></a>
-#### `ends_with()` {#collection-method}
+#### `ends_with()` {.collection-method}
 
 The `ends_with` function determines if the given string ends with the given value:
 
@@ -745,7 +745,7 @@ The `ends_with` function determines if the given string ends with the given valu
     // true
 
 <a name="method-kebab-case"></a>
-#### `kebab_case()` {#collection-method}
+#### `kebab_case()` {.collection-method}
 
 The `kebab_case` function converts the given string to `kebab-case`:
 
@@ -754,7 +754,7 @@ The `kebab_case` function converts the given string to `kebab-case`:
     // foo-bar
 
 <a name="method-preg-replace-array"></a>
-#### `preg_replace_array()` {#collection-method}
+#### `preg_replace_array()` {.collection-method}
 
 The `preg_replace_array` function replaces a given pattern in the string sequentially using an array:
 
@@ -765,7 +765,7 @@ The `preg_replace_array` function replaces a given pattern in the string sequent
     // The event will take place between 8:30 and 9:00
 
 <a name="method-snake-case"></a>
-#### `snake_case()` {#collection-method}
+#### `snake_case()` {.collection-method}
 
 The `snake_case` function converts the given string to `snake_case`:
 
@@ -774,7 +774,7 @@ The `snake_case` function converts the given string to `snake_case`:
     // foo_bar
 
 <a name="method-starts-with"></a>
-#### `starts_with()` {#collection-method}
+#### `starts_with()` {.collection-method}
 
 The `starts_with` function determines if the given string begins with the given value:
 
@@ -783,7 +783,7 @@ The `starts_with` function determines if the given string begins with the given 
     // true
 
 <a name="method-str-after"></a>
-#### `str_after()` {#collection-method}
+#### `str_after()` {.collection-method}
 
 The `str_after` function returns everything after the given value in a string:
 
@@ -792,7 +792,7 @@ The `str_after` function returns everything after the given value in a string:
     // ' my name'
 
 <a name="method-str-before"></a>
-#### `str_before()` {#collection-method}
+#### `str_before()` {.collection-method}
 
 The `str_before` function returns everything before the given value in a string:
 
@@ -801,7 +801,7 @@ The `str_before` function returns everything before the given value in a string:
     // 'This is '
 
 <a name="method-str-contains"></a>
-#### `str_contains()` {#collection-method}
+#### `str_contains()` {.collection-method}
 
 The `str_contains` function determines if the given string contains the given value (case sensitive):
 
@@ -816,7 +816,7 @@ You may also pass an array of values to determine if the given string contains a
     // true
 
 <a name="method-str-finish"></a>
-#### `str_finish()` {#collection-method}
+#### `str_finish()` {.collection-method}
 
 The `str_finish` function adds a single instance of the given value to a string if it does not already end with the value:
 
@@ -829,7 +829,7 @@ The `str_finish` function adds a single instance of the given value to a string 
     // this/string/
 
 <a name="method-str-is"></a>
-#### `str_is()` {#collection-method}
+#### `str_is()` {.collection-method}
 
 The `str_is` function determines if a given string matches a given pattern. Asterisks may be used to indicate wildcards:
 
@@ -842,7 +842,7 @@ The `str_is` function determines if a given string matches a given pattern. Aste
     // false
 
 <a name="method-str-limit"></a>
-#### `str_limit()` {#collection-method}
+#### `str_limit()` {.collection-method}
 
 The `str_limit` function truncates the given string at the specified length:
 
@@ -857,7 +857,7 @@ You may also pass a third argument to change the string that will be appended to
     // The quick brown fox (...)
 
 <a name="method-str-ordered-uuid"></a>
-#### `Str::orderedUuid()` {#collection-method}
+#### `Str::orderedUuid()` {.collection-method}
 
 The `Str::orderedUuid` method generates a "timestamp first" UUID that may be efficiently stored in an indexed database column:
 
@@ -866,7 +866,7 @@ The `Str::orderedUuid` method generates a "timestamp first" UUID that may be eff
     return (string) Str::orderedUuid();
 
 <a name="method-str-plural"></a>
-#### `str_plural()` {#collection-method}
+#### `str_plural()` {.collection-method}
 
 The `str_plural` function converts a string to its plural form. This function currently only supports the English language:
 
@@ -889,14 +889,14 @@ You may provide an integer as a second argument to the function to retrieve the 
     // child
 
 <a name="method-str-random"></a>
-#### `str_random()` {#collection-method}
+#### `str_random()` {.collection-method}
 
 The `str_random` function generates a random string of the specified length. This function uses PHP's `random_bytes` function:
 
     $random = str_random(40);
 
 <a name="method-str-replace-array"></a>
-#### `str_replace_array()` {#collection-method}
+#### `str_replace_array()` {.collection-method}
 
 The `str_replace_array` function replaces a given value in the string sequentially using an array:
 
@@ -907,7 +907,7 @@ The `str_replace_array` function replaces a given value in the string sequential
     // The event will take place between 8:30 and 9:00
 
 <a name="method-str-replace-first"></a>
-#### `str_replace_first()` {#collection-method}
+#### `str_replace_first()` {.collection-method}
 
 The `str_replace_first` function replaces the first occurrence of a given value in a string:
 
@@ -916,7 +916,7 @@ The `str_replace_first` function replaces the first occurrence of a given value 
     // a quick brown fox jumps over the lazy dog
 
 <a name="method-str-replace-last"></a>
-#### `str_replace_last()` {#collection-method}
+#### `str_replace_last()` {.collection-method}
 
 The `str_replace_last` function replaces the last occurrence of a given value in a string:
 
@@ -925,7 +925,7 @@ The `str_replace_last` function replaces the last occurrence of a given value in
     // the quick brown fox jumps over a lazy dog
 
 <a name="method-str-singular"></a>
-#### `str_singular()` {#collection-method}
+#### `str_singular()` {.collection-method}
 
 The `str_singular` function converts a string to its singular form. This function currently only supports the English language:
 
@@ -938,7 +938,7 @@ The `str_singular` function converts a string to its singular form. This functio
     // child
 
 <a name="method-str-slug"></a>
-#### `str_slug()` {#collection-method}
+#### `str_slug()` {.collection-method}
 
 The `str_slug` function generates a URL friendly "slug" from the given string:
 
@@ -947,7 +947,7 @@ The `str_slug` function generates a URL friendly "slug" from the given string:
     // laravel-5-framework
 
 <a name="method-str-start"></a>
-#### `str_start()` {#collection-method}
+#### `str_start()` {.collection-method}
 
 The `str_start` function adds a single instance of the given value to a string if it does not already start with the value:
 
@@ -960,7 +960,7 @@ The `str_start` function adds a single instance of the given value to a string i
     // /this/string
 
 <a name="method-studly-case"></a>
-#### `studly_case()` {#collection-method}
+#### `studly_case()` {.collection-method}
 
 The `studly_case` function converts the given string to `StudlyCase`:
 
@@ -969,7 +969,7 @@ The `studly_case` function converts the given string to `StudlyCase`:
     // FooBar
 
 <a name="method-title-case"></a>
-#### `title_case()` {#collection-method}
+#### `title_case()` {.collection-method}
 
 The `title_case` function converts the given string to `Title Case`:
 
@@ -978,7 +978,7 @@ The `title_case` function converts the given string to `Title Case`:
     // A Nice Title Uses The Correct Case
 
 <a name="method-trans"></a>
-#### `trans()` {#collection-method}
+#### `trans()` {.collection-method}
 
 The `trans` function translates the given translation key using your [localization files](/docs/{{version}}/localization):
 
@@ -987,7 +987,7 @@ The `trans` function translates the given translation key using your [localizati
 If the specified translation key does not exist, the `trans` function will return the given key. So, using the example above, the `trans` function would return `messages.welcome` if the translation key does not exist.
 
 <a name="method-trans-choice"></a>
-#### `trans_choice()` {#collection-method}
+#### `trans_choice()` {.collection-method}
 
 The `trans_choice` function translates the given translation key with inflection:
 
@@ -996,7 +996,7 @@ The `trans_choice` function translates the given translation key with inflection
 If the specified translation key does not exist, the `trans_choice` function will return the given key. So, using the example above, the `trans_choice` function would return `messages.notifications` if the translation key does not exist.
 
 <a name="method-str-uuid"></a>
-#### `Str::uuid()` {#collection-method}
+#### `Str::uuid()` {.collection-method}
 
 The `Str::uuid` method generates a UUID (version 4):
 
@@ -1008,7 +1008,7 @@ The `Str::uuid` method generates a UUID (version 4):
 ## URLs
 
 <a name="method-action"></a>
-#### `action()` {#collection-method}
+#### `action()` {.collection-method}
 
 The `action` function generates a URL for the given controller action. You do not need to pass the full namespace of the controller. Instead, pass the controller class name relative to the `App\Http\Controllers` namespace:
 
@@ -1019,21 +1019,21 @@ If the method accepts route parameters, you may pass them as the second argument
     $url = action('UserController@profile', ['id' => 1]);
 
 <a name="method-asset"></a>
-#### `asset()` {#collection-method}
+#### `asset()` {.collection-method}
 
 The `asset` function generates a URL for an asset using the current scheme of the request (HTTP or HTTPS):
 
     $url = asset('img/photo.jpg');
 
 <a name="method-secure-asset"></a>
-#### `secure_asset()` {#collection-method}
+#### `secure_asset()` {.collection-method}
 
 The `secure_asset` function generates a URL for an asset using HTTPS:
 
     $url = secure_asset('img/photo.jpg');
 
 <a name="method-route"></a>
-#### `route()` {#collection-method}
+#### `route()` {.collection-method}
 
 The `route` function generates a URL for the given named route:
 
@@ -1048,7 +1048,7 @@ By default, the `route` function generates an absolute URL. If you wish to gener
     $url = route('routeName', ['id' => 1], false);
 
 <a name="method-secure-url"></a>
-#### `secure_url()` {#collection-method}
+#### `secure_url()` {.collection-method}
 
 The `secure_url` function generates a fully qualified HTTPS URL to the given path:
 
@@ -1057,7 +1057,7 @@ The `secure_url` function generates a fully qualified HTTPS URL to the given pat
     $url = secure_url('user/profile', [1]);
 
 <a name="method-url"></a>
-#### `url()` {#collection-method}
+#### `url()` {.collection-method}
 
 The `url` function generates a fully qualified URL to the given path:
 
@@ -1077,7 +1077,7 @@ If no path is provided, a `Illuminate\Routing\UrlGenerator` instance is returned
 ## Miscellaneous
 
 <a name="method-abort"></a>
-#### `abort()` {#collection-method}
+#### `abort()` {.collection-method}
 
 The `abort` function throws [an HTTP exception](/docs/{{version}}/errors#http-exceptions) which will be rendered by the [exception handler](/docs/{{version}}/errors#the-exception-handler):
 
@@ -1088,7 +1088,7 @@ You may also provide the exception's response text and custom response headers:
     abort(403, 'Unauthorized.', $headers);
 
 <a name="method-abort-if"></a>
-#### `abort_if()` {#collection-method}
+#### `abort_if()` {.collection-method}
 
 The `abort_if` function throws an HTTP exception if a given boolean expression evaluates to `true`:
 
@@ -1097,7 +1097,7 @@ The `abort_if` function throws an HTTP exception if a given boolean expression e
 Like the `abort` method, you may also provide the exception's response text as the third argument and an array of custom response headers as the fourth argument.
 
 <a name="method-abort-unless"></a>
-#### `abort_unless()` {#collection-method}
+#### `abort_unless()` {.collection-method}
 
 The `abort_unless` function throws an HTTP exception if a given boolean expression evaluates to `false`:
 
@@ -1106,7 +1106,7 @@ The `abort_unless` function throws an HTTP exception if a given boolean expressi
 Like the `abort` method, you may also provide the exception's response text as the third argument and an array of custom response headers as the fourth argument.
 
 <a name="method-app"></a>
-#### `app()` {#collection-method}
+#### `app()` {.collection-method}
 
 The `app` function returns the [service container](/docs/{{version}}/container) instance:
 
@@ -1117,7 +1117,7 @@ You may pass a class or interface name to resolve it from the container:
     $api = app('HelpSpot\API');
 
 <a name="method-auth"></a>
-#### `auth()` {#collection-method}
+#### `auth()` {.collection-method}
 
 The `auth` function returns an [authenticator](/docs/{{version}}/authentication) instance. You may use it instead of the `Auth` facade for convenience:
 
@@ -1128,7 +1128,7 @@ If needed, you may specify which guard instance you would like to access:
     $user = auth('admin')->user();
 
 <a name="method-back"></a>
-#### `back()` {#collection-method}
+#### `back()` {.collection-method}
 
 The `back` function generates a [redirect HTTP response](/docs/{{version}}/responses#redirects) to the user's previous location:
 
@@ -1137,21 +1137,21 @@ The `back` function generates a [redirect HTTP response](/docs/{{version}}/respo
     return back();
 
 <a name="method-bcrypt"></a>
-#### `bcrypt()` {#collection-method}
+#### `bcrypt()` {.collection-method}
 
 The `bcrypt` function [hashes](/docs/{{version}}/hashing) the given value using Bcrypt. You may use it as an alternative to the `Hash` facade:
 
     $password = bcrypt('my-secret-password');
 
 <a name="method-broadcast"></a>
-#### `broadcast()` {#collection-method}
+#### `broadcast()` {.collection-method}
 
 The `broadcast` function [broadcasts](/docs/{{version}}/broadcasting) the given [event](/docs/{{version}}/events) to its listeners:
 
     broadcast(new UserRegistered($user));
 
 <a name="method-blank"></a>
-#### `blank()` {#collection-method}
+#### `blank()` {.collection-method}
 
 The `blank` function returns whether the given value is "blank":
 
@@ -1171,7 +1171,7 @@ The `blank` function returns whether the given value is "blank":
 For the inverse of `blank`, see the [`filled`](#method-filled) method.
 
 <a name="method-cache"></a>
-#### `cache()` {#collection-method}
+#### `cache()` {.collection-method}
 
 The `cache` function may be used to get values from the [cache](/docs/{{version}}/cache). If the given key does not exist in the cache, an optional default value will be returned:
 
@@ -1186,21 +1186,21 @@ You may add items to the cache by passing an array of key / value pairs to the f
     cache(['key' => 'value'], now()->addSeconds(10));
 
 <a name="method-class-uses-recursive"></a>
-#### `class_uses_recursive()` {#collection-method}
+#### `class_uses_recursive()` {.collection-method}
 
 The `class_uses_recursive` function returns all traits used by a class, including traits used by all of its parent classes:
 
     $traits = class_uses_recursive(App\User::class);
 
 <a name="method-collect"></a>
-#### `collect()` {#collection-method}
+#### `collect()` {.collection-method}
 
 The `collect` function creates a [collection](/docs/{{version}}/collections) instance from the given value:
 
     $collection = collect(['taylor', 'abigail']);
 
 <a name="method-config"></a>
-#### `config()` {#collection-method}
+#### `config()` {.collection-method}
 
 The `config` function gets the value of a [configuration](/docs/{{version}}/configuration) variable. The configuration values may be accessed using "dot" syntax, which includes the name of the file and the option you wish to access. A default value may be specified and is returned if the configuration option does not exist:
 
@@ -1213,28 +1213,28 @@ You may set configuration variables at runtime by passing an array of key / valu
     config(['app.debug' => true]);
 
 <a name="method-cookie"></a>
-#### `cookie()` {#collection-method}
+#### `cookie()` {.collection-method}
 
 The `cookie` function creates a new [cookie](/docs/{{version}}/requests#cookies) instance:
 
     $cookie = cookie('name', 'value', $minutes);
 
 <a name="method-csrf-field"></a>
-#### `csrf_field()` {#collection-method}
+#### `csrf_field()` {.collection-method}
 
 The `csrf_field` function generates an HTML `hidden` input field containing the value of the CSRF token. For example, using [Blade syntax](/docs/{{version}}/blade):
 
     {{ csrf_field() }}
 
 <a name="method-csrf-token"></a>
-#### `csrf_token()` {#collection-method}
+#### `csrf_token()` {.collection-method}
 
 The `csrf_token` function retrieves the value of the current CSRF token:
 
     $token = csrf_token();
 
 <a name="method-dd"></a>
-#### `dd()` {#collection-method}
+#### `dd()` {.collection-method}
 
 The `dd` function dumps the given variables and ends execution of the script:
 
@@ -1245,28 +1245,28 @@ The `dd` function dumps the given variables and ends execution of the script:
 If you do not want to halt the execution of your script, use the [`dump`](#method-dump) function instead.
 
 <a name="method-decrypt"></a>
-#### `decrypt()` {#collection-method}
+#### `decrypt()` {.collection-method}
 
 The `decrypt` function decrypts the given value using Laravel's [encrypter](/docs/{{version}}/encryption):
 
     $decrypted = decrypt($encrypted_value);
 
 <a name="method-dispatch"></a>
-#### `dispatch()` {#collection-method}
+#### `dispatch()` {.collection-method}
 
 The `dispatch` function pushes the given [job](/docs/{{version}}/queues#creating-jobs) onto the Laravel [job queue](/docs/{{version}}/queues):
 
     dispatch(new App\Jobs\SendEmails);
 
 <a name="method-dispatch-now"></a>
-#### `dispatch_now()` {#collection-method}
+#### `dispatch_now()` {.collection-method}
 
 The `dispatch_now` function runs the given [job](/docs/{{version}}/queues#creating-jobs) immediately and returns the value from its `handle` method:
 
     $result = dispatch_now(new App\Jobs\SendEmails);
 
 <a name="method-dump"></a>
-#### `dump()` {#collection-method}
+#### `dump()` {.collection-method}
 
 The `dump` function dumps the given variables:
 
@@ -1277,14 +1277,14 @@ The `dump` function dumps the given variables:
 If you want to stop executing the script after dumping the variables, use the [`dd`](#method-dd) function instead.
 
 <a name="method-encrypt"></a>
-#### `encrypt()` {#collection-method}
+#### `encrypt()` {.collection-method}
 
 The `encrypt` function encrypts the given value using Laravel's [encrypter](/docs/{{version}}/encryption):
 
     $encrypted = encrypt($unencrypted_value);
 
 <a name="method-env"></a>
-#### `env()` {#collection-method}
+#### `env()` {.collection-method}
 
 The `env` function retrieves the value of an [environment variable](/docs/{{version}}/configuration#environment-configuration) or returns a default value:
 
@@ -1296,21 +1296,21 @@ The `env` function retrieves the value of an [environment variable](/docs/{{vers
 > {note} If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded and all calls to the `env` function will return `null`.
 
 <a name="method-event"></a>
-#### `event()` {#collection-method}
+#### `event()` {.collection-method}
 
 The `event` function dispatches the given [event](/docs/{{version}}/events) to its listeners:
 
     event(new UserRegistered($user));
 
 <a name="method-factory"></a>
-#### `factory()` {#collection-method}
+#### `factory()` {.collection-method}
 
 The `factory` function creates a model factory builder for a given class, name, and amount. It can be used while [testing](/docs/{{version}}/database-testing#writing-factories) or [seeding](/docs/{{version}}/seeding#using-model-factories):
 
     $user = factory(App\User::class)->make();
 
 <a name="method-filled"></a>
-#### `filled()` {#collection-method}
+#### `filled()` {.collection-method}
 
 The `filled` function returns whether the given value is not "blank":
 
@@ -1330,7 +1330,7 @@ The `filled` function returns whether the given value is not "blank":
 For the inverse of `filled`, see the [`blank`](#method-blank) method.
 
 <a name="method-info"></a>
-#### `info()` {#collection-method}
+#### `info()` {.collection-method}
 
 The `info` function will write information to the [log](/docs/{{version}}/errors#logging):
 
@@ -1341,7 +1341,7 @@ An array of contextual data may also be passed to the function:
     info('User login attempt failed.', ['id' => $user->id]);
 
 <a name="method-logger"></a>
-#### `logger()` {#collection-method}
+#### `logger()` {.collection-method}
 
 The `logger` function can be used to write a `debug` level message to the [log](/docs/{{version}}/errors#logging):
 
@@ -1356,7 +1356,7 @@ A [logger](/docs/{{version}}/errors#logging) instance will be returned if no val
     logger()->error('You are not allowed here.');
 
 <a name="method-method-field"></a>
-#### `method_field()` {#collection-method}
+#### `method_field()` {.collection-method}
 
 The `method_field` function generates an HTML `hidden` input field containing the spoofed value of the form's HTTP verb. For example, using [Blade syntax](/docs/{{version}}/blade):
 
@@ -1365,14 +1365,14 @@ The `method_field` function generates an HTML `hidden` input field containing th
     </form>
 
 <a name="method-now"></a>
-#### `now()` {#collection-method}
+#### `now()` {.collection-method}
 
 The `now` function creates a new `Illuminate\Support\Carbon` instance for the current time:
 
     $now = now();
 
 <a name="method-old"></a>
-#### `old()` {#collection-method}
+#### `old()` {.collection-method}
 
 The `old` function [retrieves](/docs/{{version}}/requests#retrieving-input) an [old input](/docs/{{version}}/requests#old-input) value flashed into the session:
 
@@ -1381,7 +1381,7 @@ The `old` function [retrieves](/docs/{{version}}/requests#retrieving-input) an [
     $value = old('value', 'default');
 
 <a name="method-optional"></a>
-#### `optional()` {#collection-method}
+#### `optional()` {.collection-method}
 
 The `optional` function accepts any argument and allows you to access properties on that object. If the given object is `null`, accessing a property will return `null` instead of causing an error:
 
@@ -1402,14 +1402,14 @@ If the method you want to call is not actually on the object itself, you can pas
 If the given object is not `null`, the Closure will be called and its return value will be returned as is. If the given object is actually `null`, the Closure will not be called, and `optional` will return `null` instead of causing an error.
 
 <a name="method-policy"></a>
-#### `policy()` {#collection-method}
+#### `policy()` {.collection-method}
 
 The `policy` method retrieves a [policy](/docs/{{version}}/authorization#creating-policies) instance for a given class:
 
     $policy = policy(App\User::class);
 
 <a name="method-redirect"></a>
-#### `redirect()` {#collection-method}
+#### `redirect()` {.collection-method}
 
 The `redirect` function returns a [redirect HTTP response](/docs/{{version}}/responses#redirects), or returns the redirector instance if called with no arguments:
 
@@ -1420,14 +1420,14 @@ The `redirect` function returns a [redirect HTTP response](/docs/{{version}}/res
     return redirect()->route('route.name');
 
 <a name="method-report"></a>
-#### `report()` {#collection-method}
+#### `report()` {.collection-method}
 
 The `report` function will report an exception using your [exception handler](/docs/{{version}}/errors#the-exception-handler)'s `report` method:
 
     report($e);
 
 <a name="method-request"></a>
-#### `request()` {#collection-method}
+#### `request()` {.collection-method}
 
 The `request` function returns the current [request](/docs/{{version}}/requests) instance or obtains an input item:
 
@@ -1436,7 +1436,7 @@ The `request` function returns the current [request](/docs/{{version}}/requests)
     $value = request('key', $default);
 
 <a name="method-rescue"></a>
-#### `rescue()` {#collection-method}
+#### `rescue()` {.collection-method}
 
 The `rescue` function executes the given Closure and catches any exceptions that occur during its execution. All exceptions that are caught will be sent to your [exception handler](/docs/{{version}}/errors#the-exception-handler)'s `report` method; however, the request will continue processing:
 
@@ -1457,14 +1457,14 @@ You may also pass a second argument to the `rescue` function. This argument will
     });
 
 <a name="method-resolve"></a>
-#### `resolve()` {#collection-method}
+#### `resolve()` {.collection-method}
 
 The `resolve` function resolves a given class or interface name to its instance using the [service container](/docs/{{version}}/container):
 
     $api = resolve('HelpSpot\API');
 
 <a name="method-response"></a>
-#### `response()` {#collection-method}
+#### `response()` {.collection-method}
 
 The `response` function creates a [response](/docs/{{version}}/responses) instance or obtains an instance of the response factory:
 
@@ -1473,7 +1473,7 @@ The `response` function creates a [response](/docs/{{version}}/responses) instan
     return response()->json(['foo' => 'bar'], 200, $headers);
 
 <a name="method-retry"></a>
-#### `retry()` {#collection-method}
+#### `retry()` {.collection-method}
 
 The `retry` function attempts to execute the given callback until the given maximum attempt threshold is met. If the callback does not throw an exception, its return value will be returned. If the callback throws an exception, it will automatically be retried. If the maximum attempt count is exceeded, the exception will be thrown:
 
@@ -1482,7 +1482,7 @@ The `retry` function attempts to execute the given callback until the given maxi
     }, 100);
 
 <a name="method-session"></a>
-#### `session()` {#collection-method}
+#### `session()` {.collection-method}
 
 The `session` function may be used to get or set [session](/docs/{{version}}/session) values:
 
@@ -1499,7 +1499,7 @@ The session store will be returned if no value is passed to the function:
     session()->put('key', $value);
 
 <a name="method-tap"></a>
-#### `tap()` {#collection-method}
+#### `tap()` {.collection-method}
 
 The `tap` function accepts two arguments: an arbitrary `$value` and a Closure. The `$value` will be passed to the Closure and then be returned by the `tap` function. The return value of the Closure is irrelevant:
 
@@ -1517,14 +1517,14 @@ If no Closure is passed to the `tap` function, you may call any method on the gi
     ]);
 
 <a name="method-today"></a>
-#### `today()` {#collection-method}
+#### `today()` {.collection-method}
 
 The `today` function creates a new `Illuminate\Support\Carbon` instance for the current date:
 
     $today = today();
 
 <a name="method-throw-if"></a>
-#### `throw_if()` {#collection-method}
+#### `throw_if()` {.collection-method}
 
 The `throw_if` function throws the given exception if a given boolean expression evaluates to `true`:
 
@@ -1537,7 +1537,7 @@ The `throw_if` function throws the given exception if a given boolean expression
     );
 
 <a name="method-throw-unless"></a>
-#### `throw_unless()` {#collection-method}
+#### `throw_unless()` {.collection-method}
 
 The `throw_unless` function throws the given exception if a given boolean expression evaluates to `false`:
 
@@ -1550,14 +1550,14 @@ The `throw_unless` function throws the given exception if a given boolean expres
     );
 
 <a name="method-trait-uses-recursive"></a>
-#### `trait_uses_recursive()` {#collection-method}
+#### `trait_uses_recursive()` {.collection-method}
 
 The `trait_uses_recursive` function returns all traits used by a trait:
 
     $traits = trait_uses_recursive(\Illuminate\Notifications\Notifiable::class);
 
 <a name="method-transform"></a>
-#### `transform()` {#collection-method}
+#### `transform()` {.collection-method}
 
 The `transform` function executes a `Closure` on a given value if the value is not [blank](#method-blank) and returns the result of the `Closure`:
 
@@ -1576,14 +1576,14 @@ A default value or `Closure` may also be passed as the third parameter to the me
     // The value is blank
 
 <a name="method-validator"></a>
-#### `validator()` {#collection-method}
+#### `validator()` {.collection-method}
 
 The `validator` function creates a new [validator](/docs/{{version}}/validation) instance with the given arguments. You may use it instead of the `Validator` facade for convenience:
 
     $validator = validator($data, $rules, $messages);
 
 <a name="method-value"></a>
-#### `value()` {#collection-method}
+#### `value()` {.collection-method}
 
 The `value` function returns the value it is given. However, if you pass a `Closure` to the function, the `Closure` will be executed then its result will be returned:
 
@@ -1598,14 +1598,14 @@ The `value` function returns the value it is given. However, if you pass a `Clos
     // false
 
 <a name="method-view"></a>
-#### `view()` {#collection-method}
+#### `view()` {.collection-method}
 
 The `view` function retrieves a [view](/docs/{{version}}/views) instance:
 
     return view('auth.login');
 
 <a name="method-with"></a>
-#### `with()` {#collection-method}
+#### `with()` {.collection-method}
 
 The `with` function returns the value it is given. If a `Closure` is passed as the second argument to the function, the `Closure` will be executed and its result will be returned:
 


### PR DESCRIPTION
Collection and helper function heading tags are currently broken for several older versions of the docs. This PR targets `5.6`.

On server render, the heading tags all contain the same literal `id="collection-method" attribute; IDs are meant to be unique.

```html
<h4 id="collection-method"><code>random()</code></h4>
```

When the JavaScript kicks in, the ID attribute is updated its corresponding `<a name="...">` link, however the intended styling is then broken because it targets the `id` attribute, e.g., `#collection-method { ... }`.

This PR updates the `5.1` branch to use classes instead of IDs, which means that it:

- Matches the later documentation versions
- Gets the intended styling applied
- Has no flash of styled / unstyled content