### PR TITLE
[12.x] Use env() helper for Brevo API key example in mail configuration

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -1551,7 +1551,7 @@ Once the Brevo mailer package has been installed, you may add an entry for your 
 
 ```php
 'brevo' => [
-    'key' => 'your-api-key',
+    'key' => env('BREVO_API_KEY'),
 ],
 ```
 


### PR DESCRIPTION
Description
---
This PR updates the `brevo` mailer configuration example to use the `env()` helper for the API key, consistent with the `mailchimp` example and Laravel’s general practice of keeping sensitive credentials in environment variables.