### PR TITLE
Update default node version installed by laravel/sail

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -442,7 +442,7 @@ sail up
 <a name="sail-node-versions"></a>
 ## Node Versions
 
-Sail installs Node 20 by default. To change the Node version that is installed when building your images, you may update the `build.args` definition of the `laravel.test` service in your application's `docker-compose.yml` file:
+Sail installs Node 22 by default. To change the Node version that is installed when building your images, you may update the `build.args` definition of the `laravel.test` service in your application's `docker-compose.yml` file:
 
 ```yaml
 build:


### PR DESCRIPTION
This PR changes information about the version of Node that is installed by default by `laravel/sail`, it seems that new default version is `22`. https://github.com/laravel/sail/blob/3e7d899232a8c5e3ea4fc6dee7525ad583887e72/runtimes/8.0/Dockerfile#L6