### PR TITLE
[12.x] Use environment variable for Pusher Channels Key

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -368,7 +368,7 @@ import Pusher from 'pusher-js';
 
 const options = {
     broadcaster: 'pusher',
-    key: 'your-pusher-channels-key'
+    key: import.meta.env.VITE_PUSHER_APP_KEY
 }
 
 window.Echo = new Echo({


### PR DESCRIPTION
Description
---
This PR uses environment variable for `pusher channels key` instead of hardcoding it. This change aligns with Laravel’s recommendation to avoid hardcoding sensitive values and to use `import.meta.env` for accessing environment variables.