### PR TITLE
[12.x] Remove outdated upgrade note from Laravel 12 docs

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -165,9 +165,6 @@ public static function middleware(): array
 }
 ```
 
-> [!WARNING]
-> Controllers implementing `Illuminate\Routing\Controllers\HasMiddleware` should not extend `Illuminate\Routing\Controller`.
-
 <a name="resource-controllers"></a>
 ## Resource Controllers
 


### PR DESCRIPTION
Description
---
This PR removes warning related to `Illuminate\Routing\Controller`:

Since this instruction is only relevant to projects upgrading to Laravel 11.x, I believe it doesn't belong in the Laravel 12 documentation. Keeping it in the Laravel 11 docs is sufficient and avoids cluttering the latest version's documentation with upgrade steps that no longer apply.