### PR TITLE
[12.x] Fix attach method description

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -162,7 +162,7 @@ $response = Http::withBody(
 <a name="multi-part-requests"></a>
 #### Multi-Part Requests
 
-If you would like to send files as multi-part requests, you should call the `attach` method before making your request. This method accepts the name of the file and its contents. If needed, you may provide a third argument which will be considered the file's filename, while a fourth argument may be used to provide headers associated with the file:
+If you would like to send files as multi-part requests, you should call the `attach` method before making your request. This method accepts the name of the field and the file contents. If needed, you may provide a third argument which will be considered the file's filename, while a fourth argument may be used to provide headers associated with the file:
 
 ```php
 $response = Http::attach(


### PR DESCRIPTION
Description
---
According to https://docs.guzzlephp.org/en/stable/request-options.html#multipart the attach method expects the form field name as its first argument and the file content as the second one.

However, the current documentation incorrectly states that the first argument is the file name, which is inaccurate.