### PR TITLE
Add assertCount() and component() to Laravel Dusk docs

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -1761,7 +1761,7 @@ $browser->assertSeeNothingIn($selector);
 <a name="assert-count"></a>
 #### assertCount
 
-Assert that the given element is present a given number of times:
+Assert that elements matching the given selector appear the specified number of times:
 
 ```php
 $browser->assertCount($selector, $count);

--- a/dusk.md
+++ b/dusk.md
@@ -1414,6 +1414,7 @@ Dusk provides a variety of assertions that you may make against your application
 [assertDontSeeIn](#assert-dont-see-in)
 [assertSeeAnythingIn](#assert-see-anything-in)
 [assertSeeNothingIn](#assert-see-nothing-in)
+[assertCount](#assert-count)
 [assertScript](#assert-script)
 [assertSourceHas](#assert-source-has)
 [assertSourceMissing](#assert-source-missing)
@@ -1755,6 +1756,15 @@ Assert that no text is present within the selector:
 
 ```php
 $browser->assertSeeNothingIn($selector);
+```
+
+<a name="assert-count"></a>
+#### assertCount
+
+Assert that the given element is present a given number of times:
+
+```php
+$browser->assertCount($selector, $count);
 ```
 
 <a name="assert-script"></a>

--- a/dusk.md
+++ b/dusk.md
@@ -2515,6 +2515,14 @@ class ExampleTest extends DuskTestCase
 }
 ```
 
+The `component()` method returns a browser instance scoped to a component. It works identically to `with()`, only it doesn't require a closure.
+
+```
+$datePicker = $browser->component(new DatePickerComponent);
+$datePicker->selectDate(2019, 1, 30);
+$datePicker->assertSee('January');
+```
+
 <a name="continuous-integration"></a>
 ## Continuous Integration
 

--- a/dusk.md
+++ b/dusk.md
@@ -2515,11 +2515,13 @@ class ExampleTest extends DuskTestCase
 }
 ```
 
-The `component()` method returns a browser instance scoped to a component. It works identically to `with()`, only it doesn't require a closure.
+The `component` method may be used to retrieve a browser instance scoped to the given component:
 
-```
+```php
 $datePicker = $browser->component(new DatePickerComponent);
+
 $datePicker->selectDate(2019, 1, 30);
+
 $datePicker->assertSee('January');
 ```
 


### PR DESCRIPTION
This PR updates `dusk.md` to include the `assertCount()` assertion and `component()` method. 