### PR TITLE
[11.X] Incorrect property name for Reverb Allowed Origins

### DIFF
--- a/reverb.md
+++ b/reverb.md
@@ -57,7 +57,7 @@ You may also define the origins from which client requests may originate by upda
 ```php
 'apps' => [
     [
-        'id' => 'my-app-id',
+        'app_id' => 'my-app-id',
         'allowed_origins' => ['laravel.com'],
         // ...
     ]


### PR DESCRIPTION
Update `id` to be `app_id` in the Reverb Allowed Origins section