### PR TITLE
[11.x] Get back old installation/application creation methods

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -91,7 +91,7 @@ composer global require laravel/installer
 <a name="creating-an-application"></a>
 ### Creating an Application
 
-After you have installed PHP, Composer, and the Laravel installer, you're ready to create a new Laravel application. The Laravel installer will prompt you to select your preferred testing framework, database, and starter kit. Optionally, if you want to configure your application manually, you may create a new Laravel application using a Composer command:
+After you have installed PHP, Composer, and the Laravel installer, you're ready to create a new Laravel application. The Laravel installer will prompt you to select your preferred testing framework, database, and starter kit:
 
 ```nothing
 laravel new example-app

--- a/installation.md
+++ b/installation.md
@@ -82,13 +82,23 @@ After running one of the commands above, you should restart your terminal sessio
 > [!NOTE]
 > For a fully-featured, graphical PHP installation and management experience, check out [Laravel Herd](#local-installation-using-herd).
 
+In case you already have PHP and Composer configured, you may install the Laravel installer binary using:
+
+```shell
+composer global require laravel/installer
+```
+
 <a name="creating-an-application"></a>
 ### Creating an Application
 
-After you have installed PHP, Composer, and the Laravel installer, you're ready to create a new Laravel application. The Laravel installer will prompt you to select your preferred testing framework, database, and starter kit:
+After you have installed PHP, Composer, and the Laravel installer, you're ready to create a new Laravel application. The Laravel installer will prompt you to select your preferred testing framework, database, and starter kit. Optionally, if you want to configure your application manually, you may create a new Laravel application using a Composer command:
 
-```nothing
+```nothing tab=Using Laravel installer
 laravel new example-app
+```
+
+```nothing tab=Using Composer
+composer create-project --prefer-dist laravel/laravel example-app
 ```
 
 Once the application has been created, you can start Laravel's local development server, queue worker, and Vite development server using the `dev` Composer script:

--- a/installation.md
+++ b/installation.md
@@ -79,26 +79,22 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 
 After running one of the commands above, you should restart your terminal session. To update PHP, Composer, and the Laravel installer after installing them via `php.new`, you can re-run the command in your terminal.
 
-> [!NOTE]
-> For a fully-featured, graphical PHP installation and management experience, check out [Laravel Herd](#local-installation-using-herd).
-
-In case you already have PHP and Composer configured, you may install the Laravel installer binary using:
+In you already have PHP and Composer installed, you may install the Laravel installer via Composer:
 
 ```shell
 composer global require laravel/installer
 ```
+
+> [!NOTE]
+> For a fully-featured, graphical PHP installation and management experience, check out [Laravel Herd](#local-installation-using-herd).
 
 <a name="creating-an-application"></a>
 ### Creating an Application
 
 After you have installed PHP, Composer, and the Laravel installer, you're ready to create a new Laravel application. The Laravel installer will prompt you to select your preferred testing framework, database, and starter kit. Optionally, if you want to configure your application manually, you may create a new Laravel application using a Composer command:
 
-```nothing tab=Using Laravel installer
+```nothing
 laravel new example-app
-```
-
-```nothing tab=Using Composer
-composer create-project --prefer-dist laravel/laravel example-app
 ```
 
 Once the application has been created, you can start Laravel's local development server, queue worker, and Vite development server using the `dev` Composer script:


### PR DESCRIPTION
New way of installation is nice in case you want to have Laravel development setup ASAP, but it's not enough for complete setup — sometimes you need to have extra PHP extensions, sometimes you are using Bun, Deno or different version of Node.js. And for such cases developers prefer to manage their binaries manually. I think removal of standard installation methods from the docs in 44f2375021852c0b1f0c9b6d3316436d3fc590d3 are a bit [harmful](https://reddit.com/r/laravel/comments/1g47c4r/). In this PR I tried to address 2 issues created by this change:

- **What if developer already have PHP and Composer setup?**
  Then he may only need a Laravel installer binary.
- **What if developer don't want to use Laravel installer and/or don't need extra configuration for starter repository?**
  Just use `composer create-project`.