### PR TITLE
[12.x] Add Str::uuid7 to string helpers

### DIFF
--- a/strings.md
+++ b/strings.md
@@ -110,6 +110,7 @@ Laravel includes a variety of functions for manipulating string values. Many of 
 [Str::ulid](#method-str-ulid)
 [Str::unwrap](#method-str-unwrap)
 [Str::uuid](#method-str-uuid)
+[Str::uuid7](#method-str-uuid7)
 [Str::wordCount](#method-str-word-count)
 [Str::wordWrap](#method-str-word-wrap)
 [Str::words](#method-str-words)
@@ -1681,6 +1682,19 @@ To instruct the `uuid` method to return to generating UUIDs normally, you may in
 ```php
 Str::createUuidsNormally();
 ```
+
+<a name="method-str-uuid7"></a>
+#### `Str::uuid7()` {.collection-method}
+
+The `Str::uuid7` method generates a UUID (version 7):
+
+```php
+use Illuminate\Support\Str;
+
+return (string) Str::uuid7(); // Example: 019548fa-0421-71d3-a72e-12e668351c0d
+return (string) Str::uuid7(time: now()); // Example 019548fa-0421-71d3-a72e-12e668f617b3
+```
+Optionally, a timestamp `time` of the type `DateTimeInterface` can be passed as a parameter, which is represented in the UUID.
 
 <a name="method-str-word-count"></a>
 #### `Str::wordCount()` {.collection-method}

--- a/strings.md
+++ b/strings.md
@@ -1691,10 +1691,14 @@ The `Str::uuid7` method generates a UUID (version 7):
 ```php
 use Illuminate\Support\Str;
 
-return (string) Str::uuid7(); // Example: 019548fa-0421-71d3-a72e-12e668351c0d
-return (string) Str::uuid7(time: now()); // Example 019548fa-0421-71d3-a72e-12e668f617b3
+return (string) Str::uuid7();
 ```
-Optionally, a timestamp `time` of the type `DateTimeInterface` can be passed as a parameter, which is represented in the UUID.
+
+A `DateTimeInterface` may be passed as an optional parameter which will be used to generate the ordered UUID:
+
+```php
+return (string) Str::uuid7(time: now());
+```
 
 <a name="method-str-word-count"></a>
 #### `Str::wordCount()` {.collection-method}


### PR DESCRIPTION
During an update and in the upgrade guide, I saw that v7 type uuids are now used instead of v4.

In the course of the update, I briefly looked into the topic of migrating IDs and realized that there is already a `Str::uuid7` method in the code, but it does not appear anywhere on the documentation page of the [string helpers](https://laravel.com/docs/12.x/strings#strings-method-list). 

I have now tried to add this new method.