### PR TITLE
[11.x] Add Number Helpers: `defaultLocale`, `defaultCurrency`

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -93,6 +93,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [Number::abbreviate](#method-number-abbreviate)
 [Number::clamp](#method-number-clamp)
 [Number::currency](#method-number-currency)
+[Number::defaultCurrency](#method-default-currency)
 [Number::defaultLocale](#method-default-locale)
 [Number::fileSize](#method-number-file-size)
 [Number::forHumans](#method-number-for-humans)
@@ -1232,6 +1233,17 @@ The `Number::currency` method returns the currency representation of the given v
 
     // 1.000,00 €
 
+<a name="method-default-currency"></a>
+#### `Number::defaultCurrency()` {.collection-method}
+
+The `Number::defaultCurrency` method returns the default currency for your application:
+
+    use Illuminate\Support\Number;
+
+    $currency = Number::defaultCurrency();
+
+    // USD
+
 <a name="method-default-locale"></a>
 #### `Number::defaultLocale()` {.collection-method}
 
@@ -1242,7 +1254,6 @@ The `Number::defaultLocale` method returns the default number locale for your ap
     $locale = Number::defaultLocale();
 
     // en
-
 
 <a name="method-number-file-size"></a>
 #### `Number::fileSize()` {.collection-method}

--- a/helpers.md
+++ b/helpers.md
@@ -93,6 +93,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [Number::abbreviate](#method-number-abbreviate)
 [Number::clamp](#method-number-clamp)
 [Number::currency](#method-number-currency)
+[Number::defaultLocale](#method-default-locale)
 [Number::fileSize](#method-number-file-size)
 [Number::forHumans](#method-number-for-humans)
 [Number::format](#method-number-format)
@@ -1230,6 +1231,18 @@ The `Number::currency` method returns the currency representation of the given v
     $currency = Number::currency(1000, in: 'EUR', locale: 'de');
 
     // 1.000,00 €
+
+<a name="method-default-locale"></a>
+#### `Number::defaultLocale()` {.collection-method}
+
+The `Number::defaultLocale` method returns the default number locale for your application:
+
+    use Illuminate\Support\Number;
+
+    $locale = Number::defaultLocale();
+
+    // en
+
 
 <a name="method-number-file-size"></a>
 #### `Number::fileSize()` {.collection-method}

--- a/helpers.md
+++ b/helpers.md
@@ -1236,7 +1236,7 @@ The `Number::currency` method returns the currency representation of the given v
 <a name="method-default-currency"></a>
 #### `Number::defaultCurrency()` {.collection-method}
 
-The `Number::defaultCurrency` method returns the default currency for your application:
+The `Number::defaultCurrency` method returns the default currency being used by the `Number` class:
 
     use Illuminate\Support\Number;
 
@@ -1247,7 +1247,7 @@ The `Number::defaultCurrency` method returns the default currency for your appli
 <a name="method-default-locale"></a>
 #### `Number::defaultLocale()` {.collection-method}
 
-The `Number::defaultLocale` method returns the default number locale for your application:
+The `Number::defaultLocale` method returns the default locale being used by the `Number` class:
 
     use Illuminate\Support\Number;
 


### PR DESCRIPTION
This PR adds Number helpers, `defaultLocale` and `defaultCurrency`.

https://github.com/laravel/framework/pull/53101