### PR TITLE
[12.x] Fix typo in interface name

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -476,7 +476,7 @@ When mapping collections to objects, the object should implement the `Illuminate
 namespace App\ValueObjects;
 
 use Illuminate\Contracts\Support\Arrayable;
-use JsonSerilizable;
+use JsonSerializable;
 
 class Option implements Arrayable, JsonSerializable
 {


### PR DESCRIPTION
**Description:**
This pull request corrects a small typo where the interface name `JsonSerilizable` was misspelled. The correct spelling is `JsonSerializable`, which matches the [official PHP interface](https://www.php.net/manual/en/class.jsonserializable.php).