### PR TITLE
Add warning about restoring default Meilisearch index settings

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -323,6 +323,9 @@ After configuring your application's index settings, you must invoke the `scout:
 php artisan scout:sync-index-settings
 ```
 
+> [!WARNING]  
+> If an index setting is later removed from the `index_settings` array, default settings will not be automatically restored by the `scout:sync-index-settings` artisan command. The setting must be explicitly defined as its default value before running this command for the change to be reflected.
+
 <a name="configuring-the-model-id"></a>
 ### Configuring the Model ID
 


### PR DESCRIPTION
I discovered the hard way that if I overwrote a default setting for an index, e.g. `'proximityPrecision' => 'byAttribute'` and used the artisan command to sync it, removing that setting and syncing again doesn't automatically restore the default, I have to explicitly set `'proximityPrecision' => 'byWord'` for that default to be restored. I'm not sure if my wording here captures that in the clearest way so feel free to edit as you see fit.