### PR TITLE
added missing "whereMorphedTo" on Eloquent relationship page

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1502,9 +1502,11 @@ You may occasionally need to add query constraints based on the "type" of the re
         }
     )->get();
 
-Sometimes you may want to query for the children of a "morph to" relationship. You may find it more convenient to use the `whereMorphedTo` method, which will automatically determine the proper morph type mapping for the given model:
+Sometimes you may want to query for the children of a "morph to" relationship. You may find it more convenient to use the `whereMorphedTo` and `whereNotMorphedTo` methods, which will automatically determine the proper morph type mapping for the given model. These methods accepts the name of the `morphTo` relationship as its first argument, and the related parent model as its second argument. For example, we may query all for all comments that belongs to either a specific `$post` or a specific `$video`:
 
-    $comments = Comment::whereMorphedTo('commentable', $post);
+    $comments = Comment::whereMorphedTo('commentable', $post)
+                          ->orWhereMorphedTo('commentable', $video)
+                          ->get();
 
 <a name="querying-all-morph-to-related-models"></a>
 #### Querying All Related Models

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1502,6 +1502,10 @@ You may occasionally need to add query constraints based on the "type" of the re
         }
     )->get();
 
+Sometimes you may want to query for the children of a "morph to" relationship. You may find it more convenient to use the `whereMorphedTo` method, which will automatically determine the proper morph type mapping for the given model:
+
+    $comments = Comment::whereMorphedTo('commentable', $post);
+
 <a name="querying-all-morph-to-related-models"></a>
 #### Querying All Related Models
 

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1502,7 +1502,7 @@ You may occasionally need to add query constraints based on the "type" of the re
         }
     )->get();
 
-Sometimes you may want to query for the children of a "morph to" relationship. You may find it more convenient to use the `whereMorphedTo` and `whereNotMorphedTo` methods, which will automatically determine the proper morph type mapping for the given model. These methods accepts the name of the `morphTo` relationship as its first argument, and the related parent model as its second argument. For example, we may query all for all comments that belongs to either a specific `$post` or a specific `$video`:
+Sometimes you may want to query for the children of a "morph to" relationship's parent. You may accomplish this using the `whereMorphedTo` and `whereNotMorphedTo` methods, which will automatically determine the proper morph type mapping for the given model. These methods accept the name of the `morphTo` relationship as their first argument and the related parent model as their second argument:
 
     $comments = Comment::whereMorphedTo('commentable', $post)
                           ->orWhereMorphedTo('commentable', $video)


### PR DESCRIPTION
From [laravel/framework \#53041](https://github.com/laravel/framework/pull/53041), it turns out there's Polymorphic equivalent to `whereBelongsTo()` that is not mentioned anywhere in the docs.

This PR adds a mention of said method on Eloquent relationships page. I'm open to suggestions on what and where to put it.

Thank you.