### PR TITLE
[11.x] remove "unique" SQL injection warning

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1860,9 +1860,6 @@ To instruct the validator to ignore the user's ID, we'll use the `Rule` class to
         ],
     ]);
 
-> [!WARNING]  
-> You should never pass any user controlled request input into the `ignore` method. Instead, you should only pass a system generated unique ID such as an auto-incrementing ID or UUID from an Eloquent model instance. Otherwise, your application will be vulnerable to an SQL injection attack.
-
 Instead of passing the model key's value to the `ignore` method, you may also pass the entire model instance. Laravel will automatically extract the key from the model:
 
     Rule::unique('users')->ignore($user)


### PR DESCRIPTION
I don't believe this warning is actually valid anymore. Best I can tell, using the default `DatabasePresenceVerifier`, we are executing an aggregate "count" query, which use Prepared Statements with variable binding.

the note was added 5 years ago [here](https://github.com/laravel/docs/commit/8c63ad24fdb6750e0372e4ee9170ac2b119c377f)

the query is built [here](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Validation/DatabasePresenceVerifier.php#L46)

for the example of updating a user and ensuring the email remains unique, the generated query is

```sql
select count(*) as aggregate from `users` where `email` = ? and `id` <> ? and `users`.`deleted_at` is null
```

we could also go the route of not removing this completely, but softening the language to something like "*may* be vulnerable..." in case we're worried about people using alternate "Presence Verifiers".