### PR TITLE
[12.x] Add readNotifications relationship method

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -981,22 +981,22 @@ foreach ($user->notifications as $notification) {
 }
 ```
 
-If you want to retrieve only the "read" notifications, you may use the `readNotifications` relationship. Again, these notifications will be sorted by the `created_at` timestamp with the most recent notifications at the beginning of the collection:
-
-```php
-$user = App\Models\User::find(1);
-
-foreach ($user->readNotifications as $notification) {
-    echo $notification->type;
-}
-```
-
 If you want to retrieve only the "unread" notifications, you may use the `unreadNotifications` relationship. Again, these notifications will be sorted by the `created_at` timestamp with the most recent notifications at the beginning of the collection:
 
 ```php
 $user = App\Models\User::find(1);
 
 foreach ($user->unreadNotifications as $notification) {
+    echo $notification->type;
+}
+```
+
+If you want to retrieve only the "read" notifications, you may use the `readNotifications` relationship:
+
+```php
+$user = App\Models\User::find(1);
+
+foreach ($user->readNotifications as $notification) {
     echo $notification->type;
 }
 ```

--- a/notifications.md
+++ b/notifications.md
@@ -981,6 +981,16 @@ foreach ($user->notifications as $notification) {
 }
 ```
 
+If you want to retrieve only the "read" notifications, you may use the `readNotifications` relationship. Again, these notifications will be sorted by the `created_at` timestamp with the most recent notifications at the beginning of the collection:
+
+```php
+$user = App\Models\User::find(1);
+
+foreach ($user->readNotifications as $notification) {
+    echo $notification->type;
+}
+```
+
 If you want to retrieve only the "unread" notifications, you may use the `unreadNotifications` relationship. Again, these notifications will be sorted by the `created_at` timestamp with the most recent notifications at the beginning of the collection:
 
 ```php


### PR DESCRIPTION
Description
---
This pull request adds documentation for the `readNotifications` method, which exists on notifiable models through the `Illuminate\Notifications\Notifiable` trait.

This method can be particularly useful in cases where you want to display "unread" notifications first, followed by "read" notifications, providing more control over how notifications are presented to the user.

The `readNotifications` section has been documented before the `unreadNotifications` section to maintain alphabetical order, which is also the same order used in the [HasDatabaseNotifications trait within the Laravel core](https://github.com/laravel/framework/blob/d41f408ff1fde6b20c3a91e41ab9955e2fd52dff/src/Illuminate/Notifications/HasDatabaseNotifications.php#L5).

Lastly, the tone and wording used in this addition mirrors the existing `unreadNotifications` documentation to maintain consistency across the section.