### PR TITLE
Added note warning about excess indentation for markdown notifications

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -831,6 +831,9 @@ Thanks,<br>
 </x-mail::message>
 ```
 
+> [!NOTE]  
+> Do not use excess indentation when writing Markdown emails. Per Markdown standards, Markdown parsers will render indented content as code blocks.
+
 <a name="button-component"></a>
 #### Button Component
 


### PR DESCRIPTION
Although this note is also mentioned inside the similar [markdown mailables documenation](https://laravel.com/docs/12.x/mail#writing-markdown-messages), I think it should also be mentioned inside the Notifications documentation, as I have just been caught out for longer than I care to admit.