### PR TITLE
Fix API documentation URLs in Routing section

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -1008,7 +1008,7 @@ $name = Route::currentRouteName(); // string
 $action = Route::currentRouteAction(); // string
 ```
 
-You may refer to the API documentation for both the [underlying class of the Route facade](https://laravel.com/api/{{version}}/Illuminate/Routing/Router.html) and [Route instance](https://laravel.com/api/{{version}}/Illuminate/Routing/Route.html) to review all of the methods that are available on the router and route classes.
+You may refer to the API documentation for both the [underlying class of the Route facade](https://api.laravel.com/docs/{{version}}/Illuminate/Routing/Router.html) and [Route instance](https://api.laravel.com/docs/{{version}}/Illuminate/Routing/Route.html) to review all of the methods that are available on the router and route classes.
 
 <a name="cors"></a>
 ## Cross-Origin Resource Sharing (CORS)


### PR DESCRIPTION
# Fix API documentation URLs

This PR addresses an issue with outdated API documentation URLs in the Routing section. The Laravel API documentation has changed its URL format from `https://laravel.com/api/{{version}}/` to `https://api.laravel.com/docs/{{version}}/`.

## Changes:
- Updated the URL format in the documentation to reflect the new API documentation structure
- Fixed a broken link in the "Accessing the Current Route" section that was returning a 404 error

Fixes [#54927](https://github.com/laravel/framework/issues/54927)
