### PR TITLE
[12.x] Add schedule useCache example

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -388,6 +388,17 @@ Schedule::call(fn () => User::resetApiRequestCount())
     ->onOneServer();
 ```
 
+<a name="customizing-cache-driver"></a>
+#### Customizing the Cache Driver
+If you need to override the default cache driver used for scheduling's atomic mutex locks, you can chain the `useCache` method after `onOneServer`. This allows you to specify a different cache driver (e.g. `'database'`) for the mutex without changing your application's primary cache configuration:
+
+```php
+Schedule::command('recipes:sync')
+    ->everyThirtyMinutes()
+    ->onOneServer();
+    ->useCache('database');
+```
+
 <a name="background-tasks"></a>
 ### Background Tasks
 

--- a/scheduling.md
+++ b/scheduling.md
@@ -362,6 +362,15 @@ Schedule::command('report:generate')
     ->onOneServer();
 ```
 
+You may use the `useCache` method to customize the cache store used by the scheduler to obtain the atomic locks necessary for single-server tasks:
+
+```php
+Schedule::command('recipes:sync')
+    ->everyThirtyMinutes()
+    ->onOneServer();
+    ->useCache('database');
+```
+
 <a name="naming-unique-jobs"></a>
 #### Naming Single Server Jobs
 
@@ -386,17 +395,6 @@ Schedule::call(fn () => User::resetApiRequestCount())
     ->name('reset-api-request-count')
     ->daily()
     ->onOneServer();
-```
-
-<a name="customizing-cache-driver"></a>
-#### Customizing the Cache Driver
-If you need to override the default cache driver used for scheduling's atomic mutex locks, you can chain the `useCache` method after `onOneServer`. This allows you to specify a different cache driver (e.g. `'database'`) for the mutex without changing your application's primary cache configuration:
-
-```php
-Schedule::command('recipes:sync')
-    ->everyThirtyMinutes()
-    ->onOneServer();
-    ->useCache('database');
 ```
 
 <a name="background-tasks"></a>


### PR DESCRIPTION
Add information about how to configure the scheduling cache store that should be used for storing mutexes, and that it can differ from the primary application cache store.