### PR TITLE
[12.x] Fix parameter order

### DIFF
--- a/prompts.md
+++ b/prompts.md
@@ -858,8 +858,8 @@ The `spin` function displays a spinner along with an optional message while exec
 use function Laravel\Prompts\spin;
 
 $response = spin(
-    message: 'Fetching response...',
     callback: fn () => Http::get('http://example.com')
+    message: 'Fetching response...',
 );
 ```
 


### PR DESCRIPTION
The [parameter order](https://github.com/laravel/prompts/blob/main/src/helpers.php#L212-L215) to Prompts' `spin` method is different to the docs and this just caught me out.