### PR TITLE
[12.x] Include the SFTP driver

### DIFF
--- a/filesystem.md
+++ b/filesystem.md
@@ -168,6 +168,7 @@ Laravel's Flysystem integrations work great with SFTP; however, a sample configu
     // 'hostFingerprint' => env('SFTP_HOST_FINGERPRINT'),
     // 'maxTries' => 4,
     // 'passphrase' => env('SFTP_PASSPHRASE'),
+    // 'url' => env('SFTP_URL'),
     // 'port' => env('SFTP_PORT', 22),
     // 'root' => env('SFTP_ROOT', ''),
     // 'timeout' => 30,
@@ -311,7 +312,7 @@ return Storage::download('file.jpg', $name, $headers);
 <a name="file-urls"></a>
 ### File URLs
 
-You may use the `url` method to get the URL for a given file. If you are using the `local` driver, this will typically just prepend `/storage` to the given path and return a relative URL to the file. If you are using the `s3` driver, the fully qualified remote URL will be returned:
+You may use the `url` method to get the URL for a given file. If you are using the `local` driver, this will typically just prepend `/storage` to the given path and return a relative URL to the file. If you are using the `sftp` or `s3` drivers, the fully qualified remote URL will be returned:
 
 ```php
 use Illuminate\Support\Facades\Storage;


### PR DESCRIPTION
Description
---
This PR updates the docs for the `url` method to include the `SFTP` driver, which was previously omitted from the explanation. The PR also adds the missing:

```php
'url' => env('SFTP_URL'),
```

configuration option to the `SFTP` filesystem configuration example to help users understand how to properly configure `SFTP` disks to work with the `url` method, as this parameter is essential for generating accessible URLs.

Note
---
The `SFTP` driver is placed between `local` and `s3` to maintain consistency with the driver ordering established elsewhere in the documentation.