### PR TITLE
[12.x] Updating the docs to reflect the actual implementation

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -186,8 +186,8 @@ window.Echo = new Echo({
     broadcaster: 'reverb',
     key: import.meta.env.VITE_REVERB_APP_KEY,
     wsHost: import.meta.env.VITE_REVERB_HOST,
-    wsPort: import.meta.env.VITE_REVERB_PORT,
-    wssPort: import.meta.env.VITE_REVERB_PORT,
+    wsPort: import.meta.env.VITE_REVERB_PORT ?? 80,
+    wssPort: import.meta.env.VITE_REVERB_PORT ?? 443,
     forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
     enabledTransports: ['ws', 'wss'],
 });


### PR DESCRIPTION
Laravel documentation does not provide default values for `wsPort` and `wssPort`, while the actual implementation assigns them default values (`80` and `443`, respectively).

For consistency, the docs should be updated to match the actual generated code.