### PR TITLE
[11.x] Add documentation for Context::missing()

### DIFF
--- a/context.md
+++ b/context.md
@@ -269,6 +269,14 @@ Context::has('key');
 // true
 ```
 
+To determine if a key is not present in the context, you may use the `missing` method. The missing method returns true if the key has not been added to the context:
+
+```php
+if (Context::missing('key')) {
+    // ...
+}
+```
+
 <a name="removing-context"></a>
 ## Removing Context
 


### PR DESCRIPTION
This PR introduces some new documentation for `Context::missing` which has been added to the framework in this PR: https://github.com/laravel/framework/pull/54499