### PR TITLE
Fix "Facade Class Reference" table rendering (Firefox)

### DIFF
--- a/facades.md
+++ b/facades.md
@@ -301,7 +301,7 @@ class PodcastTest extends TestCase
 
 Below you will find every facade and its underlying class. This is a useful tool for quickly digging into the API documentation for a given facade root. The [service container binding](/docs/{{version}}/container) key is also included where applicable.
 
-<div class="overflow-auto">
+<div>
 
 | Facade | Class | Service Container Binding |
 | --- | --- | --- |


### PR DESCRIPTION
Here is how it currently renders (how I see the table):

![image](https://github.com/user-attachments/assets/160c7895-760a-4f96-b5fd-d2920da16b4e)

By removing the `overflow-auto` class, here is how it renders to me:

![image](https://github.com/user-attachments/assets/8ad41f57-7f2a-4476-995c-147e0d59ff59)

On Windows, this happens in Firefox, but not in Chrome. I have not tested other browsers or systems.