### PR TITLE
[12.x] standardize `bash` vs `shell` code fence language

### DIFF
--- a/concurrency.md
+++ b/concurrency.md
@@ -44,7 +44,7 @@ The `Concurrency` facade supports three drivers: `process` (the default), `fork`
 
 The `fork` driver offers improved performance compared to the default `process` driver, but it may only be used within PHP's CLI context, as PHP does not support forking during web requests. Before using the `fork` driver, you need to install the `spatie/fork` package:
 
-```bash
+```shell
 composer require spatie/fork
 ```
 
@@ -73,7 +73,7 @@ $results = Concurrency::driver('fork')->run(...);
 
 Or, to change the default concurrency driver, you should publish the `concurrency` configuration file via the `config:publish` Artisan command and update the `default` option within the file:
 
-```bash
+```shell
 php artisan config:publish concurrency
 ```
 

--- a/folio.md
+++ b/folio.md
@@ -33,13 +33,13 @@ For example, to create a page that is accessible at the `/greeting` URL, just cr
 
 To get started, install Folio into your project using the Composer package manager:
 
-```bash
+```shell
 composer require laravel/folio
 ```
 
 After installing Folio, you may execute the `folio:install` Artisan command, which will install Folio's service provider into your application. This service provider registers the directory where Folio will search for routes / pages:
 
-```bash
+```shell
 php artisan folio:install
 ```
 
@@ -99,7 +99,7 @@ Once a Blade template has been placed in a Folio mounted directory, you may imme
 
 To quickly view a list of all of your Folio pages / routes, you may invoke the `folio:list` Artisan command:
 
-```bash
+```shell
 php artisan folio:list
 ```
 
@@ -108,7 +108,7 @@ php artisan folio:list
 
 You may create a nested route by creating one or more directories within one of Folio's directories. For instance, to create a page that is accessible via `/user/profile`, create a `profile.blade.php` template within the `pages/user` directory:
 
-```bash
+```shell
 php artisan folio:page user/profile
 
 # pages/user/profile.blade.php → /user/profile
@@ -119,7 +119,7 @@ php artisan folio:page user/profile
 
 Sometimes, you may wish to make a given page the "index" of a directory. By placing an `index.blade.php` template within a Folio directory, any requests to the root of that directory will be routed to that page:
 
-```bash
+```shell
 php artisan folio:page index
 # pages/index.blade.php → /
 
@@ -132,7 +132,7 @@ php artisan folio:page users/index
 
 Often, you will need to have segments of the incoming request's URL injected into your page so that you can interact with them. For example, you may need to access the "ID" of the user whose profile is being displayed. To accomplish this, you may encapsulate a segment of the page's filename in square brackets:
 
-```bash
+```shell
 php artisan folio:page "users/[id]"
 
 # pages/users/[id].blade.php → /users/1
@@ -148,7 +148,7 @@ Captured segments can be accessed as variables within your Blade template:
 
 To capture multiple segments, you can prefix the encapsulated segment with three dots `...`:
 
-```bash
+```shell
 php artisan folio:page "users/[...ids]"
 
 # pages/users/[...ids].blade.php → /users/1/2/3
@@ -169,7 +169,7 @@ When capturing multiple segments, the captured segments will be injected into th
 
 If a wildcard segment of your page template's filename corresponds one of your application's Eloquent models, Folio will automatically take advantage of Laravel's route model binding capabilities and attempt to inject the resolved model instance into your page:
 
-```bash
+```shell
 php artisan folio:page "users/[User]"
 
 # pages/users/[User].blade.php → /users/1
@@ -193,7 +193,7 @@ On Windows, you should use `-` to separate the model name from the key: `[Post-s
 
 By default, Folio will search for your model within your application's `app/Models` directory. However, if needed, you may specify the fully-qualified model class name in your template's filename:
 
-```bash
+```shell
 php artisan folio:page "users/[.App.Models.User]"
 
 # pages/users/[.App.Models.User].blade.php → /users/1

--- a/hashing.md
+++ b/hashing.md
@@ -22,7 +22,7 @@ By default, Laravel uses the `bcrypt` hashing driver when hashing data. However,
 
 You may specify your application's hashing driver using the `HASH_DRIVER` environment variable. But, if you want to customize all of Laravel's hashing driver options, you should publish the complete `hashing` configuration file using the `config:publish` Artisan command:
 
-```bash
+```shell
 php artisan config:publish hashing
 ```
 

--- a/logging.md
+++ b/logging.md
@@ -490,7 +490,7 @@ Laravel Pail is a package that allows you to easily dive into your Laravel appli
 
 To get started, install Pail into your project using the Composer package manager:
 
-```bash
+```shell
 composer require laravel/pail
 ```
 
@@ -499,19 +499,19 @@ composer require laravel/pail
 
 To start tailing logs, run the `pail` command:
 
-```bash
+```shell
 php artisan pail
 ```
 
 To increase the verbosity of the output and avoid truncation (…), use the `-v` option:
 
-```bash
+```shell
 php artisan pail -v
 ```
 
 For maximum verbosity and to display exception stack traces, use the `-vv` option:
 
-```bash
+```shell
 php artisan pail -vv
 ```
 
@@ -525,7 +525,7 @@ To stop tailing logs, press `Ctrl+C` at any time.
 
 You may use the `--filter` option to filter logs by their type, file, message, and stack trace content:
 
-```bash
+```shell
 php artisan pail --filter="QueryException"
 ```
 
@@ -534,7 +534,7 @@ php artisan pail --filter="QueryException"
 
 To filter logs by only their message, you may use the `--message` option:
 
-```bash
+```shell
 php artisan pail --message="User created"
 ```
 
@@ -543,7 +543,7 @@ php artisan pail --message="User created"
 
 The `--level` option may be used to filter logs by their [log level](#log-levels):
 
-```bash
+```shell
 php artisan pail --level=error
 ```
 
@@ -552,6 +552,6 @@ php artisan pail --level=error
 
 To only display logs that were written while a given user was authenticated, you may provide the user's ID to the `--user` option:
 
-```bash
+```shell
 php artisan pail --user=1
 ```

--- a/sanctum.md
+++ b/sanctum.md
@@ -275,7 +275,7 @@ If you are having trouble authenticating with your application from an SPA that 
 
 The `config/cors.php` configuration file is not published by default. If you need to customize Laravel's CORS options, you should publish the complete `cors` configuration file using the `config:publish` Artisan command:
 
-```bash
+```shell
 php artisan config:publish cors
 ```
 

--- a/scheduling.md
+++ b/scheduling.md
@@ -54,7 +54,7 @@ If you prefer to reserve your `routes/console.php` file for command definitions 
 
 If you would like to view an overview of your scheduled tasks and the next time they are scheduled to run, you may use the `schedule:list` Artisan command:
 
-```bash
+```shell
 php artisan schedule:list
 ```
 


### PR DESCRIPTION
both `bash` and `shell` are used interchangably for the code blocks they surround, so we'll standardize to the more common `shell` option.