### PR TITLE
Update cache.md

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -88,7 +88,7 @@ For more information on configuring Redis, consult its [Laravel documentation pa
 
 Before using the [DynamoDB](https://aws.amazon.com/dynamodb) cache driver, you must create a DynamoDB table to store all of the cached data. Typically, this table should be named `cache`. However, you should name the table based on the value of the `stores.dynamodb.table` configuration value within the `cache` configuration file. The table name may also be set via the `DYNAMODB_CACHE_TABLE` environment variable.
 
-This table should also have a string partition key with a name that corresponds to the value of the `stores.dynamodb.attributes.key` configuration item within your application's `cache` configuration file. By default, the partition key should be named `key`.
+The table must have a string partition key named `key`. 
 
 Typically, DynamoDB will not proactively remove expired items from a table. Therefore, you should [enable Time to Live (TTL)](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html) on the table. When configuring the table's TTL settings, you should set the TTL attribute name to `expires_at`.
 


### PR DESCRIPTION
The documentation incorrectly states that `stores.dynamodb.attributes.key` refers to the partition key for the DynamoDB table, when it actually holds the AWS access key (`AWS_ACCESS_KEY_ID`). This change clarifies that the table should simply have a string partition key named `key`, without any reference to the `stores.dynamodb.attributes.key` configuration item.