### PR TITLE
Closing missing `php` Tag

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -2211,6 +2211,7 @@ The `downloadInvoice` method also allows for a custom filename via its third arg
 
 ```php
 return $request->user()->downloadInvoice($invoiceId, [], 'my-invoice');
+```
 
 <a name="custom-invoice-render"></a>
 #### Custom Invoice Renderer


### PR DESCRIPTION
Small fix for Cashier (Stripe) page with a missing closing in the PHP tag.

![CleanShot 2025-04-24 at 10 53 12](https://github.com/user-attachments/assets/dff5e831-6675-409d-85be-98975be8387a)
