### PR TITLE
Minor fix to the AsCollection Option example

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -480,15 +480,18 @@ use JsonSerializable;
 
 class Option implements Arrayable, JsonSerializable
 {
+    public string $name;
+    public mixed $value;
+    public bool $isLocked;
+
     /**
      * Create a new Option instance.
      */
-    public function __construct(
-        public string $name,
-        public mixed $value,
-        public bool $isLocked = false
-    ) {
-        //
+    public function __construct(array $data)
+    {
+        $this->name = $data['name'];
+        $this->value = $data['value'];
+        $this->isLocked = $data['is_locked'];
     }
 
     /**


### PR DESCRIPTION
To avoid confusion, the option constructor should receive an `array`, not each array member values. This is because `mapInto` and `map` will receive the item array completely.