### PR TITLE
Update Symfony documentation link to the latest maintained version (7.3)

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -740,7 +740,7 @@ $bar->finish();
 ```
 
 > [!NOTE]
-> For more advanced options, check out the [Symfony Progress Bar component documentation](https://symfony.com/doc/7.3/components/console/helpers/progressbar.html).
+> For more advanced options, check out the [Symfony Progress Bar component documentation](https://symfony.com/doc/current/components/console/helpers/progressbar.html).
 
 <a name="registering-commands"></a>
 ## Registering Commands

--- a/artisan.md
+++ b/artisan.md
@@ -740,7 +740,7 @@ $bar->finish();
 ```
 
 > [!NOTE]
-> For more advanced options, check out the [Symfony Progress Bar component documentation](https://symfony.com/doc/7.0/components/console/helpers/progressbar.html).
+> For more advanced options, check out the [Symfony Progress Bar component documentation](https://symfony.com/doc/7.3/components/console/helpers/progressbar.html).
 
 <a name="registering-commands"></a>
 ## Registering Commands


### PR DESCRIPTION
**Description:**

This PR updates a reference link to Symfony’s documentation in the Laravel docs. The current link points to `Symfony 7.0`, which is no longer maintained. Since `Symfony 7.3` is the latest maintained version, I’ve updated the link accordingly.