### PR TITLE
Docs: Add documentation for `unique()->withoutTrashed()` method

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -2015,6 +2015,18 @@ By default, the `unique` rule will check the uniqueness of the column matching t
 
     Rule::unique('users', 'email_address')->ignore($user->id)
 
+**Ignoring Soft Deleted Records in Unique Checks:**
+
+By default, the unique rule includes soft deleted records in its uniqueness check.  To explicitly ensure soft deleted records are excluded from the uniqueness check (effectively making the rule ignore soft-deleted records), you can use the withoutTrashed method:
+
+    Rule::unique('users')->withoutTrashed();
+
+If your model uses a column name other than deleted_at for soft deletes, you can specify the column name as the $deletedAtColumn parameter in withoutTrashed():
+
+    Rule::unique('users')->withoutTrashed('custom_deleted_column');
+
+This allows you to use withoutTrashed with models that have a custom soft delete column name. If no parameter is provided, deleted_at is used as the default.
+
 **Adding Additional Where Clauses:**
 
 You may specify additional query conditions by customizing the query using the `where` method. For example, let's add a query condition that scopes the query to only search records that have an `account_id` column value of `1`:


### PR DESCRIPTION
This pull request adds documentation to the `validation.md` file to explain the usage of the `withoutTrashed()` method when using `Rule::unique()` in Laravel validation rules.✅

Currently, the documentation lacks a clear explanation of how to exclude soft-deleted records when performing uniqueness checks. This can lead to confusion for developers who are using soft deletes in their applications and need to ensure uniqueness only among non-deleted records.

This PR addresses this gap by:

- Explaining the default behavior of the `unique` rule in relation to soft-deleted records (it includes them).
- Clearly demonstrating how to use `withoutTrashed()` to explicitly exclude soft-deleted records from uniqueness validation.

