### PR TITLE
[12.x] Clarify the behavior of collapseWithKeys method

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -436,7 +436,7 @@ $collapsed->all();
 <a name="method-collapsewithkeys"></a>
 #### `collapseWithKeys()` {.collection-method}
 
-The `collapseWithKeys` method flattens a collection of arrays or collections into a single collection, keeping the original keys intact:
+The `collapseWithKeys` method flattens a collection of arrays or collections into a single collection, keeping the original keys intact. If the collection is already flat, it will return an empty collection:
 
 ```php
 $collection = collect([


### PR DESCRIPTION
Description
---
This PR clarifies the behavior of the `collapseWithKeys` method when used on an already flat collection. It helps developers understand that the method will return an empty collection in such cases, which might not be immediately obvious.

See: https://github.com/laravel/framework/pull/56002