### PR TITLE
Expand S3-compatible storage options in file storage documentation (filesystems.md)

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -203,7 +203,7 @@ Next, you may include the `read-only` configuration option in one or more of you
 <a name="amazon-s3-compatible-filesystems"></a>
 ### Amazon S3 Compatible Filesystems
 
-By default, your application's `filesystems` configuration file contains a disk configuration for the `s3` disk. In addition to using this disk to interact with Amazon S3, you may use it to interact with any S3 compatible file storage service such as [MinIO](https://github.com/minio/minio) or [DigitalOcean Spaces](https://www.digitalocean.com/products/spaces/).
+By default, your application's `filesystems` configuration file contains a disk configuration for the `s3` disk. In addition to using this disk to interact with [Amazon S3](https://aws.amazon.com/s3/), you may use it to interact with any S3-compatible file storage service such as [MinIO](https://github.com/minio/minio), [DigitalOcean Spaces](https://www.digitalocean.com/products/spaces/), [Akamai / Linode Object Storage](https://www.linode.com/products/object-storage/), [Vultr Object Storage](https://www.vultr.com/products/object-storage/), or [Hetzner Cloud Storage](https://www.hetzner.com/storage/object-storage/).
 
 Typically, after updating the disk's credentials to match the credentials of the service you are planning to use, you only need to update the value of the `endpoint` configuration option. This option's value is typically defined via the `AWS_ENDPOINT` environment variable:
 


### PR DESCRIPTION
feat(docs): Expand S3-compatible storage options in file storage documentation

- Updated the file storage documentation to include additional S3-compatible storage services.
- Added references to Amazon S3, MinIO, DigitalOcean Spaces, Akamai / Linode Object Storage, Vultr Object Storage, and Hetzner Cloud Storage.
- Ensured all links are accurate and point to the respective service documentation.