### PR TITLE
[12.x] Complete Mailchimp transport example

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -1521,7 +1521,7 @@ public function boot(): void
     Mail::extend('mailchimp', function (array $config = []) {
         $client = new ApiClient;
 
-        $client->setApiKey($config['mailchimp_api_key']);
+        $client->setApiKey($config['key']);
 
         return new MailchimpTransport($client);
     });
@@ -1533,7 +1533,7 @@ Once your custom transport has been defined and registered, you may create a mai
 ```php
 'mailchimp' => [
     'transport' => 'mailchimp',
-    'mailchimp_api_key' => env('MAILCHIMP_API_KEY'),
+    'key' => env('MAILCHIMP_API_KEY'),
     // ...
 ],
 ```

--- a/mail.md
+++ b/mail.md
@@ -1511,6 +1511,7 @@ Once you've defined your custom transport, you may register it via the `extend` 
 ```php
 use App\Mail\MailchimpTransport;
 use Illuminate\Support\Facades\Mail;
+use MailchimpTransactional\ApiClient;
 
 /**
  * Bootstrap any application services.
@@ -1518,7 +1519,11 @@ use Illuminate\Support\Facades\Mail;
 public function boot(): void
 {
     Mail::extend('mailchimp', function (array $config = []) {
-        return new MailchimpTransport(/* ... */);
+        $client = new ApiClient;
+
+        $client->setApiKey($config['mailchimp_api_key']);
+
+        return new MailchimpTransport($client);
     });
 }
 ```
@@ -1528,6 +1533,7 @@ Once your custom transport has been defined and registered, you may create a mai
 ```php
 'mailchimp' => [
     'transport' => 'mailchimp',
+    'mailchimp_api_key' => env('MAILCHIMP_API_KEY'),
     // ...
 ],
 ```


### PR DESCRIPTION
Description
---
Complete the Mailchimp custom transport example by providing the actual implementation for the `Mail::extend()` closure and configuration setup.

The current placeholder makes the example incomplete and potentially confusing for beginners, who might mistakenly assume that the service container will automatically handle the dependency injection.