### PR TITLE
[11.x] standardize constructor examples

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -672,10 +672,7 @@ Finally, you may place the authorization logic for your channel in the channel c
         /**
          * Create a new channel instance.
          */
-        public function __construct()
-        {
-            // ...
-        }
+        public function __construct() {}
 
         /**
          * Authenticate the user's access to the channel.

--- a/collections.md
+++ b/collections.md
@@ -1488,7 +1488,7 @@ The `mapInto()` method iterates over the collection, creating a new instance of 
          * Create a new currency instance.
          */
         function __construct(
-            public string $code
+            public string $code,
         ) {}
     }
 
@@ -1842,7 +1842,7 @@ The `pipeInto` method creates a new instance of the given class and passes the c
          * Create a new ResourceCollection instance.
          */
         public function __construct(
-          public Collection $collection,
+            public Collection $collection,
         ) {}
     }
 

--- a/container.md
+++ b/container.md
@@ -199,7 +199,7 @@ This statement tells the container that it should inject the `RedisEventPusher` 
      * Create a new class instance.
      */
     public function __construct(
-        protected EventPusher $pusher
+        protected EventPusher $pusher,
     ) {}
 
 <a name="contextual-binding"></a>
@@ -380,7 +380,7 @@ If you would like to have the Laravel container instance itself injected into a 
      * Create a new class instance.
      */
     public function __construct(
-        protected Container $container
+        protected Container $container,
     ) {}
 
 <a name="automatic-injection"></a>

--- a/events.md
+++ b/events.md
@@ -220,10 +220,7 @@ Next, let's take a look at the listener for our example event. Event listeners r
         /**
          * Create the event listener.
          */
-        public function __construct()
-        {
-            // ...
-        }
+        public function __construct() {}
 
         /**
          * Handle the event.

--- a/queues.md
+++ b/queues.md
@@ -236,8 +236,9 @@ Or, to prevent relations from being serialized, you can call the `withoutRelatio
     /**
      * Create a new job instance.
      */
-    public function __construct(Podcast $podcast)
-    {
+    public function __construct(
+        Podcast $podcast,
+    ) {
         $this->podcast = $podcast->withoutRelations();
     }
 
@@ -250,9 +251,8 @@ If you are using PHP constructor property promotion and would like to indicate t
      */
     public function __construct(
         #[WithoutRelations]
-        public Podcast $podcast
-    ) {
-    }
+        public Podcast $podcast,
+    ) {}
 
 If a job receives a collection or array of Eloquent models instead of a single model, the models within that collection will not have their relationships restored when the job is deserialized and executed. This is to prevent excessive resource usage on jobs that deal with large numbers of models.
 


### PR DESCRIPTION
- always use trailing commas in signature
- always use multiline arguments
- correct indentation
- remove empty bodies