### PR TITLE
[12.x] Add Code Fencing to the File Storage Documentation

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -310,13 +310,11 @@ When accessing this hidden route, you will then be redirected to the `/` route o
 
 By default, Laravel determines if your application is in maintenance mode using a file-based system. This means to activate maintenance mode, the `php artisan down` command has to be executed on each server hosting your application.
 
-Alternatively, Laravel offers a cache-based method for handling maintenance mode. This method requires running the `php artisan down` command on just one server. To use this approach, modify the "driver" setting in the `config/app.php` file of your application to `cache`. Then, select a cache `store` that is accessible by all your servers. This ensures the maintenance mode status is consistently maintained across every server:
+Alternatively, Laravel offers a cache-based method for handling maintenance mode. This method requires running the `php artisan down` command on just one server. To use this approach, modify the maintenance mode variables in your application's `.env` file. You should select a cache `store` that is accessible by all of your servers. This ensures the maintenance mode status is consistently maintained across every server:
 
-```php
-'maintenance' => [
-    'driver' => 'cache',
-    'store' => 'database',
-],
+```ini
+APP_MAINTENANCE_DRIVER=cache
+APP_MAINTENANCE_STORE=database
 ```
 
 <a name="pre-rendering-the-maintenance-mode-view"></a>

--- a/container.md
+++ b/container.md
@@ -312,34 +312,38 @@ Route::get('/user', function (#[CurrentUser] User $user) {
 
 You can create your own contextual attributes by implementing the `Illuminate\Contracts\Container\ContextualAttribute` contract. The container will call your attribute's `resolve` method, which should resolve the value that should be injected into the class utilizing the attribute. In the example below, we will re-implement Laravel's built-in `Config` attribute:
 
-    <?php
+```php
+<?php
 
-    namespace App\Attributes;
+namespace App\Attributes;
 
-    use Illuminate\Contracts\Container\ContextualAttribute;
+use Attribute;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
 
-    #[Attribute(Attribute::TARGET_PARAMETER)]
-    class Config implements ContextualAttribute
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Config implements ContextualAttribute
+{
+    /**
+     * Create a new attribute instance.
+     */
+    public function __construct(public string $key, public mixed $default = null)
     {
-        /**
-         * Create a new attribute instance.
-         */
-        public function __construct(public string $key, public mixed $default = null)
-        {
-        }
-
-        /**
-         * Resolve the configuration value.
-         *
-         * @param  self  $attribute
-         * @param  \Illuminate\Contracts\Container\Container  $container
-         * @return mixed
-         */
-        public static function resolve(self $attribute, Container $container)
-        {
-            return $container->make('config')->get($attribute->key, $attribute->default);
-        }
     }
+
+    /**
+     * Resolve the configuration value.
+     *
+     * @param  self  $attribute
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return mixed
+     */
+    public static function resolve(self $attribute, Container $container)
+    {
+        return $container->make('config')->get($attribute->key, $attribute->default);
+    }
+}
+```
 
 <a name="binding-primitives"></a>
 ### Binding Primitives

--- a/documentation.md
+++ b/documentation.md
@@ -106,4 +106,4 @@
     - [Socialite](/docs/{{version}}/socialite)
     - [Telescope](/docs/{{version}}/telescope)
     - [Valet](/docs/{{version}}/valet)
-- [API Documentation](/api/11.x)
+- [API Documentation](https://api.laravel.com/docs/11.x)

--- a/filesystem.md
+++ b/filesystem.md
@@ -114,6 +114,7 @@ composer require league/flysystem-ftp "^3.0"
 
 Laravel's Flysystem integrations work great with FTP; however, a sample configuration is not included with the framework's default `config/filesystems.php` configuration file. If you need to configure an FTP filesystem, you may use the configuration example below:
 
+```php
     'ftp' => [
         'driver' => 'ftp',
         'host' => env('FTP_HOST'),
@@ -127,6 +128,7 @@ Laravel's Flysystem integrations work great with FTP; however, a sample configur
         // 'ssl' => true,
         // 'timeout' => 30,
     ],
+```
 
 <a name="sftp-driver-configuration"></a>
 #### SFTP Driver Configuration
@@ -139,6 +141,7 @@ composer require league/flysystem-sftp-v3 "^3.0"
 
 Laravel's Flysystem integrations work great with SFTP; however, a sample configuration is not included with the framework's default `config/filesystems.php` configuration file. If you need to configure an SFTP filesystem, you may use the configuration example below:
 
+```php
     'sftp' => [
         'driver' => 'sftp',
         'host' => env('SFTP_HOST'),
@@ -164,7 +167,7 @@ Laravel's Flysystem integrations work great with SFTP; however, a sample configu
         // 'timeout' => 30,
         // 'useAgent' => true,
     ],
-
+```
 <a name="scoped-and-read-only-filesystems"></a>
 ### Scoped and Read-Only Filesystems
 
@@ -207,7 +210,9 @@ By default, your application's `filesystems` configuration file contains a disk 
 
 Typically, after updating the disk's credentials to match the credentials of the service you are planning to use, you only need to update the value of the `endpoint` configuration option. This option's value is typically defined via the `AWS_ENDPOINT` environment variable:
 
+```php
     'endpoint' => env('AWS_ENDPOINT', 'https://minio:9000'),
+```
 
 <a name="minio"></a>
 #### MinIO
@@ -226,13 +231,17 @@ AWS_URL=http://localhost:9000/local
 
 The `Storage` facade may be used to interact with any of your configured disks. For example, you may use the `put` method on the facade to store an avatar on the default disk. If you call methods on the `Storage` facade without first calling the `disk` method, the method will automatically be passed to the default disk:
 
+```php
     use Illuminate\Support\Facades\Storage;
 
     Storage::put('avatars/1', $content);
+```
 
 If your application interacts with multiple disks, you may use the `disk` method on the `Storage` facade to work with files on a particular disk:
 
+```php
     Storage::disk('s3')->put('avatars/1', $content);
+```
 
 <a name="on-demand-disks"></a>
 ### On-Demand Disks
@@ -255,41 +264,53 @@ $disk->put('image.jpg', $content);
 
 The `get` method may be used to retrieve the contents of a file. The raw string contents of the file will be returned by the method. Remember, all file paths should be specified relative to the disk's "root" location:
 
+```php
     $contents = Storage::get('file.jpg');
+```
 
 If the file you are retrieving contains JSON, you may use the `json` method to retrieve the file and decode its contents:
 
+```php
     $orders = Storage::json('orders.json');
+```
 
 The `exists` method may be used to determine if a file exists on the disk:
 
+```php
     if (Storage::disk('s3')->exists('file.jpg')) {
         // ...
     }
+```
 
 The `missing` method may be used to determine if a file is missing from the disk:
 
+```php
     if (Storage::disk('s3')->missing('file.jpg')) {
         // ...
     }
+```
 
 <a name="downloading-files"></a>
 ### Downloading Files
 
 The `download` method may be used to generate a response that forces the user's browser to download the file at the given path. The `download` method accepts a filename as the second argument to the method, which will determine the filename that is seen by the user downloading the file. Finally, you may pass an array of HTTP headers as the third argument to the method:
 
+```php
     return Storage::download('file.jpg');
 
     return Storage::download('file.jpg', $name, $headers);
+```
 
 <a name="file-urls"></a>
 ### File URLs
 
 You may use the `url` method to get the URL for a given file. If you are using the `local` driver, this will typically just prepend `/storage` to the given path and return a relative URL to the file. If you are using the `s3` driver, the fully qualified remote URL will be returned:
 
+```php
     use Illuminate\Support\Facades\Storage;
 
     $url = Storage::url('file.jpg');
+```
 
 When using the `local` driver, all files that should be publicly accessible should be placed in the `storage/app/public` directory. Furthermore, you should [create a symbolic link](#the-public-disk) at `public/storage` which points to the `storage/app/public` directory.
 
@@ -301,6 +322,7 @@ When using the `local` driver, all files that should be publicly accessible shou
 
 If you would like to modify the host for URLs generated using the `Storage` facade, you may add or change the `url` option in the disk's configuration array:
 
+```php
     'public' => [
         'driver' => 'local',
         'root' => storage_path('app/public'),
@@ -308,17 +330,20 @@ If you would like to modify the host for URLs generated using the `Storage` faca
         'visibility' => 'public',
         'throw' => false,
     ],
+```
 
 <a name="temporary-urls"></a>
 ### Temporary URLs
 
 Using the `temporaryUrl` method, you may create temporary URLs to files stored using the `local` and `s3` drivers. This method accepts a path and a `DateTime` instance specifying when the URL should expire:
 
+```php
     use Illuminate\Support\Facades\Storage;
 
     $url = Storage::temporaryUrl(
         'file.jpg', now()->addMinutes(5)
     );
+```
 
 <a name="enabling-local-temporary-urls"></a>
 #### Enabling Local Temporary URLs
@@ -339,6 +364,7 @@ If you started developing your application before support for temporary URLs was
 
 If you need to specify additional [S3 request parameters](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html#RESTObjectGET-requests), you may pass the array of request parameters as the third argument to the `temporaryUrl` method:
 
+```php
     $url = Storage::temporaryUrl(
         'file.jpg',
         now()->addMinutes(5),
@@ -347,12 +373,14 @@ If you need to specify additional [S3 request parameters](https://docs.aws.amazo
             'ResponseContentDisposition' => 'attachment; filename=file2.jpg',
         ]
     );
+```
 
 <a name="customizing-temporary-urls"></a>
 #### Customizing Temporary URLs
 
 If you need to customize how temporary URLs are created for a specific storage disk, you can use the `buildTemporaryUrlsUsing` method. For example, this can be useful if you have a controller that allows you to download files stored via a disk that doesn't typically support temporary URLs. Usually, this method should be called from the `boot` method of a service provider:
 
+```php
     <?php
 
     namespace App\Providers;
@@ -380,6 +408,7 @@ If you need to customize how temporary URLs are created for a specific storage d
             );
         }
     }
+```
 
 <a name="temporary-upload-urls"></a>
 #### Temporary Upload URLs
@@ -389,11 +418,13 @@ If you need to customize how temporary URLs are created for a specific storage d
 
 If you need to generate a temporary URL that can be used to upload a file directly from your client-side application, you may use the `temporaryUploadUrl` method. This method accepts a path and a `DateTime` instance specifying when the URL should expire. The `temporaryUploadUrl` method returns an associative array which may be destructured into the upload URL and the headers that should be included with the upload request:
 
+```php
     use Illuminate\Support\Facades\Storage;
 
     ['url' => $url, 'headers' => $headers] = Storage::temporaryUploadUrl(
         'file.jpg', now()->addMinutes(5)
     );
+```
 
 This method is primarily useful in serverless environments that require the client-side application to directly upload files to a cloud storage system such as Amazon S3.
 
@@ -402,78 +433,97 @@ This method is primarily useful in serverless environments that require the clie
 
 In addition to reading and writing files, Laravel can also provide information about the files themselves. For example, the `size` method may be used to get the size of a file in bytes:
 
+```php
     use Illuminate\Support\Facades\Storage;
 
     $size = Storage::size('file.jpg');
+```
 
 The `lastModified` method returns the UNIX timestamp of the last time the file was modified:
 
+```php
     $time = Storage::lastModified('file.jpg');
+```
 
 The MIME type of a given file may be obtained via the `mimeType` method:
 
+```php
     $mime = Storage::mimeType('file.jpg');
+```
 
 <a name="file-paths"></a>
 #### File Paths
 
 You may use the `path` method to get the path for a given file. If you are using the `local` driver, this will return the absolute path to the file. If you are using the `s3` driver, this method will return the relative path to the file in the S3 bucket:
 
+```php
     use Illuminate\Support\Facades\Storage;
 
     $path = Storage::path('file.jpg');
+```
 
 <a name="storing-files"></a>
 ## Storing Files
 
 The `put` method may be used to store file contents on a disk. You may also pass a PHP `resource` to the `put` method, which will use Flysystem's underlying stream support. Remember, all file paths should be specified relative to the "root" location configured for the disk:
 
+```php
     use Illuminate\Support\Facades\Storage;
 
     Storage::put('file.jpg', $contents);
 
     Storage::put('file.jpg', $resource);
+```
 
 <a name="failed-writes"></a>
 #### Failed Writes
 
 If the `put` method (or other "write" operations) is unable to write the file to disk, `false` will be returned:
 
+```php
     if (! Storage::put('file.jpg', $contents)) {
         // The file could not be written to disk...
     }
+```
 
 If you wish, you may define the `throw` option within your filesystem disk's configuration array. When this option is defined as `true`, "write" methods such as `put` will throw an instance of `League\Flysystem\UnableToWriteFile` when write operations fail:
 
+```php
     'public' => [
         'driver' => 'local',
         // ...
         'throw' => true,
     ],
+```
 
 <a name="prepending-appending-to-files"></a>
 ### Prepending and Appending To Files
 
 The `prepend` and `append` methods allow you to write to the beginning or end of a file:
 
+```php
     Storage::prepend('file.log', 'Prepended Text');
 
     Storage::append('file.log', 'Appended Text');
+```
 
 <a name="copying-moving-files"></a>
 ### Copying and Moving Files
 
 The `copy` method may be used to copy an existing file to a new location on the disk, while the `move` method may be used to rename or move an existing file to a new location:
 
+```php
     Storage::copy('old/file.jpg', 'new/file.jpg');
 
     Storage::move('old/file.jpg', 'new/file.jpg');
+```
 
 <a name="automatic-streaming"></a>
 ### Automatic Streaming
 
 Streaming files to storage offers significantly reduced memory usage. If you would like Laravel to automatically manage streaming a given file to your storage location, you may use the `putFile` or `putFileAs` method. This method accepts either an `Illuminate\Http\File` or `Illuminate\Http\UploadedFile` instance and will automatically stream the file to your desired location:
 
+```php
     use Illuminate\Http\File;
     use Illuminate\Support\Facades\Storage;
 
@@ -482,18 +532,22 @@ Streaming files to storage offers significantly reduced memory usage. If you wou
 
     // Manually specify a filename...
     $path = Storage::putFileAs('photos', new File('/path/to/photo'), 'photo.jpg');
+```
 
 There are a few important things to note about the `putFile` method. Note that we only specified a directory name and not a filename. By default, the `putFile` method will generate a unique ID to serve as the filename. The file's extension will be determined by examining the file's MIME type. The path to the file will be returned by the `putFile` method so you can store the path, including the generated filename, in your database.
 
 The `putFile` and `putFileAs` methods also accept an argument to specify the "visibility" of the stored file. This is particularly useful if you are storing the file on a cloud disk such as Amazon S3 and would like the file to be publicly accessible via generated URLs:
 
+```php
     Storage::putFile('photos', new File('/path/to/photo'), 'public');
+```
 
 <a name="file-uploads"></a>
 ### File Uploads
 
 In web applications, one of the most common use-cases for storing files is storing user uploaded files such as photos and documents. Laravel makes it very easy to store uploaded files using the `store` method on an uploaded file instance. Call the `store` method with the path at which you wish to store the uploaded file:
 
+```php
     <?php
 
     namespace App\Http\Controllers;
@@ -513,27 +567,34 @@ In web applications, one of the most common use-cases for storing files is stori
             return $path;
         }
     }
+```
 
 There are a few important things to note about this example. Note that we only specified a directory name, not a filename. By default, the `store` method will generate a unique ID to serve as the filename. The file's extension will be determined by examining the file's MIME type. The path to the file will be returned by the `store` method so you can store the path, including the generated filename, in your database.
 
 You may also call the `putFile` method on the `Storage` facade to perform the same file storage operation as the example above:
 
+```php
     $path = Storage::putFile('avatars', $request->file('avatar'));
+```
 
 <a name="specifying-a-file-name"></a>
 #### Specifying a File Name
 
 If you do not want a filename to be automatically assigned to your stored file, you may use the `storeAs` method, which receives the path, the filename, and the (optional) disk as its arguments:
 
+```php
     $path = $request->file('avatar')->storeAs(
         'avatars', $request->user()->id
     );
+```
 
 You may also use the `putFileAs` method on the `Storage` facade, which will perform the same file storage operation as the example above:
 
+```php
     $path = Storage::putFileAs(
         'avatars', $request->file('avatar'), $request->user()->id
     );
+```
 
 > [!WARNING]  
 > Unprintable and invalid unicode characters will automatically be removed from file paths. Therefore, you may wish to sanitize your file paths before passing them to Laravel's file storage methods. File paths are normalized using the `League\Flysystem\WhitespacePathNormalizer::normalizePath` method.
@@ -543,34 +604,42 @@ You may also use the `putFileAs` method on the `Storage` facade, which will perf
 
 By default, this uploaded file's `store` method will use your default disk. If you would like to specify another disk, pass the disk name as the second argument to the `store` method:
 
+```php
     $path = $request->file('avatar')->store(
         'avatars/'.$request->user()->id, 's3'
     );
+```
 
 If you are using the `storeAs` method, you may pass the disk name as the third argument to the method:
 
+```php
     $path = $request->file('avatar')->storeAs(
         'avatars',
         $request->user()->id,
         's3'
     );
+```
 
 <a name="other-uploaded-file-information"></a>
 #### Other Uploaded File Information
 
 If you would like to get the original name and extension of the uploaded file, you may do so using the `getClientOriginalName` and `getClientOriginalExtension` methods:
 
+```php
     $file = $request->file('avatar');
 
     $name = $file->getClientOriginalName();
     $extension = $file->getClientOriginalExtension();
+```
 
 However, keep in mind that the `getClientOriginalName` and `getClientOriginalExtension` methods are considered unsafe, as the file name and extension may be tampered with by a malicious user. For this reason, you should typically prefer the `hashName` and `extension` methods to get a name and an extension for the given file upload:
 
+```php
     $file = $request->file('avatar');
 
     $name = $file->hashName(); // Generate a unique, random name...
     $extension = $file->extension(); // Determine the file's extension based on the file's MIME type...
+```
 
 <a name="file-visibility"></a>
 ### File Visibility
@@ -578,19 +647,23 @@ However, keep in mind that the `getClientOriginalName` and `getClientOriginalExt
 In Laravel's Flysystem integration, "visibility" is an abstraction of file permissions across multiple platforms. Files may either be declared `public` or `private`. When a file is declared `public`, you are indicating that the file should generally be accessible to others. For example, when using the S3 driver, you may retrieve URLs for `public` files.
 
 You can set the visibility when writing the file via the `put` method:
-
+```php
     use Illuminate\Support\Facades\Storage;
 
     Storage::put('file.jpg', $contents, 'public');
+```
 
 If the file has already been stored, its visibility can be retrieved and set via the `getVisibility` and `setVisibility` methods:
 
+```php
     $visibility = Storage::getVisibility('file.jpg');
 
     Storage::setVisibility('file.jpg', 'public');
+```
 
 When interacting with uploaded files, you may use the `storePublicly` and `storePubliclyAs` methods to store the uploaded file with `public` visibility:
 
+```php
     $path = $request->file('avatar')->storePublicly('avatars', 's3');
 
     $path = $request->file('avatar')->storePubliclyAs(
@@ -598,12 +671,13 @@ When interacting with uploaded files, you may use the `storePublicly` and `store
         $request->user()->id,
         's3'
     );
+```
 
 <a name="local-files-and-visibility"></a>
 #### Local Files and Visibility
 
 When using the `local` driver, `public` [visibility](#file-visibility) translates to `0755` permissions for directories and `0644` permissions for files. You can modify the permissions mappings in your application's `filesystems` configuration file:
-
+```php
     'local' => [
         'driver' => 'local',
         'root' => storage_path('app'),
@@ -619,23 +693,26 @@ When using the `local` driver, `public` [visibility](#file-visibility) translate
         ],
         'throw' => false,
     ],
+```
 
 <a name="deleting-files"></a>
 ## Deleting Files
 
 The `delete` method accepts a single filename or an array of files to delete:
-
+```php
     use Illuminate\Support\Facades\Storage;
 
     Storage::delete('file.jpg');
 
     Storage::delete(['file.jpg', 'file2.jpg']);
+```
 
 If necessary, you may specify the disk that the file should be deleted from:
-
+```php
     use Illuminate\Support\Facades\Storage;
 
     Storage::disk('s3')->delete('path/file.jpg');
+```
 
 <a name="directories"></a>
 ## Directories
@@ -645,34 +722,40 @@ If necessary, you may specify the disk that the file should be deleted from:
 
 The `files` method returns an array of all of the files in a given directory. If you would like to retrieve a list of all files within a given directory including all subdirectories, you may use the `allFiles` method:
 
+```php
     use Illuminate\Support\Facades\Storage;
 
     $files = Storage::files($directory);
 
     $files = Storage::allFiles($directory);
+```
 
 <a name="get-all-directories-within-a-directory"></a>
 #### Get All Directories Within a Directory
 
 The `directories` method returns an array of all the directories within a given directory. Additionally, you may use the `allDirectories` method to get a list of all directories within a given directory and all of its subdirectories:
 
+```php
     $directories = Storage::directories($directory);
 
     $directories = Storage::allDirectories($directory);
+```
 
 <a name="create-a-directory"></a>
 #### Create a Directory
 
 The `makeDirectory` method will create the given directory, including any needed subdirectories:
-
+```php
     Storage::makeDirectory($directory);
+```
 
 <a name="delete-a-directory"></a>
 #### Delete a Directory
 
 Finally, the `deleteDirectory` method may be used to remove a directory and all of its files:
-
+```php
     Storage::deleteDirectory($directory);
+```
 
 <a name="testing"></a>
 ## Testing
@@ -763,7 +846,7 @@ composer require spatie/flysystem-dropbox
 ```
 
 Next, you can register the driver within the `boot` method of one of your application's [service providers](/docs/{{version}}/providers). To accomplish this, you should use the `extend` method of the `Storage` facade:
-
+```php
     <?php
 
     namespace App\Providers;
@@ -804,6 +887,7 @@ Next, you can register the driver within the `boot` method of one of your applic
             });
         }
     }
+```
 
 The first argument of the `extend` method is the name of the driver and the second is a closure that receives the `$app` and `$config` variables. The closure must return an instance of `Illuminate\Filesystem\FilesystemAdapter`. The `$config` variable contains the values defined in `config/filesystems.php` for the specified disk.
 

--- a/helpers.md
+++ b/helpers.md
@@ -66,6 +66,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [Arr::pull](#method-array-pull)
 [Arr::query](#method-array-query)
 [Arr::random](#method-array-random)
+[Arr::reject](#method-array-reject)
 [Arr::set](#method-array-set)
 [Arr::shuffle](#method-array-shuffle)
 [Arr::sort](#method-array-sort)
@@ -755,6 +756,21 @@ You may also specify the number of items to return as an optional second argumen
     $items = Arr::random($array, 2);
 
     // [2, 5] - (retrieved randomly)
+
+<a name="method-array-reject"></a>
+#### `Arr::reject()` {.collection-method}
+
+The `Arr::reject` method removes items from an array using the given closure:
+
+    use Illuminate\Support\Arr;
+
+    $array = [100, '200', 300, '400', 500];
+
+    $filtered = Arr::reject($array, function (string|int $value, int $key) {
+        return is_string($value);
+    });
+
+    // [0 => 100, 2 => 300, 4 => 500]
 
 <a name="method-array-set"></a>
 #### `Arr::set()` {.collection-method}

--- a/http-tests.md
+++ b/http-tests.md
@@ -946,6 +946,7 @@ Laravel's `Illuminate\Testing\TestResponse` class provides a variety of custom a
 [assertMovedPermanently](#assert-moved-permanently)
 [assertContent](#assert-content)
 [assertNoContent](#assert-no-content)
+[assertStreamed](#assert-streamed)
 [assertStreamedContent](#assert-streamed-content)
 [assertNotFound](#assert-not-found)
 [assertOk](#assert-ok)
@@ -1344,6 +1345,13 @@ Assert that the given string matches the response content:
 Assert that the response has the given HTTP status code and no content:
 
     $response->assertNoContent($status = 204);
+
+<a name="assert-streamed"></a>
+#### assertStreamed
+
+Assert that the response was a streamed response:
+
+    $response->assertStreamed();
 
 <a name="assert-streamed-content"></a>
 #### assertStreamedContent

--- a/responses.md
+++ b/responses.md
@@ -334,6 +334,39 @@ If you need to stream JSON data incrementally, you may utilize the `streamJson` 
         ]);
     });
 
+<a name="event-streams"></a>
+#### Event Streams
+
+The `eventStream` method may be used to return a server-sent events (SSE) streamed response using the `text/event-stream` content type. The `eventStream` method accepts a closure which should [yield](https://www.php.net/manual/en/language.generators.overview.php) responses to the stream as the responses become available:
+
+```php
+Route::get('/chat', function () {
+    return response()->eventStream(function () {
+        $stream = OpenAI::client()->chat()->createStreamed(...);
+
+        foreach ($stream as $response) {
+            yield $response->choices[0];
+        }
+    });
+});
+```
+
+This event stream may be consumed via an [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) object by your application's frontend. The `eventStream` method will automatically send a `</stream>` update to the event stream when the stream is complete:
+
+```js
+const source = new EventSource('/chat');
+
+source.addEventListener('update', (event) => {
+    if (event.data === '</stream>') {
+        source.close();
+
+        return;
+    }
+
+    console.log(event.data);
+})
+```
+
 <a name="streamed-downloads"></a>
 #### Streamed Downloads
 

--- a/strings.md
+++ b/strings.md
@@ -3100,6 +3100,6 @@ The `wrap` method wraps the given string with an additional string or pair of st
 
     // "Laravel"
 
-    Str::is('is')->wrap(before: 'This ', after: ' Laravel!');
+    Str::of('is')->wrap(before: 'This ', after: ' Laravel!');
 
     // This is Laravel!


### PR DESCRIPTION
I've notice that some of the code block have the `php` code fencing, some is not. And I've notice the code example is not printed in a proper way. So this PR is about helping the docs look consistent

<img width="866" alt="Screenshot 2025-02-24 at 3 14 09 PM" src="https://github.com/user-attachments/assets/fb6f2a5c-450d-41c8-8d14-38c52441055b" />

