### PR TITLE
[11.x] Delete all models example

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -954,6 +954,10 @@ Of course, you may build an Eloquent query to delete all models matching your qu
 
     $deleted = Flight::where('active', 0)->delete();
 
+To delete all models you can build query without conditions:
+
+    $deleted = Flight::query()->delete();
+
 > [!WARNING]  
 > When executing a mass delete statement via Eloquent, the `deleting` and `deleted` model events will not be dispatched for the deleted models. This is because the models are never actually retrieved when executing the delete statement.
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -954,7 +954,7 @@ Of course, you may build an Eloquent query to delete all models matching your qu
 
     $deleted = Flight::where('active', 0)->delete();
 
-To delete all models you can build query without conditions:
+To delete all models in a table, you should execute a query without adding any conditions:
 
     $deleted = Flight::query()->delete();
 


### PR DESCRIPTION
In discussion about incorrect usage of truncate (https://github.com/laravel/docs/pull/10118 , https://github.com/laravel/docs/pull/10116), supprisely found, that Eloquent page does not contain example of deletion all rows in table other than with truncate.

To delete it with query we should write `Model::query()->delete()`, not just `Model::delete()`, and this is not obvious, because this page does not contain any other example starting with `Model::query()`.

As the result, many users use `truncate` for deletion of all records, leading to issues like https://github.com/laravel/framework/issues/35157 and https://github.com/laravel/framework/issues/29506 . Now i understand, is because truncate is documented better and higher in documentation, than delete.

This PR adds example of deletion of all modles in table.