### PR TITLE
Update eloquent-mutators.md

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -443,7 +443,7 @@ To specify the format that should be used when actually storing a model's dates 
 
 By default, the `date` and `datetime` casts will serialize dates to a UTC ISO-8601 date string (`YYYY-MM-DDTHH:MM:SS.uuuuuuZ`), regardless of the timezone specified in your application's `timezone` configuration option. You are strongly encouraged to always use this serialization format, as well as to store your application's dates in the UTC timezone by not changing your application's `timezone` configuration option from its default `UTC` value. Consistently using the UTC timezone throughout your application will provide the maximum level of interoperability with other date manipulation libraries written in PHP and JavaScript.
 
-If a custom format is applied to the `date` or `datetime` cast, such as `datetime:Y-m-d H:i:s`, the inner timezone of the Carbon instance will be used during date serialization. Typically, this will be the timezone specified in your application's `timezone` configuration option. However, it's important to note that timestamp columns like `created_at` and `updated_at` are exempt from this behavior and are always formatted in UTC, regardless of the application's timezone setting.
+If a custom format is applied to the `date` or `datetime` cast, such as `datetime:Y-m-d H:i:s`, the inner timezone of the Carbon instance will be used during date serialization. Typically, this will be the timezone specified in your application's `timezone` configuration option. However, it's important to note that `timestamp` columns such as `created_at` and `updated_at` are exempt from this behavior and are always formatted in UTC, regardless of the application's timezone setting.
 
 <a name="enum-casting"></a>
 ### Enum Casting

--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -443,7 +443,7 @@ To specify the format that should be used when actually storing a model's dates 
 
 By default, the `date` and `datetime` casts will serialize dates to a UTC ISO-8601 date string (`YYYY-MM-DDTHH:MM:SS.uuuuuuZ`), regardless of the timezone specified in your application's `timezone` configuration option. You are strongly encouraged to always use this serialization format, as well as to store your application's dates in the UTC timezone by not changing your application's `timezone` configuration option from its default `UTC` value. Consistently using the UTC timezone throughout your application will provide the maximum level of interoperability with other date manipulation libraries written in PHP and JavaScript.
 
-If a custom format is applied to the `date` or `datetime` cast, such as `datetime:Y-m-d H:i:s`, the inner timezone of the Carbon instance will be used during date serialization. Typically, this will be the timezone specified in your application's `timezone` configuration option.
+If a custom format is applied to the `date` or `datetime` cast, such as `datetime:Y-m-d H:i:s`, the inner timezone of the Carbon instance will be used during date serialization. Typically, this will be the timezone specified in your application's `timezone` configuration option. However, it's important to note that timestamp columns like `created_at` and `updated_at` are exempt from this behavior and are always formatted in UTC, regardless of the application's timezone setting.
 
 <a name="enum-casting"></a>
 ### Enum Casting


### PR DESCRIPTION
This PR clarifies the behavior of timestamp columns in relation to date/datetime casting and timezone handling in Laravel.

Key points:

1. This update is related to #9287 and laravel/framework#49899.

2. While the referenced issues state that dates are always displayed in UTC regardless of custom formatting, this is not entirely accurate. For non-timestamp columns, Carbon instances are created based on the app.timezone configuration and formatted in local time, as per the original documentation.

3. However, for timestamp columns (created_at, updated_at), the timezone setting is lost during pre-casting processing (serializeDate, Date::parse, format methods), resulting in consistent UTC formatting.

4. This discrepancy can lead to confusion for developers who expect consistent behavior across all date columns with similar cast settings.

5. It's important to note that following the documentation's recommendation to keep app.timezone set to the default UTC value would prevent these inconsistencies.

6. Given the potential impact on many applications, we believe updating the documentation is preferable to modifying this core behavior.