### PR TITLE
[12.x] Add `exceptHidden` method in Context

### DIFF
--- a/context.md
+++ b/context.md
@@ -374,6 +374,7 @@ Context::getHidden(/* ... */);
 Context::pullHidden(/* ... */);
 Context::popHidden(/* ... */);
 Context::onlyHidden(/* ... */);
+Context::exceptHidden(/* ... */);
 Context::allHidden(/* ... */);
 Context::hasHidden(/* ... */);
 Context::forgetHidden(/* ... */);


### PR DESCRIPTION
Description
---
This PR introduces the `exceptHidden` method, complementing the previously added `onlyHidden` method. I have added the `exceptHidden` method after the `onlyHidden` method.

Continuation of https://github.com/laravel/framework/pull/55692 and https://github.com/laravel/docs/pull/10388