### PR TITLE
[11.x] Add middleware alias registration example for EnsureUserHasRole middleware

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -392,6 +392,16 @@ Additional middleware parameters will be passed to the middleware after the `$ne
 
     }
 
+To use this middleware, you need to register an alias for it in your application's `bootstrap/app.php` file:
+
+    use App\Http\Middleware\EnsureUserHasRole;
+    
+    ->withMiddleware(function (Middleware $middleware) {
+        $middleware->alias([
+            'role' => EnsureUserHasRole::class,
+        ]);
+    })
+
 Middleware parameters may be specified when defining the route by separating the middleware name and parameters with a `:`:
 
     Route::put('/post/{id}', function (string $id) {

--- a/middleware.md
+++ b/middleware.md
@@ -394,6 +394,8 @@ Additional middleware parameters will be passed to the middleware after the `$ne
 
 Middleware parameters may be specified when defining the route by separating the middleware name and parameters with a `:`:
 
+    use App\Http\Middleware\EnsureUserHasRole;
+
     Route::put('/post/{id}', function (string $id) {
         // ...
     })->middleware(EnsureUserHasRole::class.':editor');

--- a/middleware.md
+++ b/middleware.md
@@ -392,27 +392,17 @@ Additional middleware parameters will be passed to the middleware after the `$ne
 
     }
 
-To use this middleware, you need to register an alias for it in your application's `bootstrap/app.php` file:
-
-    use App\Http\Middleware\EnsureUserHasRole;
-    
-    ->withMiddleware(function (Middleware $middleware) {
-        $middleware->alias([
-            'role' => EnsureUserHasRole::class,
-        ]);
-    })
-
 Middleware parameters may be specified when defining the route by separating the middleware name and parameters with a `:`:
 
     Route::put('/post/{id}', function (string $id) {
         // ...
-    })->middleware('role:editor');
+    })->middleware(EnsureUserHasRole::class.':editor');
 
 Multiple parameters may be delimited by commas:
 
     Route::put('/post/{id}', function (string $id) {
         // ...
-    })->middleware('role:editor,publisher');
+    })->middleware(EnsureUserHasRole::class.':editor,publisher');
 
 <a name="terminable-middleware"></a>
 ## Terminable Middleware


### PR DESCRIPTION
This pull request adds information about registering a middleware alias for the `EnsureUserHasRole` middleware example in the "Middleware Parameters" section of the documentation.

The current documentation provides an example of the `EnsureUserHasRole` middleware and how to use it with parameters, but it doesn't mention the necessary step of registering the middleware alias. This addition will help users avoid confusion when implementing the middleware in their applications.

Changes made:
1. Added a code snippet demonstrating how to register the `EnsureUserHasRole` middleware alias in the `bootstrap/app.php` file.
2. Placed the new information immediately after the middleware class example and before the route definition examples.