### PR TITLE
[12.x] The push method accepts variadic parameters

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -2341,6 +2341,18 @@ $collection->all();
 // [1, 2, 3, 4, 5]
 ```
 
+You may also provide multiple items to append to the end of the collection:
+
+```php
+$collection = collect([1, 2, 3, 4]);
+
+$collection->push(5, 6, 7);
+ 
+$collection->all();
+ 
+// [1, 2, 3, 4, 5, 6, 7]
+```
+
 <a name="method-put"></a>
 #### `put()` {.collection-method}
 


### PR DESCRIPTION
Description
---
This PR updates the `push()` method documentation to clarify that it accepts multiple arguments via variadic parameters, not just a single value. This may help users to avoid unnecessary loops.