### PR TITLE
[12.x] Add link to migrate Carbon from version 2 to 3

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -50,7 +50,7 @@ You should update the following dependencies in your application's `composer.jso
 
 **Likelihood Of Impact: Low**
 
-Support for [Carbon 2.x](https://carbon.nesbot.com/docs/) has been removed. All Laravel 12 applications now require Carbon 3.x.
+Support for [Carbon 2.x](https://carbon.nesbot.com/docs/) has been removed. All Laravel 12 applications now require [Carbon 3.x](https://carbon.nesbot.com/docs/#api-carbon-3).
 
 <a name="updating-the-laravel-installer"></a>
 ### Updating the Laravel Installer


### PR DESCRIPTION
A small quality of life addition.

This PR adds a link to the migration guide of Carbon from v2 to v3. It took me a couple of minutes to find the list of changes on Carbon website.