### PR TITLE
[12.x] sync indentation with framework formatting

### DIFF
--- a/console-tests.md
+++ b/console-tests.md
@@ -139,8 +139,8 @@ test('console command', function () {
 public function test_console_command(): void
 {
     $this->artisan('example')
-            ->doesntExpectOutput()
-            ->assertExitCode(0);
+        ->doesntExpectOutput()
+        ->assertExitCode(0);
 }
 ```
 
@@ -161,8 +161,8 @@ test('console command', function () {
 public function test_console_command(): void
 {
     $this->artisan('example')
-            ->expectsOutputToContain('Taylor')
-            ->assertExitCode(0);
+        ->expectsOutputToContain('Taylor')
+        ->assertExitCode(0);
 }
 ```
 

--- a/dusk.md
+++ b/dusk.md
@@ -1764,7 +1764,7 @@ Assert that the given JavaScript expression evaluates to the given value:
 
 ```php
 $browser->assertScript('window.isLoaded')
-        ->assertScript('document.readyState', 'complete');
+    ->assertScript('document.readyState', 'complete');
 ```
 
 <a name="assert-source-has"></a>
@@ -2288,9 +2288,9 @@ Sometimes you may already be on a given page and need to "load" the page's selec
 use Tests\Browser\Pages\CreatePlaylist;
 
 $browser->visit('/dashboard')
-        ->clickLink('Create Playlist')
-        ->on(new CreatePlaylist)
-        ->assertSee('@create');
+    ->clickLink('Create Playlist')
+    ->on(new CreatePlaylist)
+    ->assertSee('@create');
 ```
 
 <a name="shorthand-selectors"></a>
@@ -2372,8 +2372,8 @@ Once the method has been defined, you may use it within any test that utilizes t
 use Tests\Browser\Pages\Dashboard;
 
 $browser->visit(new Dashboard)
-        ->createPlaylist('My Playlist')
-        ->assertSee('My Playlist');
+    ->createPlaylist('My Playlist')
+    ->assertSee('My Playlist');
 ```
 
 <a name="components"></a>

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -932,7 +932,7 @@ The `wherePivot` adds a where clause constraint to the query, but does not add t
 
 ```php
 return $this->belongsToMany(Role::class)
-        ->withPivotValue('approved', 1);
+    ->withPivotValue('approved', 1);
 ```
 
 <a name="ordering-queries-via-intermediate-table-columns"></a>

--- a/eloquent.md
+++ b/eloquent.md
@@ -1130,8 +1130,8 @@ You may also use the `restore` method in a query to restore multiple models. Aga
 
 ```php
 Flight::withTrashed()
-        ->where('airline_id', 1)
-        ->restore();
+    ->where('airline_id', 1)
+    ->restore();
 ```
 
 The `restore` method may also be used when building [relationship](/docs/{{version}}/eloquent-relationships) queries:


### PR DESCRIPTION
in the framework, we are usign a single indent on new lines, so this mirrors that in the docs