### PR TITLE
[11.x] Add tabs for attribute sample code blocks

### DIFF
--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -242,45 +242,47 @@ The `unique` method returns all of the unique models in the collection. Any mode
 <a name="custom-collections"></a>
 ## Custom Collections
 
-If you would like to use a custom `Collection` object when interacting with a given model, you may add the `CollectedBy` attribute to your model:
+If you would like to use a custom `Collection` object when interacting with a given model, you may add the `CollectedBy` attribute to your model. Alternatively, you may define a `newCollection` method on your model:
 
-    <?php
+```php tab=Attribute
+<?php
 
-    namespace App\Models;
+namespace App\Models;
 
-    use App\Support\UserCollection;
-    use Illuminate\Database\Eloquent\Attributes\CollectedBy;
-    use Illuminate\Database\Eloquent\Model;
+use App\Support\UserCollection;
+use Illuminate\Database\Eloquent\Attributes\CollectedBy;
+use Illuminate\Database\Eloquent\Model;
 
-    #[CollectedBy(UserCollection::class)]
-    class User extends Model
+#[CollectedBy(UserCollection::class)]
+class User extends Model
+{
+    // ...
+}
+```
+
+```php tab=Manually
+<?php
+
+namespace App\Models;
+
+use App\Support\UserCollection;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    /**
+     * Create a new Eloquent Collection instance.
+     *
+     * @param  array<int, \Illuminate\Database\Eloquent\Model>  $models
+     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>
+     */
+    public function newCollection(array $models = []): Collection
     {
-        // ...
+        return new UserCollection($models);
     }
-
-Alternatively, you may define a `newCollection` method on your model:
-
-    <?php
-
-    namespace App\Models;
-
-    use App\Support\UserCollection;
-    use Illuminate\Database\Eloquent\Collection;
-    use Illuminate\Database\Eloquent\Model;
-
-    class User extends Model
-    {
-        /**
-         * Create a new Eloquent Collection instance.
-         *
-         * @param  array<int, \Illuminate\Database\Eloquent\Model>  $models
-         * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>
-         */
-        public function newCollection(array $models = []): Collection
-        {
-            return new UserCollection($models);
-        }
-    }
+}
+```
 
 Once you have defined a `newCollection` method or added the `CollectedBy` attribute to your model, you will receive an instance of your custom collection anytime Eloquent would normally return an `Illuminate\Database\Eloquent\Collection` instance.
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -1224,40 +1224,42 @@ Writing a global scope is simple. First, use the `make:scope` command to generat
 <a name="applying-global-scopes"></a>
 #### Applying Global Scopes
 
-To assign a global scope to a model, you may simply place the `ScopedBy` attribute on the model:
+To assign a global scope to a model, you may simply place the `ScopedBy` attribute on the model. Or, you may manually register the global scope by overriding the model's `booted` method and invoke the model's `addGlobalScope` method. The `addGlobalScope` method accepts an instance of your scope as its only argument:
 
-    <?php
+```php tab=Attribute
+<?php
 
-    namespace App\Models;
+namespace App\Models;
 
-    use App\Models\Scopes\AncientScope;
-    use Illuminate\Database\Eloquent\Attributes\ScopedBy;
+use App\Models\Scopes\AncientScope;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 
-    #[ScopedBy([AncientScope::class])]
-    class User extends Model
+#[ScopedBy([AncientScope::class])]
+class User extends Model
+{
+    //
+}
+```
+
+```php tab=Manually
+<?php
+
+namespace App\Models;
+
+use App\Models\Scopes\AncientScope;
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    /**
+     * The "booted" method of the model.
+     */
+    protected static function booted(): void
     {
-        //
+        static::addGlobalScope(new AncientScope);
     }
-
-Or, you may manually register the global scope by overriding the model's `booted` method and invoke the model's `addGlobalScope` method. The `addGlobalScope` method accepts an instance of your scope as its only argument:
-
-    <?php
-
-    namespace App\Models;
-
-    use App\Models\Scopes\AncientScope;
-    use Illuminate\Database\Eloquent\Model;
-
-    class User extends Model
-    {
-        /**
-         * The "booted" method of the model.
-         */
-        protected static function booted(): void
-        {
-            static::addGlobalScope(new AncientScope);
-        }
-    }
+}
+```
 
 After adding the scope in the example above to the `App\Models\User` model, a call to the `User::all()` method will execute the following SQL query:
 
@@ -1545,29 +1547,31 @@ This command will place the new observer in your `app/Observers` directory. If t
         }
     }
 
-To register an observer, you may place the `ObservedBy` attribute on the corresponding model:
+To register an observer, you may place the `ObservedBy` attribute on the corresponding model. Or, you may manually register an observer by invoking the `observe` method on the model you wish to observe. You may register observers in the `boot` method of your application's `AppServiceProvider` class:
 
-    use App\Observers\UserObserver;
-    use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+```php tab=Attribute
+use App\Observers\UserObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 
-    #[ObservedBy([UserObserver::class])]
-    class User extends Authenticatable
-    {
-        //
-    }
+#[ObservedBy([UserObserver::class])]
+class User extends Authenticatable
+{
+    //
+}
+```
 
-Or, you may manually register an observer by invoking the `observe` method on the model you wish to observe. You may register observers in the `boot` method of your application's `AppServiceProvider` class:
+```php tab=Manually
+use App\Models\User;
+use App\Observers\UserObserver;
 
-    use App\Models\User;
-    use App\Observers\UserObserver;
-
-    /**
-     * Bootstrap any application services.
-     */
-    public function boot(): void
-    {
-        User::observe(UserObserver::class);
-    }
+/**
+ * Bootstrap any application services.
+ */
+public function boot(): void
+{
+    User::observe(UserObserver::class);
+}
+```
 
 > [!NOTE]  
 > There are additional events an observer can listen to, such as `saving` and `retrieved`. These events are described within the [events](#events) documentation.

--- a/queues.md
+++ b/queues.md
@@ -232,28 +232,30 @@ If you would like to take total control over how the container injects dependenc
 
 Because all loaded Eloquent model relationships also get serialized when a job is queued, the serialized job string can sometimes become quite large. Furthermore, when a job is deserialized and model relationships are re-retrieved from the database, they will be retrieved in their entirety. Any previous relationship constraints that were applied before the model was serialized during the job queueing process will not be applied when the job is deserialized. Therefore, if you wish to work with a subset of a given relationship, you should re-constrain that relationship within your queued job.
 
-Or, to prevent relations from being serialized, you can call the `withoutRelations` method on the model when setting a property value. This method will return an instance of the model without its loaded relationships:
+Or, to prevent relations from being serialized, you can call the `withoutRelations` method on the model when setting a property value. This method will return an instance of the model without its loaded relationships. If you are using PHP constructor property promotion and would like to indicate that an Eloquent model should not have its relations serialized, you may use the `WithoutRelations` attribute
 
-    /**
-     * Create a new job instance.
-     */
-    public function __construct(
-        Podcast $podcast,
-    ) {
-        $this->podcast = $podcast->withoutRelations();
-    }
+```php tab=Method
+/**
+ * Create a new job instance.
+ */
+public function __construct(
+    Podcast $podcast,
+) {
+    $this->podcast = $podcast->withoutRelations();
+}
+```
 
-If you are using PHP constructor property promotion and would like to indicate that an Eloquent model should not have its relations serialized, you may use the `WithoutRelations` attribute:
+```php tab=Attribute
+use Illuminate\Queue\Attributes\WithoutRelations;
 
-    use Illuminate\Queue\Attributes\WithoutRelations;
-
-    /**
-     * Create a new job instance.
-     */
-    public function __construct(
-        #[WithoutRelations]
-        public Podcast $podcast,
-    ) {}
+/**
+ * Create a new job instance.
+ */
+public function __construct(
+    #[WithoutRelations]
+    public Podcast $podcast,
+) {}
+```
 
 If a job receives a collection or array of Eloquent models instead of a single model, the models within that collection will not have their relationships restored when the job is deserialized and executed. This is to prevent excessive resource usage on jobs that deal with large numbers of models.
 


### PR DESCRIPTION
Fixes laravel/framework#52973

#9291 and laravel/laravel.com#318 introduced tabs for PHPUnit vs Pest

| | |
|-|-|
| ![laravel-docs-code-sample-block-tabs-phpunit](https://github.com/user-attachments/assets/80c5b5c9-79ca-4ad8-9a09-d207a8be587e) | ![laravel-docs-code-sample-block-tabs-attribute](https://github.com/user-attachments/assets/fb589209-696a-4e9b-8bd9-b2dc0aae9630) |