### PR TITLE
fix incompatible return type

### DIFF
--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -101,7 +101,7 @@ The `HasFactory` trait's `factory` method will use conventions to determine the 
     /**
      * Create a new factory instance for the model.
      */
-    protected static function newFactory(): Factory
+    protected static function newFactory()
     {
         return FlightFactory::new();
     }

--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -95,7 +95,6 @@ Once you have defined your factories, you may use the static `factory` method pr
 
 The `HasFactory` trait's `factory` method will use conventions to determine the proper factory for the model the trait is assigned to. Specifically, the method will look for a factory in the `Database\Factories` namespace that has a class name matching the model name and is suffixed with `Factory`. If these conventions do not apply to your particular application or factory, you may overwrite the `newFactory` method on your model to return an instance of the model's corresponding factory directly:
 
-    use Illuminate\Database\Eloquent\Factories\Factory;
     use Database\Factories\Administration\FlightFactory;
 
     /**

--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -100,6 +100,8 @@ The `HasFactory` trait's `factory` method will use conventions to determine the 
 
     /**
      * Create a new factory instance for the model.
+     *
+     * @return TFactory|null
      */
     protected static function newFactory()
     {

--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -100,8 +100,6 @@ The `HasFactory` trait's `factory` method will use conventions to determine the 
 
     /**
      * Create a new factory instance for the model.
-     *
-     * @return TFactory|null
      */
     protected static function newFactory()
     {


### PR DESCRIPTION
`HasFactory::newFactory()` doesn't actually enforce the `Factory` return type. Following the docs here as is leads to an exception.

https://github.com/laravel/framework/blob/abf86b08b08c5ea5c9247877bc8b6ea259805f80/src/Illuminate/Database/Eloquent/Factories/HasFactory.php#L31