### PR TITLE
Grammatical fix in scout.md

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -168,7 +168,7 @@ Additional settings and schema definitions for your Typesense collections can be
 <a name="preparing-data-for-storage-in-typesense"></a>
 #### Preparing Data for Storage in Typesense
 
-When utilizing Typesense, your searchable model's must define a `toSearchableArray` method that casts your model's primary key to a string and creation date to a UNIX timestamp:
+When utilizing Typesense, your searchable models must define a `toSearchableArray` method that casts your model's primary key to a string and creation date to a UNIX timestamp:
 
 ```php
 /**


### PR DESCRIPTION
In this context, 'models' is not possesssive. 
> your searchable **models** must define a

**Note:** something that I cannot fix via this repository is a navigation error on the Packages/Dusk page. When clicked, the main navigation jumps to the 'Testing' section.


<img width="1376" alt="Screenshot 2025-04-28 at 1 59 36 pm" src="https://github.com/user-attachments/assets/964112ad-594e-4f5b-b223-7ce873ad8d83" />
