### PR TITLE
Fix typo in Eloquent serialization

### DIFF
--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -171,7 +171,7 @@ class User extends Model
      */
     protected function isAdmin(): Attribute
     {
-        return new Attribute(
+        return new Attribute::make(
             get: fn () => 'yes',
         );
     }


### PR DESCRIPTION
I copied the code for a quick test but got the error: `Call to undefined function App\Models\Attribute()`.