### PR TITLE
[12.x] Improve `anticipate` method example

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -626,7 +626,7 @@ $name = $this->anticipate('What is your address?', function (string $input) {
     return Address::whereLike('name', "{$input}%")
         ->limit(5)
         ->pluck('name')
-        ->toArray();
+        ->all();
 });
 ```
 

--- a/artisan.md
+++ b/artisan.md
@@ -620,8 +620,13 @@ $name = $this->anticipate('What is your name?', ['Taylor', 'Dayle']);
 Alternatively, you may pass a closure as the second argument to the `anticipate` method. The closure will be called each time the user types an input character. The closure should accept a string parameter containing the user's input so far, and return an array of options for auto-completion:
 
 ```php
+use App\Models\Address;
+
 $name = $this->anticipate('What is your address?', function (string $input) {
-    // Return auto-completion options...
+    return Address::whereLIKE('name', "{$input}%")
+        ->limit(5)
+        ->pluck('name')
+        ->toArray();
 });
 ```
 

--- a/artisan.md
+++ b/artisan.md
@@ -623,7 +623,7 @@ Alternatively, you may pass a closure as the second argument to the `anticipate`
 use App\Models\Address;
 
 $name = $this->anticipate('What is your address?', function (string $input) {
-    return Address::whereLIKE('name', "{$input}%")
+    return Address::whereLike('name', "{$input}%")
         ->limit(5)
         ->pluck('name')
         ->toArray();


### PR DESCRIPTION
**Description:**
This PR enhances the anticipate method example by replacing the placeholder comment with a real-world example using Eloquent. The new example demonstrates how to fetch address suggestions dynamically based on user input.

**Why?**
This makes the documentation more practical by providing a concrete use case, helping developers understand how anticipate can be used with database queries.