### PR TITLE
[12.x] Add missing import for RetryException in retry helper example

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -2805,6 +2805,7 @@ return retry([100, 200], function () {
 To only retry under specific conditions, you may pass a closure as the fourth argument to the `retry` function:
 
 ```php
+use App\Exceptions\RetryException;
 use Exception;
 
 return retry(5, function () {

--- a/helpers.md
+++ b/helpers.md
@@ -2805,13 +2805,13 @@ return retry([100, 200], function () {
 To only retry under specific conditions, you may pass a closure as the fourth argument to the `retry` function:
 
 ```php
-use App\Exceptions\RetryException;
+use App\Exceptions\TemporaryException;
 use Exception;
 
 return retry(5, function () {
     // ...
 }, 100, function (Exception $exception) {
-    return $exception instanceof RetryException;
+    return $exception instanceof TemporaryException;
 });
 ```
 


### PR DESCRIPTION
Description
---
This PR adds the missing use `App\Exceptions\RetryException;` import statement to the retry helper example in the docs.

Since RetryException is a user-defined class (not provided by Laravel), including the import makes it clearer to readers that they need to define this exception themselves and avoids confusion about it being a built-in class.