### PR TITLE
Update installation.md

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -70,7 +70,7 @@ If you don't have PHP and Composer installed on your local machine, the followin
 ```
 
 ```shell tab=Windows PowerShell
-Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://php.new/install/windows'))
+Set-ExecutionPolicy Bypass -Scope Process -Force; irm https://php.new/install/windows | iex
 ```
 
 ```shell tab=Linux


### PR DESCRIPTION
The PHP Installation commands for Windows can be simplified, as newer versions of PowerShell/Windows now provide more concise and readable commands and aliases, as well as set the TLS version to 1.2 at minimum by default.

An alternative to the proposed change could be `winget install php`, thanks to the Windows Package Manager. However, if the user has a version of Windows that does not include winget, that might hinder or otherwise exclude users without it. Some users may also just not want PHP managed by winget, which is understandable