### PR TITLE
fix inaccurate return type

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -399,7 +399,7 @@ import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 createInertiaApp({
   resolve: (name) => resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('./Pages/**/*.vue')),
   setup({ el, App, props, plugin }) {
-    return createApp({ render: () => h(App, props) })
+    createApp({ render: () => h(App, props) })
       .use(plugin)
       .mount(el)
   },


### PR DESCRIPTION
Example given in the docs works but produces a type error when used with typescript because `setup` function given to  `createInertiaApp` has the following signature:
`(props:{ el: Element; App: InertiaApp; props: InertiaAppProps; plugin: Plugin; }) => void | App<any>`

While the example (because it ends with `.mount(el)`) returns `ComponentPublicInstance`.

Changes I made work and do not produce type errors.

[Example from inertia docs](https://inertiajs.com/client-side-setup#initialize-the-inertia-app) doesn't return created instance either so I don't think it's necessary.