### PR TITLE
Add \Illuminate\Database\Schema\Blueprint changed constructor signature description

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -186,7 +186,7 @@ The `db:table` and `db:show` commands now output the results of all schemas on M
 
 **Likelihood Of Impact: Very Low**
 
-The constructor of the `Illuminate\Database\Schema\Blueprint` class now expects `Illuminate\Database\Connection` `$connection` as first argument.
+The constructor of the `Illuminate\Database\Schema\Blueprint` class now expects an instance of `Illuminate\Database\Connection` as its first argument.
 
 <a name="eloquent"></a>
 ### Eloquent

--- a/upgrade.md
+++ b/upgrade.md
@@ -181,6 +181,13 @@ $table = Schema::getTableListing(schema: 'main', schemaQualified: false);
 
 The `db:table` and `db:show` commands now output the results of all schemas on MySQL, MariaDB, and SQLite, just like PostgreSQL and SQL Server.
 
+<a name="updated-blueprint-constructor-signature"></a>
+#### Updated `Blueprint` Constructor Signature
+
+**Likelihood Of Impact: Very Low**
+
+The constructor of the `Illuminate\Database\Schema\Blueprint` class now expects `Illuminate\Database\Connection` `$connection` as first argument.
+
 <a name="eloquent"></a>
 ### Eloquent
 


### PR DESCRIPTION
laravel/framework#51821 introduced `\Illuminate\Database\Schema\Blueprint` public constructor change. Although a rare scenario, this class can be used in application-level code to write DB type-agnostic code to get string representation of SQL DDL command (i.e. SQL command to add a comment to table), which later can be executed via `\Illuminate\Database\Connection::unprepared()`.