### PR TITLE
[12.x] Document `image` rule SVG security changes

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1389,7 +1389,11 @@ The field under validation must contain a valid color value in [hexadecimal](htt
 <a name="rule-image"></a>
 #### image
 
-The file under validation must be an image (jpg, jpeg, png, bmp, gif, svg, or webp).
+The file under validation must be an image (jpg, jpeg, png, bmp, gif, or webp).
+
+> [!WARNING]  
+> By default the image rule does not allow SVG files due to possible XSS attacks.
+> If you need to allow SVG files, you can use the `image:allow_svg` rule and handle potentially unsafe SVG files manually.
 
 <a name="rule-in"></a>
 #### in:_foo_,_bar_,...
@@ -2102,7 +2106,27 @@ Laravel provides a variety of validation rules that may be used to validate uplo
         ],
     ]);
 
-If your application accepts images uploaded by your users, you may use the `File` rule's `image` constructor method to indicate that the uploaded file should be an image. In addition, the `dimensions` rule may be used to limit the dimensions of the image:
+If your application accepts images uploaded by your users, you may use the `File` rule's `image` constructor method to indicate that the uploaded file should be an image.
+
+    use Illuminate\Support\Facades\Validator;
+    use Illuminate\Validation\Rule;
+    use Illuminate\Validation\Rules\File;
+
+    Validator::validate($input, [
+        'photo' => [
+            'required',
+            File::image(),
+        ],
+    ]);
+
+> [!WARNING]  
+> By default the File::image() rule does not allow SVG files due to possible XSS attacks.
+> If you need to allow SVG files, you can pass `allowSvg: true` as argument, e.g. `File::image(allowSvg: true)` and handle potentially unsafe SVG files manually.
+
+<a name="validating-files-file-sizes"></a>
+#### File Dimensions
+
+You may also validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
 
     use Illuminate\Support\Facades\Validator;
     use Illuminate\Validation\Rule;
@@ -2112,8 +2136,6 @@ If your application accepts images uploaded by your users, you may use the `File
         'photo' => [
             'required',
             File::image()
-                ->min(1024)
-                ->max(12 * 1024)
                 ->dimensions(Rule::dimensions()->maxWidth(1000)->maxHeight(500)),
         ],
     ]);

--- a/validation.md
+++ b/validation.md
@@ -2108,7 +2108,7 @@ Laravel provides a variety of validation rules that may be used to validate uplo
 
 
 <a name="validating-files-file-sizes"></a>
-#### File Sizes
+#### Validating File Sizes
 
 For convenience, minimum and maximum file sizes may be specified as a string with a suffix indicating the file size units. The `kb`, `mb`, `gb`, and `tb` suffixes are supported.
 You may also validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
@@ -2122,7 +2122,7 @@ File::types(['mp3', 'wav'])
 <a name="validating-files-image-files"></a>
 #### Validating Image Files
 
-If your application accepts images uploaded by your users, you may use the `File` rule's `image` constructor method to indicate that the uploaded file should be an image.
+To validate that uploaded files are images, you can use the `File` rule's image constructor method.
 
     use Illuminate\Support\Facades\Validator;
     use Illuminate\Validation\Rule;
@@ -2155,7 +2155,7 @@ File::image()
 > More information regarding validating image dimensions may be found in the [dimension rule documentation](#rule-dimensions).
 
 <a name="validating-files-file-types"></a>
-#### File Types
+#### Validating File Types
 
 Even though you only need to specify the extensions when invoking the `types` method, this method actually validates the MIME type of the file by reading the file's contents and guessing its MIME type. A full listing of MIME types and their corresponding extensions may be found at the following location:
 

--- a/validation.md
+++ b/validation.md
@@ -2106,7 +2106,6 @@ Laravel provides a variety of validation rules that may be used to validate uplo
         ],
     ]);
 
-
 <a name="validating-files-file-sizes"></a>
 #### Validating File Sizes
 

--- a/validation.md
+++ b/validation.md
@@ -2106,6 +2106,22 @@ Laravel provides a variety of validation rules that may be used to validate uplo
         ],
     ]);
 
+
+<a name="validating-files-file-sizes"></a>
+#### File Sizes
+
+For convenience, minimum and maximum file sizes may be specified as a string with a suffix indicating the file size units. The `kb`, `mb`, `gb`, and `tb` suffixes are supported.
+You may also validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
+
+```php
+File::types(['mp3', 'wav'])
+    ->min('1kb')
+    ->max('10mb');
+```
+
+<a name="validating-files-image-files"></a>
+#### Validating Image Files
+
 If your application accepts images uploaded by your users, you may use the `File` rule's `image` constructor method to indicate that the uploaded file should be an image.
 
     use Illuminate\Support\Facades\Validator;
@@ -2125,16 +2141,13 @@ The `File::image()` rule makes sure that the file under validation must be an im
 > By default the File::image() rule does not allow SVG files due to possible XSS attacks.
 > If you need to allow SVG files, you can pass `allowSvg: true` as argument, e.g. `File::image(allowSvg: true)` and handle potentially unsafe SVG files manually.
 
-<a name="validating-files-file-sizes-and-dimensions"></a>
-#### File Sizes & Dimensions
+<a name="validating-files-image-dimensions"></a>
+#### Validating Image Dimensions
 
-For convenience, minimum and maximum file sizes may be specified as a string with a suffix indicating the file size units. The `kb`, `mb`, `gb`, and `tb` suffixes are supported.
-You may also validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
+You may validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
 
 ```php
 File::image()
-    ->min('1kb')
-    ->max('10mb')
     ->dimensions(Rule::dimensions()->maxWidth(1000)->maxHeight(500))
 ```
 

--- a/validation.md
+++ b/validation.md
@@ -2125,36 +2125,21 @@ The `File::image()` rule makes sure that the file under validation must be an im
 > By default the File::image() rule does not allow SVG files due to possible XSS attacks.
 > If you need to allow SVG files, you can pass `allowSvg: true` as argument, e.g. `File::image(allowSvg: true)` and handle potentially unsafe SVG files manually.
 
-<a name="validating-files-file-sizes"></a>
-#### File Dimensions
+<a name="validating-files-file-sizes-and-dimensions"></a>
+#### File Sizes & Dimensions
 
+For convenience, minimum and maximum file sizes may be specified as a string with a suffix indicating the file size units. The `kb`, `mb`, `gb`, and `tb` suffixes are supported.
 You may also validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
-
-    use Illuminate\Support\Facades\Validator;
-    use Illuminate\Validation\Rule;
-    use Illuminate\Validation\Rules\File;
-
-    Validator::validate($input, [
-        'photo' => [
-            'required',
-            File::image()
-                ->dimensions(Rule::dimensions()->maxWidth(1000)->maxHeight(500)),
-        ],
-    ]);
-
-> [!NOTE]  
-> More information regarding validating image dimensions may be found in the [dimension rule documentation](#rule-dimensions).
-
-<a name="validating-files-file-sizes"></a>
-#### File Sizes
-
-For convenience, minimum and maximum file sizes may be specified as a string with a suffix indicating the file size units. The `kb`, `mb`, `gb`, and `tb` suffixes are supported:
 
 ```php
 File::image()
     ->min('1kb')
     ->max('10mb')
+    ->dimensions(Rule::dimensions()->maxWidth(1000)->maxHeight(500))
 ```
+
+> [!NOTE]  
+> More information regarding validating image dimensions may be found in the [dimension rule documentation](#rule-dimensions).
 
 <a name="validating-files-file-types"></a>
 #### File Types

--- a/validation.md
+++ b/validation.md
@@ -2119,6 +2119,8 @@ If your application accepts images uploaded by your users, you may use the `File
         ],
     ]);
 
+The `File::image()` rule makes sure that the file under validation must be an image (jpg, jpeg, png, bmp, gif, or webp).
+
 > [!WARNING]  
 > By default the File::image() rule does not allow SVG files due to possible XSS attacks.
 > If you need to allow SVG files, you can pass `allowSvg: true` as argument, e.g. `File::image(allowSvg: true)` and handle potentially unsafe SVG files manually.


### PR DESCRIPTION
This pull request updates the validation documentation to reflect the [12.x changes for image validation](https://github.com/laravel/framework/pull/54331), focusing on secure defaults and better guidance for developers.

#### Key Updates:
- **SVG Default Exclusion**:  
  The documentation highlights that SVG files are excluded by default in the `image` and `File::image()` rules due to potential XSS risks.

- **Opt-In SVG Allowance**:  
  Provides examples for explicitly allowing SVGs using `image:allow_svg` or `File::image(allowSvg: true)`. Developers are encouraged to sanitize SVGs manually if they enable this option.

- **Improved Structure**:  
  Content is reorganized into clearly labeled sections:  
  - Validating File Sizes  
  - Validating Image Files  
  - Validating Image Dimensions  
  This makes the documentation easier to navigate and reference.

- **Actionable Warnings**:  
  Adds warning blocks to raise developer awareness about SVG risks and encourage secure handling practices.
