### PR TITLE
[11.x] Enhance eventStream to Support Custom Events and Start Messages

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -351,7 +351,7 @@ Route::get('/chat', function () {
 });
 ```
 
-This event stream may be consumed via an [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) object by your application's frontend. The `eventStream` method will automatically send a `</stream>` update to the event stream when the stream is complete::
+This event stream may be consumed via an [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) object by your application's frontend. The `eventStream` method will automatically send a `</stream>` update to the event stream when the stream is complete:
 
 ```js
 const source = new EventSource('/chat');


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### **[11.x] Enhance `eventStream` to Support Custom Events and Start Messages**

#### **Summary**

⚠️ BREAKING CHANGE: This PR changes the `eventStream` method in `ResponseFactory` by allowing customization of:  

- **Event Name (`$as`)** – Previously hardcoded as `"update"`, now configurable and each message can also implement the `Illuminate\Contracts\Routing\EventStreamable` interface to customize the name using `streamAs` method.
- **Start Stream Message (`$startStreamWith`)** – Optional message sent before streaming begins.  
- **End Stream Message (`$endStreamWith`)** – Now optional instead of required.  

#### **Why This Change?**

- **More Flexible SSE Handling**: Developers can now specify custom event names, making it easier to differentiate between different types of SSE messages and also they can now decide if they want start/end messages.
- **Improved Client Communication**: Some clients expect an initial message when connecting. The `$startStreamWith` parameter allows for this. 


#### **Implementation Details**

The method signature now includes:  

  ```php
  public function eventStream(
      Closure $callback, 
      array $headers = [], 
      string $as = 'update', 
      ?string $startStreamWith = null, 
      ?string $endStreamWith = '</stream>'
  ) {}
```

This has also been updated to fix the issue raised in the last PR:

> Reverted this PR. The update "as" name should be customizable per update, not for the entire event stream.

I have added the following interface that each message can implement to override the function `$as` parameter.

```php
<?php

namespace Illuminate\Contracts\Routing;

interface EventStreamable
{
    /**
     * Get the name for event streams.
     *
     * @return string
     */
    public function streamAs();
}
```

Example:

```php
<?php

namespace App\Models;

use Illuminate\Database\Eloquent\Model;
use Illuminate\Contracts\Routing\EventStreamable;

class Notification extends Model implements EventStreamable
{
    public function streamAs()
    {
        return 'notification';
    }
}
```