### PR TITLE
[12.x] Update queue docs: Include queued notifications for tries and retryUntil

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1273,7 +1273,7 @@ public function retryUntil(): DateTime
 If both `retryUntil` and `tries` are defined, Laravel gives precedence to the `retryUntil` method.
 
 > [!NOTE]
-> You may also define a `tries` property or `retryUntil` method on your [queued event listeners](/docs/{{version}}/events#queued-event-listeners).
+> You may also define a `tries` property or `retryUntil` method on your [queued event listeners](/docs/{{version}}/events#queued-event-listeners) and [queued notifications](/docs/{{version}}/notifications#queueing-notifications).
 
 <a name="max-exceptions"></a>
 #### Max Exceptions


### PR DESCRIPTION
This PR updates the Laravel documentation to clarify that the tries property and retryUntil method are also available on queued notifications, in addition to queued event listeners.

Why this change is necessary:
Currently, the documentation only mentions that these properties can be defined on "queued event listeners." However, Laravel also supports tries and retryUntil on queued notifications. This change provides better clarity for developers utilizing notification queues, ensuring they are aware of retry capabilities.