### PR TITLE
[11.x] Improve flashed session data docs with @session directive

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -231,11 +231,11 @@ Redirecting to a new URL and [flashing data to the session](/docs/{{version}}/se
 
 After the user is redirected, you may display the flashed message from the [session](/docs/{{version}}/session). For example, using [Blade syntax](/docs/{{version}}/blade):
 
-    @if (session('status'))
+    @session('status')
         <div class="alert alert-success">
-            {{ session('status') }}
+            {{ $value }}
         </div>
-    @endif
+    @endsession
 
 <a name="redirecting-with-input"></a>
 #### Redirecting With Input


### PR DESCRIPTION
Hi!

Since Laravel 10, we have a new blade directive called @session. This directive allows us to replace `@if(session('some_value'))` with `@session('some_value')`, making the code cleaner and more up-to-date.

Would it be possible to update the documentation to reflect this?

Thanks!