### PR TITLE
Instructions for composer on existing apps

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -9,6 +9,7 @@
 - [Executing Commands](#executing-sail-commands)
     - [Executing PHP Commands](#executing-php-commands)
     - [Executing Composer Commands](#executing-composer-commands)
+    - [Installing Composer Dependencies for Existing Applications](#installing-composer-dependencies-for-existing-projects)
     - [Executing Artisan Commands](#executing-artisan-commands)
     - [Executing Node / NPM Commands](#executing-node-npm-commands)
 - [Interacting With Databases](#interacting-with-sail-databases)
@@ -182,6 +183,24 @@ Composer commands may be executed using the `composer` command. Laravel Sail's a
 ```shell
 sail composer require laravel/sanctum
 ```
+
+<a name="installing-composer-dependencies-for-existing-projects"></a>
+#### Installing Composer Dependencies for Existing Applications
+
+If you are developing an application with a team, you may not be the one that initially creates the Laravel application. Therefore, none of the application's Composer dependencies, including Sail, will be installed after you clone the application's repository to your local computer.
+
+You may install the application's dependencies by navigating to the application's directory and executing the following command. This command uses a small Docker container containing PHP and Composer to install the application's dependencies:
+
+```shell
+docker run --rm \
+    -u "$(id -u):$(id -g)" \
+    -v "$(pwd):/var/www/html" \
+    -w /var/www/html \
+    laravelsail/php84-composer:latest \
+    composer install --ignore-platform-reqs
+```
+
+When using the `laravelsail/phpXX-composer` image, you should use the same version of PHP that you plan to use for your application (`82`, `83`, or `84`).
 
 <a name="executing-artisan-commands"></a>
 ### Executing Artisan Commands


### PR DESCRIPTION
These instruction were in previous versions as well, without these it's unable to install the composer packages (including sail itself) without having an local development environs already. 