### PR TITLE
[12.x] Typo in Queues > Failing Jobs on Specific Exceptions

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1467,8 +1467,8 @@ class SyncChatHistory implements ShouldQueue
         $user->authorize('sync-chat-history');
 
         $response = Http::throw()->get(
-            "https://chat.laravel.test/?user={$user->uuid}
-        ");
+            "https://chat.laravel.test/?user={$user->uuid}"
+        );
 
 
         // ...


### PR DESCRIPTION
Moved the closing quotation mark to the line above.