### PR TITLE
Document associative array where clauses

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -547,6 +547,15 @@ $users = DB::table('users')->where([
 ])->get();
 ```
 
+Associative arrays are also supported for cases where you don't need to pass a value for the `operator` argument. The key should be the column name and the value should be the value to compare against:
+
+```php
+$users = DB::table('users')->where([
+    'first_name' => 'Jane',
+    'last_name' => 'Doe',
+])->get();
+```
+
 > [!WARNING]
 > PDO does not support binding column names. Therefore, you should never allow user input to dictate the column names referenced by your queries, including "order by" columns.
 

--- a/queries.md
+++ b/queries.md
@@ -522,6 +522,15 @@ For convenience, if you want to verify that a column is `=` to a given value, yo
 $users = DB::table('users')->where('votes', 100)->get();
 ```
 
+You may also provide an associative array to the `where` method to quickly query against multiple columns:
+
+```php
+$users = DB::table('users')->where([
+    'first_name' => 'Jane',
+    'last_name' => 'Doe',
+])->get();
+```
+
 As previously mentioned, you may use any operator that is supported by your database system:
 
 ```php
@@ -544,15 +553,6 @@ You may also pass an array of conditions to the `where` function. Each element o
 $users = DB::table('users')->where([
     ['status', '=', '1'],
     ['subscribed', '<>', '1'],
-])->get();
-```
-
-Associative arrays are also supported for cases where you don't need to pass a value for the `operator` argument. The key should be the column name and the value should be the value to compare against:
-
-```php
-$users = DB::table('users')->where([
-    'first_name' => 'Jane',
-    'last_name' => 'Doe',
 ])->get();
 ```
 


### PR DESCRIPTION
In January 2016 a feature was added to allow where clauses with associative arrays, where the column name is the array key and the where value is the array value. It seems like this was never documented, however I imagine since it's such an intuitive way to use the where clause a number of projects are likely using it without realising it's an undocumented feature. It's also a good feature that should stay as it's a common use case to already have such an array and want to be able to use it in a query.

- Original commit: https://github.com/laravel/framework/commit/491feeb82ac27542c6a5512f26735451a2d9c09f
- Framework code: /Illuminate/Database/Query/Builder.php::addArrayOfWheres()

Code block (the else statement is the feature implementation):
```    
    protected function addArrayOfWheres($column, $boolean, $method = 'where')
    {
        return $this->whereNested(function ($query) use ($column, $method, $boolean) {
            foreach ($column as $key => $value) {
                if (is_numeric($key) && is_array($value)) {
                    $query->{$method}(...array_values($value), boolean: $boolean);
                } else {
                    $query->{$method}($key, '=', $value, $boolean);
                }
            }
        }, $boolean);
    }
```

This code is still there in the latest version.