### PR TITLE
Add output example for once helper function in documentation

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -2016,13 +2016,13 @@ class NumberService
 
 $service = new NumberService;
 
-$service->all();
-$service->all(); // (cached result)
+$service->all(); // 2
+$service->all(); // 2 (cached result)
 
 $secondService = new NumberService;
 
-$secondService->all();
-$secondService->all(); // (cached result)
+$secondService->all(); // 1
+$secondService->all(); // 1 (cached result)
 ```
 <a name="method-optional"></a>
 #### `optional()` {.collection-method}


### PR DESCRIPTION
This PR adds an output example for the `once` helper function in the Laravel documentation. The example demonstrates how the `once` function caches results within the same instance and ensures that the method is executed only once per instance.