### PR TITLE
[11.x] Add PHP 8.4

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -27,8 +27,8 @@ For all Laravel releases, bug fixes are provided for 18 months and security fixe
 | --- | --- | --- | --- | --- |
 | 9 | 8.0 - 8.2 | February 8th, 2022 | August 8th, 2023 | February 6th, 2024 |
 | 10 | 8.1 - 8.3 | February 14th, 2023 | August 6th, 2024 | February 4th, 2025 |
-| 11 | 8.2 - 8.3 | March 12th, 2024 | September 3rd, 2025 | March 12th, 2026 |
-| 12 | 8.2 - 8.3 | Q1 2025 | Q3 2026 | Q1 2027 |
+| 11 | 8.2 - 8.4 | March 12th, 2024 | September 3rd, 2025 | March 12th, 2026 |
+| 12 | 8.2 - 8.4 | Q1 2025 | Q3 2026 | Q1 2027 |
 
 </div>
 

--- a/sail.md
+++ b/sail.md
@@ -398,9 +398,12 @@ sail tinker
 <a name="sail-php-versions"></a>
 ## PHP Versions
 
-Sail currently supports serving your application via PHP 8.3, 8.2, 8.1, or PHP 8.0. The default PHP version used by Sail is currently PHP 8.3. To change the PHP version that is used to serve your application, you should update the `build` definition of the `laravel.test` container in your application's `docker-compose.yml` file:
+Sail currently supports serving your application via PHP 8.4, 8.3, 8.2, 8.1, or PHP 8.0. The default PHP version used by Sail is currently PHP 8.3. To change the PHP version that is used to serve your application, you should update the `build` definition of the `laravel.test` container in your application's `docker-compose.yml` file:
 
 ```yaml
+# PHP 8.4
+context: ./vendor/laravel/sail/runtimes/8.4
+
 # PHP 8.3
 context: ./vendor/laravel/sail/runtimes/8.3
 


### PR DESCRIPTION
Laravel 11 and 12 will support PHP 8.4.

Sail already has a PHP 8.4 runtime, but it should not be the default until PHP 8.4 is released.

Laravel Homestead does not support PHP 8.4 yet. (At least I saw no commit indicating that)

Depends on https://github.com/laravel/framework/pull/52633