### PR TITLE
[12.x] Improve phrasing consistency

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -2320,7 +2320,7 @@ $collection = collect(['Taylor', 'Abigail']);
 <a name="method-config"></a>
 #### `config()` {.collection-method}
 
-The `config` function gets the value of a [configuration](/docs/{{version}}/configuration) variable. The configuration values may be accessed using "dot" syntax, which includes the name of the file and the option you wish to access. A default value may be specified and is returned if the configuration option does not exist:
+The `config` function gets the value of a [configuration](/docs/{{version}}/configuration) variable. The configuration values may be accessed using "dot" syntax, which includes the name of the file and the option you wish to access. You may also provide a default value that will be returned if the configuration option does not exist:
 
 ```php
 $value = config('app.timezone');
@@ -2337,7 +2337,7 @@ config(['app.debug' => true]);
 <a name="method-context"></a>
 #### `context()` {.collection-method}
 
-The `context` function gets the value from the [current context](/docs/{{version}}/context). A default value may be specified and is returned if the context key does not exist:
+The `context` function gets the value from the [current context](/docs/{{version}}/context). You may also provide a default value that will be returned if the context key does not exist:
 
 ```php
 $value = context('trace_id');


### PR DESCRIPTION
Description
--
This PR updates the descriptions of the `config()` and `context()` helper functions to improve consistency and readability.

Replaces the phrase "A default value may be specified and is returned if..." with "You may also provide a default value that will be returned if..."

This mirrors phrasing used in other parts of the docs and aligns with Laravel's general tone.