### PR TITLE
[12.x] only use and document the `limit` and `offset` methods

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -431,7 +431,7 @@ The Eloquent `all` method will return all of the results in the model's table. H
 ```php
 $flights = Flight::where('active', 1)
     ->orderBy('name')
-    ->take(10)
+    ->limit(10)
     ->get();
 ```
 

--- a/queries.md
+++ b/queries.md
@@ -1210,16 +1210,7 @@ To build more advanced `having` statements, see the [havingRaw](#raw-methods) me
 <a name="limit-and-offset"></a>
 ### Limit and Offset
 
-<a name="skip-take"></a>
-#### The `skip` and `take` Methods
-
-You may use the `skip` and `take` methods to limit the number of results returned from the query or to skip a given number of results in the query:
-
-```php
-$users = DB::table('users')->skip(10)->take(5)->get();
-```
-
-Alternatively, you may use the `limit` and `offset` methods. These methods are functionally equivalent to the `take` and `skip` methods, respectively:
+You may use the `limit` and `offset` methods to limit the number of results returned from the query or to skip a given number of results in the query:
 
 ```php
 $users = DB::table('users')


### PR DESCRIPTION
`skip()` and `take()` are alias methods to `offset()` and `limit()`. IMO we should only use and document the main methods, not the aliases.  This will encourage more performant coding, just like we now do in `laravel/framework`.

IF it's decided we still want to mention the aliases, I'd recommended listing them second as the alternatives.  I can make that change if desired.

follow up to https://github.com/laravel/framework/pull/56080 and https://github.com/laravel/framework/pull/56081