### PR TITLE
Add documentation for MongoDB support

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -53,7 +53,7 @@ Want to get started fast? Install a [Laravel application starter kit](/docs/{{ve
 <a name="introduction-database-considerations"></a>
 ### Database Considerations
 
-By default, Laravel includes an `App\Models\User` [Eloquent model](/docs/{{version}}/eloquent) in your `app/Models` directory. This model may be used with the default Eloquent authentication driver. If your application is not using Eloquent, you may use the `database` authentication provider which uses the Laravel query builder.
+By default, Laravel includes an `App\Models\User` [Eloquent model](/docs/{{version}}/eloquent) in your `app/Models` directory. This model may be used with the default Eloquent authentication driver. If your application is not using Eloquent, you may use the `database` authentication provider which uses the Laravel query builder. If your application is using MongoDB, see the [User Authentication](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/user-authentication/) page in the `mongodb/laravel-mongodb` package's documentation for additional information.
 
 When building the database schema for the `App\Models\User` model, make sure the password column is at least 60 characters in length. Of course, the `users` table migration that is included in new Laravel applications already creates a column that exceeds this length.
 

--- a/authentication.md
+++ b/authentication.md
@@ -53,7 +53,9 @@ Want to get started fast? Install a [Laravel application starter kit](/docs/{{ve
 <a name="introduction-database-considerations"></a>
 ### Database Considerations
 
-By default, Laravel includes an `App\Models\User` [Eloquent model](/docs/{{version}}/eloquent) in your `app/Models` directory. This model may be used with the default Eloquent authentication driver. If your application is not using Eloquent, you may use the `database` authentication provider which uses the Laravel query builder. If your application is using MongoDB, see the [User Authentication](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/user-authentication/) page in the `mongodb/laravel-mongodb` package's documentation for additional information.
+By default, Laravel includes an `App\Models\User` [Eloquent model](/docs/{{version}}/eloquent) in your `app/Models` directory. This model may be used with the default Eloquent authentication driver.
+
+If your application is not using Eloquent, you may use the `database` authentication provider which uses the Laravel query builder. If your application is using MongoDB, check out MongoDB's official [Laravel user authentication documentation](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/user-authentication/) .
 
 When building the database schema for the `App\Models\User` model, make sure the password column is at least 60 characters in length. Of course, the `users` table migration that is included in new Laravel applications already creates a column that exceeds this length.
 

--- a/cache.md
+++ b/cache.md
@@ -111,6 +111,13 @@ In addition, you should ensure that values are provided for the DynamoDB cache s
 ],
 ```
 
+<a name="mongodb"></a>
+#### MongoDB
+
+If you are using MongoDB, a `mongodb` cache driver is provided by the `mongodb/laravel-mongodb` package and can be configured using a `mongodb` database connection. MongoDB supports TTL indexes, which can be used to automatically clear expired cache items.
+
+For more information on configuring MongoDB, see the [Cache and Locks](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/cache/) page in its documentation.
+
 <a name="cache-usage"></a>
 ## Cache Usage
 

--- a/cache.md
+++ b/cache.md
@@ -114,9 +114,9 @@ In addition, you should ensure that values are provided for the DynamoDB cache s
 <a name="mongodb"></a>
 #### MongoDB
 
-If you are using MongoDB, a `mongodb` cache driver is provided by the `mongodb/laravel-mongodb` package and can be configured using a `mongodb` database connection. MongoDB supports TTL indexes, which can be used to automatically clear expired cache items.
+If you are using MongoDB, a `mongodb` cache driver is provided by the official `mongodb/laravel-mongodb` package and can be configured using a `mongodb` database connection. MongoDB supports TTL indexes, which can be used to automatically clear expired cache items.
 
-For more information on configuring MongoDB, see the [Cache and Locks](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/cache/) page in its documentation.
+For more information on configuring MongoDB, please refer to the MongoDB [Cache and Locks documentation](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/cache/).
 
 <a name="cache-usage"></a>
 ## Cache Usage

--- a/database.md
+++ b/database.md
@@ -27,6 +27,8 @@ Almost every modern web application interacts with a database. Laravel makes int
 
 </div>
 
+Additionally, MongoDB is supported via the `mongodb/laravel-mongodb` package, which is officially maintained by MongoDB. See the [Laravel MongoDB](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/) documentation for more information.
+
 <a name="configuration"></a>
 ### Configuration
 

--- a/database.md
+++ b/database.md
@@ -27,7 +27,7 @@ Almost every modern web application interacts with a database. Laravel makes int
 
 </div>
 
-Additionally, MongoDB is supported via the `mongodb/laravel-mongodb` package, which is officially maintained by MongoDB. See the [Laravel MongoDB](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/) documentation for more information.
+Additionally, MongoDB is supported via the `mongodb/laravel-mongodb` package, which is officially maintained by MongoDB. Check out the [Laravel MongoDB](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/) documentation for more information.
 
 <a name="configuration"></a>
 ### Configuration

--- a/documentation.md
+++ b/documentation.md
@@ -64,6 +64,7 @@
     - [Migrations](/docs/{{version}}/migrations)
     - [Seeding](/docs/{{version}}/seeding)
     - [Redis](/docs/{{version}}/redis)
+    - [MongoDB](/docs/{{version}}/mongodb)
 - ## Eloquent ORM
     - [Getting Started](/docs/{{version}}/eloquent)
     - [Relationships](/docs/{{version}}/eloquent-relationships)

--- a/mongodb.md
+++ b/mongodb.md
@@ -1,0 +1,99 @@
+# MongoDB
+
+- [Introduction](#introduction)
+- [Installation](#installation)
+    - [Starting a MongoDB server](#starting-a-mongodb-server)
+    - [MongoDB Driver](#mongodb-driver)
+    - [Install the Laravel MongoDB package](#install-the-laravel-mongodb-package)
+- [Configuration](#configuration)
+- [Features](#features)
+
+<a name="introduction"></a>
+## Introduction
+
+[MongoDB](https://www.mongodb.com/resources/products/fundamentals/why-use-mongodb) is one of the most popular NoSQL document-oriented database, used for its high write load (useful for analytics or IoT) and high availability (easy to set replica sets with automatic failover). It can also shard the database easily for horizontal scalability and has a powerful query language for doing aggregation, text search or geospatial queries. Instead of storing data in tables of rows or columns like SQL databases, each record in a MongoDB database is a document described in BSON, a binary representation of the data. Applications can then retrieve this information in a JSON format. It supports a wide variety of data types, including documents, arrays, embedded documents, and binary data.
+
+Before using MongoDB with Laravel, we recommend installing and using the `mongodb/laravel-mongodb` package via Composer. While MongoDB is natively supported by PHP through the MongoDB driver, the [Laravel MongoDB](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/) package provides a richer integration with Eloquent and other Laravel features.
+
+```shell
+composer require mongodb/laravel-mongodb
+```
+
+<a name="installation"></a>
+## Installation
+
+<a name="starting-a-mongodb-server"></a>
+#### Starting a MongoDB server
+
+The MongoDB Community Server can be used to create a Laravel application. It is available for installation in Windows, macOS, Linux, or as Docker container. Read how to [Install MongoDB Community Edition](https://docs.mongodb.com/manual/administration/install-community/).
+
+The connection string for the MongoDB server can be set in the `.env` file:
+
+```
+MONGODB_URI=mongodb://localhost:27017
+MONGODB_DATABASE=laravel_app
+```
+
+For hosting MongoDB in the cloud, consider using [MongoDB Atlas](https://www.mongodb.com/cloud/atlas).
+To access a MongoDB Atlas cluster locally from your application, you will need to [add your own IP address in the cluster's network settings](https://www.mongodb.com/docs/atlas/security/add-ip-address-to-list/) to the project's IP Access List.
+
+The connection string for MongoDB Atlas can be set in the `.env` file:
+
+```
+MONGODB_URI=mongodb+srv://<username>:<password>@<cluster>.mongodb.net/<dbname>?retryWrites=true&w=majority
+MONGODB_DATABASE=laravel_app
+```
+
+<a name="mongodb-driver"></a>
+#### MongoDB Driver
+
+To connect to a MongoDB database, the `mongodb` PHP extension is required. This extension can be installed using PECL:
+
+```shell
+pecl install mongodb
+```
+
+Read the [MongoDB PHP extension installation instructions](https://www.php.net/manual/en/mongodb.installation.php) for more information.
+
+<a name="install-the-laravel-mongodb-package"></a>
+#### Install the Laravel MongoDB package
+
+Use Composer to install the Laravel MongoDB package:
+
+```shell
+composer require mongodb/laravel-mongodb
+```
+
+> [!NOTE]  
+> This installation of the package will fail if the `mongodb` PHP extension is not installed. The PHP configuration can differ between the CLI and the web server, so ensure the extension is enabled in both configurations.
+
+<a name="configuration"></a>
+## Configuration
+
+You may configure your MongoDB connection via the `config/database.php` configuration file.
+Within this file, you can add a `mongodb` connection using the `mongodb` driver:
+
+```php
+'connections' => [
+    'mongodb' => [
+        'driver' => 'mongodb',
+        'dsn' => env('MONGODB_URI', 'mongodb://localhost:27017'),
+        'database' => env('MONGODB_DATABASE', 'laravel_app'),
+    ],
+],
+```
+
+<a name="features"></a>
+## Features
+
+Once your configuration is complete, you can use the `mongodb` connection in your application:
+
+- [Using Eloquent](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/eloquent-models/), models can be stored in MongoDB collections. In addition to the standard Eloquent features, the Laravel MongoDB package provides additional features such as embedded relationships. The package also provides direct access to the MongoDB driver, which can be used to execute operations such as raw queries and aggregation pipelines.
+- [Write complex queries](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/query-builder/) using the query builder.
+- [Using the Cache](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/cache/), the `mongodb` cache driver is optimized to use MongoDB features such as TTL indexes to automatically clear expired cache entries.
+- Using the Session with Laravel's `cache` and the `mongodb` cache driver. 
+- [Using the Queue](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/queues/) with the `mongodb` queue driver.
+- [Storing files in GridFS](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/gridfs/), by way of the [GridFS Adapter for Flysystem](https://flysystem.thephpleague.com/docs/adapter/gridfs/).
+- Most third party packages using a database connection or Eloquent can be used with MongoDB.
+
+Refer to the [**Quick Start**](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/quick-start/) guide to connect a Laravel application to MongoDB, and perform read/write operations on the data.

--- a/mongodb.md
+++ b/mongodb.md
@@ -2,18 +2,20 @@
 
 - [Introduction](#introduction)
 - [Installation](#installation)
-    - [Starting a MongoDB server](#starting-a-mongodb-server)
     - [MongoDB Driver](#mongodb-driver)
-    - [Install the Laravel MongoDB package](#install-the-laravel-mongodb-package)
+    - [Starting a MongoDB Server](#starting-a-mongodb-server)
+    - [Install the Laravel MongoDB Package](#install-the-laravel-mongodb-package)
 - [Configuration](#configuration)
 - [Features](#features)
 
 <a name="introduction"></a>
 ## Introduction
 
-[MongoDB](https://www.mongodb.com/resources/products/fundamentals/why-use-mongodb) is one of the most popular NoSQL document-oriented database, used for its high write load (useful for analytics or IoT) and high availability (easy to set replica sets with automatic failover). It can also shard the database easily for horizontal scalability and has a powerful query language for doing aggregation, text search or geospatial queries. Instead of storing data in tables of rows or columns like SQL databases, each record in a MongoDB database is a document described in BSON, a binary representation of the data. Applications can then retrieve this information in a JSON format. It supports a wide variety of data types, including documents, arrays, embedded documents, and binary data.
+[MongoDB](https://www.mongodb.com/resources/products/fundamentals/why-use-mongodb) is one of the most popular NoSQL document-oriented database, used for its high write load (useful for analytics or IoT) and high availability (easy to set replica sets with automatic failover). It can also shard the database easily for horizontal scalability and has a powerful query language for doing aggregation, text search or geospatial queries.
 
-Before using MongoDB with Laravel, we recommend installing and using the `mongodb/laravel-mongodb` package via Composer. While MongoDB is natively supported by PHP through the MongoDB driver, the [Laravel MongoDB](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/) package provides a richer integration with Eloquent and other Laravel features.
+Instead of storing data in tables of rows or columns like SQL databases, each record in a MongoDB database is a document described in BSON, a binary representation of the data. Applications can then retrieve this information in a JSON format. It supports a wide variety of data types, including documents, arrays, embedded documents, and binary data.
+
+Before using MongoDB with Laravel, we recommend installing and using the `mongodb/laravel-mongodb` package via Composer. The `laravel-mongodb` package is officially maintained by MongoDB, and while MongoDB is natively supported by PHP through the MongoDB driver, the [Laravel MongoDB](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/) package provides a richer integration with Eloquent and other Laravel features:
 
 ```shell
 composer require mongodb/laravel-mongodb
@@ -22,43 +24,43 @@ composer require mongodb/laravel-mongodb
 <a name="installation"></a>
 ## Installation
 
-<a name="starting-a-mongodb-server"></a>
-#### Starting a MongoDB server
-
-The MongoDB Community Server can be used to create a Laravel application. It is available for installation in Windows, macOS, Linux, or as Docker container. Read how to [Install MongoDB Community Edition](https://docs.mongodb.com/manual/administration/install-community/).
-
-The connection string for the MongoDB server can be set in the `.env` file:
-
-```
-MONGODB_URI=mongodb://localhost:27017
-MONGODB_DATABASE=laravel_app
-```
-
-For hosting MongoDB in the cloud, consider using [MongoDB Atlas](https://www.mongodb.com/cloud/atlas).
-To access a MongoDB Atlas cluster locally from your application, you will need to [add your own IP address in the cluster's network settings](https://www.mongodb.com/docs/atlas/security/add-ip-address-to-list/) to the project's IP Access List.
-
-The connection string for MongoDB Atlas can be set in the `.env` file:
-
-```
-MONGODB_URI=mongodb+srv://<username>:<password>@<cluster>.mongodb.net/<dbname>?retryWrites=true&w=majority
-MONGODB_DATABASE=laravel_app
-```
-
 <a name="mongodb-driver"></a>
-#### MongoDB Driver
+### MongoDB Driver
 
-To connect to a MongoDB database, the `mongodb` PHP extension is required. This extension can be installed using PECL:
+To connect to a MongoDB database, the `mongodb` PHP extension is required. If you are developing locally using [Laravel Herd](https://herd.laravel.com) or installed PHP via `php.new`, you already have this extension installed on your system. However, if you need to install the extension manually, you may do so via PECL:
 
 ```shell
 pecl install mongodb
 ```
 
-Read the [MongoDB PHP extension installation instructions](https://www.php.net/manual/en/mongodb.installation.php) for more information.
+For more information on installing the MongoDB PHP extension, check out the [MongoDB PHP extension installation instructions](https://www.php.net/manual/en/mongodb.installation.php).
+
+<a name="starting-a-mongodb-server"></a>
+### Starting a MongoDB Server
+
+The MongoDB Community Server can be used to run MongoDB locally and is available for installation on Windows, macOS, Linux, or as a Docker container. To learn how to install MongoDB, please refer to the [official MongoDB Community installation guide](https://docs.mongodb.com/manual/administration/install-community/).
+
+The connection string for the MongoDB server can be set in your `.env` file:
+
+```ini
+MONGODB_URI="mongodb://localhost:27017"
+MONGODB_DATABASE="laravel_app"
+```
+
+For hosting MongoDB in the cloud, consider using [MongoDB Atlas](https://www.mongodb.com/cloud/atlas).
+To access a MongoDB Atlas cluster locally from your application, you will need to [add your own IP address in the cluster's network settings](https://www.mongodb.com/docs/atlas/security/add-ip-address-to-list/) to the project's IP Access List.
+
+The connection string for MongoDB Atlas can also be set in your `.env` file:
+
+```ini
+MONGODB_URI="mongodb+srv://<username>:<password>@<cluster>.mongodb.net/<dbname>?retryWrites=true&w=majority"
+MONGODB_DATABASE="laravel_app"
+```
 
 <a name="install-the-laravel-mongodb-package"></a>
-#### Install the Laravel MongoDB package
+### Install the Laravel MongoDB Package
 
-Use Composer to install the Laravel MongoDB package:
+Finally, use Composer to install the Laravel MongoDB package:
 
 ```shell
 composer require mongodb/laravel-mongodb
@@ -70,8 +72,7 @@ composer require mongodb/laravel-mongodb
 <a name="configuration"></a>
 ## Configuration
 
-You may configure your MongoDB connection via the `config/database.php` configuration file.
-Within this file, you can add a `mongodb` connection using the `mongodb` driver:
+You may configure your MongoDB connection via your application's `config/database.php` configuration file. Within this file, add a `mongodb` connection that utilizes the `mongodb` driver:
 
 ```php
 'connections' => [
@@ -86,14 +87,13 @@ Within this file, you can add a `mongodb` connection using the `mongodb` driver:
 <a name="features"></a>
 ## Features
 
-Once your configuration is complete, you can use the `mongodb` connection in your application:
+Once your configuration is complete, you can use the `mongodb` package and database connection in your application to leverage a variety of powerful features:
 
 - [Using Eloquent](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/eloquent-models/), models can be stored in MongoDB collections. In addition to the standard Eloquent features, the Laravel MongoDB package provides additional features such as embedded relationships. The package also provides direct access to the MongoDB driver, which can be used to execute operations such as raw queries and aggregation pipelines.
 - [Write complex queries](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/query-builder/) using the query builder.
-- [Using the Cache](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/cache/), the `mongodb` cache driver is optimized to use MongoDB features such as TTL indexes to automatically clear expired cache entries.
-- Using the Session with Laravel's `cache` and the `mongodb` cache driver. 
-- [Using the Queue](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/queues/) with the `mongodb` queue driver.
-- [Storing files in GridFS](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/gridfs/), by way of the [GridFS Adapter for Flysystem](https://flysystem.thephpleague.com/docs/adapter/gridfs/).
+- The `mongodb` [cache driver](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/cache/) is optimized to use MongoDB features such as TTL indexes to automatically clear expired cache entries.
+- [Dispatch and process queued jobs](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/queues/) with the `mongodb` queue driver.
+- [Storing files in GridFS](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/gridfs/), via the [GridFS Adapter for Flysystem](https://flysystem.thephpleague.com/docs/adapter/gridfs/).
 - Most third party packages using a database connection or Eloquent can be used with MongoDB.
 
-Refer to the [**Quick Start**](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/quick-start/) guide to connect a Laravel application to MongoDB, and perform read/write operations on the data.
+To continue learning how to use MongoDB and Laravel, refer to MongoDB's [Quick Start guide](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/quick-start/).

--- a/queues.md
+++ b/queues.md
@@ -151,6 +151,7 @@ The following dependencies are needed for the listed queue drivers. These depend
 - Amazon SQS: `aws/aws-sdk-php ~3.0`
 - Beanstalkd: `pda/pheanstalk ~5.0`
 - Redis: `predis/predis ~2.0` or phpredis PHP extension
+- MongoDB: `mongodb/laravel-mongodb`, read more about [Laravel Queue with MongoDB](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/queues/)
 
 </div>
 

--- a/queues.md
+++ b/queues.md
@@ -151,7 +151,7 @@ The following dependencies are needed for the listed queue drivers. These depend
 - Amazon SQS: `aws/aws-sdk-php ~3.0`
 - Beanstalkd: `pda/pheanstalk ~5.0`
 - Redis: `predis/predis ~2.0` or phpredis PHP extension
-- MongoDB: `mongodb/laravel-mongodb`, read more about [Laravel Queue with MongoDB](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/queues/)
+- [MongoDB](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/queues/): `mongodb/laravel-mongodb`
 
 </div>
 

--- a/session.md
+++ b/session.md
@@ -245,7 +245,7 @@ If you need to regenerate the session ID and remove all data from the session in
 ## Session Blocking
 
 > [!WARNING]  
-> To utilize session blocking, your application must be using a cache driver that supports [atomic locks](/docs/{{version}}/cache#atomic-locks). Currently, those cache drivers include the `memcached`, `dynamodb`, `redis`, `database`, `file`, and `array` drivers. In addition, you may not use the `cookie` session driver.
+> To utilize session blocking, your application must be using a cache driver that supports [atomic locks](/docs/{{version}}/cache#atomic-locks). Currently, those cache drivers include the `memcached`, `dynamodb`, `redis`, `mongodb` (included in `mongodb/laravel-mongodb` package), `database`, `file`, and `array` drivers. In addition, you may not use the `cookie` session driver.
 
 By default, Laravel allows requests using the same session to execute concurrently. So, for example, if you use a JavaScript HTTP library to make two HTTP requests to your application, they will both execute at the same time. For many applications, this is not a problem; however, session data loss can occur in a small subset of applications that make concurrent requests to two different application endpoints which both write data to the session.
 
@@ -293,6 +293,9 @@ If none of the existing session drivers fit your application's needs, Laravel ma
 
 > [!NOTE]  
 > Laravel does not ship with a directory to contain your extensions. You are free to place them anywhere you like. In this example, we have created an `Extensions` directory to house the `MongoSessionHandler`.
+
+> [!NOTE]
+> We use MongoDB as an example, but if you are looking for a MongoDB session driver, you can use the `cache` session driver with a `mongodb` cache store. Read more about the [MongoDB Cache Driver](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/cache/).
 
 Since the purpose of these methods is not readily understandable, let's quickly cover what each of the methods do:
 

--- a/session.md
+++ b/session.md
@@ -306,9 +306,6 @@ Since the purpose of these methods is not readily understandable, here is an ove
 
 </div>
 
-> [!NOTE]
-> If you are looking for an official MongoDB session driver, you can use the `cache` session driver with a `mongodb` cache store. Check out the [MongoDB Cache Driver documentation](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/cache/) for more information.
-
 <a name="registering-the-driver"></a>
 ### Registering the Driver
 

--- a/session.md
+++ b/session.md
@@ -245,7 +245,7 @@ If you need to regenerate the session ID and remove all data from the session in
 ## Session Blocking
 
 > [!WARNING]  
-> To utilize session blocking, your application must be using a cache driver that supports [atomic locks](/docs/{{version}}/cache#atomic-locks). Currently, those cache drivers include the `memcached`, `dynamodb`, `redis`, `mongodb` (included in `mongodb/laravel-mongodb` package), `database`, `file`, and `array` drivers. In addition, you may not use the `cookie` session driver.
+> To utilize session blocking, your application must be using a cache driver that supports [atomic locks](/docs/{{version}}/cache#atomic-locks). Currently, those cache drivers include the `memcached`, `dynamodb`, `redis`, `mongodb` (included in the official `mongodb/laravel-mongodb` package), `database`, `file`, and `array` drivers. In addition, you may not use the `cookie` session driver.
 
 By default, Laravel allows requests using the same session to execute concurrently. So, for example, if you use a JavaScript HTTP library to make two HTTP requests to your application, they will both execute at the same time. For many applications, this is not a problem; however, session data loss can occur in a small subset of applications that make concurrent requests to two different application endpoints which both write data to the session.
 
@@ -291,13 +291,9 @@ If none of the existing session drivers fit your application's needs, Laravel ma
         public function gc($lifetime) {}
     }
 
-> [!NOTE]  
-> Laravel does not ship with a directory to contain your extensions. You are free to place them anywhere you like. In this example, we have created an `Extensions` directory to house the `MongoSessionHandler`.
+Since Laravel does not include a default directory to house your extensions. You are free to place them anywhere you like. In this example, we have created an `Extensions` directory to house the `MongoSessionHandler`.
 
-> [!NOTE]
-> We use MongoDB as an example, but if you are looking for a MongoDB session driver, you can use the `cache` session driver with a `mongodb` cache store. Read more about the [MongoDB Cache Driver](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/cache/).
-
-Since the purpose of these methods is not readily understandable, let's quickly cover what each of the methods do:
+Since the purpose of these methods is not readily understandable, here is an overview of the purpose of each method:
 
 <div class="content-list" markdown="1">
 
@@ -309,6 +305,9 @@ Since the purpose of these methods is not readily understandable, let's quickly 
 - The `gc` method should destroy all session data that is older than the given `$lifetime`, which is a UNIX timestamp. For self-expiring systems like Memcached and Redis, this method may be left empty.
 
 </div>
+
+> [!NOTE]
+> If you are looking for an official MongoDB session driver, you can use the `cache` session driver with a `mongodb` cache store. Check out the [MongoDB Cache Driver documentation](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/cache/) for more information.
 
 <a name="registering-the-driver"></a>
 ### Registering the Driver


### PR DESCRIPTION
MongoDB maintains a package for Laravel integration: [mongodb/laravel-mongodb](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/)

- Add MongoDB page under "Databases" menu
- Add MongoDB relevant information on authentication, cache, database, queue and session pages.