### PR TITLE
Add scopedIf method for container

### DIFF
--- a/container.md
+++ b/container.md
@@ -170,7 +170,7 @@ The `scoped` method binds a class or interface into the container that should on
         return new Transistor($app->make(PodcastParser::class));
     });
 
-You may use the `scopedIf` method to register a scope container binding only if a binding has not already been registered for the given type:
+You may use the `scopedIf` method to register a scoped container binding only if a binding has not already been registered for the given type:
 
     $this->app->scopedIf(Transistor::class, function (Application $app) {
         return new Transistor($app->make(PodcastParser::class));

--- a/container.md
+++ b/container.md
@@ -170,6 +170,12 @@ The `scoped` method binds a class or interface into the container that should on
         return new Transistor($app->make(PodcastParser::class));
     });
 
+You may use the `scopedIf` method to register a scope container binding only if a binding has not already been registered for the given type:
+
+    $this->app->scopedIf(Transistor::class, function (Application $app) {
+        return new Transistor($app->make(PodcastParser::class));
+    });
+
 <a name="binding-instances"></a>
 #### Binding Instances
 


### PR DESCRIPTION
I explained that scopedIf can be used to register bindings that have not previously been registered to this type