### PR TITLE
[12.x] Redirect helper last argument

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -2653,7 +2653,7 @@ $policy = policy(App\Models\User::class);
 The `redirect` function returns a [redirect HTTP response](/docs/{{version}}/responses#redirects), or returns the redirector instance if called with no arguments:
 
 ```php
-return redirect($to = null, $status = 302, $headers = [], $https = null);
+return redirect($to = null, $status = 302, $headers = [], $secure = null);
 
 return redirect('/home');
 


### PR DESCRIPTION
Description
---
According to the current implementation I think the argument name is `secure` not `https`, see: https://github.com/laravel/framework/blob/3c3e0e6d9afc333d6e62f1e54f0e7f079761e2fa/src/Illuminate/Foundation/helpers.php#L705