### PR TITLE
[12.x] Clarify unless method usage in collections docs

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -3457,16 +3457,16 @@ This method has the same signature as the [unique](#method-unique) method; howev
 <a name="method-unless"></a>
 #### `unless()` {.collection-method}
 
-The `unless` method will execute the given callback unless the first argument given to the method evaluates to `true`:
+The `unless` method will execute the given callback unless the first argument given to the method evaluates to `true`. The collection instance and the first argument given to the `unless` method will be provided to the closure:
 
 ```php
 $collection = collect([1, 2, 3]);
 
-$collection->unless(true, function (Collection $collection) {
+$collection->unless(true, function (Collection $collection, int $value) {
     return $collection->push(4);
 });
 
-$collection->unless(false, function (Collection $collection) {
+$collection->unless(false, function (Collection $collection, int $value) {
     return $collection->push(5);
 });
 
@@ -3480,9 +3480,9 @@ A second callback may be passed to the `unless` method. The second callback will
 ```php
 $collection = collect([1, 2, 3]);
 
-$collection->unless(true, function (Collection $collection) {
+$collection->unless(true, function (Collection $collection, int $value) {
     return $collection->push(4);
-}, function (Collection $collection) {
+}, function (Collection $collection, int $value) {
     return $collection->push(5);
 });
 
@@ -3589,7 +3589,7 @@ $collection = collect([1, 2, 3]);
 
 $collection->when(false, function (Collection $collection, int $value) {
     return $collection->push(4);
-}, function (Collection $collection) {
+}, function (Collection $collection, int $value) {
     return $collection->push(5);
 });
 


### PR DESCRIPTION
Description
---
This PR updates the description for the `unless` method to clarify that both the collection instance and the first argument are passed to the closure similar to the behavior of the `when` method.

As the `when` method explicitly states that:

> The collection instance and the first argument given to the when method will be provided to the closure:

Let's do the same for the `unless` method to maintain consistency and improve clarity for developers reading the documentation, especially since `when` and `unless` are behave similarly in terms of callback parameters.