### PR TITLE
[12.x] Consistency with Laravel's best practices

### DIFF
--- a/authorization.md
+++ b/authorization.md
@@ -87,7 +87,6 @@ To authorize an action using gates, you should use the `allows` or `denies` meth
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Models\Post;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -542,7 +541,6 @@ The `App\Models\User` model that is included with your Laravel application inclu
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Models\Post;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -577,7 +575,6 @@ Remember, some actions may correspond to policy methods like `create` that do no
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Models\Post;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -612,7 +609,6 @@ Like the `can` method, this method accepts the name of the action you wish to au
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Models\Post;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;

--- a/controllers.md
+++ b/controllers.md
@@ -125,7 +125,6 @@ Or, you may find it convenient to specify middleware within your controller clas
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Controllers\Middleware;
 

--- a/database.md
+++ b/database.md
@@ -141,7 +141,6 @@ To run a basic SELECT query, you may use the `select` method on the `DB` facade:
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -730,7 +730,6 @@ Of course, when using Eloquent, we don't only need to retrieve models from the d
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Models\Flight;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;

--- a/events.md
+++ b/events.md
@@ -586,7 +586,6 @@ To dispatch an event, you may call the static `dispatch` method on the event. Th
 namespace App\Http\Controllers;
 
 use App\Events\OrderShipped;
-use App\Http\Controllers\Controller;
 use App\Models\Order;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;

--- a/facades.md
+++ b/facades.md
@@ -158,7 +158,6 @@ The `Facade` base class makes use of the `__callStatic()` magic-method to defer 
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\View\View;
 

--- a/filesystem.md
+++ b/filesystem.md
@@ -559,7 +559,6 @@ In web applications, one of the most common use-cases for storing files is stori
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
 class UserAvatarController extends Controller

--- a/frontend.md
+++ b/frontend.md
@@ -125,7 +125,6 @@ After installing Inertia into your Laravel application, you will write routes an
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Models\User;
 use Inertia\Inertia;
 use Inertia\Response;

--- a/logging.md
+++ b/logging.md
@@ -213,7 +213,6 @@ You may call any of these methods to log a message for the corresponding level. 
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;

--- a/mail.md
+++ b/mail.md
@@ -920,7 +920,6 @@ To send a message, use the `to` method on the `Mail` [facade](/docs/{{version}}/
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Mail\OrderShipped;
 use App\Models\Order;
 use Illuminate\Http\RedirectResponse;

--- a/pagination.md
+++ b/pagination.md
@@ -48,7 +48,6 @@ In this example, the only argument passed to the `paginate` method is the number
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 

--- a/queues.md
+++ b/queues.md
@@ -793,7 +793,6 @@ Once you have written your job class, you may dispatch it using the `dispatch` m
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Jobs\ProcessPodcast;
 use App\Models\Podcast;
 use Illuminate\Http\RedirectResponse;
@@ -837,7 +836,6 @@ If you would like to specify that a job should not be immediately available for 
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Jobs\ProcessPodcast;
 use App\Models\Podcast;
 use Illuminate\Http\RedirectResponse;
@@ -903,7 +901,6 @@ If you would like to dispatch a job immediately (synchronously), you may use the
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Jobs\ProcessPodcast;
 use App\Models\Podcast;
 use Illuminate\Http\RedirectResponse;
@@ -1067,7 +1064,6 @@ By pushing jobs to different queues, you may "categorize" your queued jobs and e
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Jobs\ProcessPodcast;
 use App\Models\Podcast;
 use Illuminate\Http\RedirectResponse;
@@ -1125,7 +1121,6 @@ If your application interacts with multiple queue connections, you may specify w
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Jobs\ProcessPodcast;
 use App\Models\Podcast;
 use Illuminate\Http\RedirectResponse;

--- a/redis.md
+++ b/redis.md
@@ -245,7 +245,6 @@ You may interact with Redis by calling various methods on the `Redis` [facade](/
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\View\View;
 


### PR DESCRIPTION
**Problem:**
The explicit using for `use App\Http\Controllers\Controller;` in Laravel controllers is unnecessary when the base controller `Controller.php` is in the same `namespace`. Since Laravel's artisan `make:controller` command does not include this import, and Laravel `Pint` also removes it, it makes sense to align the documentation with this convention.

**Reasons:**
- The import statement is redundant because the `base Controller` is in the `same namespace`.
- Laravel's `artisan command` does not generate this import.
- Laravel `Pint` removes it as an unnecessary statement.

Updating the documentation will ensure consistency with Laravel's best practices.