### PR TITLE
Fix invalid useCache() example

### DIFF
--- a/scheduling.md
+++ b/scheduling.md
@@ -365,10 +365,7 @@ Schedule::command('report:generate')
 You may use the `useCache` method to customize the cache store used by the scheduler to obtain the atomic locks necessary for single-server tasks:
 
 ```php
-Schedule::command('recipes:sync')
-    ->everyThirtyMinutes()
-    ->onOneServer();
-    ->useCache('database');
+Schedule::useCache('database');
 ```
 
 <a name="naming-unique-jobs"></a>


### PR DESCRIPTION
There are two problems with the current example:
- It's invalid PHP syntax (method call after semicolon)
- It makes you think that the cache connection can be configured _per event_, which you can't.