### PR TITLE
[12.x] fixed the incorrect output in scope context example

### DIFF
--- a/context.md
+++ b/context.md
@@ -188,7 +188,9 @@ Context::scope(
 );
 
 Context::all();
-// []
+// [
+//     'trace_id' => 'abc-999',
+// ]
 
 Context::allHidden();
 // [


### PR DESCRIPTION
I ran the same code while exploring, and here is the ss of dd. it also aligns with docs.
![image](https://github.com/user-attachments/assets/5372d77e-f4c2-4894-8114-bf0e1fa1c4cd)
