### PR TITLE
[5.8] fix: The lack of blank lines leads to invalid styles

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -57,6 +57,7 @@ Homestead runs on any Windows, Mac, or Linux system, and includes Nginx, PHP, My
 </style>
 
 <div id="software-list" markdown="1">
+
 - Ubuntu 18.04
 - Git
 - PHP 7.3
@@ -80,6 +81,7 @@ Homestead runs on any Windows, Mac, or Linux system, and includes Nginx, PHP, My
 - Xdebug
 - XHProf / Tideways / XHGui
 - wp-cli
+
 </div>
 
 <a name="optional-software"></a>
@@ -94,6 +96,7 @@ Homestead runs on any Windows, Mac, or Linux system, and includes Nginx, PHP, My
 </style>
 
 <div id="software-list" markdown="1">
+
 - Apache
 - Blackfire
 - Cassandra
@@ -118,6 +121,7 @@ Homestead runs on any Windows, Mac, or Linux system, and includes Nginx, PHP, My
 - RabbitMQ
 - Solr
 - Webdriver & Laravel Dusk Utilities
+
 </div>
 
 <a name="installation-and-setup"></a>


### PR DESCRIPTION
https://laravel.com/docs/5.8/homestead

![image](https://github.com/user-attachments/assets/e982872f-5315-455a-bad2-4e967533e2f0)

This is normal
https://laravel.com/docs/6.x/homestead
![image](https://github.com/user-attachments/assets/20f26a4f-b31b-4355-adbb-8f4edcae43d8)
