### PR TITLE
Make argument to Checkout::guest() an array

### DIFF
--- a/cashier-paddle.md
+++ b/cashier-paddle.md
@@ -558,7 +558,7 @@ Sometimes, you may need to create a checkout session for users that do not need 
     use Laravel\Paddle\Checkout;
 
     Route::get('/buy', function (Request $request) {
-        $checkout = Checkout::guest('pri_34567')
+        $checkout = Checkout::guest(['pri_34567'])
             ->returnTo(route('home'));
 
         return view('billing', ['checkout' => $checkout]);


### PR DESCRIPTION
Checkout::guest() expects an array, not a string: https://github.com/laravel/cashier-paddle/blob/5019728a54604c9fede22c7162d33f8cf7a820d9/src/Checkout.php#L33