### PR TITLE
[12.x] Clarify custom Artisan command discovery outside default directory

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -108,7 +108,7 @@ Typically, Tinker automatically aliases classes as you interact with them in Tin
 <a name="writing-commands"></a>
 ## Writing Commands
 
-In addition to the commands provided with Artisan, you may build your own custom commands. Commands are typically stored in the `app/Console/Commands` directory; however, you are free to choose your own storage location as long as you can instruct Laravel to [scan other directories for Artisan commands](#registering-commands).
+In addition to the commands provided with Artisan, you may build your own custom commands. Commands are typically stored in the `app/Console/Commands` directory; however, you are free to choose your own storage location as long as you instruct Laravel to [scan other directories for Artisan commands](#registering-commands).
 
 <a name="generating-commands"></a>
 ### Generating Commands


### PR DESCRIPTION
Description
---
This PR updates the "Writing Commands" section in the Artisan docs to clarify that while users are free to choose custom storage locations for Artisan commands, they must explicitly instruct Laravel to scan those directories using the `withCommands()` method.

Currently, the wording may lead readers to assume that placing commands in any directory will work automatically via Composer's autoloading, which is not the case. The update includes a direct link to the "Registering Commands" section for clear guidance.