### PR TITLE
Add documentation for retrieving input values as integers to requests.md

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -317,6 +317,13 @@ When dealing with HTML elements like checkboxes, your application may receive "t
 
     $archived = $request->boolean('archived');
 
+<a name="retrieving-integer-input-values"></a>
+#### Retrieving Integer Input Values
+
+To retrieve input values as integers, you may use the `integer` method. This method will attempt to cast the input value to an integer. If the input is not present or the cast fails, it will return the default value you specify. This is particularly useful for pagination or other numeric inputs:
+
+    $perPage = $request->integer('per_page');
+
 <a name="retrieving-date-input-values"></a>
 #### Retrieving Date Input Values
 

--- a/requests.md
+++ b/requests.md
@@ -310,19 +310,19 @@ Instead of retrieving the request's input data as a primitive `string`, you may 
 
     $name = $request->string('name')->trim();
 
-<a name="retrieving-boolean-input-values"></a>
-#### Retrieving Boolean Input Values
-
-When dealing with HTML elements like checkboxes, your application may receive "truthy" values that are actually strings. For example, "true" or "on". For convenience, you may use the `boolean` method to retrieve these values as booleans. The `boolean` method returns `true` for 1, "1", true, "true", "on", and "yes". All other values will return `false`:
-
-    $archived = $request->boolean('archived');
-
 <a name="retrieving-integer-input-values"></a>
 #### Retrieving Integer Input Values
 
 To retrieve input values as integers, you may use the `integer` method. This method will attempt to cast the input value to an integer. If the input is not present or the cast fails, it will return the default value you specify. This is particularly useful for pagination or other numeric inputs:
 
     $perPage = $request->integer('per_page');
+
+<a name="retrieving-boolean-input-values"></a>
+#### Retrieving Boolean Input Values
+
+When dealing with HTML elements like checkboxes, your application may receive "truthy" values that are actually strings. For example, "true" or "on". For convenience, you may use the `boolean` method to retrieve these values as booleans. The `boolean` method returns `true` for 1, "1", true, "true", "on", and "yes". All other values will return `false`:
+
+    $archived = $request->boolean('archived');
 
 <a name="retrieving-date-input-values"></a>
 #### Retrieving Date Input Values


### PR DESCRIPTION
Getting the `per_page` input from a request and passing it to `Builder`'s `paginate()` doesn't make PHPStan happy, nor does casting the result of `$request->input()`, which is `mixed`, to an `integer`. This method is quite useful but doesn't seem to be documented.