### PR TITLE
Clarify install process for Sanctum

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -54,7 +54,13 @@ Sanctum will only attempt to authenticate using cookies when the incoming reques
 <a name="installation"></a>
 ## Installation
 
-You may install Laravel Sanctum via the `install:api` Artisan command:
+You may install Laravel Sanctum via composer:
+
+```
+composer require laravel/sanctum
+```
+
+and then activate it using the `install:api` Artisan command:
 
 ```shell
 php artisan install:api


### PR DESCRIPTION
Documentation is missing a step when it says to use sanctum:install when it needs to be installed through composer first