### PR TITLE
[12.x] Remove Mix from Vite docs

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -38,21 +38,6 @@
 
 Laravel integrates seamlessly with Vite by providing an official plugin and Blade directive to load your assets for development and production.
 
-> [!NOTE]
-> Are you running Laravel Mix? Vite has replaced Laravel Mix in new Laravel installations. For Mix documentation, please visit the [Laravel Mix](https://laravel-mix.com/) website. If you would like to switch to Vite, please see our [migration guide](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite).
-
-<a name="vite-or-mix"></a>
-#### Choosing Between Vite and Laravel Mix
-
-Before transitioning to Vite, new Laravel applications utilized [Mix](https://laravel-mix.com/), which is powered by [webpack](https://webpack.js.org/), when bundling assets. Vite focuses on providing a faster and more productive experience when building rich JavaScript applications. If you are developing a Single Page Application (SPA), including those developed with tools like [Inertia](https://inertiajs.com), Vite will be the perfect fit.
-
-Vite also works well with traditional server-side rendered applications with JavaScript "sprinkles", including those using [Livewire](https://livewire.laravel.com). However, it lacks some features that Laravel Mix supports, such as the ability to copy arbitrary assets into the build that are not referenced directly in your JavaScript application.
-
-<a name="migrating-back-to-mix"></a>
-#### Migrating Back to Mix
-
-Have you started a new Laravel application using our Vite scaffolding but need to move back to Laravel Mix and webpack? No problem. Please consult our [official guide on migrating from Vite to Mix](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-vite-to-laravel-mix).
-
 <a name="installation"></a>
 ## Installation & Setup
 


### PR DESCRIPTION
Description
---
Laravel Mix has been deprecated in recent Laravel versions in favor of the Vite-based asset bundling. This PR removes it from the `vite.md` documentation to keep it aligned with current Laravel standards.

---
Continuation of: #10520