### PR TITLE
[12.x] Add `DatabaseTokenRepository` constructor signature update to upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -32,7 +32,6 @@
 - [Image Validation Now Excludes SVGs](#image-validation)
 - [Multi-Schema Database Inspecting](#multi-schema-database-inspecting)
 - [Nested Array Request Merging](#nested-array-request-merging)
-- [Updated `DatabaseTokenRepository` constructor signature](#updated-databasetokenrepository-constructor-signature)
 
 </div>
 
@@ -96,13 +95,11 @@ Or, if you are using [Laravel Herd's](https://herd.laravel.com) bundled copy of 
 ### Authentication
 
 <a name="updated-databasetokenrepository-constructor-signature"></a>
-#### Updated `DatabaseTokenRepository` constructor signature
+#### Updated `DatabaseTokenRepository` Constructor Signature
 
-**Likelihood Of Impact: Low**
+**Likelihood Of Impact: Very Low**
 
-The constructor of the `DatabaseTokenRepository` class now expects the `$expires` parameter to be given in seconds, rather than minutes.
-If you manually instantiate this class, or override the `PasswordBrokerManager` class that creates instances,
-you may have to change your values.
+The constructor of the `Illuminate\Auth\Passwords\DatabaseTokenRepository` class now expects the `$expires` parameter to be given in seconds, rather than minutes.
 
 <a name="concurrency"></a>
 ### Concurrency

--- a/upgrade.md
+++ b/upgrade.md
@@ -32,6 +32,7 @@
 - [Image Validation Now Excludes SVGs](#image-validation)
 - [Multi-Schema Database Inspecting](#multi-schema-database-inspecting)
 - [Nested Array Request Merging](#nested-array-request-merging)
+- [Updated `DatabaseTokenRepository` constructor signature](#updated-databasetokenrepository-constructor-signature)
 
 </div>
 
@@ -90,6 +91,18 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 ```
 
 Or, if you are using [Laravel Herd's](https://herd.laravel.com) bundled copy of the Laravel installer, you should update your Herd installation to the latest release.
+
+<a name="authentication"></a>
+### Authentication
+
+<a name="updated-databasetokenrepository-constructor-signature"></a>
+#### Updated `DatabaseTokenRepository` constructor signature
+
+**Likelihood Of Impact: Low**
+
+The constructor of the `DatabaseTokenRepository` class now expects the `$expires` parameter to be given in seconds, rather than minutes.
+If you manually instantiate this class, or override the `PasswordBrokerManager` class that creates instances,
+you may have to change your values.
 
 <a name="concurrency"></a>
 ### Concurrency


### PR DESCRIPTION
In https://github.com/laravel/framework/pull/53746 the `DatabaseTokenRepository` constructor was altered to parse the `$expires` argument as given in seconds rather than minutes. When manually instantiating this, using a custom class extending it that calls the parent constructor or override the `resolve` method on the `PasswordBrokerManager`, this may cause changes in behavior resulting in incorrect expiry times. I think this makes it noteworthy enough to mention in the upgrade guide.