### PR TITLE
[12.x] Make it more clear what is happening with email RFC validation

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1506,8 +1506,8 @@ The example above will apply the `RFCValidation` and `DNSCheckValidation` valida
 
 <div class="content-list" markdown="1">
 
-- `rfc`: `RFCValidation` - Validate the email address according to RFC 5322.
-- `strict`: `NoRFCWarningsValidation` - Validate the email according to RFC 5322, rejecting trailing periods or multiple consecutive periods.
+- `rfc`: `RFCValidation` - Validate the email address according to [supported RFCs](https://github.com/egulias/EmailValidator?tab=readme-ov-file#supported-rfcs).
+- `strict`: `NoRFCWarningsValidation` - Validate the email according to [supported RFCs](https://github.com/egulias/EmailValidator?tab=readme-ov-file#supported-rfcs), failing when warnings are found (e.g. trailing periods and multiple consecutive periods).
 - `dns`: `DNSCheckValidation` - Ensure the email address's domain has a valid MX record.
 - `spoof`: `SpoofCheckValidation` - Ensure the email address does not contain homograph or deceptive Unicode characters.
 - `filter`: `FilterEmailValidation` - Ensure the email address is valid according to PHP's `filter_var` function.


### PR DESCRIPTION
As of a [commit since 12.x](https://github.com/laravel/docs/commit/572395406fc6cf79d1577c335d7aa6e50a210b4e), the email validation docs could be seen as misleading/confusing.

The email validation does not validate against RFC 5322, but also allows other RFCs. This is important, as other RFCs allow emails that are not compatible with several (most?) major email platforms.

Also, the `strict` validation mentions "rejecting trailing periods or multiple consecutive periods", which I think is an oversimplification.

I don't see a way in the upstream [`egulias/EmailValidator`](https://github.com/egulias/EmailValidator) to selectively validate against certain RFCs.

As the list of RFCs is subject to change, I propose changing the docs to mention "supported RFCs", with a link to the list. The link might be deemed superfluous as the package itself is linked to earlier in this docs section.

Alternative approach would be to delegate to the [`egulias/EmailValidator`](https://github.com/egulias/EmailValidator) docs for the `rfc` and `strict` rule styles.

Related topics:
- https://github.com/laravel/ideas/issues/1555
- https://github.com/laravel/framework/issues/27875