### PR TITLE
add documentation for Str::split method

### DIFF
--- a/strings.md
+++ b/strings.md
@@ -89,6 +89,7 @@ Laravel includes a variety of functions for manipulating string values. Many of 
 [Str::singular](#method-str-singular)
 [Str::slug](#method-str-slug)
 [Str::snake](#method-snake-case)
+[Str::split](#method-str-split)
 [Str::squish](#method-str-squish)
 [Str::start](#method-str-start)
 [Str::startsWith](#method-starts-with)
@@ -1350,6 +1351,26 @@ $converted = Str::snake('fooBar', '-');
 // foo-bar
 ```
 
+<a name="method-str-split"></a>
+#### `Str::split()` {.collection-method}
+
+The `Str::split` method splits a string into an array using a given separator. You may also optionally specify a limit on the number of resulting segments:
+
+```php
+use Illuminate\Support\Str;
+
+$segments = Str::split('-', 'laravel-framework');
+
+// ['laravel', 'framework']
+```
+
+You may pass a third argument to limit the number of splits:
+
+```php
+$segments = Str::split(',', 'one,two,three,four', 3);
+
+// ['one', 'two', 'three,four']
+```
 <a name="method-str-squish"></a>
 #### `Str::squish()` {.collection-method}
 


### PR DESCRIPTION
##  Documentation for  `Str::split` Method

This PR adds documentation for a new `Str::split` method that is being proposed in the Laravel framework.

### About the Method

`Str::split` is a convenient, expressive wrapper around PHP’s native `explode()` function. It allows developers to split a string by a given separator, with optional support for a limit.

This method is particularly helpful for developers working across multiple languages like JavaScript or Python, where `split` is the standard method for string separation—providing familiarity and consistency in Laravel’s `Str` API.

### Example Usage

```php
use Illuminate\Support\Str;

Str::split('-', 'laravel-framework');
// ['laravel', 'framework']

Str::split(',', 'one,two,three,four', 3);
// ['one', 'two', 'three,four']
```