### PR TITLE
[11.x] Note about bathes ignore job's connection and queue

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1376,7 +1376,7 @@ Some tools such as Laravel Horizon and Laravel Telescope may provide more user-f
 <a name="batch-connection-queue"></a>
 #### Batch Connection and Queue
 
-If you would like to specify the connection and queue that should be used for the batched jobs, you may use the `onConnection` and `onQueue` methods. All batched jobs must execute within the same connection and queue:
+Unlike [chains](#chain-connection-and-queue), batches ignore queue and connection explicitly assigned to jobs. If you would like to specify the connection and queue that should be used for the batched jobs, you may use the `onConnection` and `onQueue` methods. All batched jobs must execute within the same connection and queue:
 
     $batch = Bus::batch([
         // ...


### PR DESCRIPTION
Some discussion here https://github.com/laravel/framework/issues/54286 , some code example (combined from examples from docs) here https://github.com/vadimonus/laravel-batch-bug-report/commit/3c60ccec80c74375dcafe99f15f0b3fd5fa71808

Currently documentation only says, `All batched jobs must execute within the same connection and queue`. But having all jobs have same queue and connection explicitely set with onQueue / onConnection , they're pushed to default queue/connection. And this behaviour is not same as for Bus::chain, while other syntax is mostly the same, leading to mistakes.

This PR clarifies this behaviour.