### PR TITLE
[12.x] Add `Authenticated` Attribute in Container

### DIFF
--- a/container.md
+++ b/container.md
@@ -300,6 +300,8 @@ namespace App\Http\Controllers;
 
 use App\Models\Photo;
 use Illuminate\Container\Attributes\Auth;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Container\Attributes\Authenticated;
 use Illuminate\Container\Attributes\Cache;
 use Illuminate\Container\Attributes\Config;
 use Illuminate\Container\Attributes\DB;
@@ -315,6 +317,7 @@ class PhotoController extends Controller
 {
     public function __construct(
         #[Auth('web')] protected Guard $auth,
+        #[Authenticated('web')] protected Authenticatable $authenticatable,
         #[Cache('redis')] protected Repository $cache,
         #[Config('app.timezone')] protected string $timezone,
         #[DB('mysql')] protected Connection $connection,


### PR DESCRIPTION
This PR updates the Laravel documentation to include an example of using the new `#[Authenticated]` attribute alongside the #[Auth] attribute in controller constructors.

This addition complements the existing examples of other container attributes like `#[Cache]`, `#[Config]`, and `#[DB]`, providing a more complete picture of how to leverage attribute-based dependency injection in Laravel controllers.

