### PR TITLE
Update typo error in installation.md

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -79,7 +79,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 
 After running one of the commands above, you should restart your terminal session. To update PHP, Composer, and the Laravel installer after installing them via `php.new`, you can re-run the command in your terminal.
 
-In you already have PHP and Composer installed, you may install the Laravel installer via Composer:
+If you already have PHP and Composer installed, you may install the Laravel installer via Composer:
 
 ```shell
 composer global require laravel/installer


### PR DESCRIPTION
Changed "In you already have PHP and Composer installed, you may install the Laravel"
to "If you already have PHP and Composer installed, you may install the Laravel"