### PR TITLE
[12.x] Fix wording in Arr::forget method

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -482,7 +482,7 @@ $value = Arr::float($array, 'name');
 <a name="method-array-forget"></a>
 #### `Arr::forget()` {.collection-method}
 
-The `Arr::forget` method removes a given key / value pair from a deeply nested array using "dot" notation:
+The `Arr::forget` method removes a given key / value pairs from a deeply nested array using "dot" notation:
 
 ```php
 use Illuminate\Support\Arr;


### PR DESCRIPTION
Description
---
Since the current implementation of `Arr::forget()` also can accept an array of keys, it would be more accurate to use "s" as we did with the `Arr::except()` method.

References
---
- The [forget comment](https://github.com/laravel/framework/blob/c0955af55f216ba0b864a3819acb435859957f0a/src/Illuminate/Collections/Arr.php#L358) indicates that it can "Remove one or many array items".
- The [current docs](https://github.com/laravel/docs/blob/388799f067a30bc0e0996e8d33fd1576548d1ece/helpers.md?plain=1#L392) about the `Arr::except()` method that uses "s" indicating that it can except one or more pairs.