### PR TITLE
Remove unnecessary warning about Route::fallback() being last

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -737,9 +737,6 @@ Using the `Route::fallback` method, you may define a route that will be executed
         // ...
     });
 
-> [!WARNING]  
-> The fallback route should always be the last route registered by your application.
-
 <a name="rate-limiting"></a>
 ## Rate Limiting
 


### PR DESCRIPTION
This warning is unnecessary as the code will find the fallback route and put it at the end of the route list regardless as seen here in the source:

https://github.com/laravel/framework/blob/a296e813d041ddff000d856aa2f7ae1cd4d616b7/src/Illuminate/Routing/AbstractRouteCollection.php#L81-L85

L81-83 partitions the routes into the fallback and the rest of the routes, L85 merges the fallback partition into the regular routes partition, ensuring it is always last.