### PR TITLE
[12.x] Fix Typo of eventName for useEventStream Hook

### DIFF
--- a/responses.md
+++ b/responses.md
@@ -791,7 +791,7 @@ import { useEventStream } from "@laravel/stream-react";
 
 function App() {
   const { message } = useEventStream("/stream", {
-    event: "update",
+    eventName: "update",
     onMessage: (message) => {
       //
     },
@@ -814,7 +814,7 @@ function App() {
 import { useEventStream } from "@laravel/stream-vue";
 
 const { message } = useEventStream("/chat", {
-  event: "update",
+  eventName: "update",
   onMessage: (message) => {
     // ...
   },


### PR DESCRIPTION
When reviewing the [Build and AI Chat with Laravel](https://youtu.be/BuUbTRHuvAw) video, I noticed that the documentation for `useEventStream` was not correct to match the eventName that is specified in the JS packages.