### PR TITLE
[12.x] Update Logging Documentation to Use handler_with

### DIFF
--- a/logging.md
+++ b/logging.md
@@ -422,7 +422,7 @@ When using the `monolog` driver, the `handler` configuration option is used to s
 'logentries' => [
     'driver'  => 'monolog',
     'handler' => Monolog\Handler\SyslogUdpHandler::class,
-    'with' => [
+    'handler_with' => [
         'host' => 'my.logentries.internal.datahubhost.company.com',
         'port' => '10000',
     ],
@@ -466,7 +466,7 @@ If you would like to customize the processors for a `monolog` driver, add a `pro
 'memory' => [
     'driver' => 'monolog',
     'handler' => Monolog\Handler\StreamHandler::class,
-    'with' => [
+    'handler_with' => [
         'stream' => 'php://stderr',
     ],
     'processors' => [


### PR DESCRIPTION
This PR updates the logging documentation to reflect the recent change in the Laravel framework, where the `with` option for handlers was renamed to `handler_with`.

Why?
The framework now uses `handler_with` instead of `with` to explicitly indicate that these options configure the log handler's constructor parameters.

This ensures consistency between the documentation and the actual implementation.
[Reference](https://github.com/laravel/laravel/pull/6574/commits/fd7f1deecb6cdc89ed79c65abf412ea3a516d7bd)