### PR TITLE
Explain cache prefix change when not default value

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -206,6 +206,16 @@ protected function configureEmailVerification()
 
 Previously, if a cache key prefix was defined for the DynamoDB, Memcached, or Redis cache stores, Laravel would append a `:` to the prefix. In Laravel 11, the cache key prefix does not receive the `:` suffix. If you would like to maintain the previous prefixing behavior, you can manually add the `:` suffix to your cache key prefix.
 
+If you do not have a cache prefix defined, ie were using the default cache prefix, you can simply add `:` to the end of the `prefix` property in your `cache.php` confile file to ensure your cache prefixes remain the same.
+
+Before:
+
+`'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache_'),`
+
+After:
+
+`'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache_:'),`
+
 <a name="collections"></a>
 ### Collections
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -206,7 +206,7 @@ protected function configureEmailVerification()
 
 Previously, if a cache key prefix was defined for the DynamoDB, Memcached, or Redis cache stores, Laravel would append a `:` to the prefix. In Laravel 11, the cache key prefix does not receive the `:` suffix. If you would like to maintain the previous prefixing behavior, you can manually add the `:` suffix to your cache key prefix.
 
-If you do not have a cache prefix defined, ie were using the default cache prefix, you can simply add `:` to the end of the `prefix` property in your `cache.php` confile file to ensure your cache prefixes remain the same.
+If you do not have a cache prefix defined, ie were using the default cache prefix, you can simply add `:` to the end of the `prefix` property in your `cache.php` config file to ensure your existing cache prefixes remain the same.
 
 Before:
 


### PR DESCRIPTION
When not using an explicit cache prefix the default is used. Removing the prefix in v11 causes new keys to be created and old keys forgotten about.