### PR TITLE
[12.x] Add `php artisan horizon:clear-metrics` command

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -449,9 +449,7 @@ use Illuminate\Support\Facades\Schedule;
 Schedule::command('horizon:snapshot')->everyFiveMinutes();
 ```
 
-#### Deleting metrics
-
-If you would like to delete all metrics, you may do so using the `horizon:clear-metrics` Artisan command:
+If you would like to delete all metric data, you can invoke the `horizon:clear-metrics` Artisan command:
 
 ```shell
 php artisan horizon:clear-metrics

--- a/horizon.md
+++ b/horizon.md
@@ -449,6 +449,14 @@ use Illuminate\Support\Facades\Schedule;
 Schedule::command('horizon:snapshot')->everyFiveMinutes();
 ```
 
+#### Deleting metrics
+
+If you would like to delete all metrics, you may do so using the `horizon:clear-metrics` Artisan command:
+
+```shell
+php artisan horizon:clear-metrics
+```
+
 <a name="deleting-failed-jobs"></a>
 ## Deleting Failed Jobs
 


### PR DESCRIPTION
I didn’t even realize you could clear Horizon metrics until I went looking for it. Adding this to the docs makes it easier for others to discover without having to dig around.