### PR TITLE
[11.X] Clarify availability of Http::failedConnection() in the 11.x branch

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -557,6 +557,10 @@ Sometimes you may need to test your application's behavior if the HTTP client en
         'github.com/*' => Http::failedConnection(),
     ]);
 
+> [!WARNING]  
+> This method is only available since Laravel v.11.32.0
+
+
 <a name="faking-response-sequences"></a>
 #### Faking Response Sequences
 


### PR DESCRIPTION
I was working on a personal project that was on 11.x and tried this and noticed it didn't work, it seems this is only available on v11.32.0+ (I got that from the commit view [here](https://github.com/laravel/framework/commit/30dd87421e7cfff84e82aba325e4419d3604f2ac), if that's wrong, feel free to change it)

I'm not sure if there's a better pattern than a "warning" for this, but something to denote that this is not available in every 11.x release that catches the eye is the idea, open to suggestions