### PR TITLE
[12.x] Fix incorrect parameter reference

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -655,7 +655,7 @@ $isList = Arr::isList(['product' => ['name' => 'Desk', 'price' => 100]]);
 <a name="method-array-join"></a>
 #### `Arr::join()` {.collection-method}
 
-The `Arr::join` method joins array elements with a string. Using this method's second argument, you may also specify the joining string for the final element of the array:
+The `Arr::join` method joins array elements with a string. Using this method's third argument, you may also specify the joining string for the final element of the array:
 
 ```php
 use Illuminate\Support\Arr;


### PR DESCRIPTION
Description
---
This PR corrects a minor documentation issue for the `Arr::join()` method. The string used for the final element is actually passed as the `third` argument, not the `second`. This PR updates the text to accurately reflect that.