### PR TITLE
[12.x]Add Sockudo to Broadcasting Documentation

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -501,7 +501,7 @@ npm run dev
 
 [Laravel Echo](https://github.com/laravel/echo) is a JavaScript library that makes it painless to subscribe to channels and listen for events broadcast by your server-side broadcasting driver.
 
-When installing broadcasting support via the `install:broadcasting --sockudo` Artisan command, Sockudo and Echo's scaffolding and configuration will be injected into your application automatically. However, if you wish to manually configure Laravel Echo, you may do so by following the instructions below.
+When installing broadcasting support via the `install:broadcasting --pusher` Artisan command, Sockudo and Echo's scaffolding and configuration will be injected into your application automatically. However, if you wish to manually configure Laravel Echo, you may do so by following the instructions below.
 
 <a name="sockudo-client-manual-installation"></a>
 #### Manual Installation


### PR DESCRIPTION
* Included a new "Sockudo" section under "Server Side Installation," detailing:
    * Sockudo server setup prerequisites.
    * Installation of the `pusher/pusher-php-server` SDK.
    * Configuration of the `sockudo` driver in `config/broadcasting.php` to point to a Sockudo instance (host, port, scheme, app credentials).
    * Relevant `.env` variable setup.
* Included a new "Sockudo" section under "Client Side Installation," detailing:
    * Installation of `laravel-echo` and `pusher-js`.
    * Configuration of Laravel Echo to connect to Sockudo, including `wsHost`, `wsPort`, `wssPort`, and `forceTLS` settings.
    * Relevant Vite environment variable setup (`VITE_SOCKUDO_HOST`, etc.).