### PR TITLE
[11.x] Replace deprecated PHP CS rules

### DIFF
--- a/pint.md
+++ b/pint.md
@@ -115,10 +115,10 @@ However, if you wish, you may enable or disable specific rules in your `pint.jso
     "preset": "laravel",
     "rules": {
         "simplified_null_return": true,
-        "braces": false,
-        "new_with_braces": {
-            "anonymous_class": false,
-            "named_class": false
+        "array_indentation": false,
+        "new_with_parentheses": {
+            "anonymous_class": true,
+            "named_class": true
         }
     }
 }


### PR DESCRIPTION
This PR replaces deprecated PHP CS rules with other examples.
https://mlocati.github.io/php-cs-fixer-configurator/#version:3.64|configurator|fixer:new_with_braces
https://mlocati.github.io/php-cs-fixer-configurator/#version:3.64|configurator|fixer:braces

The mentioned values are opposites of what's configured in the [laravel preset](https://github.com/laravel/pint/blob/main/resources/presets/laravel.php).