### PR TITLE
docs: add decodedPath method to request documentation

### DIFF
--- a/requests.md
+++ b/requests.md
@@ -116,6 +116,13 @@ The `path` method returns the request's path information. So, if the incoming re
 ```php
 $uri = $request->path();
 ```
+If your URL contains encoded characters,
+you can use the `decodedPath` method to get the decoded version of the path.
+For example, if the URL is `http://example.com/foo/user%2Dprofile` the `decodedPath` method will return `foo/user-profile`:
+
+```php
+$uri = $request->decodedPath();
+```
 
 <a name="inspecting-the-request-path"></a>
 #### Inspecting the Request Path / Route


### PR DESCRIPTION
This PR adds documentation for the decodedPath method alongside the existing path method documentation. The addition clarifies how to handle URL-encoded characters in request paths by showing a practical example of the difference between these two methods.