### PR TITLE
[11.x] Update validation.md documentation for uuid to mention RFC 9562

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1907,7 +1907,7 @@ The field under validation must be a valid [Universally Unique Lexicographically
 <a name="rule-uuid"></a>
 #### uuid
 
-The field under validation must be a valid RFC 4122 (version 1, 3, 4, or 5) universally unique identifier (UUID).
+The field under validation must be a valid RFC 9562 (version 1, 3, 4, 5, 6, 7 or 8) universally unique identifier (UUID).
 
 <a name="conditionally-adding-rules"></a>
 ## Conditionally Adding Rules

--- a/validation.md
+++ b/validation.md
@@ -1907,7 +1907,7 @@ The field under validation must be a valid [Universally Unique Lexicographically
 <a name="rule-uuid"></a>
 #### uuid
 
-The field under validation must be a valid RFC 9562 (version 1, 3, 4, 5, 6, 7 or 8) universally unique identifier (UUID).
+The field under validation must be a valid RFC 9562 (version 1, 3, 4, 5, 6, 7, or 8) universally unique identifier (UUID).
 
 <a name="conditionally-adding-rules"></a>
 ## Conditionally Adding Rules


### PR DESCRIPTION
RFC 4122 has been made obsolete by RFC 9562 which the uuid rule does actually implement. So uuid validation rule docs should be updated to reflect that change