### PR TITLE
Fix: Change perPage from string to int in Paginate scope

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -1638,7 +1638,7 @@ class Paginate
     public function __construct(
         private string $sortBy = 'timestamp',
         private string $sortDirection = 'desc',
-        private string $perPage = 25,
+        private int $perPage = 25,
     ) {
         //
     }


### PR DESCRIPTION
Cannot use int as default value for parameter $perPage of type string