### PR TITLE
【10.x】Individual wrapping in `Collection::sortByMany` allows sorting with multiple attributes by just an array of attributes(without direction, defaulting to asceding sort), but the spec is missing in docs

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -2437,7 +2437,31 @@ Alternatively, you may pass your own closure to determine how to sort the collec
         ]
     */
 
-If you would like to sort your collection by multiple attributes, you may pass an array of sort operations to the `sortBy` method. Each sort operation should be an array consisting of the attribute that you wish to sort by and the direction of the desired sort:
+If you would like to sort your collection by multiple attributes, you may pass an array of the attributes that you wish to sort by.
+
+    $collection = collect([
+        ['name' => 'Taylor Otwell', 'age' => 34],
+        ['name' => 'Abigail Otwell', 'age' => 30],
+        ['name' => 'Taylor Otwell', 'age' => 36],
+        ['name' => 'Abigail Otwell', 'age' => 32],
+    ]);
+
+    $sorted = $collection->sortBy(['name', 'age']);
+
+    $sorted->values()->all();
+
+    /*
+        [
+            ['name' => 'Abigail Otwell', 'age' => 30],
+            ['name' => 'Abigail Otwell', 'age' => 32],
+            ['name' => 'Taylor Otwell', 'age' => 34],
+            ['name' => 'Taylor Otwell', 'age' => 36],
+        ]
+    */
+
+
+
+When sorting in multiple attributes and directions, you may pass an array of sort operations to the `sortBy` method. Each sort operation should be an array consisting of the attribute that you wish to sort by and the direction of the desired sort:
 
     $collection = collect([
         ['name' => 'Taylor Otwell', 'age' => 34],

--- a/collections.md
+++ b/collections.md
@@ -2437,7 +2437,7 @@ Alternatively, you may pass your own closure to determine how to sort the collec
         ]
     */
 
-If you would like to sort your collection by multiple attributes, you may pass an array of the attributes that you wish to sort by.
+If you would like to sort your collection by multiple attributes, you may pass an array of the attributes that you wish to sort by:
 
     $collection = collect([
         ['name' => 'Taylor Otwell', 'age' => 34],


### PR DESCRIPTION
Calling sortBy with a flat array allows sorting asc by multiple attributes. 

The method works but not documented, causing confusion by explicit directions or workarounds like chaining sortBy in reverse order, i.e. `$collection->sortBy('second-priority')->sortBy('first-priority')`, which does not happen in similir `Builder::orderBy` method.

> [!CAUTION]
> I haven't tested this on versions above 11 or below 9, so, not confident if it works for other versions

## Example
```php
> collect([['order_index'=>3,'id'=>4],['order_index'=>2,'id'=>1],['order_index'=>1,'id'=>3],['order_index'=>1,'id'=>2]])->sortBy(['order_index','id'])
= Illuminate\Support\Collection {#7016
    all: [
      3 => [
        "order_index" => 1,
        "id" => 2,
      ],
      2 => [
        "order_index" => 1,
        "id" => 3,
      ],
      1 => [
        "order_index" => 2,
        "id" => 1,
      ],
      0 => [
        "order_index" => 3,
        "id" => 4,
      ],
    ],
  }
```

## Why it works?

In `Collection::sortByMany`, When passing each comparisons,

- `Arr::wrap` is called, which wraps string to array
- 1st index of array would be undefined, but it defaults to true for `$ascending`

https://github.com/laravel/framework/blob/37455bbd9ece2ab48443b4ad2af85abf2140e326/src/Illuminate/Collections/Collection.php#L1458-L1460