### PR TITLE
Add warning about null key edge case for Arr::get()

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -417,6 +417,9 @@ The `Arr::get` method also accepts a default value, which will be returned if th
 
     // 0
 
+> [!WARNING]  
+> If passed a `null` value for the key, the `Arr::get` method will return the entire array instead of the default value.
+
 <a name="method-array-has"></a>
 #### `Arr::has()` {.collection-method}
 


### PR DESCRIPTION
When passed a `null` value for the `$key` variable, `Arr::get()` returns the entire array, instead of the `$default` variable. In my opinion (and [quite](https://github.com/laravel/framework/discussions/41138) [a few](https://github.com/laravel/framework/pull/36872) [others](https://github.com/laravel/framework/pull/36728) over the years) this is not at all the expected behavior. While I considered PR'ing a breaking change for L12, it seems like that would break the test suite and has little chance of being accepted.

Instead, I propose adding this warning to the docs. While this is an edge case for sure, it bit me pretty hard this week and I think it's worth adding the warning.