### PR TITLE
Fix incorrect Artisan command for generating session table

### DIFF
--- a/session.md
+++ b/session.md
@@ -51,7 +51,7 @@ The session `driver` configuration option defines where session data will be sto
 When using the `database` session driver, you will need to ensure that you have a database table to contain the session data. Typically, this is included in Laravel's default `0001_01_01_000000_create_users_table.php` [database migration](/docs/{{version}}/migrations); however, if for any reason you do not have a `sessions` table, you may use the `make:session-table` Artisan command to generate this migration:
 
 ```shell
-php artisan make:session-table
+php artisan session:table
 
 php artisan migrate
 ```


### PR DESCRIPTION
PR Description:
This pull request fixes a typo in the Laravel documentation where the wrong Artisan command was mentioned for generating the session table.

**Incorrect**:

`php artisan make:session-table`

**Correct**:

`php artisan session:table`

This change ensures the documentation reflects the actual command available in Laravel, preventing confusion for developers following the guide.