### PR TITLE
[12.x] Fix implode method examples to show actual return values

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -1421,7 +1421,7 @@ $collection = collect([
 
 $collection->implode('product', ', ');
 
-// Desk, Chair
+// 'Desk, Chair'
 ```
 
 If the collection contains simple strings or numeric values, you should pass the "glue" as the only argument to the method:
@@ -1439,7 +1439,7 @@ $collection->implode(function (array $item, int $key) {
     return strtoupper($item['product']);
 }, ', ');
 
-// DESK, CHAIR
+// 'DESK, CHAIR'
 ```
 
 <a name="method-intersect"></a>


### PR DESCRIPTION
**Description:**
This PR updates the `implode` method's first and third output examples for consistency with the second example, which correctly shows the return value as a string.