### PR TITLE
[12.x] Add link to Laravel Tinker GitHub repository

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -51,7 +51,7 @@ If you are using [Laravel Sail](/docs/{{version}}/sail) as your local developmen
 <a name="tinker"></a>
 ### Tinker (REPL)
 
-Laravel [Tinker](https://github.com/laravel/tinker) is a powerful REPL for the Laravel framework, powered by the [PsySH](https://github.com/bobthecow/psysh) package.
+[Laravel Tinker](https://github.com/laravel/tinker) is a powerful REPL for the Laravel framework, powered by the [PsySH](https://github.com/bobthecow/psysh) package.
 
 <a name="installation"></a>
 #### Installation

--- a/artisan.md
+++ b/artisan.md
@@ -51,7 +51,7 @@ If you are using [Laravel Sail](/docs/{{version}}/sail) as your local developmen
 <a name="tinker"></a>
 ### Tinker (REPL)
 
-Laravel Tinker is a powerful REPL for the Laravel framework, powered by the [PsySH](https://github.com/bobthecow/psysh) package.
+Laravel [Tinker](https://github.com/laravel/tinker) is a powerful REPL for the Laravel framework, powered by the [PsySH](https://github.com/bobthecow/psysh) package.
 
 <a name="installation"></a>
 #### Installation


### PR DESCRIPTION
**Description:**
Added a link to the official Laravel Tinker GitHub repository for easier access to the source code and more up-to-date information.

Additionally, the Tinker link was previously not mentioned in the documentation, and this update provides direct access to the repository.