### PR TITLE
Add warning regarding using `HasMiddleware` interface and extends `Illuminate\Routing\Controller`

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -153,7 +153,7 @@ You may also define controller middleware as closures, which provides a convenie
     }
 
 > [!WARNING]  
-> You need to ensure that controllers implementing `Illuminate\Routing\Controllers\HasMiddleware` does not extends `Illuminate\Routing\Controller`.  
+> Controllers implementing `Illuminate\Routing\Controllers\HasMiddleware` should not extend `Illuminate\Routing\Controller`.
 
 <a name="resource-controllers"></a>
 ## Resource Controllers

--- a/controllers.md
+++ b/controllers.md
@@ -152,6 +152,9 @@ You may also define controller middleware as closures, which provides a convenie
         ];
     }
 
+> [!WARNING]  
+> You need to ensure that controllers implementing `Illuminate\Routing\Controllers\HasMiddleware` does not extends `Illuminate\Routing\Controller`.  
+
 <a name="resource-controllers"></a>
 ## Resource Controllers
 


### PR DESCRIPTION
fixes laravel/framework#54181

This note will be useful for upgraded application coming from Laravel 10 and below which would default to extending `Illuminate\Routing\Controller`.