### PR TITLE
Nullable User in Pulse Gate definition

### DIFF
--- a/pulse.md
+++ b/pulse.md
@@ -84,7 +84,7 @@ use Illuminate\Support\Facades\Gate;
  */
 public function boot(): void
 {
-    Gate::define('viewPulse', function (User $user) {
+    Gate::define('viewPulse', function (?User $user) {
         return $user->isAdmin();
     });
 


### PR DESCRIPTION
The `Gate` is failing all the time when defining it in the format from documentation.