### PR TITLE
Remove unnecessary code blocks in file storage documentation

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -687,8 +687,6 @@ $path = $request->file('avatar')->storePubliclyAs(
 When using the `local` driver, `public` [visibility](#file-visibility) translates to `0755` permissions for directories and `0644` permissions for files. You can modify the permissions mappings in your application's `filesystems` configuration file:
 
 ```php
-
-``````php
 'local' => [
     'driver' => 'local',
     'root' => storage_path('app'),
@@ -712,8 +710,6 @@ When using the `local` driver, `public` [visibility](#file-visibility) translate
 The `delete` method accepts a single filename or an array of files to delete:
 
 ```php
-
-``````php
 use Illuminate\Support\Facades\Storage;
 
 Storage::delete('file.jpg');
@@ -724,8 +720,6 @@ Storage::delete(['file.jpg', 'file2.jpg']);
 If necessary, you may specify the disk that the file should be deleted from:
 
 ```php
-
-``````php
 use Illuminate\Support\Facades\Storage;
 
 Storage::disk('s3')->delete('path/file.jpg');


### PR DESCRIPTION
This pull request corrects the code block formatting in the [Local Files and Visibility](https://laravel.com/docs/12.x/filesystem#local-files-and-visibility) and [Deleting Files](https://laravel.com/docs/12.x/filesystem#deleting-files) section of the file storage documentation by replacing incorrect code fences.