### PR TITLE
[11x.] Add queued listener `backoff` docs

### DIFF
--- a/events.md
+++ b/events.md
@@ -499,7 +499,7 @@ If you would like to configure how many seconds Laravel should wait before retry
      */
     public $backoff = 3;
 
-If you require more complex logic for determining the listeners's backoff time, you may define a backoff method on your job class:
+If you require more complex logic for determining the listeners's backoff time, you may define a backoff method on your listener class:
 
     /**
      * Calculate the number of seconds to wait before retrying the queued listener.

--- a/events.md
+++ b/events.md
@@ -490,7 +490,7 @@ As an alternative to defining how many times a listener may be attempted before 
 <a name="specifying-queued-listener-backoff"></a>
 #### Specifying Queued Listener Backoff
 
-If you would like to configure how many seconds Laravel should wait before retrying a listener that has encountered an exception, you may do so by defining a backoff property on your listener class:
+If you would like to configure how many seconds Laravel should wait before retrying a listener that has encountered an exception, you may do so by defining a `backoff` property on your listener class:
     
     /**
      * The number of seconds to wait before retrying the queued listener.
@@ -499,7 +499,7 @@ If you would like to configure how many seconds Laravel should wait before retry
      */
     public $backoff = 3;
 
-If you require more complex logic for determining the listeners's backoff time, you may define a backoff method on your listener class:
+If you require more complex logic for determining the listeners's backoff time, you may define a `backoff` method on your listener class:
 
     /**
      * Calculate the number of seconds to wait before retrying the queued listener.
@@ -509,7 +509,7 @@ If you require more complex logic for determining the listeners's backoff time, 
         return 3;
     }
 
-You may easily configure "exponential" backoffs by returning an array of backoff values from the backoff method. In this example, the retry delay will be 1 second for the first retry, 5 seconds for the second retry, 10 seconds for the third retry, and 10 seconds for every subsequent retry if there are more attempts remaining:
+You may easily configure "exponential" backoffs by returning an array of backoff values from the `backoff` method. In this example, the retry delay will be 1 second for the first retry, 5 seconds for the second retry, 10 seconds for the third retry, and 10 seconds for every subsequent retry if there are more attempts remaining:
 
     /**
      * Calculate the number of seconds to wait before retrying the queued listener.

--- a/events.md
+++ b/events.md
@@ -487,6 +487,40 @@ As an alternative to defining how many times a listener may be attempted before 
         return now()->addMinutes(5);
     }
 
+<a name="specifying-queued-listener-backoff"></a>
+#### Specifying Queued Listener Backoff
+
+If you would like to configure how many seconds Laravel should wait before retrying a listener that has encountered an exception, you may do so by defining a backoff property on your listener class:
+    
+    /**
+     * The number of seconds to wait before retrying the queued listener.
+     *
+     * @var int
+     */
+    public $backoff = 3;
+
+If you require more complex logic for determining the listeners's backoff time, you may define a backoff method on your job class:
+
+    /**
+     * Calculate the number of seconds to wait before retrying the queued listener.
+     */
+    public function backoff(): int
+    {
+        return 3;
+    }
+
+You may easily configure "exponential" backoffs by returning an array of backoff values from the backoff method. In this example, the retry delay will be 1 second for the first retry, 5 seconds for the second retry, 10 seconds for the third retry, and 10 seconds for every subsequent retry if there are more attempts remaining:
+
+    /**
+     * Calculate the number of seconds to wait before retrying the queued listener.
+     *
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [1, 5, 10];
+    }
+
 <a name="dispatching-events"></a>
 ## Dispatching Events
 


### PR DESCRIPTION
This PR adds documentation informing developers that it is possible to configure a backoff, like you can on a queued job:

https://laravel.com/docs/11.x/queues#dealing-with-failed-jobs

https://github.com/laravel/framework/blob/7db7ea950d3df663391718730f4490a4e189234a/src/Illuminate/Events/Dispatcher.php#L673-L679