### PR TITLE
Use `expects` and remove unnecessary `once`

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -27,7 +27,7 @@ test('something can be mocked', function () {
     $this->instance(
         Service::class,
         Mockery::mock(Service::class, function (MockInterface $mock) {
-            $mock->shouldReceive('process')->once();
+            $mock->expects('process');
         })
     );
 });
@@ -43,7 +43,7 @@ public function test_something_can_be_mocked(): void
     $this->instance(
         Service::class,
         Mockery::mock(Service::class, function (MockInterface $mock) {
-            $mock->shouldReceive('process')->once();
+            $mock->expects('process');
         })
     );
 }
@@ -56,7 +56,7 @@ use App\Service;
 use Mockery\MockInterface;
 
 $mock = $this->mock(Service::class, function (MockInterface $mock) {
-    $mock->shouldReceive('process')->once();
+    $mock->expects('process');
 });
 ```
 
@@ -67,7 +67,7 @@ use App\Service;
 use Mockery\MockInterface;
 
 $mock = $this->partialMock(Service::class, function (MockInterface $mock) {
-    $mock->shouldReceive('process')->once();
+    $mock->expects('process');
 });
 ```
 
@@ -119,8 +119,7 @@ We can mock the call to the `Cache` facade by using the `shouldReceive` method, 
 use Illuminate\Support\Facades\Cache;
 
 test('get index', function () {
-    Cache::shouldReceive('get')
-        ->once()
+    Cache::expects('get')
         ->with('key')
         ->andReturn('value');
 
@@ -142,8 +141,7 @@ class UserControllerTest extends TestCase
 {
     public function test_get_index(): void
     {
-        Cache::shouldReceive('get')
-            ->once()
+        Cache::expects('get')
             ->with('key')
             ->andReturn('value');
 
@@ -174,7 +172,7 @@ test('values are be stored in cache', function () {
 
     $response->assertStatus(200);
 
-    Cache::shouldHaveReceived('put')->once()->with('name', 'Taylor', 10);
+    Cache::shouldHaveReceived('put')->with('name', 'Taylor', 10);
 });
 ```
 
@@ -189,7 +187,7 @@ public function test_values_are_be_stored_in_cache(): void
 
     $response->assertStatus(200);
 
-    Cache::shouldHaveReceived('put')->once()->with('name', 'Taylor', 10);
+    Cache::shouldHaveReceived('put')->with('name', 'Taylor', 10);
 }
 ```
 


### PR DESCRIPTION
This streamlines `shouldReceive->once` calls to the more succinct, but explicit `expects`. Generally, this code is the same as `expects` is an alias for `shouldReceive->once`. However, using `expects` avoids pesky false positives when a developer forgets to quantify `shouldReceive`. So I feel the docs should build  the habit by using `expects`.

In the case of spies, `once` is unnecessary as `shouldHaveReceived` is built with `atLeast->once`. Again, removed for succinctness.