### PR TITLE
[12.x] Fix invalid PHP code

### DIFF
--- a/prompts.md
+++ b/prompts.md
@@ -858,8 +858,8 @@ The `spin` function displays a spinner along with an optional message while exec
 use function Laravel\Prompts\spin;
 
 $response = spin(
-    callback: fn () => Http::get('http://example.com')
-    message: 'Fetching response...',
+    callback: fn () => Http::get('http://example.com'),
+    message: 'Fetching response...'
 );
 ```
 


### PR DESCRIPTION
Description
---
Add a comma after the first parameter and remove the one after the last parameter to match the style used elsewhere in the docs.