### PR TITLE
[11.x] update docs to include `ddJson()` 

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -303,7 +303,7 @@ class ExampleTest extends TestCase
 }
 ```
 
-Alternatively, you may use the `dd`, `ddHeaders`, and `ddSession` methods to dump information about the response and then stop execution:
+Alternatively, you may use the `dd`, `ddHeaders`, `ddSession`, `ddJson` methods to dump information about the response and then stop execution:
 
 ```php tab=Pest
 <?php
@@ -314,6 +314,8 @@ test('basic test', function () {
     $response->ddHeaders();
 
     $response->ddSession();
+    
+    $response->ddJson();
 
     $response->dd();
 });

--- a/http-tests.md
+++ b/http-tests.md
@@ -303,7 +303,7 @@ class ExampleTest extends TestCase
 }
 ```
 
-Alternatively, you may use the `dd`, `ddHeaders`, `ddSession`, `ddJson` methods to dump information about the response and then stop execution:
+Alternatively, you may use the `dd`, `ddHeaders`, `ddSession`, and `ddJson` methods to dump information about the response and then stop execution:
 
 ```php tab=Pest
 <?php
@@ -312,11 +312,8 @@ test('basic test', function () {
     $response = $this->get('/');
 
     $response->ddHeaders();
-
     $response->ddSession();
-    
     $response->ddJson();
-
     $response->dd();
 });
 ```


### PR DESCRIPTION
This PR updates the docs to include the new `ddJson()` function.

[[11.x] new: ddJson method on TestResponse class](https://github.com/laravel/framework/pull/54673)