### PR TITLE
[12.x] Correct the URI documentation link

### DIFF
--- a/urls.md
+++ b/urls.md
@@ -279,7 +279,7 @@ $uri = Uri::of('https://example.com')
     ->withFragment('section-1');
 ```
 
-For more information on working with fluent URI objects, consult the [URI documentation](/docs/{{version}}/helpers#uris).
+For more information on working with fluent URI objects, consult the [URI documentation](/docs/{{version}}/helpers#uri).
 
 <a name="default-values"></a>
 ## Default Values


### PR DESCRIPTION
The correct link is: https://laravel.com/docs/12.x/helpers#uri

Not: https://laravel.com/docs/12.x/helpers#uris