### PR TITLE
Document `withAttributes`

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -829,10 +829,10 @@ You can also filter the results returned by `belongsToMany` relationship queries
                     ->as('subscriptions')
                     ->wherePivotNotNull('expired_at');
 
-Note that `wherePivot` adds a constraint for querying but does not add the specified value when creating new models via the defined relationship. If you need to both query and create relationships with a "scoped" pivot, you may use the `withPivotValue` method:
+The `wherePivot` adds a where clause constraint to the query, but does not add the specified value when creating new models via the defined relationship. If you need to both query and create relationships with a particular pivot value, you may use the `withPivotValue` method:
 
     return $this->belongsToMany(Role::class)
-                ->withPivotValue('approved', 1);
+            ->withPivotValue('approved', 1);
 
 <a name="ordering-queries-via-intermediate-table-columns"></a>
 ### Ordering Queries via Intermediate Table Columns

--- a/eloquent.md
+++ b/eloquent.md
@@ -32,6 +32,7 @@
 - [Query Scopes](#query-scopes)
     - [Global Scopes](#global-scopes)
     - [Local Scopes](#local-scopes)
+    - [Pending Attributes](#pending-attributes)
 - [Comparing Models](#comparing-models)
 - [Events](#events)
     - [Using Closures](#events-using-closures)
@@ -1389,6 +1390,38 @@ Sometimes you may wish to define a scope that accepts parameters. To get started
 Once the expected arguments have been added to your scope method's signature, you may pass the arguments when calling the scope:
 
     $users = User::ofType('admin')->get();
+
+<a name="pending-attributes"></a>
+### Pending attributes
+
+If you want to utilize the scopes to create models in the "same scope", you should use the `withAttributes` method.
+
+    <?php
+
+    namespace App\Models;
+
+    use Illuminate\Database\Eloquent\Builder;
+    use Illuminate\Database\Eloquent\Model;
+
+    class Post extends Model
+    {
+        public function scopeDraft(Builder $query): void
+        {
+            $query->withAttributes([
+                'hidden' => true,
+            ]);
+        }
+    }
+
+It will add the specified attributes to newly created models:
+
+    // Create a post with `hidden` set to `true`
+    $draft = Post::draft()->create(['title' => 'WIP article']);
+
+The `withAttributes` method also adds the specified attributes as constraints. This allows to use the same scope for querying without any additional `where` calls.
+
+    // Retrieve the "hidden" posts
+    $drafts = Post::draft()->get();
 
 <a name="comparing-models"></a>
 ## Comparing Models

--- a/eloquent.md
+++ b/eloquent.md
@@ -1392,9 +1392,9 @@ Once the expected arguments have been added to your scope method's signature, yo
     $users = User::ofType('admin')->get();
 
 <a name="pending-attributes"></a>
-### Pending attributes
+### Pending Attributes
 
-If you want to utilize the scopes to create models in the "same scope", you should use the `withAttributes` method.
+If you would like to use scopes to create models that have the same attributes as those used to constrain the scope, you may use the `withAttributes` method when building the scope query:
 
     <?php
 
@@ -1405,6 +1405,9 @@ If you want to utilize the scopes to create models in the "same scope", you shou
 
     class Post extends Model
     {
+        /**
+         * Scope the query to only include drafts.
+         */
         public function scopeDraft(Builder $query): void
         {
             $query->withAttributes([
@@ -1413,15 +1416,11 @@ If you want to utilize the scopes to create models in the "same scope", you shou
         }
     }
 
-It will add the specified attributes to newly created models:
+The `withAttributes` method will add `where` clause constraints to the query using the given attributes, and it will also add the given attributes to any models created via the scope:
 
-    // Create a post with `hidden` set to `true`
-    $draft = Post::draft()->create(['title' => 'WIP article']);
+    $draft = Post::draft()->create(['title' => 'In Progress']);
 
-The `withAttributes` method also adds the specified attributes as constraints. This allows to use the same scope for querying without any additional `where` calls.
-
-    // Retrieve the "hidden" posts
-    $drafts = Post::draft()->get();
+    $draft->hidden; // true
 
 <a name="comparing-models"></a>
 ## Comparing Models


### PR DESCRIPTION
An attempt to document the feature added in laravel/framework#53720. I wrote everything that felt like it might be useful. And tried to put it in places where a reader might look exactly when this could be useful for them.  Some of my reasoning below.

The initial description of `withAttributes` is in the scopes' section of `eloquent.md` because IMO that's where the simplest use of this feature makes sense.

The feature feels most useful inside relationships so I mentioned it in that doc as well. But I added a broader section introducing the various options of "scoping" relationships. I suspect this might be useful as I've seen many new devs viewing the relationship methods as some special syntax that may only include the `$this->relationshipMethod(RelatedModel::class);` and nothing else.

I added that section at the end of the first batch of relationship methods as that's where the reader seems familiar enough with relationships themselves. In the next section (many to many) I added a note about `withPivotValue` while referring to the same concept of being "scoped" that was introduced earlier.

...or maybe these are constrained relationships, not scoped ones?