### PR TITLE
[12.x] Ensure Proper Closure of File Handle in LazyCollection

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -3988,6 +3988,8 @@ LazyCollection::make(function () {
     while (($line = fgets($handle)) !== false) {
         yield $line;
     }
+
+    fclose($handle);
 })->chunk(4)->map(function (array $lines) {
     return LogEntry::fromLines($lines);
 })->each(function (LogEntry $logEntry) {
@@ -4033,6 +4035,8 @@ LazyCollection::make(function () {
     while (($line = fgets($handle)) !== false) {
         yield $line;
     }
+
+    fclose($handle);
 });
 ```
 


### PR DESCRIPTION
**Description:**
This PR modifies the `LazyCollection::make` implementation to explicitly close the file handle after reading. This prevents potential resource leaks and ensures proper cleanup.

**Changes:**
Added `fclose($handle);` after the `while` loop to close the file handle once reading is complete.

**Why?**
Ensure better resource management.