### PR TITLE
[12.x] Fix hyphenation of cache-based for grammatical correctness and consistency

### DIFF
--- a/passwords.md
+++ b/passwords.md
@@ -29,7 +29,7 @@ The password reset `driver` configuration option defines where password reset da
 <div class="content-list" markdown="1">
 
 - `database` - password reset data is stored in a relational database.
-- `cache` - password reset data is stored in one of your cache based stores.
+- `cache` - password reset data is stored in one of your cache-based stores.
 
 </div>
 

--- a/session.md
+++ b/session.md
@@ -33,7 +33,7 @@ The session `driver` configuration option defines where session data will be sto
 - `file` - sessions are stored in `storage/framework/sessions`.
 - `cookie` - sessions are stored in secure, encrypted cookies.
 - `database` - sessions are stored in a relational database.
-- `memcached` / `redis` - sessions are stored in one of these fast, cache based stores.
+- `memcached` / `redis` - sessions are stored in one of these fast, cache-based stores.
 - `dynamodb` - sessions are stored in AWS DynamoDB.
 - `array` - sessions are stored in a PHP array and will not be persisted.
 


### PR DESCRIPTION
Description
---
This PR updates instances of `cache based` to `cache-based` across the docs. I think in standard grammar rules, compound adjectives should be hyphenated. This change ensures grammatical correctness and consistency, as both `cache based` and `cache-based` are currently used in the docs.