### PR TITLE
[12.x] use multiline parameters for casting methods

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -690,8 +690,12 @@ class AsJson implements CastsAttributes
      * @param  array<string, mixed>  $attributes
      * @return array<string, mixed>
      */
-    public function get(Model $model, string $key, mixed $value, array $attributes): array
-    {
+    public function get(
+        Model $model,
+        string $key,
+        mixed $value,
+        array $attributes,
+    ): array {
         return json_decode($value, true);
     }
 
@@ -700,8 +704,12 @@ class AsJson implements CastsAttributes
      *
      * @param  array<string, mixed>  $attributes
      */
-    public function set(Model $model, string $key, mixed $value, array $attributes): string
-    {
+    public function set(
+        Model $model,
+        string $key,
+        mixed $value,
+        array $attributes,
+    ): string {
         return json_encode($value);
     }
 }
@@ -757,8 +765,12 @@ class AsAddress implements CastsAttributes
      *
      * @param  array<string, mixed>  $attributes
      */
-    public function get(Model $model, string $key, mixed $value, array $attributes): Address
-    {
+    public function get(
+        Model $model,
+        string $key,
+        mixed $value,
+        array $attributes,
+    ): Address {
         return new Address(
             $attributes['address_line_one'],
             $attributes['address_line_two']
@@ -771,8 +783,12 @@ class AsAddress implements CastsAttributes
      * @param  array<string, mixed>  $attributes
      * @return array<string, string>
      */
-    public function set(Model $model, string $key, mixed $value, array $attributes): array
-    {
+    public function set(
+        Model $model,
+        string $key,
+        mixed $value,
+        array $attributes,
+    ): array {
         if (! $value instanceof Address) {
             throw new InvalidArgumentException('The given value is not an Address instance.');
         }
@@ -829,8 +845,12 @@ Therefore, you may specify that your custom cast class will be responsible for s
  *
  * @param  array<string, mixed>  $attributes
  */
-public function serialize(Model $model, string $key, mixed $value, array $attributes): string
-{
+public function serialize(
+    Model $model,
+    string $key,
+    mixed $value,
+    array $attributes,
+): string {
     return (string) $value;
 }
 ```
@@ -870,8 +890,12 @@ class AsHash implements CastsInboundAttributes
      *
      * @param  array<string, mixed>  $attributes
      */
-    public function set(Model $model, string $key, mixed $value, array $attributes): string
-    {
+    public function set(
+        Model $model,
+        string $key,
+        mixed $value,
+        array $attributes,
+    ): string {
         return is_null($this->algorithm)
             ? bcrypt($value)
             : hash($this->algorithm, $value);
@@ -977,16 +1001,24 @@ class Address implements Castable
     {
         return new class implements CastsAttributes
         {
-            public function get(Model $model, string $key, mixed $value, array $attributes): Address
-            {
+            public function get(
+                Model $model,
+                string $key,
+                mixed $value,
+                array $attributes,
+            ): Address {
                 return new Address(
                     $attributes['address_line_one'],
                     $attributes['address_line_two']
                 );
             }
 
-            public function set(Model $model, string $key, mixed $value, array $attributes): array
-            {
+            public function set(
+                Model $model,
+                string $key,
+                mixed $value,
+                array $attributes,
+            ): array {
                 return [
                     'address_line_one' => $value->lineOne,
                     'address_line_two' => $value->lineTwo,


### PR DESCRIPTION
I find the side scrolling for code snippets to decrease readability. these lengthy method signatures are often the culprit on this page. switching to multiline parameters to help avoid the necessity to side scroll.

followed the PSR-12 recommendation for when dealing with multiline parameters AND a return type.

I know this will be a constant battle in the documentation, and while changes like this won't completely eliminate the problem, I do think they help.

I would also like to see the Laravel documentation site make better use of the space it has available. On larger screens we have the ability to increase the container size. I would also suggest there is a lot of unused space between the columns of our 3 column layout. Changes here would also go a long way to help remove the need for side scrolling.  Since the `laravel.com` repo has been set to private, I don't believe the community has the ability to make these suggestions anymore.