### PR TITLE
Fix typo in a Precognition for Alpine.js example

### DIFF
--- a/precognition.md
+++ b/precognition.md
@@ -580,7 +580,7 @@ Alternatively, if you would like to submit the form via XHR you may use the form
         submit() {
             this.form.submit()
                 .then(response => {
-                    form.reset();
+                    this.form.reset();
 
                     alert('User created.')
                 })


### PR DESCRIPTION
In the Precognition for Alpine.js example where it's shown how to manually submit the form, `form` is being referenced instead of `this.form`.

This PR will result in:
```alpine.js
<form @submit.prevent="submit" x-data="{
    form: /* ... */,
    submit() {
        this.form.submit()
            .then(() => {
                // form.reset();
                this.form.reset();
            });
    },
}">
```