### PR TITLE
[12.x] Remove outdated PHP version warning from Octane

### DIFF
--- a/octane.md
+++ b/octane.md
@@ -47,9 +47,6 @@ php artisan octane:install
 <a name="server-prerequisites"></a>
 ## Server Prerequisites
 
-> [!WARNING]
-> Laravel Octane requires [PHP 8.1+](https://php.net/releases/).
-
 <a name="frankenphp"></a>
 ### FrankenPHP
 


### PR DESCRIPTION
Description
---
This PR removes the outdated warning stating "Laravel Octane requires PHP 8.1+" from the docs. Since Laravel 11 requires PHP 8.2+, and this has continued to increase in subsequent versions (Laravel 12 uses PHP 8.2+, Laravel 13 will require PHP 8.3+). So, the PHP 8.1 warning is now obsolete and potentially confusing.