### PR TITLE
[12.x] Fix hyphenation of class-based for grammatical correctness and consistency

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -691,9 +691,9 @@ Blade also allows you to define comments in your views. However, unlike HTML com
 <a name="components"></a>
 ## Components
 
-Components and slots provide similar benefits to sections, layouts, and includes; however, some may find the mental model of components and slots easier to understand. There are two approaches to writing components: class based components and anonymous components.
+Components and slots provide similar benefits to sections, layouts, and includes; however, some may find the mental model of components and slots easier to understand. There are two approaches to writing components: class-based components and anonymous components.
 
-To create a class based component, you may use the `make:component` Artisan command. To illustrate how to use components, we will create a simple `Alert` component. The `make:component` command will place the component in the `app/View/Components` directory:
+To create a class-based component, you may use the `make:component` Artisan command. To illustrate how to use components, we will create a simple `Alert` component. The `make:component` command will place the component in the `app/View/Components` directory:
 
 ```shell
 php artisan make:component Alert

--- a/pennant.md
+++ b/pennant.md
@@ -112,7 +112,7 @@ For convenience, if a feature definition only returns a lottery, you may omit th
 <a name="class-based-features"></a>
 ### Class Based Features
 
-Pennant also allows you to define class based features. Unlike closure-based feature definitions, there is no need to register a class based feature in a service provider. To create a class based feature, you may invoke the `pennant:feature` Artisan command. By default the feature class will be placed in your application's `app/Features` directory:
+Pennant also allows you to define class-based features. Unlike closure-based feature definitions, there is no need to register a class-based feature in a service provider. To create a class-based feature, you may invoke the `pennant:feature` Artisan command. By default, the feature class will be placed in your application's `app/Features` directory:
 
 ```shell
 php artisan pennant:feature NewApi
@@ -144,7 +144,7 @@ class NewApi
 }
 ```
 
-If you would like to manually resolve an instance of a class based feature, you may invoke the `instance` method on the `Feature` facade:
+If you would like to manually resolve an instance of a class-based feature, you may invoke the `instance` method on the `Feature` facade:
 
 ```php
 use Illuminate\Support\Facades\Feature;
@@ -240,7 +240,7 @@ Feature::someAreInactive(['new-api', 'site-redesign']);
 <a name="checking-class-based-features"></a>
 #### Checking Class Based Features
 
-For class based features, you should provide the class name when checking the feature:
+For class-based features, you should provide the class name when checking the feature:
 
 ```php
 <?php
@@ -746,7 +746,7 @@ Feature::all();
 // ]
 ```
 
-However, class based features are dynamically registered and are not known by Pennant until they are explicitly checked. This means your application's class based features may not appear in the results returned by the `all` method if they have not already been checked during the current request.
+However, class-based features are dynamically registered and are not known by Pennant until they are explicitly checked. This means your application's class-based features may not appear in the results returned by the `all` method if they have not already been checked during the current request.
 
 If you would like to ensure that feature classes are always included when using the `all` method, you may use Pennant's feature discovery capabilities. To get started, invoke the `discover` method in one of your application's service providers:
 
@@ -963,7 +963,7 @@ public function test_it_can_control_feature_values()
 }
 ```
 
-The same approach may be used for class based features:
+The same approach may be used for class-based features:
 
 ```php tab=Pest
 use Laravel\Pennant\Feature;
@@ -1159,7 +1159,7 @@ class AppServiceProvider extends ServiceProvider
 
 ### `Laravel\Pennant\Events\DynamicallyRegisteringFeatureClass`
 
-This event is dispatched when a [class based feature](#class-based-features) is dynamically checked for the first time during a request.
+This event is dispatched when a [class-based feature](#class-based-features) is dynamically checked for the first time during a request.
 
 ### `Laravel\Pennant\Events\UnexpectedNullScopeEncountered`
 

--- a/validation.md
+++ b/validation.md
@@ -1558,7 +1558,7 @@ The field under validation must end with one of the given values.
 <a name="rule-enum"></a>
 #### enum
 
-The `Enum` rule is a class based rule that validates whether the field under validation contains a valid enum value. The `Enum` rule accepts the name of the enum as its only constructor argument. When validating primitive values, a backed Enum should be provided to the `Enum` rule:
+The `Enum` rule is a class-based rule that validates whether the field under validation contains a valid enum value. The `Enum` rule accepts the name of the enum as its only constructor argument. When validating primitive values, a backed Enum should be provided to the `Enum` rule:
 
 ```php
 use App\Enums\ServerStatus;

--- a/views.md
+++ b/views.md
@@ -170,7 +170,7 @@ View composers are callbacks or class methods that are called when a view is ren
 
 Typically, view composers will be registered within one of your application's [service providers](/docs/{{version}}/providers). In this example, we'll assume that the `App\Providers\AppServiceProvider` will house this logic.
 
-We'll use the `View` facade's `composer` method to register the view composer. Laravel does not include a default directory for class based view composers, so you are free to organize them however you wish. For example, you could create an `app/View/Composers` directory to house all of your application's view composers:
+We'll use the `View` facade's `composer` method to register the view composer. Laravel does not include a default directory for class-based view composers, so you are free to organize them however you wish. For example, you could create an `app/View/Composers` directory to house all of your application's view composers:
 
 ```php
 <?php
@@ -197,7 +197,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        // Using class based composers...
+        // Using class-based composers...
         Facades\View::composer('profile', ProfileComposer::class);
 
         // Using closure-based composers...


### PR DESCRIPTION
Description
---
This PR updates instances of `class based` to `class-based` across the docs. I think in standard grammar rules, compound adjectives should be hyphenated. This change ensures grammatical correctness and consistency, as both `class based` and `class-based` are currently used in the docs.