### PR TITLE
Fix incorrect prop name in Paddle Button documentation

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -444,7 +444,7 @@ Cashier includes a `paddle-button` [Blade component](/docs/{{version}}/blade#com
 By default, this will display the widget using Paddle's default styling. You can customize the widget by adding [Paddle supported attributes](https://developer.paddle.com/paddlejs/html-data-attributes) like the  `data-theme='light'` attribute to the component:
 
 ```html
-<x-paddle-button :url="$payLink" class="px-8 py-4" data-theme="light">
+<x-paddle-button :checkout="$checkout" class="px-8 py-4" data-theme="light">
     Subscribe
 </x-paddle-button>
 ```


### PR DESCRIPTION
The documentation incorrectly suggests using ``:url="$payLink"`` with ``<x-paddle-button>``. However, this should be ``:checkout="$checkout"`` as per ``<x-paddle-button>`` component code source  https://github.com/laravel/cashier-paddle/blob/2.x/resources/views/components/button.blade.php