### PR TITLE
[11.x] Note about client sharding only with predis

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -125,7 +125,7 @@ If your application is utilizing a cluster of Redis servers, you should define t
 
 By default, Laravel will use native Redis clustering since the `options.cluster` configuration value is set to `redis`. Redis clustering is a great default option, as it gracefully handles failover.
 
-Laravel also supports client-side sharding. However, client-side sharding does not handle failover; therefore, it is primarily suited for transient cached data that is available from another primary data store.
+Laravel also supports client-side sharding (only with Predis). However, client-side sharding does not handle failover; therefore, it is primarily suited for transient cached data that is available from another primary data store.
 
 If you would like to use client-side sharding instead of native Redis clustering, you may remove the `options.cluster` configuration value within your application's `config/database.php` configuration file:
 

--- a/redis.md
+++ b/redis.md
@@ -125,7 +125,7 @@ If your application is utilizing a cluster of Redis servers, you should define t
 
 By default, Laravel will use native Redis clustering since the `options.cluster` configuration value is set to `redis`. Redis clustering is a great default option, as it gracefully handles failover.
 
-Laravel also supports client-side sharding (only with Predis). However, client-side sharding does not handle failover; therefore, it is primarily suited for transient cached data that is available from another primary data store.
+Laravel also supports client-side sharding when using Predis. However, client-side sharding does not handle failover; therefore, it is primarily suited for transient cached data that is available from another primary data store.
 
 If you would like to use client-side sharding instead of native Redis clustering, you may remove the `options.cluster` configuration value within your application's `config/database.php` configuration file:
 


### PR DESCRIPTION
Rebased https://github.com/laravel/docs/pull/10117 to 11. x


Phpredis extention does not provide client-side sharding, only Predis can do so. Currently this is unclear from docs.

This PR makes this more clear