### PR TITLE
Fix anchor link for assertServiceUnavailable and line break in Artisan documentation

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -692,8 +692,7 @@ $this->newLine(3);
 <a name="tables"></a>
 #### Tables
 
-The `table` method makes it easy to correctly format multiple rows / columns of data. All you need to do is provide the column names and the data for the table and Laravel will
-automatically calculate the appropriate width and height of the table for you:
+The `table` method makes it easy to correctly format multiple rows / columns of data. All you need to do is provide the column names and the data for the table and Laravel will automatically calculate the appropriate width and height of the table for you:
 
 ```php
 use App\Models\User;

--- a/http-tests.md
+++ b/http-tests.md
@@ -1004,7 +1004,7 @@ Laravel's `Illuminate\Testing\TestResponse` class provides a variety of custom a
 [assertSeeText](#assert-see-text)
 [assertSeeTextInOrder](#assert-see-text-in-order)
 [assertServerError](#assert-server-error)
-[assertServiceUnavailable](#assert-server-unavailable)
+[assertServiceUnavailable](#assert-service-unavailable)
 [assertSessionHas](#assert-session-has)
 [assertSessionHasInput](#assert-session-has-input)
 [assertSessionHasAll](#assert-session-has-all)
@@ -1607,7 +1607,7 @@ Assert that the response has a server error (>= 500 , < 600) HTTP status code:
 $response->assertServerError();
 ```
 
-<a name="assert-server-unavailable"></a>
+<a name="assert-service-unavailable"></a>
 #### assertServiceUnavailable
 
 Assert that the response has a "Service Unavailable" (503) HTTP status code:


### PR DESCRIPTION
- Updated anchor name from 'assert-server-unavailable' to 'assert-service-unavailable'
- Removes unwanted line break for better readability.