### PR TITLE
[12.x] Improve clarity in Isolatable commands

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -243,7 +243,7 @@ class SendEmails extends Command implements Isolatable
 }
 ```
 
-When you mark a command as `Isolatable`, Laravel automatically makes the `--isolated` option available for the command without you needing to explicitly define it in the command's options. When the command is invoked with that option, Laravel will ensure that no other instances of that command are already running. Laravel accomplishes this by attempting to acquire an atomic lock using your application's default cache driver. If other instances of the command are running, the command will not execute; however, the command will still exit with a successful exit status code:
+When you mark a command as `Isolatable`, Laravel automatically makes the `--isolated` option available for the command without needing to explicitly define it in the command's options. When the command is invoked with that option, Laravel will ensure that no other instances of that command are already running. Laravel accomplishes this by attempting to acquire an atomic lock using your application's default cache driver. If other instances of the command are running, the command will not execute; however, the command will still exit with a successful exit status code:
 
 ```shell
 php artisan mail:send 1 --isolated


### PR DESCRIPTION
Description
---
Laravel docs use both `without you needing` and `without needing`. This change aims to improve clarity and maintain consistency with the more common phrasing used elsewhere in the docs.