### PR TITLE
Fix link of PHP in installation.md

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -66,16 +66,16 @@ Before creating your first Laravel application, make sure that your local machin
 If you don't have PHP and Composer installed on your local machine, the following commands will install PHP, Composer, and the Laravel installer on macOS, Windows, or Linux:
 
 ```shell tab=macOS
-/bin/bash -c "$(curl -fsSL https://php.new/install/mac/8.3)"
+/bin/bash -c "$(curl -fsSL https://php.new/install/mac/)"
 ```
 
 ```shell tab=Windows PowerShell
 # Run as administrator...
-Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://php.new/install/windows/8.3'))
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://php.new/install/windows/'))
 ```
 
 ```shell tab=Linux
-/bin/bash -c "$(curl -fsSL https://php.new/install/linux/8.3)"
+/bin/bash -c "$(curl -fsSL https://php.new/install/linux/)"
 ```
 
 After running one of the commands above, you should restart your terminal session. To update PHP, Composer, and the Laravel installer after installing them via `php.new`, you can re-run the command in your terminal.


### PR DESCRIPTION
Identified and resolved an issue in the Laravel 11 documentation where the PHP installation script returned a 404 error when executed. Additionally, the download link in the browser resulted in a "Not Found" error. Fixed the script and updated the link to ensure proper functionality.