### PR TITLE
Add information about the mysql config `use_db_after_connecting`

### DIFF
--- a/database.md
+++ b/database.md
@@ -55,6 +55,11 @@ DB_FOREIGN_KEYS=false
 > [!NOTE]  
 > If you use the [Laravel installer](/docs/{{version}}/installation#creating-a-laravel-project) to create your Laravel application and select SQLite as your database, Laravel will automatically create a `database/database.sqlite` file and run the default [database migrations](/docs/{{version}}/migrations) for you.
 
+<a name="mysql-configuration"></a>
+#### MySQL Configuration
+
+By default, the MySQL connector runs an explicit `USE database_name` statement right after the connection has been establish (even though the database name is already passed in the DSN string). To disable this behavior, you can set the `use_db_after_connecting` config value to `false`.
+
 <a name="mssql-configuration"></a>
 #### Microsoft SQL Server Configuration
 

--- a/database.md
+++ b/database.md
@@ -58,7 +58,7 @@ DB_FOREIGN_KEYS=false
 <a name="mysql-configuration"></a>
 #### MySQL Configuration
 
-By default, the MySQL connector runs an explicit `USE database_name` statement right after the connection has been establish (even though the database name is already passed in the DSN string). To disable this behavior, you can set the `use_db_after_connecting` config value to `false`.
+By default, the MySQL connector issues an explicit `USE database_name` statement after the connection is established, even though the DSN string already includes the database name. To disable this behavior, set the `use_db_after_connecting` configuration value to `false`.
 
 <a name="mssql-configuration"></a>
 #### Microsoft SQL Server Configuration


### PR DESCRIPTION
Added information about the MySQL connector specific configuration `use_db_after_connecting`. Setting this to true will prevent an explicit `USE database_name` statement after the connection has been established.

Added in https://github.com/laravel/framework/pull/54132