### PR TITLE
[12.x] Add docs about using 'exists' rule on array

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1677,6 +1677,16 @@ You may explicitly specify the database column name that should be used by the `
 'state' => Rule::exists('states', 'abbreviation'),
 ```
 
+<a name="validate-an-array-of-values-against-database"></a>
+#### Validate an array of values against database
+Sometimes, you may wish to validate whether a collection of values exists in the database. You can do so by specifying both `exists` and [array](#rule-array) as the validation rules:
+
+```php
+'user_ids' => ['array', 'exists:users,id'],
+```
+
+Rather than validating each item in the array individually, Laravel will automatically build a single query to check if all passed values are valid.
+
 <a name="rule-extensions"></a>
 #### extensions:_foo_,_bar_,...
 

--- a/validation.md
+++ b/validation.md
@@ -1678,14 +1678,15 @@ You may explicitly specify the database column name that should be used by the `
 ```
 
 <a name="validate-an-array-of-values-against-database"></a>
-#### Validate an array of values against database
-Sometimes, you may wish to validate whether a collection of values exists in the database. You can do so by specifying both `exists` and [array](#rule-array) as the validation rules:
+#### Validating an Array of Values
+
+Sometimes, you may wish to validate whether an array of values exists in the database. You can do so by adding both the `exists` and [array](#rule-array) rules to the field being validated:
 
 ```php
 'user_ids' => ['array', 'exists:users,id'],
 ```
 
-Rather than validating each item in the array individually, Laravel will automatically build a single query to check if all passed values are valid.
+When both of these rules are assigned to a field, Laravel will automatically build a single query to determine if all of the given values exist in the specified table.
 
 <a name="rule-extensions"></a>
 #### extensions:_foo_,_bar_,...


### PR DESCRIPTION
I recently stumbled upon this bit of (to my knowledge) undocumented behaviour of the `exists` rule. 

I assumed that `exists` would not work on array values because the documentation did not specify that it would. So I validated incoming arrays of IDs like this:

```php
'user_ids' => ['array'],
'user_ids.*' => ['integer', 'exists:users,id'],
```

This queries the database for every single item in the array. Instead, you can specify the 'exists' rule as:

```php
'user_ids' => ['array', 'exists:users,id'],
```

... which only generates a single `WHERE id IN (...)` query. This PR adds a little note on this to the docs.