### PR TITLE
Update undocumented precision in documentation

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -1552,6 +1552,10 @@ $currency = Number::currency(1000, in: 'EUR');
 $currency = Number::currency(1000, in: 'EUR', locale: 'de');
 
 // 1.000,00 €
+
+$currency = Number::currency(1000, in: 'EUR', locale: 'de', precision: 0);
+
+// 1.000 €
 ```
 
 <a name="method-default-currency"></a>


### PR DESCRIPTION
In the Number helper class currency method precision not documented, but exist in the code, there is a lot of currency that do not use any subb currency Like (HUF)