### PR TITLE
[12.x] Fix strings whenEmpty code example

### DIFF
--- a/strings.md
+++ b/strings.md
@@ -3393,8 +3393,8 @@ The `whenEmpty` method invokes the given closure if the string is empty. If the 
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 
-$string = Str::of('  ')->whenEmpty(function (Stringable $string) {
-    return $string->trim()->prepend('Laravel');
+$string = Str::of('  ')->trim()->whenEmpty(function (Stringable $string) {
+    return $string->prepend('Laravel');
 });
 
 // 'Laravel'


### PR DESCRIPTION
The code example for the `whenEmpty` method is incorrect, as `whenEmtpy` doesn't execute the closure for a string containing spaces. The string would first need to be trimmed.

```php
$string = Str::of('  ')->whenEmpty(function (Stringable $string) {
    return $string->trim()->prepend('Laravel');
});

// '  '

$string = Str::of('  ')->trim()->whenEmpty(function (Stringable $string) {
    return $string->prepend('Laravel');
});

// 'Laravel'
```
