### PR TITLE
[11.x] Fix `ThrottlesExceptions` description and adjust `retryUntil()` time limit

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -619,10 +619,10 @@ For example, let's imagine a queued job that interacts with a third-party API th
      */
     public function retryUntil(): DateTime
     {
-        return now()->addMinutes(5);
+        return now()->addMinutes(30);
     }
 
-The first constructor argument accepted by the middleware is the number of exceptions the job can throw before being throttled, while the second constructor argument is the number of seconds that should elapse before the job is attempted again once it has been throttled. In the code example above, if the job throws 10 exceptions within 5 minutes, we will wait 5 minutes before attempting the job again.
+The first constructor argument accepted by the middleware is the number of exceptions the job can throw before being throttled, while the second constructor argument is the number of seconds that should elapse before the job is attempted again once it has been throttled. In the code example above, if the job throws 10 consecutive exceptions, we will wait 5 minutes before attempting the job again, continuing until the 30-minute time limit is reached.
 
 When a job throws an exception but the exception threshold has not yet been reached, the job will typically be retried immediately. However, you may specify the number of minutes such a job should be delayed by calling the `backoff` method when attaching the middleware to the job:
 


### PR DESCRIPTION

This PR addresses an incorrect description of the `ThrottlesExceptions` behavior. It clarifies that the Limiter is triggered by **10 consecutive exceptions**, not by a **5-minute time period** as previously implied. 

Additionally, this PR adjusts the time limit in the `retryUntil()` function to exceed the Limiter's decay period. This adjustment serves two purposes: it reduces potential confusion between the function's time limit and the Limiter's decay period, and it ensures that `retryUntil()` can successfully retry after the throttling period instead of failing prematurely due to reaching its time limit.




