### PR TITLE
[11.x] Clarify MinIO support for temporary URLs 

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -219,7 +219,7 @@ AWS_URL=http://localhost:9000/local
 ```
 
 > [!WARNING]  
-> Generating temporary storage URLs via the `temporaryUrl` method is not supported when using MinIO.
+> Generating temporary storage URLs via the `temporaryUrl` method may not work when using MinIO if the `endpoint` is not accessible by the client.
 
 <a name="obtaining-disk-instances"></a>
 ## Obtaining Disk Instances


### PR DESCRIPTION
This PR clarifies that MinIO actually supports the `temporaryUrl` method.

In a dockerized environment, the `endpoint` variable normally points to `https://minio:9000` as stated in the documentation.
But since the hostname `minio` only exists within the docker network, the client cannot access the resource.

If MinIO is configured for a production environment, it will be accessible directly or thanks to a reverse proxy.
This can be useful for people who want to use their own instance of MinIO in production.

I am using Laravel Herd for development connected to my own MinIO instance hosted on a private VPS for testing.
For local development it might be more reasonable to use the `temporaryUrl` with local storage as just presented in Laracon US.