### PR TITLE
[12.x] fix code fence language

### DIFF
--- a/context.md
+++ b/context.md
@@ -56,7 +56,7 @@ Log::info('User authenticated.', ['auth_id' => Auth::id()]);
 
 The written log will contain the `auth_id` passed to the log entry, but it will also contain the context's `url` and `trace_id` as metadata:
 
-```
+```text
 User authenticated. {"auth_id":27} {"url":"https://example.com/login","trace_id":"e04e1a11-e75c-4db3-b5b5-cfef4ef56697"}
 ```
 
@@ -96,7 +96,7 @@ class ProcessPodcast implements ShouldQueue
 
 The resulting log entry would contain the information that was added to the context during the request that originally dispatched the job:
 
-```
+```text
 Processing podcast. {"podcast_id":95} {"url":"https://example.com/login","trace_id":"e04e1a11-e75c-4db3-b5b5-cfef4ef56697"}
 ```
 

--- a/dusk.md
+++ b/dusk.md
@@ -234,8 +234,8 @@ By default, this trait will truncate all tables except the `migrations` table. I
  * @var array
  */
 protected $tablesToTruncate = ['users'];
-
 ```
+
 Alternatively, you may define an `$exceptTables` property on your test class to specify which tables should be excluded from truncation:
 
 ```php

--- a/filesystem.md
+++ b/filesystem.md
@@ -99,7 +99,7 @@ composer require league/flysystem-aws-s3-v3 "^3.0" --with-all-dependencies
 
 An S3 disk configuration array is located in your `config/filesystems.php` configuration file. Typically, you should configure your S3 information and credentials using the following environment variables which are referenced by the `config/filesystems.php` configuration file:
 
-```
+```ini
 AWS_ACCESS_KEY_ID=<your-key-id>
 AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
 AWS_DEFAULT_REGION=us-east-1

--- a/http-tests.md
+++ b/http-tests.md
@@ -514,7 +514,6 @@ test('asserting an exact json match', function () {
             'created' => true,
         ]);
 });
-
 ```
 
 ```php tab=PHPUnit

--- a/pennant.md
+++ b/pennant.md
@@ -1178,7 +1178,6 @@ public function boot(): void
 {
     Event::listen(UnexpectedNullScopeEncountered::class, fn () => abort(500));
 }
-
 ```
 
 ### `Laravel\Pennant\Events\FeatureUpdated`

--- a/pulse.md
+++ b/pulse.md
@@ -476,13 +476,13 @@ PULSE_DB_CONNECTION=pulse
 
 By default, Pulse will store entries directly to the [configured database connection](#using-a-different-database) after the HTTP response has been sent to the client or a job has been processed; however, you may use Pulse's Redis ingest driver to send entries to a Redis stream instead. This can be enabled by configuring the `PULSE_INGEST_DRIVER` environment variable:
 
-```
+```ini
 PULSE_INGEST_DRIVER=redis
 ```
 
 Pulse will use your default [Redis connection](/docs/{{version}}/redis#configuration) by default, but you may customize this via the `PULSE_REDIS_CONNECTION` environment variable:
 
-```
+```ini
 PULSE_REDIS_CONNECTION=pulse
 ```
 

--- a/redirects.md
+++ b/redirects.md
@@ -14,8 +14,8 @@ Redirect responses are instances of the `Illuminate\Http\RedirectResponse` class
 Route::get('/dashboard', function () {
     return redirect('/home/dashboard');
 });
-
 ```
+
 Sometimes you may wish to redirect the user to their previous location, such as when a submitted form is invalid. You may do so by using the global `back` helper function. Since this feature utilizes the [session](/docs/{{version}}/session), make sure the route calling the `back` function is using the `web` middleware group or has all of the session middleware applied:
 
 ```php

--- a/reverb.md
+++ b/reverb.md
@@ -29,7 +29,7 @@
 
 You may install Reverb using the `install:broadcasting` Artisan command:
 
-```
+```shell
 php artisan install:broadcasting
 ```
 


### PR DESCRIPTION
- use "ini" for `.env` examples
- use "text" for plain text blocks
- remove some empty line breaks at and inside the end of code blocks
- add some missing "php" and "shell" entries