### PR TITLE
[12.x] Reformat the link

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -279,7 +279,7 @@ public function viaQueues(): array
 <a name="queued-notification-middleware"></a>
 #### Queued Notification Middleware
 
-Queued notifications may define middleware [just like queued jobs](/docs/{{version}}/queues#job-middleware). To get started, define a `middleware` method on your notification class. The `middleware` method will receive `$notifiable` and `$channel` variables, which allow you to customize the returned middleware based on the notification's destination:
+Queued notifications may define middleware just like [queued jobs](/docs/{{version}}/queues#job-middleware). To get started, define a `middleware` method on your notification class. The `middleware` method will receive `$notifiable` and `$channel` variables, which allow you to customize the returned middleware based on the notification's destination:
 
 ```php
 use Illuminate\Queue\Middleware\RateLimited;


### PR DESCRIPTION
Description
---
I think only `queued jobs` should be displayed as a link, not `just like queued jobs`.