### PR TITLE
[11.x] Add support for union types in event listeners in Laravel 11

### DIFF
--- a/events.md
+++ b/events.md
@@ -234,6 +234,17 @@ Next, let's take a look at the listener for our example event. Event listeners r
 > [!NOTE]  
 > Your event listeners may also type-hint any dependencies they need on their constructors. All event listeners are resolved via the Laravel [service container](/docs/{{version}}/container), so dependencies will be injected automatically.
 
+If you need to listen to multiple events, you can do so by using a union type in your listener’s `handle` method parameter. This allows your listener to accept more than one event type:
+
+    public function handle(Login|Logout $event): void
+    {
+        if ($event instanceof Login) {
+            // Handle Login event
+        } elseif ($event instanceof Logout) {
+            // Handle Logout event
+        }
+    }
+
 <a name="stopping-the-propagation-of-an-event"></a>
 #### Stopping The Propagation Of An Event
 

--- a/events.md
+++ b/events.md
@@ -68,6 +68,16 @@ By default, Laravel will automatically find and register your event listeners by
         }
     }
 
+You may listen to multiple events using PHP's union types:
+
+    /**
+     * Handle the given event.
+     */
+    public function handle(PodcastProcessed|PodcastPublished $event): void
+    {
+        // ...
+    }
+
 If you plan to store your listeners in a different directory or within multiple directories, you may instruct Laravel to scan those directories using the `withEvents` method in your application's `bootstrap/app.php` file:
 
     ->withEvents(discover: [
@@ -229,16 +239,6 @@ Next, let's take a look at the listener for our example event. Event listeners r
         {
             // Access the order using $event->order...
         }
-    }
-
-You may listen to multiple events using PHP's union types:
-
-    /**
-     * Handle the event.
-     */
-    public function handle(OrderShipped|OrderDelivered $event): void
-    {
-        // ...
     }
 
 > [!NOTE]  

--- a/events.md
+++ b/events.md
@@ -231,19 +231,18 @@ Next, let's take a look at the listener for our example event. Event listeners r
         }
     }
 
+You may listen to multiple events using PHP's union types:
+
+    /**
+     * Handle the event.
+     */
+    public function handle(OrderShipped|OrderDelivered $event): void
+    {
+        // ...
+    }
+
 > [!NOTE]  
 > Your event listeners may also type-hint any dependencies they need on their constructors. All event listeners are resolved via the Laravel [service container](/docs/{{version}}/container), so dependencies will be injected automatically.
-
-If you need to listen to multiple events, you can do so by using a union type in your listener’s `handle` method parameter. This allows your listener to accept more than one event type:
-
-    public function handle(Login|Logout $event): void
-    {
-        if ($event instanceof Login) {
-            // Handle Login event
-        } elseif ($event instanceof Logout) {
-            // Handle Logout event
-        }
-    }
 
 <a name="stopping-the-propagation-of-an-event"></a>
 #### Stopping The Propagation Of An Event


### PR DESCRIPTION
It's something I simply discovered. It simplifies some of my listeners, so I thought it would be helpful for other developers to know that this is possible. By using union types in Laravel event listeners, you can handle multiple related events in a single listener. This reduces redundancy and makes it easier to manage similar events in one place.

The example in the documentation shows how to use union types in the `handle` method, leveraging the `instanceof` operator to differentiate and handle each event accordingly.