### PR TITLE
[12.x] Add make:job command with --batched option to queue documentation

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1473,6 +1473,12 @@ class ImportCsv implements ShouldQueue
 }
 ```
 
+You can also create a batchable job using the `make:job` Artisan command with the `--batched` option:
+
+```shell
+php artisan make:job ProcessPodcast --batched
+```
+
 <a name="dispatching-batches"></a>
 ### Dispatching Batches
 


### PR DESCRIPTION
This PR adds documentation for the `php artisan make:job` command with the `--batched` option, which allows the creation of batchable jobs.

This feature was introduced in: https://github.com/laravel/framework/pull/55929