### PR TITLE
[12.x] Fix typo in artisan.md

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -387,7 +387,7 @@ If you would like to define arguments or options to expect multiple input values
 'mail:send {user*}'
 ```
 
-When calling this method, the `user` arguments may be passed in order to the command line. For example, the following command will set the value of `user` to an array with `1` and `2` as its values:
+When running this command, the `user` arguments may be passed in order to the command line. For example, the following command will set the value of `user` to an array with `1` and `2` as its values:
 
 ```shell
 php artisan mail:send 1 2


### PR DESCRIPTION
Description
---
This PR updates a small wording issue. In this context, there's no `method` being called from the command line; what's being invoked is the Artisan `command` itself. So `method` is misleading here.

The phrase

> When calling this method ...

was replaced with

> When running this command ...