### PR TITLE
Document breaking change in password rehashing if custom password field

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -128,13 +128,13 @@ However, we do **not recommend** that Laravel 10 applications upgrading to Larav
 
 **Likelihood Of Impact: Low**
 
-Laravel 11 will automatically rehash your user's passwords during authentication if your hashing algorithm's "work factor" has been updated since the password was last hashed.
+Laravel 11 will automatically rehash your user's passwords during authentication if your hashing algorithm's "work factor" has been updated since the password was last hashed. 
 
-Typically, this should not disrupt your application; however, if your User model uses a password field other than `password`, this must be specified in the User model:
+Typically, this should not disrupt your application; however, if your `User` model's "password" field has a name other than `password`, you should specify the field's name via the model's `authPasswordName` property:
 
-    protected $authPasswordName = 'my_password_field';
+    protected $authPasswordName = 'custom_password_field';
 
-Alternatively, you may disable this behavior by adding the `rehash_on_login` option to your application's `config/hashing.php` configuration file:
+Alternatively, you may disable password rehashing by adding the `rehash_on_login` option to your application's `config/hashing.php` configuration file:
 
     'rehash_on_login' => false,
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -126,9 +126,15 @@ However, we do **not recommend** that Laravel 10 applications upgrading to Larav
 <a name="password-rehashing"></a>
 #### Password Rehashing
 
+**Likelihood Of Impact: Low**
+
 Laravel 11 will automatically rehash your user's passwords during authentication if your hashing algorithm's "work factor" has been updated since the password was last hashed.
 
-Typically, this should not disrupt your application; however, you may disable this behavior by adding the `rehash_on_login` option to your application's `config/hashing.php` configuration file:
+Typically, this should not disrupt your application; however, if your User model uses a password field other than `password`, this must be specified in the User model:
+
+    protected $authPasswordName = 'my_password_field';
+
+Alternatively, you may disable this behavior by adding the `rehash_on_login` option to your application's `config/hashing.php` configuration file:
 
     'rehash_on_login' => false,
 


### PR DESCRIPTION
I know I'm late to the game with my 11.x upgrade, but I came across what I think is an undocumented breaking change related to the password rehashing. I tested logging in after upgrade and got an exception `Column not found: 1054 Unknown column 'password' in 'field list'`. (Which is true - the app I'm upgrading uses a different field name for the password.) Based on the related documentation about the `Authenticatable` trait, I took a closer look at that trait and determined that if I defined `$authPasswordName` in my User model it fixed the issue. I adjusted the documentation on this in the upgrade guide to account for this possibility.

I also added the missing likelihood-of-impact for this subheading, which I'm calling "low" since most folks probably use the default 'password' field name.