### PR TITLE
Show database timezone key in example

### DIFF
--- a/database.md
+++ b/database.md
@@ -113,6 +113,8 @@ To see how read / write connections should be configured, let's look at this exa
         'options' => extension_loaded('pdo_mysql') ? array_filter([
             PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
         ]) : [],
+
+        'timezone' => config('app.timezone'),
     ],
 
 Note that three keys have been added to the configuration array: `read`, `write` and `sticky`. The `read` and `write` keys have array values containing a single key: `host`. The rest of the database options for the `read` and `write` connections will be merged from the main `mysql` configuration array.


### PR DESCRIPTION
\Illuminate\Database\Connectors\PostgresConnector::class
```
protected function configureTimezone($connection, array $config)
{
    if (isset($config['timezone'])) {
        $timezone = $config['timezone'];

        $connection->prepare("set time zone '{$timezone}'")->execute();
    }
}
```

If the timezone key does not exist in config/database.php for your database (PostgreSQL in my case), then $config['timezone'] will be null. As a result, the database server will use its default timezone instead of the application's timezone (i.e., the value set in config('app.timezone')). 
The existence of the config('database.dbname.timezone') key is not documented anywhere, and its impact went unnoticed until the upgrade to version 11. However, it has a significant effect: if it is not specified, timestamps in the database may become incorrect.

