### PR TITLE
[12.x] Add namespace declaration to MailchimpTransport example

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -1462,6 +1462,10 @@ class LogMessage
 Laravel includes a variety of mail transports; however, you may wish to write your own transports to deliver email via other services that Laravel does not support out of the box. To get started, define a class that extends the `Symfony\Component\Mailer\Transport\AbstractTransport` class. Then, implement the `doSend` and `__toString` methods on your transport:
 
 ```php
+<?php
+
+namespace App\Mail;
+
 use MailchimpTransactional\ApiClient;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;


### PR DESCRIPTION
Description
---
This PR updates the `MailchimpTransport` example in the custom mail transport docs to include a `namespace` declaration. This change matches the later usage in the `AppServiceProvider`:

```php
use App\Mail\MailchimpTransport;
```