### PR TITLE
[12.x] Improving the return type annotation

### DIFF
--- a/events.md
+++ b/events.md
@@ -569,7 +569,7 @@ You may easily configure "exponential" backoffs by returning an array of backoff
 /**
  * Calculate the number of seconds to wait before retrying the queued listener.
  *
- * @return array<int, int>
+ * @return list<int>
  */
 public function backoff(): array
 {


### PR DESCRIPTION
Description
---
This PR updates the PHPDoc for the `backoff()` method to use `list<int>` instead of `array<int, int>`. Since the method returns a numerically indexed array with consecutive integer keys starting from 0, I think `list<int>` more accurately describes the return type.

Note
---
I do not know how the `backoff()` method behaves behind the scenes.