### PR TITLE
Fix incorrect middleware listed in Fortify docs

### DIFF
--- a/fortify.md
+++ b/fortify.md
@@ -536,7 +536,7 @@ If the request to resend the verification link email was successful, Fortify wil
 <a name="protecting-routes"></a>
 ### Protecting Routes
 
-To specify that a route or group of routes requires that the user has verified their email address, you should attach Laravel's built-in `verified` middleware to the route. The `verified` middleware alias is automatically registered by Laravel and serves as an alias for the `Illuminate\Routing\Middleware\ValidateSignature` middleware:
+To specify that a route or group of routes requires that the user has verified their email address, you should attach Laravel's built-in `verified` middleware to the route. The `verified` middleware alias is automatically registered by Laravel and serves as an alias for the `Illuminate\Auth\Middleware\EnsureEmailIsVerified` middleware:
 
 ```php
 Route::get('/dashboard', function () {


### PR DESCRIPTION
The `ValidateSignature` middleware is actually for validating signed routes, so the docs should list `EnsureEmailIsVerified` in this section.