### PR TITLE
Clarify env() behavior after config caching

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -2438,7 +2438,7 @@ $env = env('APP_ENV', 'production');
 ```
 
 > [!WARNING]
-> If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded and all calls to the `env` function will return `null`.
+> If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files. Once the configuration has been cached, the `.env` file will not be loaded and all calls to the `env` function will return external environment variables such as server-level or system-level environment variables or `null`.
 
 <a name="method-event"></a>
 #### `event()` {.collection-method}


### PR DESCRIPTION
Clarify env() behavior after configuration caching The current documentation states that “all calls to the env function will return null” once the configuration has been cached.

However, this is only true for environment variables defined exclusively in the .env file.

If the environment variable exists at the system level (e.g., via putenv(), server configuration, env() will still return a value after caching.

This clarification helps developers understand that env() is not completely disabled after config:cache, but rather depends on the source of the environment variable.