### PR TITLE
[12.x] Fix internal link on Installation page

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -79,7 +79,7 @@ composer global require laravel/installer
 ```
 
 > [!NOTE]
-> For a fully-featured, graphical PHP installation and management experience, check out [Laravel Herd](#local-installation-using-herd).
+> For a fully-featured, graphical PHP installation and management experience, check out [Laravel Herd](#installation-using-herd).
 
 <a name="creating-an-application"></a>
 ### Creating an Application


### PR DESCRIPTION
# Summary
This PR simply fixes an anchor to Laravel Herd section on Installation chapter.

