### PR TITLE
[12.x] Add the failed method to queued mailables.

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -1076,6 +1076,26 @@ class OrderShipped extends Mailable implements ShouldQueue
 > [!NOTE]
 > To learn more about working around these issues, please review the documentation regarding [queued jobs and database transactions](/docs/{{version}}/queues#jobs-and-database-transactions).
 
+<a name="take-actions-after-queued-emails-are-failed-to-be-sent"></a>
+#### Take Actions After Queued Emails Are Failed To Be Sent
+
+When a queued email fails, you might want to notify your users so the problem can be fixed and another identical email can be resent. In order to achieve this, you can define a `failed` method on your queued mailable class. The `Throwable` instance that caused the queued email to fail will be passed to the `failed` method:
+
+```php
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class OrderDelayed extends Mailable implements ShouldQueue
+{
+    /**
+     * Handle a queued email's failure.
+     */
+    public function failed(Throwable $exception): void
+    {
+        // Send user notifications of failure, etc...
+    }
+}
+```
+
 <a name="rendering-mailables"></a>
 ## Rendering Mailables
 

--- a/mail.md
+++ b/mail.md
@@ -1076,13 +1076,20 @@ class OrderShipped extends Mailable implements ShouldQueue
 > [!NOTE]
 > To learn more about working around these issues, please review the documentation regarding [queued jobs and database transactions](/docs/{{version}}/queues#jobs-and-database-transactions).
 
-<a name="take-actions-after-queued-emails-are-failed-to-be-sent"></a>
-#### Take Actions After Queued Emails Are Failed To Be Sent
+<a name="queued-email-failures"></a>
+#### Queued Email Failures
 
-When a queued email fails, you might want to notify your users so the problem can be fixed and another identical email can be resent. In order to achieve this, you can define a `failed` method on your queued mailable class. The `Throwable` instance that caused the queued email to fail will be passed to the `failed` method:
+When a queued email fails, the `failed` method on the queued mailable class will be invoked if it has been defined. The `Throwable` instance that caused the queued email to fail will be passed to the `failed` method:
 
 ```php
+<?php
+
+namespace App\Mail;
+
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Throwable;
 
 class OrderDelayed extends Mailable implements ShouldQueue
 {
@@ -1091,7 +1098,7 @@ class OrderDelayed extends Mailable implements ShouldQueue
      */
     public function failed(Throwable $exception): void
     {
-        // Send user notifications of failure, etc...
+        // ...
     }
 }
 ```


### PR DESCRIPTION
A long time ago, I read the source code, found out the `Illuminate\Mail\SendQueuedMailable::failed()` method and realized it's possible to do this.

We have been doing this in production for years, notified of occasional email failures. Some example errors are:

```
"App\\Mail\\OrderDelayed has been attempted too many times or run too long. The job may have previously timed out."

"Expected response code \"250\" but got code \"221\", with message \"221 Closing connection. Waiting command exceed timeout. Please use NOOP for keeping idle connection.\"."

"Expected response code \"250\" but got empty code."

"Error executing \"SendRawEmail\" on \"https:\/\/email.us-east-1.amazonaws.com\"; AWS HTTP error: Client error: `POST https:\/\/email.us-east-1.amazonaws.com` resulted in a `400 Bad Request` response:\n<ErrorResponse xmlns=\"http:\/\/ses.amazonaws.com\/doc\/2010-12-01\/\">\n  <Error>\n    <Type>Sender<\/Type>\n    <Code>MessageReje (truncated...)\n MessageRejected (client): Sending paused for this account. For more information, please check the inbox of the email address associated with your AWS account. - <ErrorResponse xmlns=\"http:\/\/ses.amazonaws.com\/doc\/2010-12-01\/\">\n  <Error>\n    <Type>Sender<\/Type>\n    <Code>MessageRejected<\/Code>\n    <Message>Sending paused for this account. For more information, please check the inbox of the email address associated with your AWS account.<\/Message>\n  <\/Error>\n  <RequestId>request-id<\/RequestId>\n<\/ErrorResponse>\n"
```

Wording is a lot similar to [this section for Queue](https://laravel.com/docs/12.x/queues#cleaning-up-after-failed-jobs).