### PR TITLE
[12.x] Documenting the unless method in conditional context

### DIFF
--- a/context.md
+++ b/context.md
@@ -162,6 +162,19 @@ Context::when(
 );
 ```
 
+The `unless` method may be used to add data to the context based on a given condition. The first closure provided to the `unless` method will be invoked unless the given condition evaluates to `true`, while the second closure will be invoked unless the condition evaluates to `false`:
+
+```php
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Context;
+
+Context::unless(
+    Auth::user()->isAdmin(),
+    fn ($context) => $context->add('permissions', Auth::user()->permissions),
+    fn ($context) => $context->add('permissions', []),
+);
+```
+
 <a name="scoped-context"></a>
 #### Scoped Context
 


### PR DESCRIPTION
Description
---
This PR updates the `Conditional Context` section to include an explanation and example for the `unless` method provided by the `Conditionable` trait.

Just like `when`, the `unless` method is available on the Context facade and may be used to conditionally add data to the context. This addition ensures that both conditional helpers (`when` and `unless`) are clearly documented for developers who may prefer either style.

I’ve used the same tone and structure of the existing `when` method documentation to ensure consistency.