### PR TITLE
[10.x] backport Laravel 11 dates to Laravel 10 docs

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -29,7 +29,7 @@ For all Laravel releases, bug fixes are provided for 18 months and security fixe
 | 8 | 7.3 - 8.1 | September 8th, 2020 | July 26th, 2022 | January 24th, 2023 |
 | 9 | 8.0 - 8.2 | February 8th, 2022 | August 8th, 2023 | February 6th, 2024 |
 | 10 | 8.1 - 8.3 | February 14th, 2023 | August 6th, 2024 | February 4th, 2025 |
-| 11 | 8.2 - 8.3 | March 12th, 2024 | August 5th, 2025 | February 3rd, 2026 |
+| 11 | 8.2 - 8.4 | March 12th, 2024 | September 3rd, 2025 | March 12th, 2026 |
 
 </div>
 


### PR DESCRIPTION
This takes the latest dates from the Laravel 12 docs as they pertain to version 11 release and support dates and updates them in the Laravel 10 details