### PR TITLE
InteractsWithQueue trait is needed for Batchable jobs

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1298,7 +1298,7 @@ php artisan migrate
 <a name="defining-batchable-jobs"></a>
 ### Defining Batchable Jobs
 
-To define a batchable job, you should [create a queueable job](#creating-jobs) as normal; however, you should add the `Illuminate\Bus\Batchable` trait to the job class. This trait provides access to a `batch` method which may be used to retrieve the current batch that the job is executing within:
+To define a batchable job, you should [create a queueable job](#creating-jobs) as normal; however, you should add the `Illuminate\Bus\Batchable` and the `\Illuminate\Queue\InteractsWithQueue` traits to the job class. The `Batchable` trait provides access to a `batch` method which may be used to retrieve the current batch that the job is executing within:
 
     <?php
 
@@ -1307,10 +1307,11 @@ To define a batchable job, you should [create a queueable job](#creating-jobs) a
     use Illuminate\Bus\Batchable;
     use Illuminate\Contracts\Queue\ShouldQueue;
     use Illuminate\Foundation\Queue\Queueable;
+    use Illuminate\Queue\InteractsWithQueue;
 
     class ImportCsv implements ShouldQueue
     {
-        use Batchable, Queueable;
+        use Batchable, InteractsWithQueue, Queueable;
 
         /**
          * Execute the job.


### PR DESCRIPTION
While testing job batches found, that `then` and `finally` methods relies on InteractsWithQueue trait. 
See https://github.com/laravel/framework/blob/6eaa4b3a4d3961d90ba90def9f141367a82ac995/src/Illuminate/Queue/CallQueuedHandler.php#L183 (CallQueuedHandler::ensureSuccessfulBatchJobIsRecorded)

But documentation misses that requirements, making it difficult to find out, why `then` or `finally` not working.

creating-jobs link also says nothing about InteractsWithQueue trait (only about ShouldQueue interface)

This PR fixes that. 
Fixes also appliable for master, 10.x, 9.x, 8.x