### PR TITLE
[12.x] Updating the docs to reflect the actual generated comment

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -310,7 +310,7 @@ class InvalidOrderException extends Exception
     }
 
     /**
-     * Render the exception into an HTTP response.
+     * Render the exception as an HTTP response.
      */
     public function render(Request $request): Response
     {
@@ -323,7 +323,7 @@ If your exception extends an exception that is already renderable, such as a bui
 
 ```php
 /**
- * Render the exception into an HTTP response.
+ * Render the exception as an HTTP response.
  */
 public function render(Request $request): Response|bool
 {


### PR DESCRIPTION
The generated exception class when using the `--render` option contains the comment:
`Render the exception as an HTTP response.`
However, the documentation example currently states:
`Render the exception into an HTTP response.`
For consistency, the docs should be updated to match the actual generated class.