### PR TITLE
Change Listening Event of App.Models.User channel to .UserUpdated

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -1208,7 +1208,7 @@ Once you have obtained a channel instance, you may use the `listen` method to li
 
 ```js
 Echo.private(`App.Models.User.${this.user.id}`)
-    .listen('.PostUpdated', (e) => {
+    .listen('.UserUpdated', (e) => {
         console.log(e.model);
     });
 ```


### PR DESCRIPTION
In `App.Models.User` channel we expect to listen on `.UserUpdated` event not `.PostUpdated`

https://github.com/laravel/docs/blob/014ef3e4c2f6d44c1c640f672205afc255442627/broadcasting.md?plain=1#L1210
https://github.com/laravel/docs/blob/014ef3e4c2f6d44c1c640f672205afc255442627/broadcasting.md?plain=1#L1211