### PR TITLE
Update responses.md to make easier for new users to use stream package.

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -384,7 +384,7 @@ Route::get('/stream', function () {
 For convenience, if the closure you provide to the `stream` method returns a [Generator](https://www.php.net/manual/en/language.generators.overview.php), Laravel will automatically flush the output buffer between strings returned by the generator, as well as disable Nginx output buffering:
 
 ```php
-Route::get('/chat', function () {
+Route::post('/chat', function () {
     return response()->stream(function (): void {
         $stream = OpenAI::client()->chat()->createStreamed(...);
 
@@ -457,6 +457,9 @@ const sendMessage = () => {
 ```
 
 When sending data back to the stream via `send`, the active connection to the stream is canceled before sending the new data. All requests are sent as JSON `POST` requests.
+
+> [!WARNING]
+> Laravel's `stream` package, requires the `csrf token` to be passed manually or set to have an meta[name="csrf-token"] in the head of you application.
 
 The second argument given to `useStream` is an options object that you may use to customize the stream consumption behavior. The default values for this object are shown below:
 

--- a/responses.md
+++ b/responses.md
@@ -459,7 +459,7 @@ const sendMessage = () => {
 When sending data back to the stream via `send`, the active connection to the stream is canceled before sending the new data. All requests are sent as JSON `POST` requests.
 
 > [!WARNING]
-> Laravel's `stream` package, requires the `csrf token` to be passed manually or set to have an meta[name="csrf-token"] in the head of you application.
+> Since the `useStream` hook makes a `POST` request to your application, a valid CSRF token is required. The easiest way to provide the CSRF token is to [include it in your application layout's `head` tag](/docs/{{version}}/csrf#csrf-x-csrf-token).
 
 The second argument given to `useStream` is an options object that you may use to customize the stream consumption behavior. The default values for this object are shown below:
 


### PR DESCRIPTION
Totally understand if these changes don't get merged. Spent a day trying to understand the new streaming docs and had to go to the source of the package to see why I was having issues.

The Laravel stream package is hardcoded to use POST requests yet the second example is a GET request. Updating to POST to make it easier to onboard new developers.

The CSRF token is not alway present in the head of a layout. Make sure to call this out otherwise new users see 419 without a good error message on how to address.