### PR TITLE
[12.x] Fix typo

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -380,7 +380,7 @@ public function content(): Content
 ```
 
 > [!NOTE]
-> You may wish to create a `resources/views/emails` directory to house all of your email templates; however, you are free to place them wherever you wish within your `resources/views` directory.
+> You may wish to create a `resources/views/mail` directory to house all of your email templates; however, you are free to place them wherever you wish within your `resources/views` directory.
 
 <a name="plain-text-emails"></a>
 #### Plain Text Emails


### PR DESCRIPTION
Description
---
When I created an email using:

```sh
php artisan make:mail OrderShipped --view
```

or 

```sh
php artisan make:mail OrderShipped --markdown
```

The generated blade file placed in:

```sh
resources/views/mail
```

not

```sh
resources/views/emails
```