### PR TITLE
[12.x] Improve clarity in event subscriber docs

### DIFF
--- a/events.md
+++ b/events.md
@@ -658,7 +658,7 @@ class OrderShipped implements ShouldDispatchAfterCommit
 <a name="writing-event-subscribers"></a>
 ### Writing Event Subscribers
 
-Event subscribers are classes that may subscribe to multiple events from within the subscriber class itself, allowing you to define several event handlers within a single class. Subscribers should define a `subscribe` method, which will be passed an event dispatcher instance. You may call the `listen` method on the given dispatcher to register event listeners:
+Event subscribers are classes that may subscribe to multiple events from within the subscriber class itself, allowing you to define several event handlers within a single class. Subscribers should define a `subscribe` method, which receives an event dispatcher instance. You may call the `listen` method on the given dispatcher to register event listeners:
 
 ```php
 <?php


### PR DESCRIPTION
Description
---
This PR uses a more concise and active phrasing. Change `which will be passed an event dispatcher instance` to `which receives an event dispatcher instance` for improved readability and consistency with the overall tone of the Laravel documentation.