### PR TITLE
Document ->getDirty() in eloquent.md

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -792,6 +792,40 @@ The `getOriginal` method returns an array containing the original attributes of 
     $user->getOriginal('name'); // John
     $user->getOriginal(); // Array of original attributes...
 
+Eloquent provides the `getDirty` method to retrieve all attributes of the model that have been modified since the model was last loaded or saved. This method is particularly useful when you need to examine the exact values of attributes that have changed without persisting those changes yet.
+
+```php
+use App\Models\User;
+
+$user = User::find(1);
+
+$user->name = 'Victoria';
+$user->email = 'victoria@example.com';
+
+$dirtyAttributes = $user->getDirty();
+
+// Output the changed attributes
+var_dump($dirtyAttributes);
+
+// Example output:
+// array(2) {
+//   ["name"]=>
+//   string(8) "Victoria"
+//   ["email"]=>
+//   string(20) "victoria@example.com"
+// }
+
+$user->save();
+
+// `isDirty` is now empty:
+var_dump($user->getDirty())
+
+// array(0) {
+// }
+```
+
+The `getDirty` method returns an associative array, where the keys are the names of the attributes that have been changed, and the values are the updated values of those attributes. Attributes that remain unchanged will not appear in the returned array. Note that after you call `save` on a model, there are no 'dirty' attributes anymore, so the returned array will be empty. So retrieve them before you `save`, if you need the information.
+
 <a name="mass-assignment"></a>
 ### Mass Assignment
 


### PR DESCRIPTION
This is at least a Laravel 5.x function. About time to document it.

A new colleague recently needed it.

Function currently (11.x) lives in src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php

Submitting to oldest supported Laravel (10.x), so this has a chance to be accepted.

https://github.com/illuminate/database/blob/e9be556e6c6b1ff61de734c6fcae756489599015/Eloquent/Concerns/HasAttributes.php#L2114-L2125

Discussion: https://github.com/laravel/framework/discussions/53617