### PR TITLE
[12.x] Fix order of sections in HTTP Client docs

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -701,27 +701,6 @@ Http::fake(function (Request $request) {
 });
 ```
 
-<a name="preventing-stray-requests"></a>
-### Preventing Stray Requests
-
-If you would like to ensure that all requests sent via the HTTP client have been faked throughout your individual test or complete test suite, you can call the `preventStrayRequests` method. After calling this method, any requests that do not have a corresponding fake response will throw an exception rather than making the actual HTTP request:
-
-```php
-use Illuminate\Support\Facades\Http;
-
-Http::preventStrayRequests();
-
-Http::fake([
-    'github.com/*' => Http::response('ok'),
-]);
-
-// An "ok" response is returned...
-Http::get('https://github.com/laravel/framework');
-
-// An exception is thrown...
-Http::get('https://laravel.com');
-```
-
 <a name="inspecting-requests"></a>
 ### Inspecting Requests
 
@@ -821,6 +800,27 @@ $recorded = Http::recorded(function (Request $request, Response $response) {
     return $request->url() !== 'https://laravel.com' &&
            $response->successful();
 });
+```
+
+<a name="preventing-stray-requests"></a>
+### Preventing Stray Requests
+
+If you would like to ensure that all requests sent via the HTTP client have been faked throughout your individual test or complete test suite, you can call the `preventStrayRequests` method. After calling this method, any requests that do not have a corresponding fake response will throw an exception rather than making the actual HTTP request:
+
+```php
+use Illuminate\Support\Facades\Http;
+
+Http::preventStrayRequests();
+
+Http::fake([
+    'github.com/*' => Http::response('ok'),
+]);
+
+// An "ok" response is returned...
+Http::get('https://github.com/laravel/framework');
+
+// An exception is thrown...
+Http::get('https://laravel.com');
 ```
 
 <a name="events"></a>


### PR DESCRIPTION
Description
---
This PR corrects the order of the "Inspecting Requests" and "Preventing Stray Requests" sections in the HTTP Client testing documentation. Previously, the main content displayed "Preventing Stray Requests" before "Inspecting Requests", which did not match the order shown in the right sidebar (table of contents). The sections are now reordered to ensure consistency between the sidebar and the main documentation content.