### PR TITLE
[12.x] Add broadcast_if and broadcast_unless methods to helpers

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -170,6 +170,8 @@ Laravel includes a variety of global "helper" PHP functions. Many of these funct
 [bcrypt](#method-bcrypt)
 [blank](#method-blank)
 [broadcast](#method-broadcast)
+[broadcast_if](#method-broadcast-if)
+[broadcast_unless](#method-broadcast-unless)
 [cache](#method-cache)
 [class_uses_recursive](#method-class-uses-recursive)
 [collect](#method-collect)

--- a/helpers.md
+++ b/helpers.md
@@ -2256,6 +2256,24 @@ broadcast(new UserRegistered($user));
 broadcast(new UserRegistered($user))->toOthers();
 ```
 
+<a name="method-broadcast-if"></a>
+#### `broadcast_if()` {.collection-method}
+
+The `broadcast_if` function [broadcasts](/docs/{{version}}/broadcasting) the given [event](/docs/{{version}}/events) to its listeners if a given boolean expression evaluates to `true`:
+
+```php
+broadcast_if($user->isActive(), new UserRegistered($user));
+```
+
+<a name="method-broadcast-unless"></a>
+#### `broadcast_unless()` {.collection-method}
+
+The `broadcast_unless` function [broadcasts](/docs/{{version}}/broadcasting) the given [event](/docs/{{version}}/events) to its listeners if a given boolean expression evaluates to `false`:
+
+```php
+broadcast_unless($user->isBanned(), new UserRegistered($user));
+```
+
 <a name="method-cache"></a>
 #### `cache()` {.collection-method}
 

--- a/helpers.md
+++ b/helpers.md
@@ -2265,6 +2265,8 @@ The `broadcast_if` function [broadcasts](/docs/{{version}}/broadcasting) the giv
 
 ```php
 broadcast_if($user->isActive(), new UserRegistered($user));
+
+broadcast_if($user->isActive(), new UserRegistered($user))->toOthers();
 ```
 
 <a name="method-broadcast-unless"></a>
@@ -2274,6 +2276,8 @@ The `broadcast_unless` function [broadcasts](/docs/{{version}}/broadcasting) the
 
 ```php
 broadcast_unless($user->isBanned(), new UserRegistered($user));
+
+broadcast_unless($user->isBanned(), new UserRegistered($user))->toOthers();
 ```
 
 <a name="method-cache"></a>


### PR DESCRIPTION
Description
---
Add documentation for the newly introduced methods in: https://github.com/laravel/framework/pull/55967

Note
---
I used the same tone that we used in `broadcast()`, `abort_if()`, and `abort_unless` methods.

Question
---
I'm not sure how to document the `FakePendingBroadcast` in this context. Could you take care of it, or do you think it doesn't need documentation?