### PR TITLE
Calrifying risks of using truncate

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -941,6 +941,10 @@ Of course, you may build an Eloquent query to delete all models matching your qu
 
     $deleted = Flight::where('active', 0)->delete();
 
+To delete all models in table:
+
+    $deleted = Flight::query()->delete();
+
 > [!WARNING]  
 > When executing a mass delete statement via Eloquent, the `deleting` and `deleted` model events will not be dispatched for the deleted models. This is because the models are never actually retrieved when executing the delete statement.
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -914,6 +914,10 @@ You may call the `truncate` method to delete all of the model's associated datab
 
     Flight::truncate();
 
+> [!WARNING]
+> Using `truncate` method can lead to [data loss](/docs/{{version}}/queries#table-truncation-and-postgresql) or [inconsistency](/docs/{{version}}/queries#table-truncation-and-mysql).
+> [Deleting with queries](#deleting-models-using-queries) is better choice in most cases.
+
 <a name="deleting-an-existing-model-by-its-primary-key"></a>
 #### Deleting an Existing Model by its Primary Key
 

--- a/queries.md
+++ b/queries.md
@@ -1072,7 +1072,9 @@ If you wish to truncate an entire table, which will remove all records from the 
 
     DB::table('users')->truncate();
 
+<a name="table-truncation-engine-specific-notes"></a>
 #### Engine-specific notes
+
 <a name="table-truncation-and-mysql"></a>
 ##### MySQL
 

--- a/queries.md
+++ b/queries.md
@@ -1072,15 +1072,22 @@ If you wish to truncate an entire table, which will remove all records from the 
 
     DB::table('users')->truncate();
 
+#### Engine-specific notes
 <a name="table-truncation-and-mysql"></a>
-#### Table Truncation and MySQL
+##### MySQL
 
-To use truncate on a table referenced by foreign keys, you will need to temporarily [disable foreign key constrains](/docs/{{version}}/migrations#toggling-foreign-key-constraints). This will result in inconsistent data unless you call truncate recursively on all tables that have foreign-key references to this table.
+To use truncate on a table referenced by foreign keys, you will need to temporarily [disable foreign key constrains](/docs/{{version}}/migrations#toggling-foreign-key-constraints).
+
+> [!WARNING]
+> This will result in inconsistent data unless you call truncate recursively on all tables that have foreign-key references to this table.
 
 <a name="table-truncation-and-postgresql"></a>
-#### Table Truncation and PostgreSQL
+##### PostgreSQL
 
-When truncating a PostgreSQL database, the `CASCADE` behavior will be applied. This means that all records in all tables that have foreign-key references to this table (and recursively in all tables referencing them) will be deleted as well.
+When truncating a PostgreSQL database, the `CASCADE` behavior will be applied.
+
+> [!WARNING]
+> This means that all records in all tables that have foreign-key references to this table (and recursively in all tables referencing them) will be deleted as well.
 
 <a name="pessimistic-locking"></a>
 ## Pessimistic Locking

--- a/queries.md
+++ b/queries.md
@@ -1072,10 +1072,15 @@ If you wish to truncate an entire table, which will remove all records from the 
 
     DB::table('users')->truncate();
 
+<a name="table-truncation-and-mysql"></a>
+#### Table Truncation and MySQL
+
+To use truncate on a table referenced by foreign keys, you will need to temporarily [disable foreign key constrains](/docs/{{version}}/migrations#toggling-foreign-key-constraints). This will result in inconsistent data unless you call truncate recursively on all tables that have foreign-key references to this table.
+
 <a name="table-truncation-and-postgresql"></a>
 #### Table Truncation and PostgreSQL
 
-When truncating a PostgreSQL database, the `CASCADE` behavior will be applied. This means that all foreign key related records in other tables will be deleted as well.
+When truncating a PostgreSQL database, the `CASCADE` behavior will be applied. This means that all records in all tables that have foreign-key references to this table (and recursively in all tables referencing them) will be deleted as well.
 
 <a name="pessimistic-locking"></a>
 ## Pessimistic Locking


### PR DESCRIPTION
This PR is some way opposite to https://github.com/laravel/docs/pull/10116

The current documentation does not accurately describe the risks of using truncate (appeared in https://github.com/laravel/docs/pull/6560).
Even it documentated for 4 years, users do not understand risks. See https://github.com/laravel/framework/issues/35157#issuecomment-1625141439  and later in thread.

This PR clarifies potential problems, that comes with truncate 
 * recursive data deletion for postgresql (not only foreign key related records, but all records)
 * data inconsistency for mysql