### PR TITLE
Add note about Sanctum/Axios URI Decoding

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -321,7 +321,7 @@ axios.get('/sanctum/csrf-cookie').then(response => {
 });
 ```
 
-During this request, Laravel will set an `XSRF-TOKEN` cookie containing the current CSRF token. This token should then be passed in an `X-XSRF-TOKEN` header on subsequent requests, which some HTTP client libraries like Axios and the Angular HttpClient will do automatically for you. If your JavaScript HTTP library does not set the value for you, you will need to manually set the `X-XSRF-TOKEN` header to match the value of the `XSRF-TOKEN` cookie that is set by this route.
+During this request, Laravel will set an `XSRF-TOKEN` cookie containing the current CSRF token in a URI encoded format. This token should then be decoded and passed in an `X-XSRF-TOKEN` header on subsequent requests, which some HTTP client libraries like Axios and the Angular HttpClient will do automatically for you. If your JavaScript HTTP library does not set the value for you, you will need to decode the token and manually set the `X-XSRF-TOKEN` header to match the value of the `XSRF-TOKEN` cookie that is set by this route.
 
 <a name="logging-in"></a>
 #### Logging In

--- a/sanctum.md
+++ b/sanctum.md
@@ -288,6 +288,21 @@ axios.defaults.withCredentials = true;
 axios.defaults.withXSRFToken = true;
 ```
 
+Axios will automatically decode the URI component of the token with the above settings. If you are using an alternative library, be sure to decode it before passing it to the header.
+
+```js
+// Example using fetch
+fetch('/my-protected-route', {
+    method: 'POST',
+    headers: {
+        'X-XSRF-TOKEN': decodeURIComponent(token),
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+    },
+    credentials: 'include'
+})
+```
+
 Finally, you should ensure your application's session cookie domain configuration supports any subdomain of your root domain. You may accomplish this by prefixing the domain with a leading `.` within your application's `config/session.php` configuration file:
 
     'domain' => '.domain.com',


### PR DESCRIPTION
When a sanctum/SPA XSRF token is sent to the client, it is URL encoded. It needs to be decoded before being sent back to the server. The examples with axios shows the settings that will automatically add the token to the header. However, they don't mention that axios also decodes the token.

The current example makes it seem like you can pass in the token without decoding the value. This is false and it caused me 2 days of troubleshooting.

I added a fetch example with a note about the decoding. This should help to reduce confusion when using a library other than axios. If you don't think that a fetch example is appropriate, it can be removed. However, I think we need to include the info about the token encoding.

(This is similar to https://github.com/laravel/docs/pull/7579)