### PR TITLE
[12.x] Remove ConfirmObject import

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -1360,7 +1360,6 @@ If a notification supports being sent as a Slack message, you should define a `t
 ```php
 use Illuminate\Notifications\Slack\BlockKit\Blocks\ContextBlock;
 use Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock;
-use Illuminate\Notifications\Slack\BlockKit\Composites\ConfirmObject;
 use Illuminate\Notifications\Slack\SlackMessage;
 
 /**


### PR DESCRIPTION
Description
---
This PR removes the import of the `ConfirmObject` from the "Formatting Slack Notifications" section, as it is not used there.

Note
---
The `ConfirmObject` is only used in the "Confirmation Modals" section, where it is already imported.