### PR TITLE
Update mail.md

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -59,9 +59,9 @@ To use the Mailgun driver, install Symfony's Mailgun Mailer transport via Compos
 composer require symfony/mailgun-mailer symfony/http-client
 ```
 
-Make two changes in your application's `config/mail.php` configuration file.  First, change default MAIL_MAILER default value to `mailgun` 
+Next, you will need to make two changes in your application's `config/mail.php` configuration file. First, set your default mailer to `mailgun`:
 
-    'default' => (env('MAIL_MAILER', 'mailgun'),
+    'default' => env('MAIL_MAILER', 'mailgun'),
 
 Second, add the following configuration array to your array of `mailers`:
 

--- a/mail.md
+++ b/mail.md
@@ -59,7 +59,11 @@ To use the Mailgun driver, install Symfony's Mailgun Mailer transport via Compos
 composer require symfony/mailgun-mailer symfony/http-client
 ```
 
-Next, set the `default` option in your application's `config/mail.php` configuration file to `mailgun` and add the following configuration array to your array of `mailers`:
+Make two changes in your application's `config/mail.php` configuration file.  First, change default MAIL_MAILER default value to `mailgun` 
+
+    'default' => (env('MAIL_MAILER', 'mailgun'),
+
+Second, add the following configuration array to your array of `mailers`:
 
     'mailgun' => [
         'transport' => 'mailgun',


### PR DESCRIPTION
To send email with Mailgun (and any external mail service, probably) and Laravel, there are three changes to config files that have to be made.  Two of them had code examples in the documentation.  The third one did not.  Currently, it is just written with words as "change the default value..." but the fact that the item in the array is named "default" and value in the key/value pair is "default" leads to ambiguity.

After reading Laraval mail's documentation, doing a lot of set up and configuring, and programming a controller and mailable, I experienced hours of stress and frustration because the emails weren't being sent.  All of the Mailgun env and config vars seemed to be good.  This was the problem.

Please accept this mail documentation change.  The one-line code example is important in getting mail to work