### PR TITLE
Provide warning that storage:link needs additional steps when using sail

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -79,6 +79,9 @@ The `storage:unlink` command may be used to destroy your configured symbolic lin
 php artisan storage:unlink
 ```
 
+> [!NOTE]  
+> If your application is served by Sail, the symbolic link must be created from within the docker container to avoid permission issues delivering the assets through Vite.
+
 <a name="driver-prerequisites"></a>
 ### Driver Prerequisites
 


### PR DESCRIPTION
Looking for text along these lines or a generally better/clearer explanation from someone in the know.

When php artisan storage:link is run with sail/vite deploying the app, images in the storage folder return 403 forbidden.
This can be fixed by removing the storage link and recreating it from within the sail container.
It trips me up every time and is always confusing that the only reference to it is a stackoverflow answer, unless I'm missing it.
https://stackoverflow.com/questions/69544339/browser-doesnt-show-image-from-laravel-storage