### PR TITLE
Update concurrency.md

### DIFF
--- a/concurrency.md
+++ b/concurrency.md
@@ -17,7 +17,16 @@ Sometimes you may need to execute several slow tasks which do not depend on one 
 
 Laravel achieves concurrency by serializing the given closures and dispatching them to a hidden Artisan CLI command, which unserializes the closures and invokes it within its own PHP process. After the closure has been invoked, the resulting value is serialized back to the parent process.
 
-The `Concurrency` facade supports three drivers: `process` (the default), `fork`, and `sync`. The `fork` driver offers improved performance compared to the default `process` driver, but it may only be used within PHP's CLI context, as PHP does not support forking during web requests. The `sync` driver is primarily useful during testing when you want to disable all concurrency and simple execute the given closure in sequence within the parent process.
+The `Concurrency` facade supports three drivers: `process` (the default), `fork`, and `sync`. 
+
+
+The `fork` driver offers improved performance compared to the default `process` driver, but it may only be used within PHP's CLI context, as PHP does not support forking during web requests. Before using the `fork` driver, you need to install the `spatie/fork` package:
+
+```bash
+composer require spatie/fork
+```
+
+The `sync` driver is primarily useful during testing when you want to disable all concurrency and simple execute the given closure in sequence within the parent process.
 
 <a name="running-concurrent-tasks"></a>
 ## Running Concurrent Tasks
@@ -47,4 +56,19 @@ Concurrency::defer([
     fn () => Metrics::report('users'),
     fn () => Metrics::report('orders'),
 ]);
+```
+
+The `defer` method cannot be used within PHP's CLI context as no HTTP response is generated and the task will never run.
+
+<a name="switching-the-concurrency-driver"></a>
+## Switching the Concurrency Driver
+
+Laravel's `Concurrency` facade supports multiple drivers. 
+
+To switch the driver, use this syntax:
+
+```php
+use Illuminate\Support\Facades\Concurrency;
+
+Concurrency::setDefaultInstance('fork');
 ```

--- a/concurrency.md
+++ b/concurrency.md
@@ -19,14 +19,13 @@ Laravel achieves concurrency by serializing the given closures and dispatching t
 
 The `Concurrency` facade supports three drivers: `process` (the default), `fork`, and `sync`. 
 
-
 The `fork` driver offers improved performance compared to the default `process` driver, but it may only be used within PHP's CLI context, as PHP does not support forking during web requests. Before using the `fork` driver, you need to install the `spatie/fork` package:
 
 ```bash
 composer require spatie/fork
 ```
 
-The `sync` driver is primarily useful during testing when you want to disable all concurrency and simple execute the given closure in sequence within the parent process.
+The `sync` driver is primarily useful during testing when you want to disable all concurrency and simply execute the given closures in sequence within the parent process.
 
 <a name="running-concurrent-tasks"></a>
 ## Running Concurrent Tasks
@@ -43,6 +42,18 @@ use Illuminate\Support\Facades\DB;
 ]);
 ```
 
+To use a specific driver, you may use the `driver` method:
+
+```php
+$results = Concurrency::driver('fork')->run(...);
+```
+
+Or, to change the default concurrency driver, you should publish the `concurrency` configuration file via the `config:publish` Artisan command and update the `default` option within the file:
+
+```bash
+php artisan config:publish concurrency
+```
+
 <a name="deferring-concurrent-tasks"></a>
 ## Deferring Concurrent Tasks
 
@@ -56,19 +67,4 @@ Concurrency::defer([
     fn () => Metrics::report('users'),
     fn () => Metrics::report('orders'),
 ]);
-```
-
-The `defer` method cannot be used within PHP's CLI context as no HTTP response is generated and the task will never run.
-
-<a name="switching-the-concurrency-driver"></a>
-## Switching the Concurrency Driver
-
-Laravel's `Concurrency` facade supports multiple drivers. 
-
-To switch the driver, use this syntax:
-
-```php
-use Illuminate\Support\Facades\Concurrency;
-
-Concurrency::setDefaultInstance('fork');
 ```


### PR DESCRIPTION
- Add requirements of spatie/fork
- Show example on how to switch drivers
- Explain that the defer method will never run the tasks in the PHP CLI's context