### PR TITLE
Update pennant.md

### DIFF
--- a/pennant.md
+++ b/pennant.md
@@ -815,7 +815,7 @@ Feature::for($users)->loadMissing([
 You may load all defined features using the `loadAll` method:
 
 ```php
-Feature::for($user)->loadAll();
+Feature::for($users)->loadAll();
 ```
 
 <a name="updating-values"></a>


### PR DESCRIPTION
in [docs](https://laravel.com/docs/11.x/pennant#eager-loading) in examples 2 and 3 use `$users` but in last use `$user`, i think for continuity must use `$users`, _Knowing that two are correct_