### PR TITLE
[12.x] Improve Testing Mailable Content section

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -1182,9 +1182,7 @@ Mail::to($request->user())->send(new OrderShipped($order));
 <a name="testing-mailable-content"></a>
 ### Testing Mailable Content
 
-Laravel provides a variety of methods for inspecting your mailable's structure. In addition, Laravel provides several convenient methods for testing that your mailable contains the content that you expect. These methods are: `assertSeeInHtml`, `assertDontSeeInHtml`, `assertSeeInOrderInHtml`, `assertSeeInText`, `assertDontSeeInText`, `assertSeeInOrderInText`, `assertHasAttachment`, `assertHasAttachedData`, `assertHasAttachmentFromStorage`, and `assertHasAttachmentFromStorageDisk`.
-
-As you might expect, the "HTML" assertions assert that the HTML version of your mailable contains a given string, while the "text" assertions assert that the plain-text version of your mailable contains a given string:
+Laravel provides a variety of methods for inspecting your mailable's structure. In addition, Laravel provides several convenient methods for testing that your mailable contains the content that you expect.
 
 ```php tab=Pest
 use App\Mail\InvoicePaid;
@@ -1205,10 +1203,11 @@ test('mailable content', function () {
     $mailable->assertHasMetadata('key', 'value');
 
     $mailable->assertSeeInHtml($user->email);
-    $mailable->assertSeeInHtml('Invoice Paid');
+    $mailable->assertDontSeeInHtml('Invoice Not Paid');
     $mailable->assertSeeInOrderInHtml(['Invoice Paid', 'Thanks']);
 
     $mailable->assertSeeInText($user->email);
+    $mailable->assertDontSeeInText('Invoice Not Paid');
     $mailable->assertSeeInOrderInText(['Invoice Paid', 'Thanks']);
 
     $mailable->assertHasAttachment('/path/to/file');
@@ -1218,6 +1217,8 @@ test('mailable content', function () {
     $mailable->assertHasAttachmentFromStorageDisk('s3', '/path/to/file', 'name.pdf', ['mime' => 'application/pdf']);
 });
 ```
+
+As you might expect, the "HTML" assertions assert that the HTML version of your mailable contains a given string, while the "text" assertions assert that the plain-text version of your mailable contains a given string:
 
 ```php tab=PHPUnit
 use App\Mail\InvoicePaid;


### PR DESCRIPTION
Description
---
This PR improves the clarity and flow of the “Testing Mailable Content” section in the documentation by:

- Removing the list of available assertion methods to reduce redundancy, since all relevant assertions are demonstrated directly in the example.

- Adding examples for `assertDontSeeInHtml()` and `assertDontSeeInText()` to show how to test that specific content does not appear in the mailable.

- Removing a duplicated example of `assertSeeInHtml()` to avoid repetition.

- Moving the explanatory paragraph ("As you might expect...") after the code example for a more natural and logical reading flow.

These changes help make the section more focused and instructional.