### PR TITLE
[12.x] Updating `packages.md`

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -439,3 +439,9 @@ Now your users may publish these groups separately by referencing their tag when
 ```shell
 php artisan vendor:publish --tag=courier-config
 ```
+
+Your users can also publish all publishable files defined by your package using the `--provider` flag:
+
+```shell
+php artisan vendor:publish --provider="Your\Package\ServiceProvider"
+```


### PR DESCRIPTION
We had an issue reported in the official Laravel GitHub repository: https://github.com/laravel/framework/issues/55339, due to the simple fact that we didn't have a clarification on how to use the `--provider` flag when publishing assets, so I created this PR to provide instructions on how to use this correctly.

