### PR TITLE
Remove mentions of Eloquent truncate from docs

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -910,10 +910,6 @@ To delete a model, you may call the `delete` method on the model instance:
 
     $flight->delete();
 
-You may call the `truncate` method to delete all of the model's associated database records. The `truncate` operation will also reset any auto-incrementing IDs on the model's associated table:
-
-    Flight::truncate();
-
 <a name="deleting-an-existing-model-by-its-primary-key"></a>
 #### Deleting an Existing Model by its Primary Key
 

--- a/queries.md
+++ b/queries.md
@@ -1068,15 +1068,6 @@ The query builder's `delete` method may be used to delete records from the table
 
     $deleted = DB::table('users')->where('votes', '>', 100)->delete();
 
-If you wish to truncate an entire table, which will remove all records from the table and reset the auto-incrementing ID to zero, you may use the `truncate` method:
-
-    DB::table('users')->truncate();
-
-<a name="table-truncation-and-postgresql"></a>
-#### Table Truncation and PostgreSQL
-
-When truncating a PostgreSQL database, the `CASCADE` behavior will be applied. This means that all foreign key related records in other tables will be deleted as well.
-
 <a name="pessimistic-locking"></a>
 ## Pessimistic Locking
 


### PR DESCRIPTION
There are some issues and long dicsussions around `truncate` method and PostgreSQL CASCADE behaviour. 
some of them (and many more pull requests): 
* https://github.com/laravel/framework/issues/35157 
* https://github.com/laravel/framework/issues/29506 
* https://github.com/laravel/framework/pull/53343

Currently documentation says `This means that all foreign key related records in other tables will be deleted as well.`. This wording is very soft and does not highlight the full danger. Truncate cascade will fully truncate any tables, that has foreign keys pointing current table. Not only those records, that has foreign keys. Records, having null in foreign key columns will be also deleted.

While discussing if postgresql should use CASCADE in truncates, no one speaks, that using truncate is bad practice at all.

First of all, TRUNCATE SQL command is part of Data Definition Language (DDL), and DELETE is part of Data Manipulation Language (DML). So, using TRUNCATE is ok somewhere in migrations, but not in regular code. In other words, delete is for developers, truncate is for database administrators.  More at https://stackoverflow.com/a/139633 
Depending on sql server truncate may not respect transactions and many checks in database integrity. Delete always respects all currently enabled data integrity mechanisms (foreign keys, constraints, etc).

So, using Truncate in regular code (meaning code, that manipulates data) is bad pattern. Mentioning Truncate in the same context as Delete in the documentation gives new developers the incorrect impression that these commands are equivalent operations. We cannot change the behavior of the framework without breaking backward compatibility. But we can remove mention of truncate from the documentation, and we will save many novice developers from stupid mistakes. Experienced developers will easily find the truncate command in the source code and can use it at their own risk.

Following the rule that all undocumented methods are used at your own risk, removing the truncate method from the documentation will remove all further questions about how exactly this method should work, reducing the number of complaints to the framework developers about the fact that the method does not work as expected. This reduce need of support recently introduced PostgresGrammar::$cascadeTruncate and change it to false in future.

Introduce this change in documentation (and idea, that regular developers and new projects should not use truncate) together with release of Laravel 12 is the most gentle way to solve this complicated situation