### PR TITLE
Query builder first mention

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -568,7 +568,7 @@ $users = DB::table('users')
 If you need to group an "or" condition within parentheses, you may pass a closure as the first argument to the `orWhere` method:
 
 ```php
-use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Builder; 
 
 $users = DB::table('users')
     ->where('votes', '>', 100)

--- a/queries.md
+++ b/queries.md
@@ -568,6 +568,8 @@ $users = DB::table('users')
 If you need to group an "or" condition within parentheses, you may pass a closure as the first argument to the `orWhere` method:
 
 ```php
+use Illuminate\Database\Query\Builder;
+
 $users = DB::table('users')
     ->where('votes', '>', 100)
     ->orWhere(function (Builder $query) {

--- a/scout.md
+++ b/scout.md
@@ -168,7 +168,7 @@ Additional settings and schema definitions for your Typesense collections can be
 <a name="preparing-data-for-storage-in-typesense"></a>
 #### Preparing Data for Storage in Typesense
 
-When utilizing Typesense, your searchable model's must define a `toSearchableArray` method that casts your model's primary key to a string and creation date to a UNIX timestamp:
+When utilizing Typesense, your searchable models must define a `toSearchableArray` method that casts your model's primary key to a string and creation date to a UNIX timestamp:
 
 ```php
 /**


### PR DESCRIPTION
This is the first mention of `Builder` on the page. Should the `use` reference be included here since there are several possible imports?