### PR TITLE
[12.x] Fix wording

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -502,7 +502,7 @@ class OrderShipped extends Mailable
 }
 ```
 
-Once the data has been passed to the `with` method, it will automatically be available in your view, so you may access it like you would access any other data in your Blade templates:
+Once the data has been passed via the `with` parameter, it will automatically be available in your view, so you may access it like you would access any other data in your Blade templates:
 
 ```blade
 <div>


### PR DESCRIPTION
Description
---
This PR correct a misleading reference to the `with` keyword in the context of mailables. `with` is not a `method`, but rather a named `parameter` of the Content class constructor. Referring to it as a `method` may confuse readers or lead them to believe there is an actual `with()` method involved.