### PR TITLE
add documentation for traditional livewire components in starter kit

### DIFF
--- a/starter-kits.md
+++ b/starter-kits.md
@@ -73,7 +73,7 @@ Our Livewire starter kit provides the perfect starting point for building Larave
 
 Livewire is a powerful way of building dynamic, reactive, frontend UIs using just PHP. It's a great fit for teams that primarily use Blade templates and are looking for a simpler alternative to JavaScript-driven SPA frameworks like React and Vue.
 
-The Livewire starter kit utilizes Livewire (either traditional components or Laravel Volt), Tailwind, the [Flux UI](https://fluxui.dev) component library.
+The Livewire starter kit utilizes Livewire (either traditional components or Laravel Volt), Tailwind and the [Flux UI](https://fluxui.dev) component library.
 
 <a name="starter-kit-customization"></a>
 ## Starter Kit Customization

--- a/starter-kits.md
+++ b/starter-kits.md
@@ -239,7 +239,7 @@ resources/views
 
 #### Traditional Livewire Components
 
-The frontend code is located in the `resouces/views` directory and the authentication, user profile and settings logic is located in `app/Livewire`.
+The frontend code is located in the `resouces/views` directory, while the `app/Livewire` directory contains the corresponding backend logic for the Livewire components.
 
 <a name="livewire-available-layouts"></a>
 #### Available Layouts

--- a/starter-kits.md
+++ b/starter-kits.md
@@ -73,7 +73,7 @@ Our Livewire starter kit provides the perfect starting point for building Larave
 
 Livewire is a powerful way of building dynamic, reactive, frontend UIs using just PHP. It's a great fit for teams that primarily use Blade templates and are looking for a simpler alternative to JavaScript-driven SPA frameworks like React and Vue.
 
-The Livewire starter kit utilizes Livewire (either traditional components or Laravel Volt), Tailwind and the [Flux UI](https://fluxui.dev) component library.
+The Livewire starter kit utilizes Livewire, Tailwind, and the [Flux UI](https://fluxui.dev) component library.
 
 <a name="starter-kit-customization"></a>
 ## Starter Kit Customization
@@ -221,7 +221,7 @@ import AuthLayout from '@/layouts/auth/AuthSplitLayout.vue'; // [tl! add]
 <a name="livewire-customization"></a>
 ### Livewire
 
-Our Livewire starter kit is built with Livewire 3, Tailwind, and [Flux UI](https://fluxui.dev/). When choosing the Livewire starter kit you have the option of using Volt or traditional Livewire components. As with all of our starter kits, all of the backend and frontend code exists within your application to allow for full customization.
+Our Livewire starter kit is built with Livewire 3, Tailwind, and [Flux UI](https://fluxui.dev/). As with all of our starter kits, all of the backend and frontend code exists within your application to allow for full customization.
 
 #### Livewire and Volt
 

--- a/starter-kits.md
+++ b/starter-kits.md
@@ -73,7 +73,7 @@ Our Livewire starter kit provides the perfect starting point for building Larave
 
 Livewire is a powerful way of building dynamic, reactive, frontend UIs using just PHP. It's a great fit for teams that primarily use Blade templates and are looking for a simpler alternative to JavaScript-driven SPA frameworks like React and Vue.
 
-The Livewire starter kit utilizes Laravel Volt, Tailwind, and the [Flux UI](https://fluxui.dev) component library.
+The Livewire starter kit utilizes Livewire (either traditional components or Laravel Volt), Tailwind, the [Flux UI](https://fluxui.dev) component library.
 
 <a name="starter-kit-customization"></a>
 ## Starter Kit Customization

--- a/starter-kits.md
+++ b/starter-kits.md
@@ -221,7 +221,9 @@ import AuthLayout from '@/layouts/auth/AuthSplitLayout.vue'; // [tl! add]
 <a name="livewire-customization"></a>
 ### Livewire
 
-Our Livewire starter kit is built with Livewire 3, Laravel Volt, Tailwind, and [Flux UI](https://fluxui.dev/). As with all of our starter kits, all of the backend and frontend code exists within your application to allow for full customization.
+Our Livewire starter kit is built with Livewire 3, Tailwind, and [Flux UI](https://fluxui.dev/). When choosing the Livewire starter kit you have the option of using Volt or traditional Livewire components. As with all of our starter kits, all of the backend and frontend code exists within your application to allow for full customization.
+
+#### Livewire and Volt
 
 The majority of the frontend code is located in the `resources/views` directory. You are free to modify any of the code to customize the appearance and behavior of your application:
 
@@ -234,6 +236,10 @@ resources/views
 ├── dashboard.blade.php   # Authenticated user dashboard
 ├── welcome.blade.php     # Guest user welcome page
 ```
+
+#### Traditional Livewire Components
+
+The frontend code is located in the `resouces/views` directory and the authentication, user profile and settings logic is located in `app/Livewire`.
 
 <a name="livewire-available-layouts"></a>
 #### Available Layouts


### PR DESCRIPTION
Following the release of the laravel installer 5.13.0 the livewire starter kits now come with a traditional livewire components option.

This PR serves to update the starter kit documentation to inform users of this new addition.