### PR TITLE
Remove return keyword from example

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1354,7 +1354,7 @@ If you would like to customize the query executed by the validation rule, you ma
         'email' => [
             'required',
             Rule::exists('staff')->where(function (Builder $query) {
-                return $query->where('account_id', 1);
+                $query->where('account_id', 1);
             }),
         ],
     ]);


### PR DESCRIPTION
In `eloquent` documentation, we're omitting the `return` keyword for `Builder` $query.