### PR TITLE
[12.x] Clarify and align storage drivers list

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -35,7 +35,7 @@ Laravel provides a powerful filesystem abstraction thanks to the wonderful [Flys
 
 Laravel's filesystem configuration file is located at `config/filesystems.php`. Within this file, you may configure all of your filesystem "disks". Each disk represents a particular storage driver and storage location. Example configurations for each supported driver are included in the configuration file so you can modify the configuration to reflect your storage preferences and credentials.
 
-The `local` driver interacts with files stored locally on the server running the Laravel application while the `s3` driver is used to write to Amazon's S3 cloud storage service.
+The `local` driver interacts with files stored locally on the server running the Laravel application while the `SFTP` storage driver is used for SSH key-based authentication, and the `s3` driver is used to write to Amazon's S3 cloud storage service.
 
 > [!NOTE]
 > You may configure as many disks as you like and may even have multiple disks that use the same driver.


### PR DESCRIPTION
Description
---
This PR updates the sentence that describes the purpose of available filesystem drivers to include the `SFTP` driver, which was previously omitted. The `SFTP` driver is mentioned in the Introduction paragraph, so this change ensures consistency between the two sections.

Purpose
---
**Completeness and Clarity**: Including a brief explanation that the `SFTP` driver supports SSH key-based authentication helps users understand how it works at a glance; especially for those less familiar with Flysystem.

Note
---
Additionally, I placed `SFTP` between `local` and `s3` to match the order introduced earlier in the Introduction paragraph.