### PR TITLE
[12.x] Reorder Attribute casting

### DIFF
--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -213,8 +213,8 @@ The `casts` method should return an array where the key is the name of the attri
 <div class="content-list" markdown="1">
 
 - `array`
-- `AsUri::class`
 - `AsStringable::class`
+- `AsUri::class`
 - `boolean`
 - `collection`
 - `date`


### PR DESCRIPTION
Description
---
Reordered `AsStringable::class` and `AsUri::class` alphabetically for consistency and readability.