### PR TITLE
Use official Selenium Chromium image for Apple Silicon in Sail environment

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -352,11 +352,11 @@ sail dusk
 <a name="selenium-on-apple-silicon"></a>
 #### Selenium on Apple Silicon
 
-If your local machine contains an Apple Silicon chip, your `selenium` service must use the `seleniarm/standalone-chromium` image:
+If your local machine contains an Apple Silicon chip, your `selenium` service must use the `selenium/standalone-chromium` image:
 
 ```yaml
 selenium:
-    image: 'seleniarm/standalone-chromium'
+    image: 'selenium/standalone-chromium'
     extra_hosts:
         - 'host.docker.internal:host-gateway'
     volumes:


### PR DESCRIPTION
This PR changes the recommended image for Sail's Selenium service on Apple Silicon from `seleniarm/standalone-chromium` to `selenium/standalone-chromium`. Notice seleni*u*m instead of seleni*ar*m 😄 

Reason: The community-maintained fork was merged back into the official Selenium project in May 2024 and is now only maintained there. See the [official announcement](https://www.selenium.dev/blog/2024/multi-arch-images-via-docker-selenium/) by the Selenium project. The [latest seleniarm/standalone-chromium release](https://hub.docker.com/r/seleniarm/standalone-chromium/tags) is Chromium v124.0.6367.78 from four months ago. Its [GitHub repository is now archived](https://github.com/seleniumhq-community/docker-seleniarm). Unfortunately, until [Google provides Linux/ARM builds for Chrome](https://www.selenium.dev/blog/2024/multi-arch-images-via-docker-selenium/#browser-binaries), Apple Silicon / ARM users still need to switch from Chrome to Chromium.