### PR TITLE
Update notifications.md

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -340,13 +340,13 @@ Sometimes you may need to send a notification to someone who is not stored as a 
 If you would like to provide the recipient's name when sending an on-demand notification to the `mail` route, you may provide an array that contains the email address as the key and the name as the value of the first element in the array:
 
     Notification::route('mail', [
-        'barrett@example.com' => 'Barrett Blair',
+        ['barrett@example.com' => 'Barrett Blair'],
     ])->notify(new InvoicePaid($invoice));
 
 Using the `routes` method, you may provide ad-hoc routing information for multiple notification channels at once:
 
     Notification::routes([
-        'mail' => ['barrett@example.com' => 'Barrett Blair'],
+        'mail' => [['barrett@example.com' => 'Barrett Blair']],
         'vonage' => '5555555555',
     ])->notify(new InvoicePaid($invoice));
 


### PR DESCRIPTION
Updated the "On Demand Notification" code samples.

The mail value can be a string or an array. If it is an array then it must be a array of arrays where the inner array is like ['email' => 'name'].

If this is not the case, an "Internal Server Error" is thrown with a message 

Email "Barrett Blair" does not comply with addr-spec of RFC 2822.
