### PR TITLE
[12.x] Rename the person parameter to users

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -2471,8 +2471,8 @@ You may also validate each element of an array. For example, to validate that ea
 
 ```php
 $validator = Validator::make($request->all(), [
-    'person.*.email' => 'email|unique:users',
-    'person.*.first_name' => 'required_with:person.*.last_name',
+    'users.*.email' => 'email|unique:users',
+    'users.*.first_name' => 'required_with:users.*.last_name',
 ]);
 ```
 
@@ -2480,8 +2480,8 @@ Likewise, you may use the `*` character when specifying [custom validation messa
 
 ```php
 'custom' => [
-    'person.*.email' => [
-        'unique' => 'Each person must have a unique email address',
+    'users.*.email' => [
+        'unique' => 'Each user must have a unique email address',
     ]
 ],
 ```


### PR DESCRIPTION
Description
---
Using person in array syntax like "person.*.email" might confuse non-native English speakers who could mistakenly think it's a typo and expect "persons". The word "users" is clearer and more conventional in this context. It also aligns better with the "users" database table name.

---
reopen: #10517