### PR TITLE
[12.x] Nullable User in Pulse Gate definition

### DIFF
--- a/pulse.md
+++ b/pulse.md
@@ -84,8 +84,8 @@ use Illuminate\Support\Facades\Gate;
  */
 public function boot(): void
 {
-    Gate::define('viewPulse', function (User $user) {
-        return $user->isAdmin();
+    Gate::define('viewPulse', function (?User $user) {
+        return $user?->isAdmin() ?? false;
     });
 
     // ...


### PR DESCRIPTION
The `Gate` is always leading to 403 when defining it in the format from documentation.