### PR TITLE
[12.x] Fix outdated URLs in Mail

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -87,7 +87,7 @@ After configuring your application's default mailer, add the following options t
 ],
 ```
 
-If you are not using the United States [Mailgun region](https://documentation.mailgun.com/en/latest/api-intro.html#mailgun-regions), you may define your region's endpoint in the `services` configuration file:
+If you are not using the United States [Mailgun region](https://documentation.mailgun.com/docs/mailgun/api-reference/#mailgun-regions), you may define your region's endpoint in the `services` configuration file:
 
 ```php
 'mailgun' => [


### PR DESCRIPTION
Description
---
This PR updates one outdated and broken URL in the Laravel mail docs to point to the correct location.

Continuation of: #10595