### PR TITLE
[12.x] fix link reference in installation documentation

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -79,7 +79,7 @@ composer global require laravel/installer
 ```
 
 > [!NOTE]
-> For a fully-featured, graphical PHP installation and management experience, check out [Laravel Herd](#local-installation-using-herd).
+> For a fully-featured, graphical PHP installation and management experience, check out [Laravel Herd](#installation-using-herd).
 
 <a name="creating-an-application"></a>
 ### Creating an Application


### PR DESCRIPTION
Fixed broken link reference in Laravel docs: updated `#local-installation-using-herd` to `#installation-using-herd` for accurate navigation.