### PR TITLE
[11.x] Clarify event subscriber registration

### DIFF
--- a/events.md
+++ b/events.md
@@ -631,7 +631,7 @@ If your event listener methods are defined within the subscriber itself, you may
 <a name="registering-event-subscribers"></a>
 ### Registering Event Subscribers
 
-After writing the subscriber, Laravel will automatically register it if it follows the [event-discovery](/docs/{{version}}/events#event-discovery) rules. If your subscriber isn't auto-registered by Laravel, you may register it manually using the `subscribe` method of the `Event` facade. Typically, this should be done within the `boot` method of your application's `AppServiceProvider`:
+After writing the subscriber, Laravel will automatically register handler methods within the subscriber if they follow Laravel's [event discovery conventions](/docs/{{version}}/events#event-discovery). Otherwise, you may manually register your subscriber using the `subscribe` method of the `Event` facade. Typically, this should be done within the `boot` method of your application's `AppServiceProvider`:
 
     <?php
 

--- a/events.md
+++ b/events.md
@@ -631,7 +631,7 @@ If your event listener methods are defined within the subscriber itself, you may
 <a name="registering-event-subscribers"></a>
 ### Registering Event Subscribers
 
-After writing the subscriber, Laravel will automatically register handler methods within the subscriber if they follow Laravel's [event discovery conventions](/docs/{{version}}/events#event-discovery). Otherwise, you may manually register your subscriber using the `subscribe` method of the `Event` facade. Typically, this should be done within the `boot` method of your application's `AppServiceProvider`:
+After writing the subscriber, Laravel will automatically register handler methods within the subscriber if they follow Laravel's [event discovery conventions](#event-discovery). Otherwise, you may manually register your subscriber using the `subscribe` method of the `Event` facade. Typically, this should be done within the `boot` method of your application's `AppServiceProvider`:
 
     <?php
 

--- a/events.md
+++ b/events.md
@@ -631,7 +631,7 @@ If your event listener methods are defined within the subscriber itself, you may
 <a name="registering-event-subscribers"></a>
 ### Registering Event Subscribers
 
-After writing the subscriber, you are ready to register it with the event dispatcher. You may register subscribers using the `subscribe` method of the `Event` facade. Typically, this should be done within the `boot` method of your application's `AppServiceProvider`:
+After writing the subscriber, Laravel will automatically register it if it follows the [event-discovery](/docs/{{version}}/events#event-discovery) rules. If your subscriber isn't auto-registered by Laravel, you may register it manually using the `subscribe` method of the `Event` facade. Typically, this should be done within the `boot` method of your application's `AppServiceProvider`:
 
     <?php
 


### PR DESCRIPTION
This PR clarifies the event subscriber registration process and adds a note about automatic registration through event discovery. The PR addresses the concerns mentioned in issue [#52404](https://github.com/laravel/framework/issues/52404) as @njpanderson faced the same issue.
