### PR TITLE
[12.x] Replace `die` with `dd`

### DIFF
--- a/container.md
+++ b/container.md
@@ -74,7 +74,7 @@ class Service
 }
 
 Route::get('/', function (Service $service) {
-    die($service::class);
+    dd($service::class);
 });
 ```
 


### PR DESCRIPTION
`die` can cause problems if run in certain environments (Octane-based runtimes), since it's meant to "terminate a process". Plus, it's a nice opportunity to show readers the `dd` helper.

Reference in the case of RoadRunner (Octane):
https://spiral.dev/docs/basics-debug/current/en#avoid-using-die-and-exit-functions