### PR TITLE
[12.x] Clarify retryUntil() precedence over tries in queue jobs

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1254,6 +1254,9 @@ public function retryUntil(): DateTime
 ```
 
 > [!NOTE]
+> If both `retryUntil` and a `tries` limit are defined, Laravel will prioritize the `retryUntil` method. This means the job may be attempted multiple times until the given time expires, even if the configured `tries` limit is exceeded.
+
+> [!NOTE]
 > You may also define a `tries` property or `retryUntil` method on your [queued event listeners](/docs/{{version}}/events#queued-event-listeners).
 
 <a name="max-exceptions"></a>

--- a/queues.md
+++ b/queues.md
@@ -1253,8 +1253,7 @@ public function retryUntil(): DateTime
 }
 ```
 
-> [!NOTE]
-> If both `retryUntil` and a `tries` limit are defined, Laravel will prioritize the `retryUntil` method. This means the job may be attempted multiple times until the given time expires, even if the configured `tries` limit is exceeded.
+If both `retryUntil` and `tries` are defined, Laravel gives precedence to the `retryUntil` method.
 
 > [!NOTE]
 > You may also define a `tries` property or `retryUntil` method on your [queued event listeners](/docs/{{version}}/events#queued-event-listeners).


### PR DESCRIPTION
Laravel allows developers to define a retryUntil() method on queued jobs to specify a time limit for retry attempts. The documentation correctly describes this as an alternative to setting a tries limit.

However, the current text does not clarify what happens when both retryUntil() and tries are defined on the same job. In practice, Laravel prioritizes the retryUntil() constraint, allowing the job to continue retrying until the specified time expires — even if it exceeds the configured number of attempts.

This behavior is handled within the markJobAsFailedIfAlreadyExceedsMaxAttempts()(https://github.com/laravel/framework/blob/12.x/src/Illuminate/Queue/Worker.php) method, where the retryUntil() timestamp is checked before enforcing the maxTries logic.

This PR proposes the following note to be added to the documentation, immediately after the current explanation of retryUntil():

If both retryUntil and a tries limit are defined, Laravel will prioritize the retryUntil method. This means the job may be attempted multiple times until the given time expires, even if the configured tries limit is exceeded.

I believe this clarification will help avoid confusion for developers who define both constraints, expecting both to apply simultaneously.

Please let me know if you'd prefer a different placement or phrasing.