### PR TITLE
[11.x] Add warning about potential breaking change with eager loaded queries when using pivot columns for filtering or ordering

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -35,7 +35,7 @@
 
 - [Doctrine DBAL Removal](#doctrine-dbal-removal)
 - [Eloquent Model `casts` Method](#eloquent-model-casts-method)
-- [Eager loading query pivot columns](#eager-loading-query-pivot-columns)
+- [Eager Loading Query Pivot Columns](#eager-loading-query-pivot-columns)
 - [Spatial Types](#spatial-types)
 - [The `Enumerable` Contract](#the-enumerable-contract)
 - [The `UserProvider` Contract](#the-user-provider-contract)
@@ -232,7 +232,7 @@ public function dump(...$args);
 If your application is utilizing an SQLite database, SQLite 3.26.0 or greater is required.
 
 <a name="eager-loading-query-pivot-columns"></a>
-#### Eager loading query pivot columns
+#### Eager Loading Query Pivot Columns
 
 **Likelihood Of Impact: Very Low**
 


### PR DESCRIPTION
I am updating an old Laravel project (8) and in the process of upgrading 10 -> 11, I came across this issue. Yes its probably the wrong way to do things, but this is legacy code which i didn't write... I think it should be included in the upgrade guide for anyone else who may have been using such a query.
