### PR TITLE
Document 'only' and 'except' for blade attributes

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -1156,6 +1156,18 @@ You may retrieve a specific attribute's value using the `get` method:
 {{ $attributes->get('class') }}
 ```
 
+The `only` method may be used to retrieve only the attributes with the given keys:
+
+```blade
+{{ $attributes->only('class') }}
+```
+
+The `except` method may be used to retrieve all attributes except those with the given keys:
+
+```blade
+{{ $attributes->except('class') }}
+```
+
 <a name="reserved-keywords"></a>
 ### Reserved Keywords
 

--- a/blade.md
+++ b/blade.md
@@ -1159,13 +1159,13 @@ You may retrieve a specific attribute's value using the `get` method:
 The `only` method may be used to retrieve only the attributes with the given keys:
 
 ```blade
-{{ $attributes->only('class') }}
+{{ $attributes->only(['class']) }}
 ```
 
 The `except` method may be used to retrieve all attributes except those with the given keys:
 
 ```blade
-{{ $attributes->except('class') }}
+{{ $attributes->except(['class']) }}
 ```
 
 <a name="reserved-keywords"></a>


### PR DESCRIPTION
With blade and livewire being used more frequently with flux, I get asked more and more about components. These two come in handy and I've forgotten more than once if we can do this or not.

Let me know if you would like additional blocks to show that they both can also accept an array.

https://github.com/laravel/framework/blob/be9dea9a6ad4323514dc25736b0126e5455e17d7/src/Illuminate/View/ComponentAttributeBag.php#L133

https://github.com/laravel/framework/blob/be9dea9a6ad4323514dc25736b0126e5455e17d7/src/Illuminate/View/ComponentAttributeBag.php#L152

Could also just add them as a second line to the existing code blocks, perhaps:

```blade
{{ $attributes->except('class') }}
{{ $attributes->except(['class', 'style']) }}
```