### PR TITLE
[12.x] Avoid class name conflict

### DIFF
--- a/container.md
+++ b/container.md
@@ -298,8 +298,8 @@ In addition to the `Storage` attribute, Laravel offers `Auth`, `Cache`, `Config`
 
 namespace App\Http\Controllers;
 
+use App\Contracts\UserRepository;
 use App\Models\Photo;
-use App\Contracts\Repository;
 use App\Repositories\DatabaseRepository;
 use Illuminate\Container\Attributes\Auth;
 use Illuminate\Container\Attributes\Cache;
@@ -323,7 +323,7 @@ class PhotoController extends Controller
         #[Config('app.timezone')] protected string $timezone,
         #[Context('uuid')] protected string $uuid,
         #[DB('mysql')] protected Connection $connection,
-        #[Give(DatabaseRepository::class)] protected Repository $users,
+        #[Give(DatabaseRepository::class)] protected UserRepository $users,
         #[Log('daily')] protected LoggerInterface $log,
         #[RouteParameter('photo')] protected Photo $photo,
         #[Tag('reports')] protected iterable $reports,


### PR DESCRIPTION
Description
---
This PR fixes a class name conflict caused by importing two classes with the same name:

- `App\Contracts\Repository`
- `Illuminate\Contracts\Cache\Repository`

Since both share the same base name (Repository), PHP throws the following error:

> Cannot use Illuminate\Contracts\Cache\Repository as Repository because the name is already in use

To resolve this, I updated the constructor to use a custom `UserRepository` interface in place of the generic `Repository` contract from our app domain. This makes the intent clearer and avoids naming collisions.