### PR TITLE
[11.x] Improve File validation structure and clarify `File::image()` usage

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -2200,7 +2200,6 @@ Laravel provides a variety of validation rules that may be used to validate uplo
         ],
     ]);
 
-
 <a name="validating-files-file-sizes"></a>
 #### Validating File Sizes
 

--- a/validation.md
+++ b/validation.md
@@ -2200,6 +2200,22 @@ Laravel provides a variety of validation rules that may be used to validate uplo
         ],
     ]);
 
+
+<a name="validating-files-file-sizes"></a>
+#### File Sizes
+
+For convenience, minimum and maximum file sizes may be specified as a string with a suffix indicating the file size units. The `kb`, `mb`, `gb`, and `tb` suffixes are supported.
+You may also validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
+
+```php
+File::types(['mp3', 'wav'])
+    ->min('1kb')
+    ->max('10mb');
+```
+
+<a name="validating-files-image-files"></a>
+#### Validating Image Files
+
 If your application accepts images uploaded by your users, you may use the `File` rule's `image` constructor method to indicate that the uploaded file should be an image.
 
     use Illuminate\Support\Facades\Validator;
@@ -2219,16 +2235,13 @@ The `File::image()` rule makes sure that the file under validation must be an im
 > By default the File::image() rule does not allow SVG files due to possible XSS attacks.
 > If you need to allow SVG files, you can pass `allowSvg: true` as argument, e.g. `File::image(allowSvg: true)` and handle potentially unsafe SVG files manually.
 
-<a name="validating-files-file-sizes-and-dimensions"></a>
-#### File Sizes & Dimensions
+<a name="validating-files-image-dimensions"></a>
+#### Validating Image Dimensions
 
-For convenience, minimum and maximum file sizes may be specified as a string with a suffix indicating the file size units. The `kb`, `mb`, `gb`, and `tb` suffixes are supported.
-You may also validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
+You may validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
 
 ```php
 File::image()
-    ->min('1kb')
-    ->max('10mb')
     ->dimensions(Rule::dimensions()->maxWidth(1000)->maxHeight(500))
 ```
 

--- a/validation.md
+++ b/validation.md
@@ -1242,7 +1242,7 @@ A _ratio_ constraint should be represented as width divided by height. This can 
 
     'avatar' => 'dimensions:ratio=3/2'
 
-Since this rule requires several arguments, you may use the `Rule::dimensions` method to fluently construct the rule:
+Since this rule requires several arguments, it is often more convenient to use use the `Rule::dimensions` method to fluently construct the rule:
 
     use Illuminate\Support\Facades\Validator;
     use Illuminate\Validation\Rule;
@@ -1250,7 +1250,10 @@ Since this rule requires several arguments, you may use the `Rule::dimensions` m
     Validator::make($data, [
         'avatar' => [
             'required',
-            Rule::dimensions()->maxWidth(1000)->maxHeight(500)->ratio(3 / 2),
+            Rule::dimensions()
+                ->maxWidth(1000)
+                ->maxHeight(500)
+                ->ratio(3 / 2),
         ],
     ]);
 
@@ -2196,11 +2199,17 @@ Laravel provides a variety of validation rules that may be used to validate uplo
         ],
     ]);
 
+<a name="validating-files-file-types"></a>
+#### Validating File Types
+
+Even though you only need to specify the extensions when invoking the `types` method, this method actually validates the MIME type of the file by reading the file's contents and guessing its MIME type. A full listing of MIME types and their corresponding extensions may be found at the following location:
+
+[https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types](https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types)
+
 <a name="validating-files-file-sizes"></a>
 #### Validating File Sizes
 
-For convenience, minimum and maximum file sizes may be specified as a string with a suffix indicating the file size units. The `kb`, `mb`, `gb`, and `tb` suffixes are supported.
-You may also validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
+For convenience, minimum and maximum file sizes may be specified as a string with a suffix indicating the file size units. The `kb`, `mb`, `gb`, and `tb` suffixes are supported:
 
 ```php
 File::types(['mp3', 'wav'])
@@ -2211,40 +2220,39 @@ File::types(['mp3', 'wav'])
 <a name="validating-files-image-files"></a>
 #### Validating Image Files
 
-To validate that uploaded files are images, you can use the `File` rule's image constructor method.
+To validate that uploaded files are images, you can use the `File` rule's `image` constructor method. The `File::image()` rule ensures that the file under validation is an image (jpg, jpeg, png, bmp, gif, svg, or webp):
 
-    use Illuminate\Support\Facades\Validator;
-    use Illuminate\Validation\Rule;
-    use Illuminate\Validation\Rules\File;
+```php
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\File;
 
-    Validator::validate($input, [
-        'photo' => [
-            'required',
-            File::image(),
-        ],
-    ]);
-
-The `File::image()` rule makes sure that the file under validation must be an image (jpg, jpeg, png, bmp, gif, svg, or webp).
+Validator::validate($input, [
+    'photo' => [
+        'required',
+        File::image(),
+    ],
+]);
+```
 
 <a name="validating-files-image-dimensions"></a>
 #### Validating Image Dimensions
 
-You may validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
+You may also validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
 
 ```php
-File::image()
-    ->dimensions(Rule::dimensions()->maxWidth(1000)->maxHeight(500))
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\File;
+
+File::image()->dimensions(
+    Rule::dimensions()
+        ->maxWidth(1000)
+        ->maxHeight(500)
+)
 ```
 
 > [!NOTE]  
 > More information regarding validating image dimensions may be found in the [dimension rule documentation](#rule-dimensions).
-
-<a name="validating-files-file-types"></a>
-#### Validating File Types
-
-Even though you only need to specify the extensions when invoking the `types` method, this method actually validates the MIME type of the file by reading the file's contents and guessing its MIME type. A full listing of MIME types and their corresponding extensions may be found at the following location:
-
-[https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types](https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types)
 
 <a name="validating-passwords"></a>
 ## Validating Passwords

--- a/validation.md
+++ b/validation.md
@@ -1479,11 +1479,7 @@ The field under validation must contain a valid color value in [hexadecimal](htt
 <a name="rule-image"></a>
 #### image
 
-The file under validation must be an image (jpg, jpeg, png, bmp, gif, or webp).
-
-> [!WARNING]  
-> By default the image rule does not allow SVG files due to possible XSS attacks.
-> If you need to allow SVG files, you can use the `image:allow_svg` rule and handle potentially unsafe SVG files manually.
+The file under validation must be an image (jpg, jpeg, png, bmp, gif, svg or webp).
 
 <a name="rule-in"></a>
 #### in:_foo_,_bar_,...
@@ -2228,11 +2224,7 @@ To validate that uploaded files are images, you can use the `File` rule's image 
         ],
     ]);
 
-The `File::image()` rule makes sure that the file under validation must be an image (jpg, jpeg, png, bmp, gif, or webp).
-
-> [!WARNING]  
-> By default the File::image() rule does not allow SVG files due to possible XSS attacks.
-> If you need to allow SVG files, you can pass `allowSvg: true` as argument, e.g. `File::image(allowSvg: true)` and handle potentially unsafe SVG files manually.
+The `File::image()` rule makes sure that the file under validation must be an image (jpg, jpeg, png, bmp, gif, svg or webp).
 
 <a name="validating-files-image-dimensions"></a>
 #### Validating Image Dimensions

--- a/validation.md
+++ b/validation.md
@@ -2219,36 +2219,21 @@ The `File::image()` rule makes sure that the file under validation must be an im
 > By default the File::image() rule does not allow SVG files due to possible XSS attacks.
 > If you need to allow SVG files, you can pass `allowSvg: true` as argument, e.g. `File::image(allowSvg: true)` and handle potentially unsafe SVG files manually.
 
-<a name="validating-files-file-sizes"></a>
-#### File Dimensions
+<a name="validating-files-file-sizes-and-dimensions"></a>
+#### File Sizes & Dimensions
 
+For convenience, minimum and maximum file sizes may be specified as a string with a suffix indicating the file size units. The `kb`, `mb`, `gb`, and `tb` suffixes are supported.
 You may also validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
-
-    use Illuminate\Support\Facades\Validator;
-    use Illuminate\Validation\Rule;
-    use Illuminate\Validation\Rules\File;
-
-    Validator::validate($input, [
-        'photo' => [
-            'required',
-            File::image()
-                ->dimensions(Rule::dimensions()->maxWidth(1000)->maxHeight(500)),
-        ],
-    ]);
-
-> [!NOTE]  
-> More information regarding validating image dimensions may be found in the [dimension rule documentation](#rule-dimensions).
-
-<a name="validating-files-file-sizes"></a>
-#### File Sizes
-
-For convenience, minimum and maximum file sizes may be specified as a string with a suffix indicating the file size units. The `kb`, `mb`, `gb`, and `tb` suffixes are supported:
 
 ```php
 File::image()
     ->min('1kb')
     ->max('10mb')
+    ->dimensions(Rule::dimensions()->maxWidth(1000)->maxHeight(500))
 ```
+
+> [!NOTE]  
+> More information regarding validating image dimensions may be found in the [dimension rule documentation](#rule-dimensions).
 
 <a name="validating-files-file-types"></a>
 #### File Types

--- a/validation.md
+++ b/validation.md
@@ -1479,7 +1479,7 @@ The field under validation must contain a valid color value in [hexadecimal](htt
 <a name="rule-image"></a>
 #### image
 
-The file under validation must be an image (jpg, jpeg, png, bmp, gif, svg or webp).
+The file under validation must be an image (jpg, jpeg, png, bmp, gif, svg, or webp).
 
 <a name="rule-in"></a>
 #### in:_foo_,_bar_,...
@@ -2224,7 +2224,7 @@ To validate that uploaded files are images, you can use the `File` rule's image 
         ],
     ]);
 
-The `File::image()` rule makes sure that the file under validation must be an image (jpg, jpeg, png, bmp, gif, svg or webp).
+The `File::image()` rule makes sure that the file under validation must be an image (jpg, jpeg, png, bmp, gif, svg, or webp).
 
 <a name="validating-files-image-dimensions"></a>
 #### Validating Image Dimensions

--- a/validation.md
+++ b/validation.md
@@ -2213,6 +2213,8 @@ If your application accepts images uploaded by your users, you may use the `File
         ],
     ]);
 
+The `File::image()` rule makes sure that the file under validation must be an image (jpg, jpeg, png, bmp, gif, or webp).
+
 > [!WARNING]  
 > By default the File::image() rule does not allow SVG files due to possible XSS attacks.
 > If you need to allow SVG files, you can pass `allowSvg: true` as argument, e.g. `File::image(allowSvg: true)` and handle potentially unsafe SVG files manually.

--- a/validation.md
+++ b/validation.md
@@ -2202,7 +2202,7 @@ Laravel provides a variety of validation rules that may be used to validate uplo
 
 
 <a name="validating-files-file-sizes"></a>
-#### File Sizes
+#### Validating File Sizes
 
 For convenience, minimum and maximum file sizes may be specified as a string with a suffix indicating the file size units. The `kb`, `mb`, `gb`, and `tb` suffixes are supported.
 You may also validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
@@ -2216,7 +2216,7 @@ File::types(['mp3', 'wav'])
 <a name="validating-files-image-files"></a>
 #### Validating Image Files
 
-If your application accepts images uploaded by your users, you may use the `File` rule's `image` constructor method to indicate that the uploaded file should be an image.
+To validate that uploaded files are images, you can use the `File` rule's image constructor method.
 
     use Illuminate\Support\Facades\Validator;
     use Illuminate\Validation\Rule;
@@ -2249,7 +2249,7 @@ File::image()
 > More information regarding validating image dimensions may be found in the [dimension rule documentation](#rule-dimensions).
 
 <a name="validating-files-file-types"></a>
-#### File Types
+#### Validating File Types
 
 Even though you only need to specify the extensions when invoking the `types` method, this method actually validates the MIME type of the file by reading the file's contents and guessing its MIME type. A full listing of MIME types and their corresponding extensions may be found at the following location:
 

--- a/validation.md
+++ b/validation.md
@@ -1479,7 +1479,11 @@ The field under validation must contain a valid color value in [hexadecimal](htt
 <a name="rule-image"></a>
 #### image
 
-The file under validation must be an image (jpg, jpeg, png, bmp, gif, svg, or webp).
+The file under validation must be an image (jpg, jpeg, png, bmp, gif, or webp).
+
+> [!WARNING]  
+> By default the image rule does not allow SVG files due to possible XSS attacks.
+> If you need to allow SVG files, you can use the `image:allow_svg` rule and handle potentially unsafe SVG files manually.
 
 <a name="rule-in"></a>
 #### in:_foo_,_bar_,...
@@ -2196,7 +2200,27 @@ Laravel provides a variety of validation rules that may be used to validate uplo
         ],
     ]);
 
-If your application accepts images uploaded by your users, you may use the `File` rule's `image` constructor method to indicate that the uploaded file should be an image. In addition, the `dimensions` rule may be used to limit the dimensions of the image:
+If your application accepts images uploaded by your users, you may use the `File` rule's `image` constructor method to indicate that the uploaded file should be an image.
+
+    use Illuminate\Support\Facades\Validator;
+    use Illuminate\Validation\Rule;
+    use Illuminate\Validation\Rules\File;
+
+    Validator::validate($input, [
+        'photo' => [
+            'required',
+            File::image(),
+        ],
+    ]);
+
+> [!WARNING]  
+> By default the File::image() rule does not allow SVG files due to possible XSS attacks.
+> If you need to allow SVG files, you can pass `allowSvg: true` as argument, e.g. `File::image(allowSvg: true)` and handle potentially unsafe SVG files manually.
+
+<a name="validating-files-file-sizes"></a>
+#### File Dimensions
+
+You may also validate the dimensions of an image. For example, to validate that an uploaded image is at least 1000 pixels wide and 500 pixels tall, you may use the `dimensions` rule:
 
     use Illuminate\Support\Facades\Validator;
     use Illuminate\Validation\Rule;
@@ -2206,8 +2230,6 @@ If your application accepts images uploaded by your users, you may use the `File
         'photo' => [
             'required',
             File::image()
-                ->min(1024)
-                ->max(12 * 1024)
                 ->dimensions(Rule::dimensions()->maxWidth(1000)->maxHeight(500)),
         ],
     ]);


### PR DESCRIPTION
Split from #10136

This PR enhances the validation documentation with the following updates:

1. **Improved Structure**:
   - Adds consistent headings for file validation rules like file sizes and image dimensions.
   - Separates the explanation of `dimensions` from `File::image()` for better focus.

2. **Expanded `File::image()` Details**:
   - Clearly lists supported file types (`jpg`, `jpeg`, `png`, `bmp`, `gif`, `svg`, `webp`).
   - Adds a warning about potential XSS risks with SVG files and how to handle them safely.

3. **Streamlined Examples**:
   - Moves method chaining examples (e.g., `dimensions`) to dedicated sections for clarity.
   - Includes a concise example for file size validation.
