### PR TITLE
[12.x] Clarify behavior of pop method when the collection is empty

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -2254,7 +2254,7 @@ $plucked->all();
 <a name="method-pop"></a>
 #### `pop()` {.collection-method}
 
-The `pop` method removes and returns the last item from the collection:
+The `pop` method removes and returns the last item from the collection. If the collection is empty, `null` will be returned:
 
 ```php
 $collection = collect([1, 2, 3, 4, 5]);


### PR DESCRIPTION
Description
---
This PR updates the documentation for the `pop` method in Laravel's `Collection` class to explicitly mention that it returns null when called on an empty collection. This clarification helps avoid confusion and aligns the docs with the actual method behavior.