### PR TITLE
Updated Telescope setup for local environments

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -78,7 +78,7 @@ After running `telescope:install`, you should remove the `TelescopeServiceProvid
      */
     public function register(): void
     {
-        if ($this->app->environment('local') && class_existsLaravel\Telescope\TelescopeServiceProvider::class)) {
+        if ($this->app->environment('local') && class_exists(\Laravel\Telescope\TelescopeServiceProvider::class)) {
             $this->app->register(\Laravel\Telescope\TelescopeServiceProvider::class);
             $this->app->register(TelescopeServiceProvider::class);
         }

--- a/telescope.md
+++ b/telescope.md
@@ -78,7 +78,7 @@ After running `telescope:install`, you should remove the `TelescopeServiceProvid
      */
     public function register(): void
     {
-        if ($this->app->environment('local')) {
+        if ($this->app->environment('local') && class_exists(Laravel\Telescope\TelescopeServiceProvider::class)) {
             $this->app->register(\Laravel\Telescope\TelescopeServiceProvider::class);
             $this->app->register(TelescopeServiceProvider::class);
         }

--- a/telescope.md
+++ b/telescope.md
@@ -78,7 +78,7 @@ After running `telescope:install`, you should remove the `TelescopeServiceProvid
      */
     public function register(): void
     {
-        if ($this->app->environment('local') && class_exists(Laravel\Telescope\TelescopeServiceProvider::class)) {
+        if ($this->app->environment('local') && class_existsLaravel\Telescope\TelescopeServiceProvider::class)) {
             $this->app->register(\Laravel\Telescope\TelescopeServiceProvider::class);
             $this->app->register(TelescopeServiceProvider::class);
         }


### PR DESCRIPTION
Not a groundbreaking contribution, but I've been annoyed by this quite a few times. (Because what we do in the documentation is mostly copying and pasting.)

When you install Telescope as a dev dependency, you need to check for the class' existence first. This avoids breaks when deployed to production.

Before:

```php
/**
 * Register any application services.
 */
public function register(): void
{
    if ($this->app->environment('local')) {
        $this->app->register(\Laravel\Telescope\TelescopeServiceProvider::class);
        $this->app->register(TelescopeServiceProvider::class);
    }
}
```

After:

```php
/**
 * Register any application services.
 */
public function register(): void
{
    if ($this->app->environment('local') && class_exists(\Laravel\Telescope\TelescopeServiceProvider::class)) {
        $this->app->register(\Laravel\Telescope\TelescopeServiceProvider::class);
        $this->app->register(TelescopeServiceProvider::class);
    }
}
```

https://3v4l.org/Pc3Tj#v8.4.1