### PR TITLE
[12.x] Remove "Unicode Content" from table of contents

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -36,7 +36,6 @@
 - [SMS Notifications](#sms-notifications)
     - [Prerequisites](#sms-prerequisites)
     - [Formatting SMS Notifications](#formatting-sms-notifications)
-    - [Unicode Content](#unicode-content)
     - [Customizing the "From" Number](#customizing-the-from-number)
     - [Adding a Client Reference](#adding-a-client-reference)
     - [Routing SMS Notifications](#routing-sms-notifications)


### PR DESCRIPTION
Description
---
The "Unicode Content" section is an `h4` in the docs. So, I do not think we need to mention it in the table of contents. This improves the navigability of the documentation.

See
---
https://github.com/laravel/docs/blob/16978eb4f5adeb0a1106895336a07b902cf062b4/notifications.md?plain=1#L1240