### PR TITLE
[12.x] Add missing namespace declaration to event example

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -571,6 +571,8 @@ If you would like to broadcast your event using the `sync` queue instead of the 
 ```php
 <?php
 
+namespace App\Events;
+
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 
 class OrderShipmentStatusUpdated implements ShouldBroadcastNow


### PR DESCRIPTION
**Description:**
This PR adds the missing namespace to ensure consistency across all event examples and to avoid any confusion for readers following the documentation.