### PR TITLE
[11.x] `helpers.md` - Cancelling deferred functions

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -2401,19 +2401,14 @@ By default, deferred functions will only be executed if the HTTP response, Artis
 defer(fn () => Metrics::reportOrder($order))->always();
 ```
 
+<a name="cancelling-deferred-functions"></a>
 #### Cancelling Deferred Functions
 
-If you need to cancel a specific deferred function before it is executed, you can use the `forget` method. This allows you to remove a deferred task by referencing the name you provided when you initially set up the deferred function.
-
-To name a deferred function, pass a second argument to the defer function:
+If you need to cancel a specific deferred function before it is executed, you can use the `forget` method to cancel a function by its name. To name a deferred function, provide a second argument to the `defer` function:
 
 ```php
 defer(fn () => Metrics::report(), 'reportMetrics');
-```
 
-Then, if needed, you can cancel the execution of this deferred function using forget:
-
-```php
 defer()->forget('reportMetrics');
 ```
 

--- a/helpers.md
+++ b/helpers.md
@@ -2404,7 +2404,7 @@ defer(fn () => Metrics::reportOrder($order))->always();
 <a name="cancelling-deferred-functions"></a>
 #### Cancelling Deferred Functions
 
-If you need to cancel a deferred function before it is executed, you can use the `forget` method to cancel a function by its name. To name a deferred function, provide a second argument to the `defer` function:
+If you need to cancel a deferred function before it is executed, you can use the `forget` method to cancel the function by its name. To name a deferred function, provide a second argument to the `defer` function:
 
 ```php
 defer(fn () => Metrics::report(), 'reportMetrics');

--- a/helpers.md
+++ b/helpers.md
@@ -2404,7 +2404,7 @@ defer(fn () => Metrics::reportOrder($order))->always();
 <a name="cancelling-deferred-functions"></a>
 #### Cancelling Deferred Functions
 
-If you need to cancel a specific deferred function before it is executed, you can use the `forget` method to cancel a function by its name. To name a deferred function, provide a second argument to the `defer` function:
+If you need to cancel a deferred function before it is executed, you can use the `forget` method to cancel a function by its name. To name a deferred function, provide a second argument to the `defer` function:
 
 ```php
 defer(fn () => Metrics::report(), 'reportMetrics');

--- a/helpers.md
+++ b/helpers.md
@@ -2401,6 +2401,22 @@ By default, deferred functions will only be executed if the HTTP response, Artis
 defer(fn () => Metrics::reportOrder($order))->always();
 ```
 
+#### Cancelling Deferred Functions
+
+If you need to cancel a specific deferred function before it is executed, you can use the `forget` method. This allows you to remove a deferred task by referencing the name you provided when you initially set up the deferred function.
+
+To name a deferred function, pass a second argument to the defer function:
+
+```php
+defer(fn () => Metrics::report(), 'reportMetrics');
+```
+
+Then, if needed, you can cancel the execution of this deferred function using forget:
+
+```php
+defer()->forget('reportMetrics');
+```
+
 <a name="deferred-function-compatibility"></a>
 #### Deferred Function Compatibility
 


### PR DESCRIPTION
## Context

In my [Add cancel abilities to Deferred Callbacks #52816](https://github.com/laravel/framework/pull/52816), Taylor mentioned that there is an existing way to cancel deferred functions by using the method `forget`.

This PR includes in the documentation that reference by explaining:

- The capability of the `defer` helper to be identified with a name
- Use the name as a identifier to remove the callback from the collection

---

The forget method allows you to cancel a specific deferred function before it runs. Simply assign a name to the deferred function and use forget to remove it:

```php
defer(fn () => Metrics::report(), 'reportMetrics');
defer()->forget('reportMetrics');
```
