### PR TITLE
[11.x] consistently use "an" when preceding "SQL" or "SQLite"

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -130,7 +130,7 @@ Your `.env` file should not be committed to your application's source control, s
 <a name="databases-and-migrations"></a>
 ### Databases and Migrations
 
-Now that you have created your Laravel application, you probably want to store some data in a database. By default, your application's `.env` configuration file specifies that Laravel will be interacting with a SQLite database.
+Now that you have created your Laravel application, you probably want to store some data in a database. By default, your application's `.env` configuration file specifies that Laravel will be interacting with an SQLite database.
 
 During the creation of the application, Laravel created a `database/database.sqlite` file for you, and ran the necessary migrations to create the application's database tables.
 

--- a/validation.md
+++ b/validation.md
@@ -1860,6 +1860,9 @@ To instruct the validator to ignore the user's ID, we'll use the `Rule` class to
         ],
     ]);
 
+> [!WARNING]  
+> You should never pass any user controlled request input into the `ignore` method. Instead, you should only pass a system generated unique ID such as an auto-incrementing ID or UUID from an Eloquent model instance. Otherwise, your application will be vulnerable to an SQL injection attack.
+
 Instead of passing the model key's value to the `ignore` method, you may also pass the entire model instance. Laravel will automatically extract the key from the model:
 
     Rule::unique('users')->ignore($user)

--- a/validation.md
+++ b/validation.md
@@ -1860,9 +1860,6 @@ To instruct the validator to ignore the user's ID, we'll use the `Rule` class to
         ],
     ]);
 
-> [!WARNING]  
-> You should never pass any user controlled request input into the `ignore` method. Instead, you should only pass a system generated unique ID such as an auto-incrementing ID or UUID from an Eloquent model instance. Otherwise, your application will be vulnerable to an SQL injection attack.
-
 Instead of passing the model key's value to the `ignore` method, you may also pass the entire model instance. Laravel will automatically extract the key from the model:
 
     Rule::unique('users')->ignore($user)


### PR DESCRIPTION
my preference would be to go the other direction, but this at least makes it consistent across the docs