### PR TITLE
[12.x] Add `previousPath` usage to urls.md

### DIFF
--- a/urls.md
+++ b/urls.md
@@ -42,6 +42,9 @@ If no path is provided to the `url` helper, an `Illuminate\Routing\UrlGenerator`
     // Get the full URL for the previous request...
     echo url()->previous();
 
+    // Get the full URL for the previous request without query parameters...
+    echo url()->previousPath();
+
 Each of these methods may also be accessed via the `URL` [facade](/docs/{{version}}/facades):
 
     use Illuminate\Support\Facades\URL;


### PR DESCRIPTION
```
     // Get the full URL for the previous request...
     echo url()->previous();

+    // Get the full URL for the previous request without query parameters...
+    echo url()->previousPath();
```