### PR TITLE
 Slack notification prerequisites

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -1259,7 +1259,7 @@ composer require laravel/slack-notification-channel
 
 Additionally, you must create a [Slack App](https://api.slack.com/apps?new_app=1) for your Slack workspace.
 
-If you only need to send notifications to the same Slack workspace that the App is created in, you should ensure that your App has the `chat:write`, `chat:write.public`, and `chat:write.customize` scopes. If you want to send messages as your Slack App, you should ensure that your App also has the `chat:write:bot` scope. These scopes can be added from the "OAuth & Permissions" App management tab within Slack.
+If you only need to send notifications to the same Slack workspace that the App is created in, you should ensure that your App has the `chat:write`, `chat:write.public`, and `chat:write.customize` scopes. These scopes can be added from the "OAuth & Permissions" App management tab within Slack.
 
 Next, copy the App's "Bot User OAuth Token" and place it within a `slack` configuration array in your application's `services.php` configuration file. This token can be found on the "OAuth & Permissions" tab within Slack:
 


### PR DESCRIPTION
Scope `chat:write:bot` was mentioned in docs for [chat.postMessage](https://api.slack.com/methods/chat.postMessage) but this is outdated as perspective scopes are deprecated, see [here](https://api.slack.com/authentication/quickstart#perspective)