### PR TITLE
[12.x] Refines wording related to Isolatable commands

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -243,7 +243,7 @@ class SendEmails extends Command implements Isolatable
 }
 ```
 
-When a command is marked as `Isolatable`, Laravel will automatically add an `--isolated` option to the command. When the command is invoked with that option, Laravel will ensure that no other instances of that command are already running. Laravel accomplishes this by attempting to acquire an atomic lock using your application's default cache driver. If other instances of the command are running, the command will not execute; however, the command will still exit with a successful exit status code:
+When a command is marked as `Isolatable`, you can add an `--isolated` option to the command. When the command is invoked with that option, Laravel will ensure that no other instances of that command are already running. Laravel accomplishes this by attempting to acquire an atomic lock using your application's default cache driver. If other instances of the command are running, the command will not execute; however, the command will still exit with a successful exit status code:
 
 ```shell
 php artisan mail:send 1 --isolated

--- a/artisan.md
+++ b/artisan.md
@@ -243,7 +243,7 @@ class SendEmails extends Command implements Isolatable
 }
 ```
 
-When you mark a command as `Isolatable`, Laravel automatically makes the `--isolated` option available for this particular command, so you can add it when calling it, without explicitly specifying it in the command file. When the command is invoked with that option, Laravel will ensure that no other instances of that command are already running. Laravel accomplishes this by attempting to acquire an atomic lock using your application's default cache driver. If other instances of the command are running, the command will not execute; however, the command will still exit with a successful exit status code:
+When you mark a command as `Isolatable`, Laravel automatically makes the `--isolated` option available for the command without you needing to explicitly define it in the command's options. When the command is invoked with that option, Laravel will ensure that no other instances of that command are already running. Laravel accomplishes this by attempting to acquire an atomic lock using your application's default cache driver. If other instances of the command are running, the command will not execute; however, the command will still exit with a successful exit status code:
 
 ```shell
 php artisan mail:send 1 --isolated

--- a/artisan.md
+++ b/artisan.md
@@ -243,7 +243,7 @@ class SendEmails extends Command implements Isolatable
 }
 ```
 
-When a command is marked as `Isolatable`, you can add an `--isolated` option to the command. When the command is invoked with that option, Laravel will ensure that no other instances of that command are already running. Laravel accomplishes this by attempting to acquire an atomic lock using your application's default cache driver. If other instances of the command are running, the command will not execute; however, the command will still exit with a successful exit status code:
+When you mark a command as `Isolatable`, Laravel automatically makes the `--isolated` option available for this particular command, so you can add it when calling it, without explicitly specifying it in the command file. When the command is invoked with that option, Laravel will ensure that no other instances of that command are already running. Laravel accomplishes this by attempting to acquire an atomic lock using your application's default cache driver. If other instances of the command are running, the command will not execute; however, the command will still exit with a successful exit status code:
 
 ```shell
 php artisan mail:send 1 --isolated


### PR DESCRIPTION
Description
---
This PR updates the wording in the docs regarding `Isolatable console commands` to avoid confusion about the behavior of the `--isolated` option.

Reason
---
The current documentation state:

> "When a command is marked as Isolatable, Laravel will automatically add an --isolated option to the command."

User may understand that the command will automatically run in isolated mode when marked as Isolatable, which is not the case. In reality, Laravel makes the `--isolated` option available, and it's up to the user to explicitly pass it during execution.