### PR TITLE
[11.x] explain using `@push` with layout components

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -1721,6 +1721,26 @@ If you would like to prepend content onto the beginning of a stack, you should u
 @endprepend
 ```
 
+If you are using `@push` inside of a layout component, make sure the `@push` is declared either before or inside the component. `@push` directives after the component closing tag will not work correctly:
+
+```blade
+@push('scripts')
+    This will work...
+@endpush
+
+<x-layout>
+
+@push('scripts')
+    This will work...
+@endpush
+
+</x-layout>
+
+@push('scripts')
+    This will NOT work...
+@endpush
+```
+
 <a name="service-injection"></a>
 ## Service Injection
 


### PR DESCRIPTION
I recently converted a site from "template inheritance" layouts to "component" layouts. previously, I could have `@push`s declared anywhere within my view, and they would work fine. now I've noticed they **will not** work when declared after the closing tag of my layout component.

I'm not sure if this is intended behavior, a technical limitation, OR something that could/should be fixed.

If it's one of the first 2, I thought we should document it.