### PR TITLE
[12.x] Fix hyphenation of production-ready for grammatical correctness and consistency

### DIFF
--- a/frontend.md
+++ b/frontend.md
@@ -174,7 +174,7 @@ If you would like to build your frontend using Inertia and Vue / React, you can 
 <a name="bundling-assets"></a>
 ## Bundling Assets
 
-Regardless of whether you choose to develop your frontend using Blade and Livewire or Vue / React and Inertia, you will likely need to bundle your application's CSS into production ready assets. Of course, if you choose to build your application's frontend with Vue or React, you will also need to bundle your components into browser ready JavaScript assets.
+Regardless of whether you choose to develop your frontend using Blade and Livewire or Vue / React and Inertia, you will likely need to bundle your application's CSS into production-ready assets. Of course, if you choose to build your application's frontend with Vue or React, you will also need to bundle your components into browser ready JavaScript assets.
 
 By default, Laravel utilizes [Vite](https://vitejs.dev) to bundle your assets. Vite provides lightning-fast build times and near instantaneous Hot Module Replacement (HMR) during local development. In all new Laravel applications, including those using our [starter kits](/docs/{{version}}/starter-kits), you will find a `vite.config.js` file that loads our light-weight Laravel Vite plugin that makes Vite a joy to use with Laravel applications.
 

--- a/vite.md
+++ b/vite.md
@@ -34,7 +34,7 @@
 <a name="introduction"></a>
 ## Introduction
 
-[Vite](https://vitejs.dev) is a modern frontend build tool that provides an extremely fast development environment and bundles your code for production. When building applications with Laravel, you will typically use Vite to bundle your application's CSS and JavaScript files into production ready assets.
+[Vite](https://vitejs.dev) is a modern frontend build tool that provides an extremely fast development environment and bundles your code for production. When building applications with Laravel, you will typically use Vite to bundle your application's CSS and JavaScript files into production-ready assets.
 
 Laravel integrates seamlessly with Vite by providing an official plugin and Blade directive to load your assets for development and production.
 


### PR DESCRIPTION
Description
---
This PR updates instances of `production ready` to `production-ready` across the docs. I think in standard grammar rules, compound adjectives should be hyphenated. This change ensures grammatical correctness and consistency, as both `production ready` and `production-ready` are currently used in the docs.