### PR TITLE
[12.x] Use consistent collect([...]) syntax in random() example output

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -2376,7 +2376,7 @@ $random = $collection->random(3);
 
 $random->all();
 
-// [2, 4, 5] - (retrieved randomly)
+// collect([2, 4, 5]) - (retrieved randomly)
 ```
 
 If the collection instance has fewer items than requested, the `random` method will throw an `InvalidArgumentException`.


### PR DESCRIPTION
Description
---
This PR updates the example output of the `random()` method to match the consistent output style used throughout the collections docs when the output is a collection (e.g., in `pop()` and `shift()` examples). This change improves consistency.