### PR TITLE
[12.x] Improve clarity

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -57,7 +57,7 @@ The `Illuminate\Http\Client\Response` object also implements the PHP `ArrayAcces
 return Http::get('http://example.com/users/1')['name'];
 ```
 
-In addition to the response methods listed above, the following methods may be used to determine if the response has a given status code:
+In addition to the response methods listed above, the following methods may be used to determine if the response has a specific status code:
 
 ```php
 $response->ok() : bool;                  // 200 OK


### PR DESCRIPTION
Description
---
The phrase `determine if the response has a given status code` suggests that these methods are parameterized, which they are not. Instead, each method is hardcoded to check for a `specific` status code, so they don't allow checking for a `given` status code.