### PR TITLE
[12.x] Add "User Preferred Locales" to Mail table of contents

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -25,6 +25,7 @@
 - [Rendering Mailables](#rendering-mailables)
     - [Previewing Mailables in the Browser](#previewing-mailables-in-the-browser)
 - [Localizing Mailables](#localizing-mailables)
+    - [User Preferred Locales](#user-preferred-locales)
 - [Testing](#testing-mailables)
     - [Testing Mailable Content](#testing-mailable-content)
     - [Testing Mailable Sending](#testing-mailable-sending)


### PR DESCRIPTION
Description
---
This adds the missing "User Preferred Locales" link to the table of contents. The section exists in the content but wasn’t listed in the table of contents.

This improves the completeness and navigability of the documentation.