### PR TITLE
Clarify ASCII numerals in `alpha_dash` and `alpha_num` validation rules

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1214,7 +1214,7 @@ To restrict this validation rule to characters in the ASCII range (`a-z` and `A-
 
 The field under validation must be entirely Unicode alpha-numeric characters contained in [`\p{L}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=), [`\p{M}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=), [`\p{N}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AN%3A%5D&g=&i=), as well as ASCII dashes (`-`) and ASCII underscores (`_`).
 
-To restrict this validation rule to characters in the ASCII range (`a-z` and `A-Z`), you may provide the `ascii` option to the validation rule:
+To restrict this validation rule to characters in the ASCII range (`a-z`, `A-Z` and `0-9`), you may provide the `ascii` option to the validation rule:
 
 ```php
 'username' => 'alpha_dash:ascii',
@@ -1225,7 +1225,7 @@ To restrict this validation rule to characters in the ASCII range (`a-z` and `A-
 
 The field under validation must be entirely Unicode alpha-numeric characters contained in [`\p{L}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=), [`\p{M}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=), and [`\p{N}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AN%3A%5D&g=&i=).
 
-To restrict this validation rule to characters in the ASCII range (`a-z` and `A-Z`), you may provide the `ascii` option to the validation rule:
+To restrict this validation rule to characters in the ASCII range (`a-z`, `A-Z` and `0-9`), you may provide the `ascii` option to the validation rule:
 
 ```php
 'username' => 'alpha_num:ascii',

--- a/validation.md
+++ b/validation.md
@@ -1214,7 +1214,7 @@ To restrict this validation rule to characters in the ASCII range (`a-z` and `A-
 
 The field under validation must be entirely Unicode alpha-numeric characters contained in [`\p{L}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=), [`\p{M}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=), [`\p{N}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AN%3A%5D&g=&i=), as well as ASCII dashes (`-`) and ASCII underscores (`_`).
 
-To restrict this validation rule to characters in the ASCII range (`a-z`, `A-Z` and `0-9`), you may provide the `ascii` option to the validation rule:
+To restrict this validation rule to characters in the ASCII range (`a-z`, `A-Z`, and `0-9`), you may provide the `ascii` option to the validation rule:
 
 ```php
 'username' => 'alpha_dash:ascii',
@@ -1225,7 +1225,7 @@ To restrict this validation rule to characters in the ASCII range (`a-z`, `A-Z` 
 
 The field under validation must be entirely Unicode alpha-numeric characters contained in [`\p{L}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=), [`\p{M}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=), and [`\p{N}`](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AN%3A%5D&g=&i=).
 
-To restrict this validation rule to characters in the ASCII range (`a-z`, `A-Z` and `0-9`), you may provide the `ascii` option to the validation rule:
+To restrict this validation rule to characters in the ASCII range (`a-z`, `A-Z`, and `0-9`), you may provide the `ascii` option to the validation rule:
 
 ```php
 'username' => 'alpha_num:ascii',


### PR DESCRIPTION
ASCII characters in the `\p{L}` regex ranges are clarified as `a-z` and `A-Z` for the `alpha_dash` and `alpha_num` validation rules. ASCII numerals in the `\p{N}` range (`0-9`) are not.

This PR adds ", and `0-9`" where relevant.