### PR TITLE
[12.x] Clarify where the code should be placed

### DIFF
--- a/context.md
+++ b/context.md
@@ -227,6 +227,7 @@ Stacks can be useful to capture historical information about a request, such as 
 use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\DB;
 
+// In our service provider...
 DB::listen(function ($event) {
     Context::push('queries', [$event->time, $event->sql]);
 });

--- a/context.md
+++ b/context.md
@@ -227,7 +227,7 @@ Stacks can be useful to capture historical information about a request, such as 
 use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\DB;
 
-// In our service provider...
+// In AppServiceProvider.php...
 DB::listen(function ($event) {
     Context::push('queries', [$event->time, $event->sql]);
 });


### PR DESCRIPTION
Problem
---
The original example lacks context about where the `DB::listen` logic is expected to live, which may confuse developers unfamiliar with the typical usage patterns.

Proposed Fix
---
Add a comment to clarify that the `DB::listen` code should be placed in a service provider.

Reasoning
---
This small change improves readability by helping readers understand where the code belongs within a typical Laravel application structure.