### PR TITLE
[12.x] Fix spacing inconsistency before ellipsis in event comments

### DIFF
--- a/events.md
+++ b/events.md
@@ -918,7 +918,7 @@ test('orders can be processed', function () {
         return $order;
     });
 
-    // Events are dispatched as normal and observers will run ...
+    // Events are dispatched as normal and observers will run...
     $order->update([...]);
 });
 ```
@@ -948,7 +948,7 @@ class ExampleTest extends TestCase
             return $order;
         });
 
-        // Events are dispatched as normal and observers will run ...
+        // Events are dispatched as normal and observers will run...
         $order->update([...]);
     }
 }


### PR DESCRIPTION
Description
---
This PR fixes a minor formatting inconsistency in the Laravel Events docs. Specifically, it removes an extra space before the ellipsis (...)

This change aligns it with the formatting used in other comments throughout the codebase, where no space precedes the ellipsis.