### PR TITLE
[12.x] Remove outdated PHP version warning

### DIFF
--- a/logging.md
+++ b/logging.md
@@ -529,7 +529,7 @@ Laravel Pail is a package that allows you to easily dive into your Laravel appli
 ### Installation
 
 > [!WARNING]
-> Laravel Pail requires [PHP 8.2+](https://php.net/releases/) and the [PCNTL](https://www.php.net/manual/en/book.pcntl.php) extension.
+> Laravel Pail requires the [PCNTL](https://www.php.net/manual/en/book.pcntl.php) PHP extension.
 
 To get started, install Pail into your project using the Composer package manager:
 


### PR DESCRIPTION
Description
---
Since Laravel requires PHP 8.2+ as a minimal version to work, the PHP 8.2 warning is now obsolete and potentially confusing.