### PR TITLE
Correct Vendor Component Syntax

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -719,11 +719,11 @@ Alternatively, you may use the `componentNamespace` method to autoload component
         Blade::componentNamespace('Nightshade\\Views\\Components', 'nightshade');
     }
 
-This will allow the usage of package components by their vendor namespace using the `package-name::` syntax:
+This will allow the usage of package components by their vendor namespace using the `package-name:` syntax:
 
 ```blade
-<x-nightshade::calendar />
-<x-nightshade::color-picker />
+<nightshade:calendar />
+<nightshade:color-picker />
 ```
 
 Blade will automatically detect the class that's linked to this component by pascal-casing the component name. Subdirectories are also supported using "dot" notation.


### PR DESCRIPTION
This pull request addresses an error in the Laravel documentation regarding the syntax for using package components by their vendor namespace. The current syntax example results in the following error: Unable to locate a class or view for component [nightshade:calendar]. It should be changed to:

```blade
<nightshade:calendar />
<nightshade:color-picker />
```
and/or

```blade
<nightshade::calendar />
<nightshade::color-picker />
```