### PR TITLE
[12.x] Document `fromJson` method on `collections` docs

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -35,7 +35,7 @@ As mentioned above, the `collect` helper returns a new `Illuminate\Support\Colle
 $collection = collect([1, 2, 3]);
 ```
 
-You may also create a collection using [make](#method-make) and [fromJson](#method-fromjson) methods.
+You may also create a collection using the [make](#method-make) and [fromJson](#method-fromjson) methods.
 
 > [!NOTE]
 > The results of [Eloquent](/docs/{{version}}/eloquent) queries are always returned as `Collection` instances.
@@ -146,6 +146,7 @@ For the majority of the remaining collection documentation, we'll discuss each m
 [flip](#method-flip)
 [forget](#method-forget)
 [forPage](#method-forpage)
+[fromJson](#method-fromjson)
 [get](#method-get)
 [groupBy](#method-groupby)
 [has](#method-has)
@@ -165,7 +166,6 @@ For the majority of the remaining collection documentation, we'll discuss each m
 [lazy](#method-lazy)
 [macro](#method-macro)
 [make](#method-make)
-[fromJson](#method-fromjson)
 [map](#method-map)
 [mapInto](#method-mapinto)
 [mapSpread](#method-mapspread)
@@ -1249,6 +1249,23 @@ $chunk->all();
 // [4, 5, 6]
 ```
 
+<a name="method-fromjson"></a>
+#### `fromJson()` {.collection-method}
+
+The static `fromJson` method creates a new collection instance by decoding a given JSON string using the `json_decode` PHP function:
+
+```php
+use Illuminate\Support\Collection;
+
+$json = json_encode([
+    'name' => 'Taylor Otwell',
+    'role' => 'Developer',
+    'status' => 'Active',
+]);
+
+$collection = Collection::fromJson($json);
+```
+
 <a name="method-get"></a>
 #### `get()` {.collection-method}
 
@@ -1704,23 +1721,6 @@ The static `make` method creates a new collection instance. See the [Creating Co
 use Illuminate\Support\Collection;
 
 $collection = Collection::make([1, 2, 3]);
-```
-
-<a name="method-fromjson"></a>
-#### `fromJson()` {.collection-method}
-
-The static `fromJson` method creates a new collection instance by decoding a JSON string using `json_decode` PHP function. See the [Creating Collections](#creating-collections) section.
-
-```php
-use Illuminate\Support\Collection;
-
-$json = json_encode([
-    'name' => 'Taylor Otwell',
-    'role' => 'Developer',
-    'status' => 'Active',
-]);
-
-$collection = Collection::fromJson($json);
 ```
 
 <a name="method-map"></a>

--- a/collections.md
+++ b/collections.md
@@ -35,6 +35,8 @@ As mentioned above, the `collect` helper returns a new `Illuminate\Support\Colle
 $collection = collect([1, 2, 3]);
 ```
 
+You may also create a collection using [make](#method-make) and [fromJson](#method-fromjson) methods.
+
 > [!NOTE]
 > The results of [Eloquent](/docs/{{version}}/eloquent) queries are always returned as `Collection` instances.
 
@@ -163,6 +165,7 @@ For the majority of the remaining collection documentation, we'll discuss each m
 [lazy](#method-lazy)
 [macro](#method-macro)
 [make](#method-make)
+[fromJson](#method-fromjson)
 [map](#method-map)
 [mapInto](#method-mapinto)
 [mapSpread](#method-mapspread)
@@ -1696,6 +1699,29 @@ The static `macro` method allows you to add methods to the `Collection` class at
 #### `make()` {.collection-method}
 
 The static `make` method creates a new collection instance. See the [Creating Collections](#creating-collections) section.
+
+```php
+use Illuminate\Support\Collection;
+
+$collection = Collection::make([1, 2, 3]);
+```
+
+<a name="method-fromjson"></a>
+#### `fromJson()` {.collection-method}
+
+The static `fromJson` method creates a new collection instance by decoding a JSON string using `json_decode` PHP function. See the [Creating Collections](#creating-collections) section.
+
+```php
+use Illuminate\Support\Collection;
+
+$json = json_encode([
+    'name' => 'Taylor Otwell',
+    'role' => 'Developer',
+    'status' => 'Active',
+]);
+
+$collection = Collection::fromJson($json);
+```
 
 <a name="method-map"></a>
 #### `map()` {.collection-method}


### PR DESCRIPTION
**Description:**
Documented the newly introduced `fromJson` method see laravel/framework#55310.

Also added an example for the `make` method and included a hint for both `make` and `fromJson` methods in the `Creating Collections` section.