### PR TITLE
[11.x] standardize multiline ternary alignment

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -168,8 +168,8 @@ So far, we have only examined gates that return simple boolean values. However, 
 
     Gate::define('edit-settings', function (User $user) {
         return $user->isAdmin
-                    ? Response::allow()
-                    : Response::deny('You must be an administrator.');
+            ? Response::allow()
+            : Response::deny('You must be an administrator.');
     });
 
 Even when you return an authorization response from your gate, the `Gate::allows` method will still return a simple boolean value; however, you may use the `Gate::inspect` method to get the full authorization response returned by the gate:
@@ -199,8 +199,8 @@ When an action is denied via a Gate, a `403` HTTP response is returned; however,
 
     Gate::define('edit-settings', function (User $user) {
         return $user->isAdmin
-                    ? Response::allow()
-                    : Response::denyWithStatus(404);
+            ? Response::allow()
+            : Response::denyWithStatus(404);
     });
 
 Because hiding resources via a `404` response is such a common pattern for web applications, the `denyAsNotFound` method is offered for convenience:
@@ -211,8 +211,8 @@ Because hiding resources via a `404` response is such a common pattern for web a
 
     Gate::define('edit-settings', function (User $user) {
         return $user->isAdmin
-                    ? Response::allow()
-                    : Response::denyAsNotFound();
+            ? Response::allow()
+            : Response::denyAsNotFound();
     });
 
 <a name="intercepting-gate-checks"></a>
@@ -362,8 +362,8 @@ So far, we have only examined policy methods that return simple boolean values. 
     public function update(User $user, Post $post): Response
     {
         return $user->id === $post->user_id
-                    ? Response::allow()
-                    : Response::deny('You do not own this post.');
+            ? Response::allow()
+            : Response::deny('You do not own this post.');
     }
 
 When returning an authorization response from your policy, the `Gate::allows` method will still return a simple boolean value; however, you may use the `Gate::inspect` method to get the full authorization response returned by the gate:
@@ -399,8 +399,8 @@ When an action is denied via a policy method, a `403` HTTP response is returned;
     public function update(User $user, Post $post): Response
     {
         return $user->id === $post->user_id
-                    ? Response::allow()
-                    : Response::denyWithStatus(404);
+            ? Response::allow()
+            : Response::denyWithStatus(404);
     }
 
 Because hiding resources via a `404` response is such a common pattern for web applications, the `denyAsNotFound` method is offered for convenience:
@@ -415,8 +415,8 @@ Because hiding resources via a `404` response is such a common pattern for web a
     public function update(User $user, Post $post): Response
     {
         return $user->id === $post->user_id
-                    ? Response::allow()
-                    : Response::denyAsNotFound();
+            ? Response::allow()
+            : Response::denyAsNotFound();
     }
 
 <a name="methods-without-models"></a>

--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -727,8 +727,8 @@ A classic example of an inbound only cast is a "hashing" cast. For example, we m
         public function set(Model $model, string $key, mixed $value, array $attributes): string
         {
             return is_null($this->algorithm)
-                        ? bcrypt($value)
-                        : hash($this->algorithm, $value);
+                ? bcrypt($value)
+                : hash($this->algorithm, $value);
         }
     }
 

--- a/notifications.md
+++ b/notifications.md
@@ -681,8 +681,8 @@ If you are sending an [on-demand notification](#on-demand-notifications), the `$
     public function toMail(object $notifiable): Mailable
     {
         $address = $notifiable instanceof AnonymousNotifiable
-                ? $notifiable->routeNotificationFor('mail')
-                : $notifiable->email;
+            ? $notifiable->routeNotificationFor('mail')
+            : $notifiable->email;
 
         return (new InvoicePaidMailable($this->invoice))
                     ->to($address);

--- a/passwords.md
+++ b/passwords.md
@@ -74,8 +74,8 @@ Next, we will define a route that handles the form submission request from the "
         );
 
         return $status === Password::ResetLinkSent
-                    ? back()->with(['status' => __($status)])
-                    : back()->withErrors(['email' => __($status)]);
+            ? back()->with(['status' => __($status)])
+            : back()->withErrors(['email' => __($status)]);
     })->middleware('guest')->name('password.email');
 
 Before moving on, let's examine this route in more detail. First, the request's `email` attribute is validated. Next, we will use Laravel's built-in "password broker" (via the `Password` facade) to send a password reset link to the user. The password broker will take care of retrieving the user by the given field (in this case, the email address) and sending the user a password reset link via Laravel's built-in [notification system](/docs/{{version}}/notifications).
@@ -137,8 +137,8 @@ Of course, we need to define a route to actually handle the password reset form 
         );
 
         return $status === Password::PasswordReset
-                    ? redirect()->route('login')->with('status', __($status))
-                    : back()->withErrors(['email' => [__($status)]]);
+            ? redirect()->route('login')->with('status', __($status))
+            : back()->withErrors(['email' => [__($status)]]);
     })->middleware('guest')->name('password.update');
 
 Before moving on, let's examine this route in more detail. First, the request's `token`, `email`, and `password` attributes are validated. Next, we will use Laravel's built-in "password broker" (via the `Password` facade) to validate the password reset request credentials.

--- a/pennant.md
+++ b/pennant.md
@@ -199,8 +199,8 @@ class PodcastController
     public function index(Request $request): Response
     {
         return Feature::active('new-api')
-                ? $this->resolveNewApiResponse($request)
-                : $this->resolveLegacyApiResponse($request);
+            ? $this->resolveNewApiResponse($request)
+            : $this->resolveLegacyApiResponse($request);
     }
 
     // ...
@@ -211,8 +211,8 @@ Although features are checked against the currently authenticated user by defaul
 
 ```php
 return Feature::for($user)->active('new-api')
-        ? $this->resolveNewApiResponse($request)
-        : $this->resolveLegacyApiResponse($request);
+    ? $this->resolveNewApiResponse($request)
+    : $this->resolveLegacyApiResponse($request);
 ```
 
 Pennant also offers some additional convenience methods that may prove useful when determining if a feature is active or not:
@@ -260,8 +260,8 @@ class PodcastController
     public function index(Request $request): Response
     {
         return Feature::active(NewApi::class)
-                ? $this->resolveNewApiResponse($request)
-                : $this->resolveLegacyApiResponse($request);
+            ? $this->resolveNewApiResponse($request)
+            : $this->resolveLegacyApiResponse($request);
     }
 
     // ...
@@ -509,8 +509,8 @@ As discussed, features are typically checked against the currently authenticated
 
 ```php
 return Feature::for($user)->active('new-api')
-        ? $this->resolveNewApiResponse($request)
-        : $this->resolveLegacyApiResponse($request);
+    ? $this->resolveNewApiResponse($request)
+    : $this->resolveLegacyApiResponse($request);
 ```
 
 Of course, feature scopes are not limited to "users". Imagine you have built a new billing experience that you are rolling out to entire teams rather than individual users. Perhaps you would like the oldest teams to have a slower rollout than the newer teams. Your feature resolution closure might look something like the following:

--- a/queues.md
+++ b/queues.md
@@ -464,8 +464,8 @@ For example, you may wish to allow users to backup their data once per hour whil
     {
         RateLimiter::for('backups', function (object $job) {
             return $job->user->vipCustomer()
-                        ? Limit::none()
-                        : Limit::perHour(1)->by($job->user->id);
+                ? Limit::none()
+                : Limit::perHour(1)->by($job->user->id);
         });
     }
 

--- a/routing.md
+++ b/routing.md
@@ -791,8 +791,8 @@ Since rate limiter callbacks receive the incoming HTTP request instance, you may
 
     RateLimiter::for('uploads', function (Request $request) {
         return $request->user()->vipCustomer()
-                    ? Limit::none()
-                    : Limit::perMinute(100);
+            ? Limit::none()
+            : Limit::perMinute(100);
     });
 
 <a name="segmenting-rate-limits"></a>
@@ -802,16 +802,16 @@ Sometimes you may wish to segment rate limits by some arbitrary value. For examp
 
     RateLimiter::for('uploads', function (Request $request) {
         return $request->user()->vipCustomer()
-                    ? Limit::none()
-                    : Limit::perMinute(100)->by($request->ip());
+            ? Limit::none()
+            : Limit::perMinute(100)->by($request->ip());
     });
 
 To illustrate this feature using another example, we can limit access to the route to 100 times per minute per authenticated user ID or 10 times per minute per IP address for guests:
 
     RateLimiter::for('uploads', function (Request $request) {
         return $request->user()
-                    ? Limit::perMinute(100)->by($request->user()->id)
-                    : Limit::perMinute(10)->by($request->ip());
+            ? Limit::perMinute(100)->by($request->user()->id)
+            : Limit::perMinute(10)->by($request->ip());
     });
 
 <a name="multiple-rate-limits"></a>

--- a/telescope.md
+++ b/telescope.md
@@ -246,8 +246,8 @@ Telescope allows you to search entries by "tag". Often, tags are Eloquent model 
 
         Telescope::tag(function (IncomingEntry $entry) {
             return $entry->type === 'request'
-                        ? ['status:'.$entry->content['response_status']]
-                        : [];
+                ? ['status:'.$entry->content['response_status']]
+                : [];
         });
      }
 

--- a/validation.md
+++ b/validation.md
@@ -2389,8 +2389,8 @@ public function boot(): void
         $rule = Password::min(8);
 
         return $this->app->isProduction()
-                    ? $rule->mixedCase()->uncompromised()
-                    : $rule;
+            ? $rule->mixedCase()->uncompromised()
+            : $rule;
     });
 }
 ```


### PR DESCRIPTION
use a single indent for multiline ternary statements. this is better than alignment with an arbitrary pattern in the first line because it doesn't need to be shifted as adjustments are made to the code.

along with #10166