### PR TITLE
[12.x] Nullsafe operator

### DIFF
--- a/telescope.md
+++ b/telescope.md
@@ -475,7 +475,9 @@ public function register(): void
     // ...
 
     Telescope::avatar(function (?string $id, ?string $email) {
-        return '/avatars/'.User::find($id)?->avatar_path;
+        return ! is_null($id)
+            ? '/avatars/'.User::find($id)?->avatar_path
+            : '/generic-avatar.jpg';
     });
 }
 ```

--- a/telescope.md
+++ b/telescope.md
@@ -476,7 +476,7 @@ public function register(): void
 
     Telescope::avatar(function (?string $id, ?string $email) {
         return ! is_null($id)
-            ? '/avatars/'.User::find($id)?->avatar_path
+            ? '/avatars/'.User::find($id)->avatar_path
             : '/generic-avatar.jpg';
     });
 }

--- a/telescope.md
+++ b/telescope.md
@@ -475,7 +475,7 @@ public function register(): void
     // ...
 
     Telescope::avatar(function (?string $id, ?string $email) {
-        return '/avatars/'.User::find($id)->avatar_path;
+        return '/avatars/'.User::find($id)?->avatar_path;
     });
 }
 ```


### PR DESCRIPTION
**Description:**
Updated the `Telescope::avatar` callback to use the `null-safe` operator when accessing `avatar_path`. This ensures that if `User::find($id)` returns null, it doesn't cause an error and simply returns null instead of attempting to access a property on a non-object.

This change improves safety and prevents potential Attempt to read property on null errors.