### PR TITLE
[12.x] Use consistent Blade syntax highlighting for @use directive examples

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -648,7 +648,7 @@ Or, if you only need to use PHP to import a class, you may use the `@use` direct
 
 A second argument may be provided to the `@use` directive to alias the imported class:
 
-```php
+```blade
 @use('App\Models\Flight', 'FlightModel')
 ```
 


### PR DESCRIPTION
**Description:**

This PR updates the second `@use` directive example to use the `blade` code block instead of `php`. Currently, the first example uses the correct Blade syntax. However, the second example is using a php block. This causes inconsistent syntax highlighting and may be confusing for readers. Updating it to use the blade code block. Ensures visual consistency and better represents how this directive is used in Blade templates, similar to the experience in code editors.