### PR TITLE
Adds type hint to fillable and guarded DocBlocks to match trait structure

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -843,7 +843,7 @@ So, to get started, you should define which model attributes you want to make ma
         /**
          * The attributes that are mass assignable.
          *
-         * @var array
+         * @var array<int, string>
          */
         protected $fillable = ['name'];
     }
@@ -864,7 +864,7 @@ When assigning JSON columns, each column's mass assignable key must be specified
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $fillable = [
         'options->enabled',
@@ -878,7 +878,7 @@ If you would like to make all of your attributes mass assignable, you may define
     /**
      * The attributes that aren't mass assignable.
      *
-     * @var array
+     * @var array<string>|bool
      */
     protected $guarded = [];
 


### PR DESCRIPTION
Got warned by PHPStan because of mismatch in PHPDoc types, and found that the documentation is not up to date with the current type of the GuardsAttribute trait after this PR:

[Make GuardsAttributes fillable property DocBlock more specific (https://github.com/laravel/framework/pull/50229)](https://github.com/laravel/framework/commit/30324cf06d1f34fe359c5e458bcbb8da5413db71
)

<img width="535" alt="Screenshot 2024-11-07 at 12 51 40" src="https://github.com/user-attachments/assets/8dfc4b24-311d-48eb-a812-6ec7077c7414">
