### PR TITLE
[12.x] Add documentation for higher order static calls on collections

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -5,6 +5,7 @@
     - [Extending Collections](#extending-collections)
 - [Available Methods](#available-methods)
 - [Higher Order Messages](#higher-order-messages)
+- [Higher Order Static Calls](#higher-order-static-calls)
 - [Lazy Collections](#lazy-collections)
     - [Introduction](#lazy-collection-introduction)
     - [Creating Lazy Collections](#creating-lazy-collections)
@@ -3992,6 +3993,40 @@ Likewise, we can use the `sum` higher order message to gather the total number o
 $users = User::where('group', 'Development')->get();
 
 return $users->sum->votes;
+```
+
+<a name="higher-order-static-calls"></a>
+## Higher Order Static Calls
+
+Collections also provide support for "higher order static calls", which are short-cuts for calling static methods elegantly if you’re storing class names in collections.
+
+```php
+class Transformer1
+{
+    public static function transform(string $name): string
+    {
+        return strtoupper($name);
+    }
+}
+
+class Transformer2
+{
+    public static function transform(string $name): string
+    {
+        return strtolower($name);
+    }
+}
+
+$transformers = collect([Transformer1::class, Transformer2::class]);
+
+$results = $transformers->map->transform('taylor');
+
+$results->dd();
+
+// array:2 [
+//     0 => "TAYLOR"
+//     1 => "taylor"
+// ]
 ```
 
 <a name="lazy-collections"></a>


### PR DESCRIPTION
Description
---
This PR adds documentation for the newly introduced support for "higher order static calls" on collections, see: laravel/framework/pull/55880.

Higher order static calls allow developers to call static methods on class names stored within a collection using a clean and expressive syntax, similar to existing "higher order messages" for instance methods.

An example is included to demonstrate how this feature can be used with a collection of transformer classes.

This complements the existing section on "higher order messages" and helps developers understand and take advantage of this new feature when working with collections of class names.