### PR TITLE
[12.x] Fix typo in Homestead deprecation notice

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -37,7 +37,7 @@
 ## Introduction
 
 > [!WARNING]
-> Laravel Homestead if a legacy package that is no longer actively maintained. [Laravel Sail](/docs/{{version}}/sail) may be used as a modern alternative.
+> Laravel Homestead is a legacy package that is no longer actively maintained. [Laravel Sail](/docs/{{version}}/sail) may be used as a modern alternative.
 
 Laravel strives to make the entire PHP development experience delightful, including your local development environment. [Laravel Homestead](https://github.com/laravel/homestead) is an official, pre-packaged Vagrant box that provides you a wonderful development environment without requiring you to install PHP, a web server, or any other server software on your local machine.
 


### PR DESCRIPTION
Description
---
This PR fixes a small typo in the Homestead docs. Replaces `Laravel Homestead if a legacy package` with `Laravel Homestead is a legacy package`.