### PR TITLE
[12.x] Should we remove Lumen from the docs?

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -19,7 +19,7 @@ When referencing the Laravel framework or its components from your application o
 <a name="support-policy"></a>
 ## Support Policy
 
-For all Laravel releases, bug fixes are provided for 18 months and security fixes are provided for 2 years. For all additional libraries, including Lumen, only the latest major release receives bug fixes. In addition, please review the database versions [supported by Laravel](/docs/{{version}}/database#introduction).
+For all Laravel releases, bug fixes are provided for 18 months and security fixes are provided for 2 years. For all additional libraries, only the latest major release receives bug fixes. In addition, please review the database versions [supported by Laravel](/docs/{{version}}/database#introduction).
 
 <div class="overflow-auto">
 


### PR DESCRIPTION
Description
---
I think we need to remove Lumen from the docs, according to [Taylor Otwell's tweet](https://x.com/taylorotwell/status/1441101127496323080?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1441101127496323080%7Ctwgr%5E6acefee921fd2e29239db65dbdcc02741d6c606b%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Flaravel-news.com%2Fshould-you-use-lumen-for-a-speed-boost) and [Laravel News Post](https://laravel-news.com/should-you-use-lumen-for-a-speed-boost).