### PR TITLE
mention storage change

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -17,7 +17,6 @@
 
 <div class="content-list" markdown="1">
 
-- [Local Filesystem Disk Default Root Path](#local-filesystem-disk-default-root-path)
 - [Models and UUIDv7](#models-and-uuidv7)
 
 </div>
@@ -31,6 +30,7 @@
 - [Concurrency Result Index Mapping](#concurrency-result-index-mapping)
 - [Container Class Dependency Resolution](#container-class-dependency-resolution)
 - [Image Validation Now Excludes SVGs](#image-validation)
+- [Local Filesystem Disk Default Root Path](#local-filesystem-disk-default-root-path)
 - [Multi-Schema Database Inspecting](#multi-schema-database-inspecting)
 - [Nested Array Request Merging](#nested-array-request-merging)
 
@@ -192,13 +192,6 @@ The constructor of the `Illuminate\Database\Schema\Blueprint` class now expects 
 <a name="eloquent"></a>
 ### Eloquent
 
-<a name="local-filesystem-disk-default-root-path"></a>
-#### Local Filesystem Disk Default Root Path
-
-**Likelihood Of Impact: Medium**
-
-The default root path for the `local` filesystem disk was changed from `storage/app` to `storage/app/private`. This means that any calls to `Storage::disk('local')` will now read from or write to the `storage/app/private` directory by default.
-
 <a name="models-and-uuidv7"></a>
 #### Models and UUIDv7
 
@@ -235,6 +228,8 @@ $request->mergeIfMissing([
 <a name="image-validation"></a>
 #### Image Validation Now Excludes SVGs
 
+**Likelihood Of Impact: Low**
+
 The `image` validation rule no longer allows SVG images by default. If you would like to allow SVGs when using the `image` rule, you must explicitly allow them:
 
 ```php
@@ -245,6 +240,13 @@ use Illuminate\Validation\Rules\File;
 // Or...
 'photo' => ['required', File::image(allowSvg: true)],
 ```
+
+<a name="local-filesystem-disk-default-root-path"></a>
+#### Local Filesystem Disk Default Root Path
+
+**Likelihood Of Impact: Low**
+
+If your application does not explicitly define a `local` disk in your filesystems configuration, Laravel will now default the local disk's root to storage/app/private. In previous releases, this defaulted to storage/app. As a result, calls to Storage::disk('local') will read from and write to storage/app/private unless otherwise configured. To restore the previous behavior, you may define the local disk manually and set the desired root path.
 
 <a name="miscellaneous"></a>
 ### Miscellaneous

--- a/upgrade.md
+++ b/upgrade.md
@@ -17,6 +17,7 @@
 
 <div class="content-list" markdown="1">
 
+- [Local Filesystem Disk Default Root Path](#local-filesystem-disk-default-root-path)
 - [Models and UUIDv7](#models-and-uuidv7)
 
 </div>
@@ -190,6 +191,13 @@ The constructor of the `Illuminate\Database\Schema\Blueprint` class now expects 
 
 <a name="eloquent"></a>
 ### Eloquent
+
+<a name="local-filesystem-disk-default-root-path"></a>
+#### Local Filesystem Disk Default Root Path
+
+**Likelihood Of Impact: Medium**
+
+The default root path for the `local` filesystem disk was changed from `storage/app` to `storage/app/private`. This means that any calls to `Storage::disk('local')` will now read from or write to the `storage/app/private` directory by default.
 
 <a name="models-and-uuidv7"></a>
 #### Models and UUIDv7


### PR DESCRIPTION
We ran into this on a couple of apps after upgrading to Laravel 12 - files written to the local disk were unexpectedly landing in `storage/app/private` instead of `storage/app`.  The issue occurs when the `local` `filesystem` isn't declared (falling back on Laravel defaults), giving the default `'root' => storage_path('app/private')`.

https://github.com/laravel/framework/pull/54764

<img width="668" height="200" alt="image" src="https://github.com/user-attachments/assets/5181aa5d-ce98-4ca7-ab74-50d63b4deb4c" />
