### PR TITLE
Update installation.md

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -77,6 +77,9 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 /bin/bash -c "$(curl -fsSL https://php.new/install/linux)"
 ```
 
+> [!NOTE]
+> On Windows you should run PowerShell as an administrator before running the command.
+
 After running one of the commands above, you should restart your terminal session. To update PHP, Composer, and the Laravel installer after installing them via `php.new`, you can re-run the command in your terminal.
 
 If you already have PHP and Composer installed, you may install the Laravel installer via Composer:

--- a/installation.md
+++ b/installation.md
@@ -70,15 +70,13 @@ If you don't have PHP and Composer installed on your local machine, the followin
 ```
 
 ```shell tab=Windows PowerShell
+# Run as administrator...
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://php.new/install/windows'))
 ```
 
 ```shell tab=Linux
 /bin/bash -c "$(curl -fsSL https://php.new/install/linux)"
 ```
-
-> [!NOTE]
-> On Windows you should run PowerShell as an administrator before running the command.
 
 After running one of the commands above, you should restart your terminal session. To update PHP, Composer, and the Laravel installer after installing them via `php.new`, you can re-run the command in your terminal.
 


### PR DESCRIPTION
The proposed PowerShell command does not work if the PowerShell is not run as Administrator. 

If that's the case, the PowerShell just disappears on both Windows 10 and Windows 11 just after running the command. For a fraction of a second it's possible an error is displayed but it's not possible to see what it says (ERROR Please run this script as an administrator) as you can see from the attached video: https://github.com/user-attachments/assets/4b3f948c-31c8-41cf-8ca0-b1cbd42c04b3.

It maybe better to inform the users to use it before running the command.

By running the PowerShell as an administrator the command is executed with success.

