### PR TITLE
[12.x] Reformat the link in context() helper description

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -2337,7 +2337,7 @@ config(['app.debug' => true]);
 <a name="method-context"></a>
 #### `context()` {.collection-method}
 
-The `context` function gets the value from the [current context](/docs/{{version}}/context). You may also provide a default value that will be returned if the context key does not exist:
+The `context` function gets the value from the current [context](/docs/{{version}}/context). You may also provide a default value that will be returned if the context key does not exist:
 
 ```php
 $value = context('trace_id');


### PR DESCRIPTION
Description
---
I think that only the word `context` should be displayed as a link, not `current context`.