### PR TITLE
[12.x] Use single quotes for string consistency

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -630,7 +630,7 @@ You pass a closure to the `countBy` method to count all items by a custom value:
 $collection = collect(['alice@gmail.com', 'bob@yahoo.com', 'carlos@gmail.com']);
 
 $counted = $collection->countBy(function (string $email) {
-    return substr(strrchr($email, "@"), 1);
+    return substr(strrchr($email, '@'), 1);
 });
 
 $counted->all();


### PR DESCRIPTION
**Description:**
This PR updates string declarations to use single quotes where no variable interpolation or escape sequences are required, aligning with Laravel’s code style and improving consistency across the codebase.