### PR TITLE
[11.x] Enhance eventStream to Support Custom Events and Start Messages

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -372,7 +372,8 @@ source.addEventListener('update', (event) => {
 });
 ```
 
-You may change the event name by passing the `as` parameter to the `eventStream` method:
+##### Customizing Event Names
+By default, the event name is `update`. You can change this by passing the `as` parameter to the `eventStream` method:
 
 ```php
 Route::get('/chat', function () {
@@ -386,7 +387,24 @@ Route::get('/chat', function () {
 });
 ```
 
-You can also change the start and end indicators using `startStreamWith`/`endStreamWith` parameters respectively or pass `null` to disable the indication as needed.
+##### Customizing Start and End Indicators
+
+You can customize these indicators using the `startStreamWith` and `endStreamWith` parameters or pass `null` to disable them entirely:
+
+```php
+use App\Models\User;
+
+Route::get('/users', function () {
+    return response()->eventStream(function () {
+        $users = User::all();
+
+        foreach ($users as $user) {
+            yield $user->toJson();
+            sleep(1);
+        }
+    }, startStreamWith: '[', endStreamWith: ']');
+});
+```
 
 <a name="streamed-downloads"></a>
 #### Streamed Downloads


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### **[11.x] Enhance `eventStream` to Support Custom Events and Start Messages**  

#### **Summary**
This PR enhances the `eventStream` method in `ResponseFactory` by allowing customization of:  

- **Event Name (`$as`)** – Previously hardcoded as `"update"`, now configurable.  
- **Start Stream Message (`$startStreamWith`)** – Optional message sent before streaming begins.  
- **End Stream Message (`$endStreamWith`)** – Now optional instead of required.  

#### **Why This Change?**

- **More Flexible SSE Handling**: Developers can now specify custom event names, making it easier to differentiate between different types of SSE messages and also they can now decide if they want start/end messages.
- **Improved Client Communication**: Some clients expect an initial message when connecting. The `$startStreamWith` parameter allows for this. 
- **Backward Compatible**: Defaults maintain previous behaviour, ensuring no breaking changes.  

#### **Implementation Details**

The method signature now includes:  

  ```php
  public function eventStream(
      Closure $callback, 
      array $headers = [], 
      string $as = 'update', 
      ?string $startStreamWith = '<stream>', 
      ?string $endStreamWith = '</stream>'
  )
```

PR: https://github.com/laravel/framework/pull/54695