### PR TITLE
[11.x] new allowed filename for anonymous index components

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -1374,10 +1374,15 @@ This directory structure allows you to render the accordion component and its it
 
 However, in order to render the accordion component via `x-accordion`, we were forced to place the "index" accordion component template in the `resources/views/components` directory instead of nesting it within the `accordion` directory with the other accordion related templates.
 
-Thankfully, Blade allows you to place an `index.blade.php` file within a component's template directory. When an `index.blade.php` template exists for the component, it will be rendered as the "root" node of the component. So, we can continue to use the same Blade syntax given in the example above; however, we will adjust our directory structure like so:
+Thankfully, Blade allows you to place either an `index.blade.php` file or a file matching the directory name (in this case `accordion.blade.php`) within a component's template directory. When either of these templates exist for the component, it will be rendered as the "root" node of the component. So, we can continue to use the same Blade syntax given in the example above; however, we will adjust our directory structure like so:
 
 ```none
 /resources/views/components/accordion/index.blade.php
+/resources/views/components/accordion/item.blade.php
+
+--or--
+
+/resources/views/components/accordion/accordion.blade.php
 /resources/views/components/accordion/item.blade.php
 ```
 

--- a/blade.md
+++ b/blade.md
@@ -1374,14 +1374,9 @@ This directory structure allows you to render the accordion component and its it
 
 However, in order to render the accordion component via `x-accordion`, we were forced to place the "index" accordion component template in the `resources/views/components` directory instead of nesting it within the `accordion` directory with the other accordion related templates.
 
-Thankfully, Blade allows you to place either an `index.blade.php` file or a file matching the directory name (in this case `accordion.blade.php`) within a component's template directory. When either of these templates exist for the component, it will be rendered as the "root" node of the component. So, we can continue to use the same Blade syntax given in the example above; however, we will adjust our directory structure like so:
+Thankfully, Blade allows you to place a file matching the component's directory name within the component's directory itself. When this template exists, it can be rendered as the "root" element of the component even though it is nested within a directory. So, we can continue to use the same Blade syntax given in the example above; however, we will adjust our directory structure like so:
 
 ```none
-/resources/views/components/accordion/index.blade.php
-/resources/views/components/accordion/item.blade.php
-
---or--
-
 /resources/views/components/accordion/accordion.blade.php
 /resources/views/components/accordion/item.blade.php
 ```


### PR DESCRIPTION
we can now use either `index.blade.php` or `{directory}.blade.php` for our anonymous index components.

https://github.com/laravel/framework/pull/52669