### PR TITLE
[12.x] Is the defer function still in beta?

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -502,9 +502,9 @@ use Illuminate\Support\Arr;
 
 Arr::from((object) ['foo' => 'bar']); // ['foo' => 'bar']
 
-class TestJsonableObject implements Jsonable 
+class TestJsonableObject implements Jsonable
 {
-    public function toJson($options = 0) 
+    public function toJson($options = 0)
     {
         return json_encode(['foo' => 'bar']);
     }
@@ -3066,9 +3066,6 @@ For a thorough discussion of Carbon and its features, please consult the [offici
 
 <a name="deferred-functions"></a>
 ### Deferred Functions
-
-> [!WARNING]
-> Deferred functions are currently in beta while we gather community feedback.
 
 While Laravel's [queued jobs](/docs/{{version}}/queues) allow you to queue tasks for background processing, sometimes you may have simple tasks you would like to defer without configuring or maintaining a long-running queue worker.
 


### PR DESCRIPTION
Description
---
This PR removes the warning that labels Laravel's Deferred functions as "currently in beta."

Reason for Change
---
The Deferred functions appears to have moved beyond beta, it has no changes across recent versions.

Goal
---
This update helps prevent confusion for developers who may hesitate to use the feature due to outdated messaging.