### PR TITLE
[12.x] Fix the missing text import

### DIFF
--- a/prompts.md
+++ b/prompts.md
@@ -812,6 +812,7 @@ If you need more granular control over a prompt in a form, you may invoke the `a
 ```php
 use function Laravel\Prompts\form;
 use function Laravel\Prompts\outro;
+use function Laravel\Prompts\text;
 
 $responses = form()
     ->text('What is your name?', required: true, name: 'name')


### PR DESCRIPTION
**Description:**

This PR includes the missing import for the `text()` function. Without it, the example throws an error:

> Error: Call to undefined function App\Console\Commands\text()

This change ensures the example runs as expected.