### PR TITLE
Fix missing comma Arr::join example

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -666,9 +666,9 @@ $joined = Arr::join($array, ', ');
 
 // Tailwind, Alpine, Laravel, Livewire
 
-$joined = Arr::join($array, ', ', ' and ');
+$joined = Arr::join($array, ', ', ', and ');
 
-// Tailwind, Alpine, Laravel and Livewire
+// Tailwind, Alpine, Laravel, and Livewire
 ```
 
 <a name="method-array-keyby"></a>


### PR DESCRIPTION
Laravel docs use the Oxford comma consistently. This PR applies one to the `Arr::join` example code