### PR TITLE
[12.x] Is the Concurrency facade still in beta?

### DIFF
--- a/concurrency.md
+++ b/concurrency.md
@@ -7,9 +7,6 @@
 <a name="introduction"></a>
 ## Introduction
 
-> [!WARNING]
-> Laravel's `Concurrency` facade is currently in beta while we gather community feedback.
-
 Sometimes you may need to execute several slow tasks which do not depend on one another. In many cases, significant performance improvements can be realized by executing the tasks concurrently. Laravel's `Concurrency` facade provides a simple, convenient API for executing closures concurrently.
 
 <a name="concurrency-compatibility"></a>


### PR DESCRIPTION
Description
---
This PR removes the warning that labels Laravel's Concurrency facade as "currently in beta."

Reason for Change
---
The Concurrency facade appears to have moved beyond beta, it has no changes across recent versions.

Goal
---
This update helps prevent confusion for developers who may hesitate to use the feature due to outdated messaging.