### PR TITLE
[11.x] Bump Pint GitHub Actions instructions to use PHP 8.4

### DIFF
--- a/pint.md
+++ b/pint.md
@@ -178,7 +178,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.3]
+        php: [8.4]
 
     steps:
       - name: Checkout code
@@ -199,6 +199,4 @@ jobs:
 
       - name: Commit linted files
         uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "Fixes coding style"
 ```


### PR DESCRIPTION
PR updates Pint GitHub Actions instructions from PHP 8.3 to 8.4 and removes the reference to customizing a commit message as it defaults to writing one automatically for developers.