### PR TITLE
add clarification about `forget` method return value

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1083,7 +1083,7 @@ The `forget` method removes an item from the collection by its key:
     // []
 
 > [!WARNING]  
-> Unlike most other collection methods, `forget` does not return a new modified collection; it modifies the collection it is called on.
+> Unlike most other collection methods, `forget` does not return a new modified collection; it modifies and returns the collection it is called on.
 
 <a name="method-forpage"></a>
 #### `forPage()` {.collection-method}


### PR DESCRIPTION
the wording here is just a little unclear. the first sentence seems to suggest that the `forget()` method does not return anything, even though it does.

you are free to assign the result to a new variable even though you don't need to (and maybe shouldn't?)

```php
$collection = collect(['name' => 'taylor', 'framework' => 'laravel']);
 
$newCollection = $collection->forget('name');

dump($collection === $newCollection); // true
```