### PR TITLE
[12.x] Improve consistency in _if and _unless functions

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -2702,7 +2702,7 @@ report('Something went wrong.');
 <a name="method-report-if"></a>
 #### `report_if()` {.collection-method}
 
-The `report_if` function will report an exception using your [exception handler](/docs/{{version}}/errors#handling-exceptions) if the given condition is `true`:
+The `report_if` function will report an exception using your [exception handler](/docs/{{version}}/errors#handling-exceptions) if a given boolean expression evaluates to `true`:
 
 ```php
 report_if($shouldReport, $e);
@@ -2713,7 +2713,7 @@ report_if($shouldReport, 'Something went wrong.');
 <a name="method-report-unless"></a>
 #### `report_unless()` {.collection-method}
 
-The `report_unless` function will report an exception using your [exception handler](/docs/{{version}}/errors#handling-exceptions) if the given condition is `false`:
+The `report_unless` function will report an exception using your [exception handler](/docs/{{version}}/errors#handling-exceptions) if a given boolean expression evaluates to `false`:
 
 ```php
 report_unless($reportingDisabled, $e);


### PR DESCRIPTION
Description
---
Currently, we use `... if a given boolean expression evaluates to ...` with the following functions:
- abort_if()
- abort_unless()
- broadcast_if()
- broadcast_unless()
- throw_if()
- throw_unless()

But, we use `... if the given condition is ...` with only:
- report_if()
- report_unless()

So, let's refind them.