### PR TITLE
[12.x] Refine `replaceRecursive` method description for consistency

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -2509,7 +2509,7 @@ $replaced->all();
 <a name="method-replacerecursive"></a>
 #### `replaceRecursive()` {.collection-method}
 
-This method works like `replace`, but it will recur into arrays and apply the same replacement process to the inner values:
+The `replaceRecursive` method behaves similarly to `replace`, but it will recur into arrays and apply the same replacement process to the inner values:
 
 ```php
 $collection = collect([


### PR DESCRIPTION
Description
---
This PR updates the description of the `replaceRecursive` method in the `Collections` docs to improve consistency and clarity. Begins the sentence with the method name, matching the style used in other method's descriptions like `replace`. Uses "behaves similarly" instead of "works like" for a more formal and consistent tone.

This change aligns the tone and structure with other method's descriptions.

### replace()

> The `replace` method behaves similarly to `merge` ...

### replaceRecursive()

> The `replaceRecursive` method behaves similarly to `replace` ...