### PR TITLE
Correct session table command

### DIFF
--- a/session.md
+++ b/session.md
@@ -51,7 +51,7 @@ The session `driver` configuration option defines where session data will be sto
 When using the `database` session driver, you will need to ensure that you have a database table to contain the session data. Typically, this is included in Laravel's default `0001_01_01_000000_create_users_table.php` [database migration](/docs/{{version}}/migrations); however, if for any reason you do not have a `sessions` table, you may use the `make:session-table` Artisan command to generate this migration:
 
 ```shell
-php artisan make:session-table
+php artisan session:table
 
 php artisan migrate
 ```


### PR DESCRIPTION
The given example command `make:session-table` for creating the session table migration doesn't exist in the latest (12.18) release. Replaced by correct: `php artisan session:table`