### PR TITLE
[12.x] Add make:job-middleware command to queue docs

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -458,13 +458,7 @@ class RateLimited
 
 As you can see, like [route middleware](/docs/{{version}}/middleware), job middleware receive the job being processed and a callback that should be invoked to continue processing the job.
 
-> [!NOTE]
-> You can generate a new job middleware class using the `make:job-middleware` Artisan command:
->```shell
->php artisan make:job-middleware RateLimited
->```
-
-After creating job middleware, they may be attached to a job by returning them from the job's `middleware` method. This method does not exist on jobs scaffolded by the `make:job` Artisan command, so you will need to manually add it to your job class:
+You can generate a new job middleware class using the `make:job-middleware` Artisan command. After creating job middleware, they may be attached to a job by returning them from the job's `middleware` method. This method does not exist on jobs scaffolded by the `make:job` Artisan command, so you will need to manually add it to your job class:
 
 ```php
 use App\Jobs\Middleware\RateLimited;

--- a/queues.md
+++ b/queues.md
@@ -458,6 +458,12 @@ class RateLimited
 
 As you can see, like [route middleware](/docs/{{version}}/middleware), job middleware receive the job being processed and a callback that should be invoked to continue processing the job.
 
+> [!NOTE]
+> You can generate a new job middleware class using the `make:job-middleware` Artisan command:
+>```shell
+>php artisan make:job-middleware RateLimited
+>```
+
 After creating job middleware, they may be attached to a job by returning them from the job's `middleware` method. This method does not exist on jobs scaffolded by the `make:job` Artisan command, so you will need to manually add it to your job class:
 
 ```php


### PR DESCRIPTION
This PR adds `make:job-middleware` command to queue docs.