### PR TITLE
Add documentation for fromBase64()

### DIFF
--- a/strings.md
+++ b/strings.md
@@ -1562,7 +1562,7 @@ The `Str::fromBase64` method converts the given Base64 string back to its origin
 ```php
 use Illuminate\Support\Str;
 
-$base64 = Str::fromBase64('TGFyYXZlbA==');
+$decoded = Str::fromBase64('TGFyYXZlbA==');
 
 // Laravel
 ```
@@ -3288,7 +3288,7 @@ The `fromBase64` method converts the given Base64 string back to its original st
 ```php
 use Illuminate\Support\Str;
 
-$base64 = Str::of('TGFyYXZlbA==')->fromBase64();
+$decoded = Str::of('TGFyYXZlbA==')->fromBase64();
 
 // Laravel
 ```

--- a/strings.md
+++ b/strings.md
@@ -1562,7 +1562,7 @@ The `Str::fromBase64` method converts the given Base64 string back to its origin
 ```php
 use Illuminate\Support\Str;
 
-$base64 = Str::toBase64('TGFyYXZlbA==');
+$base64 = Str::fromBase64('TGFyYXZlbA==');
 
 // Laravel
 ```

--- a/strings.md
+++ b/strings.md
@@ -655,6 +655,19 @@ $adjusted = Str::finish('this/string/', '/');
 // this/string/
 ```
 
+<a name="method-str-from-base64"></a>
+#### `Str::fromBase64()` {.collection-method}
+
+The `Str::fromBase64` method decodes the given Base64 string:
+
+```php
+use Illuminate\Support\Str;
+
+$decoded = Str::fromBase64('TGFyYXZlbA==');
+
+// Laravel
+```
+
 <a name="method-str-headline"></a>
 #### `Str::headline()` {.collection-method}
 
@@ -1554,19 +1567,6 @@ $converted = Str::title('a nice title uses the correct case');
 // A Nice Title Uses The Correct Case
 ```
 
-<a name="method-str-from-base64"></a>
-#### `Str::fromBase64()` {.collection-method}
-
-The `Str::fromBase64` method converts the given Base64 string back to its original string:
-
-```php
-use Illuminate\Support\Str;
-
-$decoded = Str::fromBase64('TGFyYXZlbA==');
-
-// Laravel
-```
-
 <a name="method-str-to-base64"></a>
 #### `Str::toBase64()` {.collection-method}
 
@@ -2329,6 +2329,19 @@ $adjusted = Str::of('this/string')->finish('/');
 $adjusted = Str::of('this/string/')->finish('/');
 
 // this/string/
+```
+
+<a name="method-fluent-str-from-base64"></a>
+#### `fromBase64` {.collection-method}
+
+The `fromBase64` method decodes the given Base64 string:
+
+```php
+use Illuminate\Support\Str;
+
+$decoded = Str::of('TGFyYXZlbA==')->fromBase64();
+
+// Laravel
 ```
 
 <a name="method-fluent-str-hash"></a>
@@ -3278,19 +3291,6 @@ use Illuminate\Support\Str;
 $converted = Str::of('a nice title uses the correct case')->title();
 
 // A Nice Title Uses The Correct Case
-```
-
-<a name="method-fluent-str-from-base64"></a>
-#### `fromBase64` {.collection-method}
-
-The `fromBase64` method converts the given Base64 string back to its original string:
-
-```php
-use Illuminate\Support\Str;
-
-$decoded = Str::of('TGFyYXZlbA==')->fromBase64();
-
-// Laravel
 ```
 
 <a name="method-fluent-str-to-base64"></a>

--- a/strings.md
+++ b/strings.md
@@ -52,6 +52,7 @@ Laravel includes a variety of functions for manipulating string values. Many of 
 [Str::endsWith](#method-ends-with)
 [Str::excerpt](#method-excerpt)
 [Str::finish](#method-str-finish)
+[Str::fromBase64](#method-str-from-base64)
 [Str::headline](#method-str-headline)
 [Str::inlineMarkdown](#method-str-inline-markdown)
 [Str::is](#method-str-is)
@@ -154,6 +155,7 @@ Laravel includes a variety of functions for manipulating string values. Many of 
 [excerpt](#method-fluent-str-excerpt)
 [explode](#method-fluent-str-explode)
 [finish](#method-fluent-str-finish)
+[fromBase64](#method-fluent-str-from-base64)
 [hash](#method-fluent-str-hash)
 [headline](#method-fluent-str-headline)
 [inlineMarkdown](#method-fluent-str-inline-markdown)
@@ -1550,6 +1552,19 @@ use Illuminate\Support\Str;
 $converted = Str::title('a nice title uses the correct case');
 
 // A Nice Title Uses The Correct Case
+```
+
+<a name="method-str-from-base64"></a>
+#### `Str::fromBase64()` {.collection-method}
+
+The `Str::fromBase64` method converts the given Base64 string back to its original string:
+
+```php
+use Illuminate\Support\Str;
+
+$base64 = Str::toBase64('TGFyYXZlbA==');
+
+// Laravel
 ```
 
 <a name="method-str-to-base64"></a>
@@ -3263,6 +3278,19 @@ use Illuminate\Support\Str;
 $converted = Str::of('a nice title uses the correct case')->title();
 
 // A Nice Title Uses The Correct Case
+```
+
+<a name="method-fluent-str-from-base64"></a>
+#### `fromBase64` {.collection-method}
+
+The `fromBase64` method converts the given Base64 string back to its original string:
+
+```php
+use Illuminate\Support\Str;
+
+$base64 = Str::of('TGFyYXZlbA==')->fromBase64();
+
+// Laravel
 ```
 
 <a name="method-fluent-str-to-base64"></a>


### PR DESCRIPTION
This PR adds documentation for the `Str::of('...')->fromBase64()`, `Str::fromBase64('...')` and `str('...')->fromBase64()`.