### PR TITLE
[12.x] Refine wording in custom transport mail docs

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -1506,7 +1506,7 @@ class MailchimpTransport extends AbstractTransport
 }
 ```
 
-Once you've defined your custom transport, you may register it via the `extend` method provided by the `Mail` facade. Typically, this should be done within the `boot` method of your application's `AppServiceProvider` service provider. A `$config` argument will be passed to the closure provided to the `extend` method. This argument will contain the configuration array defined for the mailer in the application's `config/mail.php` configuration file:
+Once you've defined your custom transport, you may register it via the `extend` method provided by the `Mail` facade. Typically, this should be done within the `boot` method of your application's `AppServiceProvider`. A `$config` argument will be passed to the closure provided to the `extend` method. This argument will contain the configuration array defined for the mailer in the application's `config/mail.php` configuration file:
 
 ```php
 use App\Mail\MailchimpTransport;


### PR DESCRIPTION
Description
---
This PR updates the wording in the mail custom transport to match the tone and phrasing used in similar parts of the Laravel documentation (e.g., the [Registering Event Subscribers](https://laravel.com/docs/12.x/events#registering-event-subscribers)). Specifically, it removes the redundant phrase "service provider" after "AppServiceProvider". This change improves clarity and maintains a consistent voice across the documentation.