### PR TITLE
[12.x] Fix hyphenation of driver-based for grammatical correctness and consistency

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -33,7 +33,7 @@
 <a name="introduction"></a>
 ## Introduction
 
-[Laravel Scout](https://github.com/laravel/scout) provides a simple, driver based solution for adding full-text search to your [Eloquent models](/docs/{{version}}/eloquent). Using model observers, Scout will automatically keep your search indexes in sync with your Eloquent records.
+[Laravel Scout](https://github.com/laravel/scout) provides a simple, driver-based solution for adding full-text search to your [Eloquent models](/docs/{{version}}/eloquent). Using model observers, Scout will automatically keep your search indexes in sync with your Eloquent records.
 
 Currently, Scout ships with [Algolia](https://www.algolia.com/), [Meilisearch](https://www.meilisearch.com), [Typesense](https://typesense.org), and MySQL / PostgreSQL (`database`) drivers. In addition, Scout includes a "collection" driver that is designed for local development usage and does not require any external dependencies or third-party services. Furthermore, writing custom drivers is simple and you are free to extend Scout with your own search implementations.
 


### PR DESCRIPTION
Description
---
This PR updates instances of `driver based` to `driver-based` across the docs. I think in standard grammar rules, compound adjectives should be hyphenated. This change ensures grammatical correctness and consistency, as both `driver based` and `driver-based` are currently used in the docs.