### PR TITLE
[12.x] Clarify collapse method behavior

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -313,7 +313,7 @@ $value = Arr::boolean($array, 'name');
 <a name="method-array-collapse"></a>
 #### `Arr::collapse()` {.collection-method}
 
-The `Arr::collapse` method collapses an array of arrays into a single array:
+The `Arr::collapse` method collapses an array of arrays or collections into a single array:
 
 ```php
 use Illuminate\Support\Arr;


### PR DESCRIPTION
Description
---
This PR clarifies the behavior of the `collapse` method to reflect that it can collapse both arrays and collections. Currently, the documentation only mentions arrays, but the method also supports nested Collection instances.

This change not only improves clarity and accuracy but also ensures consistency with the `collapse` and `collapseWithKeys` methods that are in the `collections` docs, which explicitly states support for both arrays and collections.

Continuation of: https://github.com/laravel/docs/pull/10370