### PR TITLE
Warn about automatically registered event on the upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -182,6 +182,7 @@ if ($e instanceof AuthenticationException) {
 }
 ```
 
+<a name="email-verification-notification-on-registration"></a>
 #### Email verification notification on registration
 
 **Likelihood Of Impact: Low**

--- a/upgrade.md
+++ b/upgrade.md
@@ -182,6 +182,19 @@ if ($e instanceof AuthenticationException) {
 }
 ```
 
+#### Email verification notification on registration
+
+**Likelihood Of Impact: Low**
+
+The `SendEmailVerificationNotification` listener is now automatically registered for the `Registered` event if it's not there yet. In case you are using a custom listener instead or don't need this listener for other reasons, you should override the `configureEmailVerification` method on your `EventServiceProvider`:
+
+```php
+protected function configureEmailVerification()
+{
+    // ...
+}
+```
+
 <a name="cache"></a>
 ### Cache
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -183,11 +183,11 @@ if ($e instanceof AuthenticationException) {
 ```
 
 <a name="email-verification-notification-on-registration"></a>
-#### Email verification notification on registration
+#### Email Verification Notification on Registration
 
-**Likelihood Of Impact: Low**
+**Likelihood Of Impact: Very Low**
 
-The `SendEmailVerificationNotification` listener is now automatically registered for the `Registered` event if it's not there yet. In case you are using a custom listener instead or don't need this listener for other reasons, you should override the `configureEmailVerification` method on your `EventServiceProvider`:
+The `SendEmailVerificationNotification` listener is now automatically registered for the `Registered` event if it is not already registered by your application's `EventServiceProvider`. If your application's `EventServiceProvider` does not register this listener and you do not want Laravel to automatically register it for you, you should define an empty `configureEmailVerification` method in your application's `EventServiceProvider`:
 
 ```php
 protected function configureEmailVerification()


### PR DESCRIPTION
Just ran into an issue of having verification notifications sent twice when upgrading to Laravel 11 and noticed [others have had the same issue](https://github.com/laravel/framework/issues?q=SendEmailVerificationNotification) so I propose adding a note to the upgrade guide.

I am not sure how the guide is supposed to be organized and which topics should be included in the TOC, so in the initial revision I've made the change as small as possible.