### PR TITLE
[12.x] Consistent spacing in Blade control structures

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -2511,7 +2511,7 @@ event(new UserRegistered($user));
 The `fake` function resolves a [Faker](https://github.com/FakerPHP/Faker) singleton from the container, which can be useful when creating fake data in model factories, database seeding, tests, and prototyping views:
 
 ```blade
-@for($i = 0; $i < 10; $i++)
+@for ($i = 0; $i < 10; $i++)
     <dl>
         <dt>Name</dt>
         <dd>{{ fake()->name() }}</dd>


### PR DESCRIPTION
Description
---
This PR makes a code style improvement by updating the spacing in the Blade `@for` directive to follow the common Laravel style used elsewhere in the docs.