### PR TITLE
[12.x] Add missing imports in migration example

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -140,6 +140,9 @@ public function up(): void
 Sometimes a migration might be meant to support a feature that is not yet active and you do not want it to run yet. In this case you may define a `shouldRun` method on the migration. If the `shouldRun` method returns `false`, the migration will be skipped:
 
 ```php
+use App\Models\Flights;
+use Laravel\Pennant\Feature;
+
 /**
  * Determine if this migration should run.
  */


### PR DESCRIPTION
**Description:**
This PR adds the missing imports in the migration example under the `Skipping Migrations` section of the Laravel documentation. without these imports, the example may cause confusion for users unfamiliar with `Laravel Pennant` or the `Flights model`.

This improves clarity and ensures the example is functional as expected.