### PR TITLE
[12.x] Document the thenReturn method on helpers Pipeline

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -3297,7 +3297,7 @@ $user = Pipeline::send($user)
 
 As you can see, each invokable class or closure in the pipeline is provided the input and a `$next` closure. Invoking the `$next` closure will invoke the next callable in the pipeline. As you may have noticed, this is very similar to [middleware](/docs/{{version}}/middleware).
 
-When the last callable in the pipeline invokes the `$next` closure, the callable provided to the `then` method will be invoked. Typically, this callable will simply return the given input.
+When the last callable in the pipeline invokes the `$next` closure, the callable provided to the `then` method will be invoked. Typically, this callable will simply return the given input. For convenience, if you simply want to return the input after it has been processed, you may use the `thenReturn` method.
 
 Of course, as discussed previously, you are not limited to providing closures to your pipeline. You may also provide invokable classes. If a class name is provided, the class will be instantiated via Laravel's [service container](/docs/{{version}}/container), allowing dependencies to be injected into the invokable class:
 
@@ -3308,7 +3308,7 @@ $user = Pipeline::send($user)
         ActivateSubscription::class,
         SendWelcomeEmail::class,
     ])
-    ->then(fn (User $user) => $user);
+    ->thenReturn();
 ```
 
 <a name="sleep"></a>


### PR DESCRIPTION
Description
---
This PR adds documentation for the `thenReturn()` method on the `Illuminate\Support\Facades\Pipeline` class.

Note
---
We used:

```php
->then(fn (User $user) => $user);
```

in the two examples of the Pipeline so, I have replaced it -only in the second example- with:

```php
->thenReturn();
```