### PR TITLE
[12.x] standardize `shell` and `sh` code block languages

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -93,13 +93,13 @@ Before broadcasting any events, you should first configure and run a [queue work
 
 When running the `install:broadcasting` command, you will be prompted to install [Laravel Reverb](/docs/{{version}}/reverb). Of course, you may also install Reverb manually using the Composer package manager.
 
-```sh
+```shell
 composer require laravel/reverb
 ```
 
 Once the package is installed, you may run Reverb's installation command to publish the configuration, add Reverb's required environment variables, and enable event broadcasting in your application:
 
-```sh
+```shell
 php artisan reverb:install
 ```
 

--- a/pennant.md
+++ b/pennant.md
@@ -894,7 +894,7 @@ Feature::purge();
 
 As it can be useful to purge features as part of your application's deployment pipeline, Pennant includes a `pennant:purge` Artisan command which will purge the provided features from storage:
 
-```sh
+```shell
 php artisan pennant:purge new-api
 
 php artisan pennant:purge new-api purchase-button
@@ -902,13 +902,13 @@ php artisan pennant:purge new-api purchase-button
 
 It is also possible to purge all features _except_ those in a given feature list. For example, imagine you wanted to purge all features but keep the values for the "new-api" and "purchase-button" features in storage. To accomplish this, you can pass those feature names to the `--except` option:
 
-```sh
+```shell
 php artisan pennant:purge --except=new-api --except=purchase-button
 ```
 
 For convenience, the `pennant:purge` command also supports an `--except-registered` flag. This flag indicates that all features except those explicitly registered in a service provider should be purged:
 
-```sh
+```shell
 php artisan pennant:purge --except-registered
 ```
 

--- a/pulse.md
+++ b/pulse.md
@@ -37,7 +37,7 @@ For in-depth debugging of individual events, check out [Laravel Telescope](/docs
 
 You may install Pulse using the Composer package manager:
 
-```sh
+```shell
 composer require laravel/pulse
 ```
 
@@ -63,7 +63,7 @@ Once Pulse's database migrations have been run, you may access the Pulse dashboa
 
 Many of Pulse's configuration options can be controlled using environment variables. To see the available options, register new recorders, or configure advanced options, you may publish the `config/pulse.php` configuration file:
 
-```sh
+```shell
 php artisan vendor:publish --tag=pulse-config
 ```
 
@@ -97,7 +97,7 @@ public function boot(): void
 
 The Pulse dashboard cards and layout may be configured by publishing the dashboard view. The dashboard view will be published to `resources/views/vendor/pulse/dashboard.blade.php`:
 
-```sh
+```shell
 php artisan vendor:publish --tag=pulse-dashboard
 ```
 
@@ -256,7 +256,7 @@ php artisan pulse:check
 
 As the `pulse:check` command is a long-lived process, it will not see changes to your codebase without being restarted. You should gracefully restart the command by calling the `pulse:restart` command during your application's deployment process:
 
-```sh
+```shell
 php artisan pulse:restart
 ```
 
@@ -497,7 +497,7 @@ php artisan pulse:work
 
 As the `pulse:work` command is a long-lived process, it will not see changes to your codebase without being restarted. You should gracefully restart the command by calling the `pulse:restart` command during your application's deployment process:
 
-```sh
+```shell
 php artisan pulse:restart
 ```
 

--- a/reverb.md
+++ b/reverb.md
@@ -91,7 +91,7 @@ In most cases, secure WebSocket connections are handled by the upstream web serv
 
 However, it can sometimes be useful, such as during local development, for the Reverb server to handle secure connections directly. If you are using [Laravel Herd's](https://herd.laravel.com) secure site feature or you are using [Laravel Valet](/docs/{{version}}/valet) and have run the [secure command](/docs/{{version}}/valet#securing-sites) against your application, you may use the Herd / Valet certificate generated for your site to secure your Reverb connections. To do so, set the `REVERB_HOST` environment variable to your site's hostname or explicitly pass the hostname option when starting the Reverb server:
 
-```sh
+```shell
 php artisan reverb:start --host="0.0.0.0" --port=8080 --hostname="laravel.test"
 ```
 
@@ -112,7 +112,7 @@ You may also manually choose a certificate by defining `tls` options in your app
 
 The Reverb server can be started using the `reverb:start` Artisan command:
 
-```sh
+```shell
 php artisan reverb:start
 ```
 
@@ -120,7 +120,7 @@ By default, the Reverb server will be started at `0.0.0.0:8080`, making it acces
 
 If you need to specify a custom host or port, you may do so via the `--host` and `--port` options when starting the server:
 
-```sh
+```shell
 php artisan reverb:start --host=127.0.0.1 --port=9000
 ```
 
@@ -141,7 +141,7 @@ REVERB_PORT=443
 
 To improve performance, Reverb does not output any debug information by default. If you would like to see the stream of data passing through your Reverb server, you may provide the `--debug` option to the `reverb:start` command:
 
-```sh
+```shell
 php artisan reverb:start --debug
 ```
 
@@ -152,7 +152,7 @@ Since Reverb is a long-running process, changes to your code will not be reflect
 
 The `reverb:restart` command ensures all connections are gracefully terminated before stopping the server. If you are running Reverb with a process manager such as Supervisor, the server will be automatically restarted by the process manager after all connections have been terminated:
 
-```sh
+```shell
 php artisan reverb:restart
 ```
 
@@ -210,7 +210,7 @@ Each WebSocket connection is held in memory until either the client or server di
 
 On a Unix based operating system, you may determine the allowed number of open files using the `ulimit` command:
 
-```sh
+```shell
 ulimit -n
 ```
 
@@ -229,7 +229,7 @@ Under the hood, Reverb uses a ReactPHP event loop to manage WebSocket connection
 
 Reverb will automatically switch to an `ext-uv` powered loop when available. This PHP extension is available for install via PECL:
 
-```sh
+```shell
 pecl install uv
 ```
 
@@ -284,7 +284,7 @@ The configuration above will allow up to 10,000 Nginx workers per process to be 
 
 Unix-based operating systems typically limit the number of ports which can be opened on the server. You may see the current allowed range via the following command:
 
- ```sh
+```shell
 cat /proc/sys/net/ipv4/ip_local_port_range
 # 32768	60999
 ```

--- a/vite.md
+++ b/vite.md
@@ -64,14 +64,14 @@ Have you started a new Laravel application using our Vite scaffolding but need t
 
 You must ensure that Node.js (16+) and NPM are installed before running Vite and the Laravel plugin:
 
-```sh
+```shell
 node -v
 npm -v
 ```
 
 You can easily install the latest version of Node and NPM using simple graphical installers from [the official Node website](https://nodejs.org/en/download/). Or, if you are using [Laravel Sail](https://laravel.com/docs/{{version}}/sail), you may invoke Node and NPM through Sail:
 
-```sh
+```shell
 ./vendor/bin/sail node -v
 ./vendor/bin/sail npm -v
 ```
@@ -81,7 +81,7 @@ You can easily install the latest version of Node and NPM using simple graphical
 
 Within a fresh installation of Laravel, you will find a `package.json` file in the root of your application's directory structure. The default `package.json` file already includes everything you need to get started using Vite and the Laravel plugin. You may install your application's frontend dependencies via NPM:
 
-```sh
+```shell
 npm install
 ```
 
@@ -310,7 +310,7 @@ export default defineConfig({
 
 If you would like to build your frontend using the [Vue](https://vuejs.org/) framework, then you will also need to install the `@vitejs/plugin-vue` plugin:
 
-```sh
+```shell
 npm install --save-dev @vitejs/plugin-vue
 ```
 
@@ -354,7 +354,7 @@ export default defineConfig({
 
 If you would like to build your frontend using the [React](https://reactjs.org/) framework, then you will also need to install the `@vitejs/plugin-react` plugin:
 
-```sh
+```shell
 npm install --save-dev @vitejs/plugin-react
 ```
 
@@ -747,14 +747,14 @@ To ensure you don't forget to rebuild the SSR entry point, we recommend augmenti
 
 Then, to build and start the SSR server, you may run the following commands:
 
-```sh
+```shell
 npm run build
 node bootstrap/ssr/ssr.js
 ```
 
 If you are using [SSR with Inertia](https://inertiajs.com/server-side-rendering), you may instead use the `inertia:start-ssr` Artisan command to start the SSR server:
 
-```sh
+```shell
 php artisan inertia:start-ssr
 ```
 


### PR DESCRIPTION
standardize the language to `shell`.

also, as far as I can tell, `sh` doesn't even technically exist in Torchlight.

https://torchlight.dev/docs/languages