### PR TITLE
Add what sync methods returned array look like

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -2173,6 +2173,18 @@ If you do not want to detach existing IDs that are missing from the given array,
 
     $user->roles()->syncWithoutDetaching([1, 2, 3]);
 
+These sync methods return an array containing which values gets attached, detached, and updated:
+
+    $user->roles()->sync[1 => ['expires' => true], 2]);
+
+    $changes = $user->roles()->sync([1 => ['expires' => false], 3]);
+
+    in_array(3, $changes['attached']); // true
+
+    in_array(2, $changes['detached']); // true
+
+    in_array(1, $changes['updated']); // true
+
 <a name="toggling-associations"></a>
 #### Toggling Associations
 

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -2175,7 +2175,7 @@ If you do not want to detach existing IDs that are missing from the given array,
 
 These sync methods return an array containing which values gets attached, detached, and updated:
 
-    $user->roles()->sync[1 => ['expires' => true], 2]);
+    $user->roles()->sync([1 => ['expires' => true], 2]);
 
     $changes = $user->roles()->sync([1 => ['expires' => false], 3]);
 


### PR DESCRIPTION
Knowing what this method returned, allowed me to do something like:

```php
['attached' => $attached] = $task->assignees()->sync($request->assignees);

if (count($attached) > 0) {
    User::query()
        ->whereIn('id', $attached)
        ->get()
        ->each(function (User $user) use ($task) {
            Mail::to($user)->send(new MailTaskAssigned($user, $task));
        });
}
```

Regarding the example:

I would follow the one-liner example like in `Arr::prepend` i.e:

```php
$array = Arr::prepend($array, 'zero');
 
// ['zero', 'one', 'two', 'three', 'four']
```

But the `detached` array sometimes does not start at index 0 i.e:

```php
[
    "attached" => [1, 4],
    "detached" => [
      1 => 5,
    ],
    "updated" => [2, 3],
]
```