### PR TITLE
[12.x] Remove Duplicate CSS in Documentation

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -4041,19 +4041,6 @@ LazyCollection::make(function () {
 
 Almost all methods available on the `Collection` class are also available on the `LazyCollection` class. Both of these classes implement the `Illuminate\Support\Enumerable` contract, which defines the following methods:
 
-<style>
-    .collection-method-list > p {
-        columns: 10.8em 3; -moz-columns: 10.8em 3; -webkit-columns: 10.8em 3;
-    }
-
-    .collection-method-list a {
-        display: block;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
-</style>
-
 <div class="collection-method-list" markdown="1">
 
 [all](#method-all)

--- a/homestead.md
+++ b/homestead.md
@@ -93,14 +93,6 @@ Homestead runs on any Windows, macOS, or Linux system and includes Nginx, PHP, M
 <a name="optional-software"></a>
 ### Optional Software
 
-<style>
-    #software-list > ul {
-        column-count: 2; -moz-column-count: 2; -webkit-column-count: 2;
-        column-gap: 5em; -moz-column-gap: 5em; -webkit-column-gap: 5em;
-        line-height: 1.9;
-    }
-</style>
-
 <div id="software-list" markdown="1">
 
 - Apache


### PR DESCRIPTION
**Observation:**
I noticed that the CSS styles for `.collection-method-list` appear twice in `collections.md` page and `#software-list` also appear twice in `homestead.md` page. This might be unintentional, but I’m not certain if the duplication serves a specific purpose.

**Solution:**
I removed the duplicate `<style>` blocks to improve maintainability and avoid redundant styles.

**Impact:**
This PR helps keep the codebase cleaner.

If the duplication serves a specific purpose, feel free to close this PR.