### PR TITLE
[11.x] reference `url` config variable instead of `timezone`

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -116,7 +116,7 @@ Once you have started the development server, your application will be accessibl
 
 All of the configuration files for the Laravel framework are stored in the `config` directory. Each option is documented, so feel free to look through the files and get familiar with the options available to you.
 
-Laravel needs almost no additional configuration out of the box. You are free to get started developing! However, you may wish to review the `config/app.php` file and its documentation. It contains several options such as `timezone` and `locale` that you may wish to change according to your application.
+Laravel needs almost no additional configuration out of the box. You are free to get started developing! However, you may wish to review the `config/app.php` file and its documentation. It contains several options such as `url` and `locale` that you may wish to change according to your application.
 
 <a name="environment-based-configuration"></a>
 ### Environment Based Configuration


### PR DESCRIPTION
further discourage changing the timezone from the default "UTC" value.

for the uninformed, the previous wording might seem to suggest changing the timezone based on your application is common and/or recommended practice.