### PR TITLE
[10.x]: Updated Http `fake` method callback signature to include options array

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -548,11 +548,11 @@ If you would like to fake a sequence of responses but do not need to specify a s
 <a name="fake-callback"></a>
 #### Fake Callback
 
-If you require more complicated logic to determine what responses to return for certain endpoints, you may pass a closure to the `fake` method. This closure will receive an instance of `Illuminate\Http\Client\Request` and should return a response instance. Within your closure, you may perform whatever logic is necessary to determine what type of response to return:
+If you require more complicated logic to determine what responses to return for certain endpoints, you may pass a closure to the `fake` method. This closure will receive an instance of `Illuminate\Http\Client\Request` as well as an array of options passed to the request and should return a response instance. Within your closure, you may perform whatever logic is necessary to determine what type of response to return:
 
     use Illuminate\Http\Client\Request;
 
-    Http::fake(function (Request $request) {
+    Http::fake(function (Request $request, array $options) {
         return Http::response('Hello World', 200);
     });
 

--- a/http-client.md
+++ b/http-client.md
@@ -548,7 +548,7 @@ If you would like to fake a sequence of responses but do not need to specify a s
 <a name="fake-callback"></a>
 #### Fake Callback
 
-If you require more complicated logic to determine what responses to return for certain endpoints, you may pass a closure to the `fake` method. This closure will receive an instance of `Illuminate\Http\Client\Request` as well as an array of options passed to the request and should return a response instance. Within your closure, you may perform whatever logic is necessary to determine what type of response to return:
+If you require more complicated logic to determine what responses to return for certain endpoints, you may pass a closure to the `fake` method. This closure will receive an instance of `Illuminate\Http\Client\Request` as well as an array of options. The closure should return a response instance. Within your closure, you may perform whatever logic is necessary to determine what type of response to return:
 
     use Illuminate\Http\Client\Request;
 


### PR DESCRIPTION
Sometimes we need to access the PendingRequest options like the timeout value in a test case, hopefully this could save someone else time in the future

Am not sure about the wording as English isn't my native language, let me know if it needs any tweaking.