### PR TITLE
[12.x] Improve PHPUnit Example to Match Pest Example in Testing Documentation

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -337,11 +337,11 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->ddHeaders();
-
-        $response->ddSession();
-
         $response->dd();
+        $response->ddHeaders();
+        $response->ddBody();
+        $response->ddJson();
+        $response->ddSession();
     }
 }
 ```


### PR DESCRIPTION
Updating the `PHPUnit` example to match the structure and completeness of the `Pest` example.

**Description:**
This PR updates the `PHPUnit` example to align with the `Pest` example by including all debugging methods in the same order. This ensures consistency across both testing approaches and provides a more comprehensive debugging reference for users.