### PR TITLE
[12.x] Clarify collapse method behavior

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -417,7 +417,7 @@ $chunks->all();
 <a name="method-collapse"></a>
 #### `collapse()` {.collection-method}
 
-The `collapse` method collapses a collection of arrays into a single, flat collection:
+The `collapse` method collapses a collection of arrays or collections into a single, flat collection:
 
 ```php
 $collection = collect([


### PR DESCRIPTION
Description
---
This PR clarifies the behavior of the `collapse` method to reflect that it can collapse both arrays and collections. Currently, the documentation only mentions arrays, but the method also supports nested Collection instances.

This change not only improves clarity and accuracy but also ensures consistency with the `collapseWithKeys` method, which explicitly states support for both arrays and collections.