### PR TITLE
[12.x] Add missing codeblock start to billing

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -2218,6 +2218,7 @@ return $request->user()->downloadInvoice($invoiceId, [], 'my-invoice');
 
 Cashier also makes it possible to use a custom invoice renderer. By default, Cashier uses the `DompdfInvoiceRenderer` implementation, which utilizes the [dompdf](https://github.com/dompdf/dompdf) PHP library to generate Cashier's invoices. However, you may use any renderer you wish by implementing the `Laravel\Cashier\Contracts\InvoiceRenderer` interface. For example, you may wish to render an invoice PDF using an API call to a third-party PDF rendering service:
 
+```php
 use Illuminate\Support\Facades\Http;
 use Laravel\Cashier\Contracts\InvoiceRenderer;
 use Laravel\Cashier\Invoice;


### PR DESCRIPTION
Fixes a missing codeblock start tag in [Custom Invoice Renderer](https://laravel.com/docs/12.x/billing#custom-invoice-render). Should make `Checkout` and `Product Checkouts` work again. 👍

<img width="1020" alt="Screenshot 2025-04-30 at 17 22 17" src="https://github.com/user-attachments/assets/2e6e4985-5deb-469f-9ceb-804c45eed940" />
