### PR TITLE
[12.x] clarify how to "set" value objects with custom casts

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -736,7 +736,7 @@ class User extends Model
 <a name="value-object-casting"></a>
 ### Value Object Casting
 
-You are not limited to casting values to primitive types. You may also cast values to objects. Defining custom casts that cast values to objects is very similar to casting to primitive types; however, the `set` method should return an array of key / value pairs that will be used to set raw, storable values on the model.
+You are not limited to casting values to primitive types. You may also cast values to objects. Defining custom casts that cast values to objects is very similar to casting to primitive types; however, if your value object encompasses more than one storage value, the `set` method must return an array of key / value pairs that will be used to set raw, storable values on the model. If your value object only affects a single field, you should still return a string.
 
 As an example, we will define a custom cast class that casts multiple model values into a single `Address` value object. We will assume the `Address` value has two public properties: `lineOne` and `lineTwo`:
 


### PR DESCRIPTION
the current wording only accounts for 1 of the 2 scenarios that can occur when using a custom cast with a value object. that Value Object can encompasses either 1 or many values on the model.

the current documentation addresses the example of an `Address`, which would have multiple fields like "line1", "line2", "city", etc.  this `set` method should return the array as currently documented.

an example of a single value Value Object would be a phone number. a user might want it as an value object rather than a raw number to encapsulate behavior. this `set` method should return a string.

there is one distinct advantage to returning a string vs an array. it prevents the cast from being tied to explicit model field names. this allows a field of any name to use the cast:

```php
'phone' => AsPhone::class,
'telephone' => AsPhone::class,
```

if a user returns an array from this simple 1 value cast, the cast loses its flexibility and the above example does not work.