### PR TITLE
[11.x] Add missing .env values for Reverb configuration

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -232,6 +232,7 @@ window.Echo = new Echo({
 Next, you should define the appropriate values for the Pusher environment variables in your application's `.env` file. If these variables do not already exist in your `.env` file, you should add them:
 
 ```ini
+# Pusher settings
 PUSHER_APP_ID="your-pusher-app-id"
 PUSHER_APP_KEY="your-pusher-key"
 PUSHER_APP_SECRET="your-pusher-secret"
@@ -240,12 +241,21 @@ PUSHER_PORT=443
 PUSHER_SCHEME="https"
 PUSHER_APP_CLUSTER="mt1"
 
+# Vite Pusher settings
 VITE_APP_NAME="${APP_NAME}"
 VITE_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
 VITE_PUSHER_HOST="${PUSHER_HOST}"
 VITE_PUSHER_PORT="${PUSHER_PORT}"
 VITE_PUSHER_SCHEME="${PUSHER_SCHEME}"
 VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
+
+# Vite Reverb settings
+VITE_APP_NAME="${APP_NAME}"
+VITE_REVERB_APP_KEY="${VITE_PUSHER_APP_KEY}"
+VITE_REVERB_HOST="${VITE_PUSHER_HOST}"
+VITE_REVERB_PORT="${VITE_PUSHER_PORT}"
+VITE_REVERB_SCHEME="${VITE_PUSHER_SCHEME}"
+VITE_REVERB_APP_CLUSTER="${VITE_PUSHER_APP_CLUSTER}"
 ```
 
 Once you have adjusted the Echo configuration according to your application's needs, you may compile your application's assets:


### PR DESCRIPTION
This PR addresses the missing .env configuration values for Reverb in the broadcasting documentation. The current example references `import.meta.env.VITE_REVERB_APP_KEY`, `import.meta.env.VITE_REVERB_HOST`, and other related variables, but the corresponding .env file example only includes pusher related values.

I have added the necessary Reverb-specific .env variables:

VITE_APP_NAME="${APP_NAME}"
VITE_REVERB_APP_KEY="${VITE_PUSHER_APP_KEY}"
VITE_REVERB_HOST="${VITE_PUSHER_HOST}"
VITE_REVERB_PORT="${VITE_PUSHER_PORT}"
VITE_REVERB_SCHEME="${VITE_PUSHER_SCHEME}"
VITE_REVERB_APP_CLUSTER="${VITE_PUSHER_APP_CLUSTER}"

Including these variables ensures that users configuring Reverb for their Laravel Echo setup have a complete and accurate .env file to work with. This update helps prevent potential confusion and setup issues.
