### PR TITLE
[12.x] Typed getters for Arr helper (docs)

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -40,6 +40,8 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 
 [Arr::accessible](#method-array-accessible)
 [Arr::add](#method-array-add)
+[Arr::array](#method-array)
+[Arr::boolean](#method-boolean)
 [Arr::collapse](#method-array-collapse)
 [Arr::crossJoin](#method-array-crossjoin)
 [Arr::divide](#method-array-divide)
@@ -48,10 +50,12 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [Arr::exists](#method-array-exists)
 [Arr::first](#method-array-first)
 [Arr::flatten](#method-array-flatten)
+[Arr::float](#method-float)
 [Arr::forget](#method-array-forget)
 [Arr::get](#method-array-get)
 [Arr::has](#method-array-has)
 [Arr::hasAny](#method-array-hasany)
+[Arr::integer](#method-integer)
 [Arr::isAssoc](#method-array-isassoc)
 [Arr::isList](#method-array-islist)
 [Arr::join](#method-array-join)
@@ -76,6 +80,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [Arr::sort](#method-array-sort)
 [Arr::sortDesc](#method-array-sort-desc)
 [Arr::sortRecursive](#method-array-sort-recursive)
+[Arr::string](#method-string)
 [Arr::take](#method-array-take)
 [Arr::toCssClasses](#method-array-to-css-classes)
 [Arr::toCssStyles](#method-array-to-css-styles)
@@ -261,6 +266,45 @@ $array = Arr::add(['name' => 'Desk', 'price' => null], 'price', 100);
 // ['name' => 'Desk', 'price' => 100]
 ```
 
+<a name="method-array"></a>
+#### `Arr::array()` {.collection-method}
+
+The `Arr::array()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not an `array` (or is `NULL`).
+
+```
+use Illuminate\Support\Arr;
+
+$array = ['name' => 'Joe', 'languages' => ['PHP', 'Ruby']];
+
+$value = Arr::array($array, 'languages');
+
+// ['PHP', 'Ruby']
+
+$value = Arr::array($array, 'name');
+
+// throws InvalidArgumentException
+```
+
+<a name="method-boolean"></a>
+#### `Arr::boolean()` {.collection-method}
+
+The `Arr::boolean()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `boolean` (or is `NULL`).
+
+```
+use Illuminate\Support\Arr;
+
+$array = ['name' => 'Joe', 'available' => true];
+
+$value = Arr::boolean($array, 'available');
+
+// true
+
+$value = Arr::boolean($array, 'name');
+
+// throws InvalidArgumentException
+```
+
+
 <a name="method-array-collapse"></a>
 #### `Arr::collapse()` {.collection-method}
 
@@ -413,6 +457,25 @@ $flattened = Arr::flatten($array);
 // ['Joe', 'PHP', 'Ruby']
 ```
 
+<a name="method-float"></a>
+#### `Arr::float()` {.collection-method}
+
+The `Arr::float()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `float` (or is `NULL`).
+
+```
+use Illuminate\Support\Arr;
+
+$array = ['name' => 'Joe', 'balance' => 123.45];
+
+$value = Arr::float($array, 'balance');
+
+// 123.45
+
+$value = Arr::float($array, 'name');
+
+// throws InvalidArgumentException
+```
+
 <a name="method-array-forget"></a>
 #### `Arr::forget()` {.collection-method}
 
@@ -493,6 +556,25 @@ $contains = Arr::hasAny($array, ['product.name', 'product.discount']);
 $contains = Arr::hasAny($array, ['category', 'product.discount']);
 
 // false
+```
+
+<a name="method-integer"></a>
+#### `Arr::integer()` {.collection-method}
+
+The `Arr::integer()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not an `int` (or is `NULL`).
+
+```
+use Illuminate\Support\Arr;
+
+$array = ['name' => 'Joe', 'age' => 42];
+
+$value = Arr::integer($array, 'age');
+
+// 42
+
+$value = Arr::integer($array, 'name');
+
+// throws InvalidArgumentException
 ```
 
 <a name="method-array-isassoc"></a>
@@ -1046,6 +1128,25 @@ If you would like the results sorted in descending order, you may use the `Arr::
 
 ```php
 $sorted = Arr::sortRecursiveDesc($array);
+```
+
+<a name="method-string"></a>
+#### `Arr::string()` {.collection-method}
+
+The `Arr::string()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `string` (or is `NULL`).
+
+```
+use Illuminate\Support\Arr;
+
+$array = ['name' => 'Joe', 'languages' => ['PHP', 'Ruby']];
+
+$value = Arr::string($array, 'name');
+
+// Joe
+
+$value = Arr::string($array, 'languages');
+
+// throws InvalidArgumentException
 ```
 
 <a name="method-array-take"></a>

--- a/helpers.md
+++ b/helpers.md
@@ -40,8 +40,8 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 
 [Arr::accessible](#method-array-accessible)
 [Arr::add](#method-array-add)
-[Arr::array](#method-array)
-[Arr::boolean](#method-boolean)
+[Arr::array](#method-array-array)
+[Arr::boolean](#method-array-boolean)
 [Arr::collapse](#method-array-collapse)
 [Arr::crossJoin](#method-array-crossjoin)
 [Arr::divide](#method-array-divide)
@@ -50,12 +50,12 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [Arr::exists](#method-array-exists)
 [Arr::first](#method-array-first)
 [Arr::flatten](#method-array-flatten)
-[Arr::float](#method-float)
+[Arr::float](#method-array-float)
 [Arr::forget](#method-array-forget)
 [Arr::get](#method-array-get)
 [Arr::has](#method-array-has)
 [Arr::hasAny](#method-array-hasany)
-[Arr::integer](#method-integer)
+[Arr::integer](#method-array-integer)
 [Arr::isAssoc](#method-array-isassoc)
 [Arr::isList](#method-array-islist)
 [Arr::join](#method-array-join)
@@ -80,7 +80,7 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [Arr::sort](#method-array-sort)
 [Arr::sortDesc](#method-array-sort-desc)
 [Arr::sortRecursive](#method-array-sort-recursive)
-[Arr::string](#method-string)
+[Arr::string](#method-array-string)
 [Arr::take](#method-array-take)
 [Arr::toCssClasses](#method-array-to-css-classes)
 [Arr::toCssStyles](#method-array-to-css-styles)
@@ -266,7 +266,7 @@ $array = Arr::add(['name' => 'Desk', 'price' => null], 'price', 100);
 // ['name' => 'Desk', 'price' => 100]
 ```
 
-<a name="method-array"></a>
+<a name="method-array-array"></a>
 #### `Arr::array()` {.collection-method}
 
 The `Arr::array()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not an `array` (or is `NULL`).
@@ -285,7 +285,7 @@ $value = Arr::array($array, 'name');
 // throws InvalidArgumentException
 ```
 
-<a name="method-boolean"></a>
+<a name="method-array-boolean"></a>
 #### `Arr::boolean()` {.collection-method}
 
 The `Arr::boolean()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `boolean` (or is `NULL`).
@@ -457,7 +457,7 @@ $flattened = Arr::flatten($array);
 // ['Joe', 'PHP', 'Ruby']
 ```
 
-<a name="method-float"></a>
+<a name="method-array-float"></a>
 #### `Arr::float()` {.collection-method}
 
 The `Arr::float()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `float` (or is `NULL`).
@@ -558,7 +558,7 @@ $contains = Arr::hasAny($array, ['category', 'product.discount']);
 // false
 ```
 
-<a name="method-integer"></a>
+<a name="method-array-integer"></a>
 #### `Arr::integer()` {.collection-method}
 
 The `Arr::integer()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not an `int` (or is `NULL`).
@@ -1130,7 +1130,7 @@ If you would like the results sorted in descending order, you may use the `Arr::
 $sorted = Arr::sortRecursiveDesc($array);
 ```
 
-<a name="method-string"></a>
+<a name="method-array-string"></a>
 #### `Arr::string()` {.collection-method}
 
 The `Arr::string()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `string` (or is `NULL`).

--- a/helpers.md
+++ b/helpers.md
@@ -283,6 +283,13 @@ $value = Arr::array($array, 'languages');
 $value = Arr::array($array, 'name');
 
 // throws InvalidArgumentException
+
+// retrieve a default value if the requested key is not in the array at all:
+
+$value = Arr::array($array, 'invoice_ids', [144, 155, 182]);
+
+// [144, 155, 182]
+
 ```
 
 <a name="method-array-boolean"></a>
@@ -302,6 +309,12 @@ $value = Arr::boolean($array, 'available');
 $value = Arr::boolean($array, 'name');
 
 // throws InvalidArgumentException
+
+// retrieve a default value if the requested key is not in the array at all:
+
+$value = Arr::boolean($array, 'is_admin', false);
+
+// false
 ```
 
 
@@ -474,6 +487,13 @@ $value = Arr::float($array, 'balance');
 $value = Arr::float($array, 'name');
 
 // throws InvalidArgumentException
+
+// retrieve a default value if the requested key is not in the array at all:
+
+$value = Arr::float($array, 'tax_rate', 0.075);
+
+// 0.075
+
 ```
 
 <a name="method-array-forget"></a>
@@ -575,6 +595,12 @@ $value = Arr::integer($array, 'age');
 $value = Arr::integer($array, 'name');
 
 // throws InvalidArgumentException
+
+// retrieve a default value if the requested key is not in the array at all:
+
+$value = Arr::integer($array, 'weight', 225);
+
+// 225
 ```
 
 <a name="method-array-isassoc"></a>
@@ -1147,6 +1173,13 @@ $value = Arr::string($array, 'name');
 $value = Arr::string($array, 'languages');
 
 // throws InvalidArgumentException
+
+// retrieve a default value if the requested key is not in the array at all:
+
+$value = Arr::string($array, 'city', 'Newmarket');
+
+// Newmarket
+
 ```
 
 <a name="method-array-take"></a>

--- a/helpers.md
+++ b/helpers.md
@@ -269,7 +269,7 @@ $array = Arr::add(['name' => 'Desk', 'price' => null], 'price', 100);
 <a name="method-array-array"></a>
 #### `Arr::array()` {.collection-method}
 
-The `Arr::array()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not an `array` (or is `NULL`).
+The `Arr::array` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not an `array`:
 
 ```
 use Illuminate\Support\Arr;
@@ -283,19 +283,12 @@ $value = Arr::array($array, 'languages');
 $value = Arr::array($array, 'name');
 
 // throws InvalidArgumentException
-
-// retrieve a default value if the requested key is not in the array at all:
-
-$value = Arr::array($array, 'invoice_ids', [144, 155, 182]);
-
-// [144, 155, 182]
-
 ```
 
 <a name="method-array-boolean"></a>
 #### `Arr::boolean()` {.collection-method}
 
-The `Arr::boolean()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `boolean` (or is `NULL`).
+The `Arr::boolean` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `boolean`:
 
 ```
 use Illuminate\Support\Arr;
@@ -309,12 +302,6 @@ $value = Arr::boolean($array, 'available');
 $value = Arr::boolean($array, 'name');
 
 // throws InvalidArgumentException
-
-// retrieve a default value if the requested key is not in the array at all:
-
-$value = Arr::boolean($array, 'is_admin', false);
-
-// false
 ```
 
 
@@ -473,7 +460,7 @@ $flattened = Arr::flatten($array);
 <a name="method-array-float"></a>
 #### `Arr::float()` {.collection-method}
 
-The `Arr::float()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `float` (or is `NULL`).
+The `Arr::float` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `float`:
 
 ```
 use Illuminate\Support\Arr;
@@ -487,13 +474,6 @@ $value = Arr::float($array, 'balance');
 $value = Arr::float($array, 'name');
 
 // throws InvalidArgumentException
-
-// retrieve a default value if the requested key is not in the array at all:
-
-$value = Arr::float($array, 'tax_rate', 0.075);
-
-// 0.075
-
 ```
 
 <a name="method-array-forget"></a>
@@ -581,7 +561,7 @@ $contains = Arr::hasAny($array, ['category', 'product.discount']);
 <a name="method-array-integer"></a>
 #### `Arr::integer()` {.collection-method}
 
-The `Arr::integer()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not an `int` (or is `NULL`).
+The `Arr::integer` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not an `int`:
 
 ```
 use Illuminate\Support\Arr;
@@ -595,12 +575,6 @@ $value = Arr::integer($array, 'age');
 $value = Arr::integer($array, 'name');
 
 // throws InvalidArgumentException
-
-// retrieve a default value if the requested key is not in the array at all:
-
-$value = Arr::integer($array, 'weight', 225);
-
-// 225
 ```
 
 <a name="method-array-isassoc"></a>
@@ -1159,7 +1133,7 @@ $sorted = Arr::sortRecursiveDesc($array);
 <a name="method-array-string"></a>
 #### `Arr::string()` {.collection-method}
 
-The `Arr::string()` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `string` (or is `NULL`).
+The `Arr::string` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `string`:
 
 ```
 use Illuminate\Support\Arr;
@@ -1173,13 +1147,6 @@ $value = Arr::string($array, 'name');
 $value = Arr::string($array, 'languages');
 
 // throws InvalidArgumentException
-
-// retrieve a default value if the requested key is not in the array at all:
-
-$value = Arr::string($array, 'city', 'Newmarket');
-
-// Newmarket
-
 ```
 
 <a name="method-array-take"></a>


### PR DESCRIPTION
Adds typed getter helpers (`Arr::string()`, `Arr::integer()`, `Arr::float()`, `Arr::boolean()`, `Arr::array()`) as also exist on the `Config` facade, in an effort to make static analysis easier when using the `Arr::get()` helper.

Framework PR: https://github.com/laravel/framework/pull/55567

