### PR TITLE
[12.x] Fix invalid JSON syntax

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -1163,7 +1163,7 @@ So, for example, an update to the `App\Models\Post` model would broadcast an eve
         ...
     },
     ...
-    "socket": "someSocketId",
+    "socket": "someSocketId"
 }
 ```
 


### PR DESCRIPTION
**Description:**
This PR fixes a small JSON syntax issue. The original JSON snippet contained a trailing comma after the last key-value pair, which is invalid JSON and can cause parsing errors. The corrected version removes the trailing comma to ensure valid JSON syntax.