### PR TITLE
Removed the duplicated use in the validation documentation

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1427,7 +1427,7 @@ A _ratio_ constraint should be represented as width divided by height. This can 
 'avatar' => 'dimensions:ratio=3/2'
 ```
 
-Since this rule requires several arguments, it is often more convenient to use use the `Rule::dimensions` method to fluently construct the rule:
+Since this rule requires several arguments, it is often more convenient to use the `Rule::dimensions` method to fluently construct the rule:
 
 ```php
 use Illuminate\Support\Facades\Validator;


### PR DESCRIPTION
This PR fixes a small typo in the validation documentation where "use" was repeated twice.