### PR TITLE
[12.x] Mention different Vite integration for Tailwind v3 vs v4

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -445,6 +445,30 @@ The following example demonstrates how Vite will treat relative and absolute URL
 <a name="working-with-stylesheets"></a>
 ## Working With Stylesheets
 
+> [!NOTE]  
+> Laravel's [starter kits](/docs/{{version}}/starter-kits) already include the proper Tailwind, PostCSS, and Vite configuration. Or, if you would like to use Tailwind and Laravel without using one of our starter kits, check out [Tailwind's installation guide for Laravel](https://tailwindcss.com/docs/guides/laravel).
+
+<a name="tailwind-css-4"></a>
+#### Tailwind CSS v4
+
+If you are using v4, can use `@tailwindcss/vite` Vite plugin for installation, so it's sufficient to implement it in `vite.config.js` as follows:
+
+```js
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+    plugins: [
+        laravel(),
+        tailwindcss(),
+    ],
+});
+```
+
+<a name="tailwind-css-3"></a>
+#### Tailwind CSS v3
+
 You can learn more about Vite's CSS support within the [Vite documentation](https://vitejs.dev/guide/features.html#css). If you are using PostCSS plugins such as [Tailwind](https://tailwindcss.com), you may create a `postcss.config.js` file in the root of your project and Vite will automatically apply it:
 
 ```js
@@ -455,9 +479,6 @@ export default {
     },
 };
 ```
-
-> [!NOTE]  
-> Laravel's [starter kits](/docs/{{version}}/starter-kits) already include the proper Tailwind, PostCSS, and Vite configuration. Or, if you would like to use Tailwind and Laravel without using one of our starter kits, check out [Tailwind's installation guide for Laravel](https://tailwindcss.com/docs/guides/laravel).
 
 <a name="working-with-blade-and-routes"></a>
 ## Working With Blade and Routes

--- a/vite.md
+++ b/vite.md
@@ -446,39 +446,15 @@ The following example demonstrates how Vite will treat relative and absolute URL
 ## Working With Stylesheets
 
 > [!NOTE]  
-> Laravel's [starter kits](/docs/{{version}}/starter-kits) already include the proper Tailwind, PostCSS, and Vite configuration. Or, if you would like to use Tailwind and Laravel without using one of our starter kits, check out [Tailwind's installation guide for Laravel](https://tailwindcss.com/docs/guides/laravel).
+> Laravel's [starter kits](/docs/{{version}}/starter-kits) already include the proper Tailwind and Vite configuration. Or, if you would like to use Tailwind and Laravel without using one of our starter kits, check out [Tailwind's installation guide for Laravel](https://tailwindcss.com/docs/guides/laravel).
 
-<a name="tailwind-css-4"></a>
-#### Tailwind CSS v4
+All Laravel applications already include Tailwind and a properly configured `vite.config.js` file. So, you only need to start the Vite development server or run the `dev` Composer command, which will start both the Laravel and Vite development servers:
 
-If you are using v4, can use `@tailwindcss/vite` Vite plugin for installation, so it's sufficient to implement it in `vite.config.js` as follows:
-
-```js
-import { defineConfig } from 'vite';
-import laravel from 'laravel-vite-plugin';
-import tailwindcss from '@tailwindcss/vite';
-
-export default defineConfig({
-    plugins: [
-        laravel(),
-        tailwindcss(),
-    ],
-});
+```shell
+composer run dev
 ```
 
-<a name="tailwind-css-3"></a>
-#### Tailwind CSS v3
-
-You can learn more about Vite's CSS support within the [Vite documentation](https://vitejs.dev/guide/features.html#css). If you are using PostCSS plugins such as [Tailwind](https://v3.tailwindcss.com), you may create a `postcss.config.js` file in the root of your project and Vite will automatically apply it:
-
-```js
-export default {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
-};
-```
+Your application's CSS may be placed within the `resources/css/app.css` file.
 
 <a name="working-with-blade-and-routes"></a>
 ## Working With Blade and Routes

--- a/vite.md
+++ b/vite.md
@@ -469,7 +469,7 @@ export default defineConfig({
 <a name="tailwind-css-3"></a>
 #### Tailwind CSS v3
 
-You can learn more about Vite's CSS support within the [Vite documentation](https://vitejs.dev/guide/features.html#css). If you are using PostCSS plugins such as [Tailwind](https://tailwindcss.com), you may create a `postcss.config.js` file in the root of your project and Vite will automatically apply it:
+You can learn more about Vite's CSS support within the [Vite documentation](https://vitejs.dev/guide/features.html#css). If you are using PostCSS plugins such as [Tailwind](https://v3.tailwindcss.com), you may create a `postcss.config.js` file in the root of your project and Vite will automatically apply it:
 
 ```js
 export default {


### PR DESCRIPTION
Before the this PR, the documentation included a reference to the new v4 installation while explaining the old v3 integration.

### What's changed?

I moved the mention of Start Kits to the beginning.

After that, I introduced the TailwindCSS v4 Vite plugin (`@tailwindcss/vite`), illustrating it in a code snippet alongside the `laravel-vite-plugin`.

Then, I kept the original v3 description about PostCSS plugins and their automatic integration into Vite.






