### PR TITLE
Update queries.md, removed firstOrFail docs because not available on …

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -95,10 +95,6 @@ If you just need to retrieve a single row from a database table, you may use the
 
     return $user->email;
 
-If you would like to retrieve a single row from a database table, but throw an `Illuminate\Database\RecordNotFoundException` if no matching row is found, you may use the `firstOrFail` method. If the `RecordNotFoundException` is not caught, a 404 HTTP response is automatically sent back to the client:
-
-    $user = DB::table('users')->where('name', 'John')->firstOrFail();
-
 If you don't need an entire row, you may extract a single value from a record using the `value` method. This method will return the value of the column directly:
 
     $email = DB::table('users')->where('name', 'John')->value('email');


### PR DESCRIPTION
…query builder

when calling firstOrFail on DB facade query builder, it throws exception

local.ERROR: Call to undefined method Illuminate\Database\Query\Builder::firstOrFail() {"exception":"[object] (BadMethodCallException(code: 0): Call to undefined method Illuminate\\Database\\Query\\Builder::firstOrFail() at /var/www/html/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php:67) [stacktrace]
#0 /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(4390): Illuminate\\Database\\Query\\Builder::throwBadMethodCallException('firstOrFail') #1 /var/www/html/database/migrations/2024

function should not be in docs until readily available to use

https://stackoverflow.com/questions/79145864/call-to-undefined-method-illuminate-database-query-builderfirstorfail-lara?noredirect=1#comment139562863_79145864