### PR TITLE
[11.x] Update upgrade.md with note that the broadcasting driver env variable has been renamed

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -629,6 +629,13 @@ php artisan vendor:publish --tag=telescope-migrations
 
 Laravel 11 now provides its own [`once` function](/docs/{{version}}/helpers#method-once) to ensure that a given closure is only executed once. Therefore, if your application has a dependency on the `spatie/once` package, you should remove it from your application's `composer.json` file to avoid conflicts.
 
+<a name="broadcasting"></a>
+### Broadcasting
+
+**Likelihood Of Impact: Medium**
+
+The `BROADCAST_DRIVER` environment variable has been renamed to `BROADCAST_CONNECTION`. Update it in your `.env` file.
+
 <a name="miscellaneous"></a>
 ### Miscellaneous
 


### PR DESCRIPTION
Was lurking on Stack Overflow and saw this question asked several months ago: https://stackoverflow.com/questions/78249472/

Checking the documentation, apparently Laravel 11 uses `BROADCAST_CONNECTION` (https://laravel.com/docs/11.x/broadcasting#pusher-channels) and Laravel 10 used `BROADCAST_DRIVER` (https://laravel.com/docs/10.x/broadcasting#pusher-channels).

This updates the Upgrade Guide to include a note about the change.