### PR TITLE
[12.x] Add UUID v7 section for Models to upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -134,6 +134,21 @@ $table = Schema::getTableListing(schema: 'main', schemaQualified: false);
 
 The `db:table` and `db:show` commands now output the results of all schemas on MySQL, MariaDB, and SQLite, just like PostgreSQL and SQL Server.
 
+<a name="models"></a>
+### Models
+
+<a name="switch-models-to-uuid-v7"></a>
+#### Switch Models to UUID v7
+
+**Likelihood Of Impact: Medium**
+
+The `HasUuids` trait using v7 UUIDs by default now (formerly v4 with ordered UUID implementation). If you do not want to break your database order you can stay on v4 by using `HasVersion4Uuids` trait.
+
+```diff
+- use Illuminate\Database\Eloquent\Concerns\HasUuids;
++ use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
+```
+
 <a name="requests"></a>
 ### Requests
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -12,6 +12,15 @@
 
 </div>
 
+<a name="medium-impact-changes"></a>
+## Medium Impact Changes
+
+<div class="content-list" markdown="1">
+
+- [Models and UUIDv7](#models-and-uuidv7)
+
+</div>
+
 <a name="low-impact-changes"></a>
 ## Low Impact Changes
 
@@ -134,22 +143,22 @@ $table = Schema::getTableListing(schema: 'main', schemaQualified: false);
 
 The `db:table` and `db:show` commands now output the results of all schemas on MySQL, MariaDB, and SQLite, just like PostgreSQL and SQL Server.
 
-<a name="models"></a>
-### Models
+<a name="eloquent"></a>
+### Eloquent
 
-<a name="switch-models-to-uuid-v7"></a>
-#### Switch Models to UUID v7
+<a name="models-and-uuidv7"></a>
+#### Models and UUIDv7
 
 **Likelihood Of Impact: Medium**
 
-The `HasUuids` trait using v7 UUIDs by default now (formerly v4 with ordered UUID implementation). If you do not want to break your database order you can stay on v4 by using `HasVersion4Uuids` trait.
+The `HasUuids` trait now returns UUIDs that are compatible with version 7 of the UUID spec (ordered UUIDs). If you would like to continue using ordered UUIDv4 strings for your model's IDs, you should now use the `HasVersion4Uuids` trait:
 
-```diff
-- use Illuminate\Database\Eloquent\Concerns\HasUuids;
-+ use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
+```php
+use Illuminate\Database\Eloquent\Concerns\HasUuids; // [tl! remove]
+use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids; // [tl! add]
 ```
 
-Also `HasVersion7Uuids` trait was removed. If you are using it, you should migrate to the `HasUuids` trait.
+The `HasVersion7Uuids` trait has been removed. If you were previously using this trait, you should use the `HasUuids` trait instead, which now provides the same behavior.
 
 <a name="requests"></a>
 ### Requests

--- a/upgrade.md
+++ b/upgrade.md
@@ -149,6 +149,8 @@ The `HasUuids` trait using v7 UUIDs by default now (formerly v4 with ordered UUI
 + use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
 ```
 
+Also `HasVersion7Uuids` trait was removed. If you are using it, you should migrate to the `HasUuids` trait.
+
 <a name="requests"></a>
 ### Requests
 


### PR DESCRIPTION
With laravel 12, the `HasUuids` trait using v7 UUIDs by default. If we compare the examples below, the order of the database records may become confusing.

```
Str::orderedUuid()
Ramsey\Uuid\Rfc4122\UuidV4 {#5343
  uuid: "9e4bb9bd-f73d-41c2-aecf-8c9bf81eb188",
}

Str::uuid7()
Ramsey\Uuid\Lazy\LazyUuidFromString {#5295
  uuid: "01953cbc-ceac-73a4-9829-a14fc6528306",
}
```

I'm not sure about my writing style, but I think there should be such a section in the upgrade documentation.