### PR TITLE
[12.x] Fix ordering of Http::fake fallback explanation

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -600,7 +600,7 @@ $response = Http::post(/* ... */);
 <a name="faking-specific-urls"></a>
 #### Faking Specific URLs
 
-Alternatively, you may pass an array to the `fake` method. The array's keys should represent URL patterns that you wish to fake and their associated responses. The `*` character may be used as a wildcard character. Any requests made to URLs that have not been faked will actually be executed. You may use the `Http` facade's `response` method to construct stub / fake responses for these endpoints:
+Alternatively, you may pass an array to the `fake` method. The array's keys should represent URL patterns that you wish to fake and their associated responses. The `*` character may be used as a wildcard character. You may use the `Http` facade's `response` method to construct stub / fake responses for these endpoints:
 
 ```php
 Http::fake([
@@ -612,7 +612,7 @@ Http::fake([
 ]);
 ```
 
-If you would like to specify a fallback URL pattern that will stub all unmatched URLs, you may use a single `*` character:
+Any requests made to URLs that have not been faked will actually be executed. If you would like to specify a fallback URL pattern that will stub all unmatched URLs, you may use a single `*` character:
 
 ```php
 Http::fake([


### PR DESCRIPTION
Description
---
This PR improves the structure of the "Faking Specific URLs" section in the HTTP Client docs by making the logical flow clearer: first show how to fake specific endpoints, then explain what happens to unfaked URLs, and finally introduce the fallback option.

Note
---
This change does not introduce any new content. It only reorders an existing paragraph to improve the logical flow. No paragraphs were added or removed.