### PR TITLE
[11.x] Update scout.md about connecting to Typesense in Laravel Sail

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -147,6 +147,9 @@ TYPESENSE_API_KEY=masterKey
 TYPESENSE_HOST=localhost
 ```
 
+> [!NOTE]  
+> If you are using Laravel Sail, you will need to adjust the `TYPESENSE_HOST` to match the Docker container name.
+
 If needed, you may also specify your installation's port, path, and protocol:
 
 ```env

--- a/scout.md
+++ b/scout.md
@@ -147,10 +147,7 @@ TYPESENSE_API_KEY=masterKey
 TYPESENSE_HOST=localhost
 ```
 
-> [!NOTE]  
-> If you are using Laravel Sail, you will need to adjust the `TYPESENSE_HOST` to match the Docker container name.
-
-If needed, you may also specify your installation's port, path, and protocol:
+If you are using [Laravel Sail](/docs/{{version}}/sail), you may need to adjust the `TYPESENSE_HOST` environment variable to match the Docker container name. You may also optionally specify your installation's port, path, and protocol:
 
 ```env
 TYPESENSE_PORT=8108


### PR DESCRIPTION
Added note under Typesense section about setting the TYPESENSE_HOST to match the Docker container for Typesense allowing Scout to properly connect.