### PR TITLE
Allow only /index.php to be passed to FastCGI.

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -77,7 +77,7 @@ server {
 
     error_page 404 /index.php;
 
-    location ~ \.php$ {
+    location ~ ^/index\.php(/|$) { {
         fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;


### PR DESCRIPTION
Dear Developers and Community,

Thank you very much for the incredible marvel you do! :sparkles: 

Since Laravel should work for the most cases serving the index PHP file only on HTTP endpoints, there's probably no point allowing any PHP processing except the index itself.

Please consider checking out how Symfony [approaches](<https://github.com/symfony/symfony-docs/blob/605961e1ed03327bb26577d8056262958354533f/setup/web_server_configuration.rst?plain=1#L76>) the case:

```nginx
server {
    server_name example.com www.example.com;
    root /var/www/project/public;

    location / {
        # try to serve file directly, fallback to index.php
        try_files $uri /index.php$is_args$args;
    }
    # ...

    location ~ ^/index\.php(/|$) {
        # when using PHP-FPM as a unix socket
        fastcgi_pass unix:/var/run/php/php8.3-fpm.sock;

        # when PHP-FPM is configured to use TCP
        # fastcgi_pass 127.0.0.1:9000;

        fastcgi_split_path_info ^(.+\.php)(/.*)$;
        include fastcgi_params;
    # ...
```

Otherwise, may I ask what is the rationale of allowing PHP processing for files named differently?
Of course, it's an edge case, but wouldn't it be a security flaw in case some developer would forget checking extensions for uploads in addition to MIME, and a User surfed the uploaded malicious PHP file on someone's Laravel application?

Best and kind regards