### PR TITLE
[12.x] Clarify retryUntil() precedence over tries

### DIFF
--- a/events.md
+++ b/events.md
@@ -535,6 +535,8 @@ public function retryUntil(): DateTime
 }
 ```
 
+If both `retryUntil` and `tries` are defined, Laravel gives precedence to the `retryUntil` method.
+
 <a name="specifying-queued-listener-backoff"></a>
 #### Specifying Queued Listener Backoff
 


### PR DESCRIPTION
Continuation of: https://github.com/laravel/docs/pull/10404