### PR TITLE
[12.x] Update the output of `dd` and `dump` methods

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -697,12 +697,10 @@ $collection = collect(['John Doe', 'Jane Doe']);
 $collection->dd();
 
 /*
-    Collection {
-        #items: array:2 [
-            0 => "John Doe"
-            1 => "Jane Doe"
-        ]
-    }
+    array:2 [
+        0 => "John Doe"
+        1 => "Jane Doe"
+    ]
 */
 ```
 
@@ -871,12 +869,10 @@ $collection = collect(['John Doe', 'Jane Doe']);
 $collection->dump();
 
 /*
-    Collection {
-        #items: array:2 [
-            0 => "John Doe"
-            1 => "Jane Doe"
-        ]
-    }
+    array:2 [
+        0 => "John Doe"
+        1 => "Jane Doe"
+    ]
 */
 ```
 


### PR DESCRIPTION
Description
--
This PR updates the examples for the `dd` and `dump` methods in the Collections documentation.

Problem
---
Currently, the examples show the output as a Collection object with internal properties. However, both `dd` and `dump` actually output the underlying `array`, not the `Collection` object itself.

Proposed Fix
---
Update the sample output to accurately reflect what is printed when using these methods.

Reasoning
---
This change improves accuracy and prevents confusion for developers referencing the documentation to understand the behavior of these methods.