### PR TITLE
[12.x] Update version support table

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -28,7 +28,7 @@ For all Laravel releases, bug fixes are provided for 18 months and security fixe
 | 10 | 8.1 - 8.3 | February 14th, 2023 | August 6th, 2024 | February 4th, 2025 |
 | 11 | 8.2 - 8.4 | March 12th, 2024 | September 3rd, 2025 | March 12th, 2026 |
 | 12 | 8.2 - 8.4 | February 24th, 2025 | August 13th, 2026 | February 24th, 2027 |
-| 13 | 8.2 - 8.4 | Q1 2026 | Q3 2027 | Q1 2028 |
+| 13 | 8.3 - 8.4 | Q1 2026 | Q3 2027 | Q1 2028 |
 
 </div>
 

--- a/releases.md
+++ b/releases.md
@@ -25,10 +25,10 @@ For all Laravel releases, bug fixes are provided for 18 months and security fixe
 
 | Version | PHP (*) | Release | Bug Fixes Until | Security Fixes Until |
 | --- | --- | --- | --- | --- |
-| 9 | 8.0 - 8.2 | February 8th, 2022 | August 8th, 2023 | February 6th, 2024 |
 | 10 | 8.1 - 8.3 | February 14th, 2023 | August 6th, 2024 | February 4th, 2025 |
 | 11 | 8.2 - 8.4 | March 12th, 2024 | September 3rd, 2025 | March 12th, 2026 |
 | 12 | 8.2 - 8.4 | February 24th, 2025 | August 13th, 2026 | February 24th, 2027 |
+| 13 | 8.2 - 8.4 | Q1 2026 | Q3 2027 | Q1 2028 |
 
 </div>
 


### PR DESCRIPTION
Description
---
This PR updates the version support table in the documentation to:

- Remove Laravel 9, which is now end-of-life and no longer receives bug or security fixes.
- Add a row for Laravel 13, with a tentative release in Q1 2026, following Laravel's typical release cycle. Estimated dates for bug and security fixes are also included based on the standard 18-month and 24-month support timelines.

This change helps keep the table focused on currently supported and upcoming versions, making it easier for developers to understand what’s relevant today and in the near future.