### PR TITLE
[12.x] Add deprecation notice for Laravel Mix

### DIFF
--- a/mix.md
+++ b/mix.md
@@ -5,6 +5,9 @@
 <a name="introduction"></a>
 ## Introduction
 
+> [!WARNING]
+> Laravel Mix is a legacy package that is no longer actively maintained. [Vite](/docs/{{version}}/vite) may be used as a modern alternative.
+
 [Laravel Mix](https://github.com/laravel-mix/laravel-mix), a package developed by [Laracasts](https://laracasts.com) creator Jeffrey Way, provides a fluent API for defining [webpack](https://webpack.js.org) build steps for your Laravel application using several common CSS and JavaScript pre-processors.
 
 In other words, Mix makes it a cinch to compile and minify your application's CSS and JavaScript files. Through simple method chaining, you can fluently define your asset pipeline. For example:


### PR DESCRIPTION
Description
---
This PR adds a short deprecation note to clarify that Laravel Mix is now a legacy package and no longer actively maintained, similar to the recent update regarding Homestead. It suggests using Vite as the modern alternative, in line with current Laravel recommendations.

This update helps guide developers toward using the officially supported frontend tooling and avoids confusion when choosing between Mix and Vite.