### PR TITLE
[12.x] Fix typo in broadcasting.md

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -1155,7 +1155,7 @@ useEcho<OrderData>(`orders.${orderId}`, "OrderShipmentStatusUpdated", (e) => {
 });
 ```
 
-The `useEcho` will hook will automatically leave channels when the consuming component is unmounted; however, you may utilize the returned functions to manually stop / start listening to channels programmatically when necessary:
+The `useEcho` hook will automatically leave channels when the consuming component is unmounted; however, you may utilize the returned functions to manually stop / start listening to channels programmatically when necessary:
 
 ```js tab=React
 import { useEcho } from "@laravel/echo-react";


### PR DESCRIPTION
Removes redundant `will` word.

Continuation of: https://github.com/laravel/docs/pull/10398