### PR TITLE
[12.x] add explanation and example for prohibited_if rule

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -949,7 +949,16 @@ $request->validate([
     'middle_name' => ['nullable', 'string', 'max:50'],
 ]);
 ```
+### prohibited_if
 
+The `prohibited_if` rule prohibits a field from being present if another specified field has a certain value. This is useful for creating dynamic forms where some fields should be excluded based on the values of others.
+
+```php
+$request->validate([
+    'company_name' => 'prohibited_if:is_freelancer,true',
+    'is_freelancer' => 'boolean',
+]);
+```
 <a name="available-validation-rules"></a>
 ## Available Validation Rules
 

--- a/validation.md
+++ b/validation.md
@@ -950,6 +950,17 @@ $request->validate([
 ]);
 ```
 
+### prohibited_if
+
+The `prohibited_if` rule prohibits a field from being present if another specified field has a certain value. This is useful for creating dynamic forms where some fields should be excluded based on the values of others.
+
+```php
+$request->validate([
+    'company_name' => 'prohibited_if:is_freelancer,true',
+    'is_freelancer' => 'boolean',
+]);
+```
+
 <a name="available-validation-rules"></a>
 ## Available Validation Rules
 

--- a/validation.md
+++ b/validation.md
@@ -949,16 +949,7 @@ $request->validate([
     'middle_name' => ['nullable', 'string', 'max:50'],
 ]);
 ```
-### prohibited_if
 
-The `prohibited_if` rule prohibits a field from being present if another specified field has a certain value. This is useful for creating dynamic forms where some fields should be excluded based on the values of others.
-
-```php
-$request->validate([
-    'company_name' => 'prohibited_if:is_freelancer,true',
-    'is_freelancer' => 'boolean',
-]);
-```
 <a name="available-validation-rules"></a>
 ## Available Validation Rules
 

--- a/validation.md
+++ b/validation.md
@@ -940,6 +940,15 @@ After defining this value, the validation rule will produce the following error 
 ```text
 The credit card number field is required when payment type is credit card.
 ```
+### nullable
+
+The `nullable` rule allows a field to be `null`. If the field is `null`, no other validation rules will be applied to it.
+
+```php
+$request->validate([
+    'middle_name' => ['nullable', 'string', 'max:50'],
+]);
+```
 
 <a name="available-validation-rules"></a>
 ## Available Validation Rules


### PR DESCRIPTION
This pull request adds a clear explanation and a practical example for the `prohibited_if` validation rule in the Laravel 12 documentation.

It helps users understand how to conditionally prohibit a field based on another field’s value, which is useful for dynamic form validations.
