### PR TITLE
Update when helper example for rendering HTML attributes.

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -2317,7 +2317,7 @@ The `when` function returns the value it is given if a given condition evaluates
 The `when` function is primarily useful for conditionally rendering HTML attributes:
 
 ```blade
-<div {{ when($condition, 'wire:poll="calculate"') }}>
+<div {!! when($condition, 'wire:poll="calculate"') !!}>
     ...
 </div>
 ```


### PR DESCRIPTION
Josh Cirre DM'd me that he was having an issue with using when() with livewire, and noted that the docs example shows it using `{{` blade tags, where it should be using `{!!` to prevent output escaping.

quick fix!