### PR TITLE
[12.x] Fix PHPDoc for consistency

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -123,7 +123,7 @@ The `mergeConfigFrom` method accepts the path to your package's configuration fi
 
 ```php
 /**
- * Register any application services.
+ * Register any package services.
  */
 public function register(): void
 {


### PR DESCRIPTION
Description
---
The PHPDoc for the `register` method currently says: `Register any application services.`. For consistency with the `boot` method's comment: `Bootstrap any package services.`, it should be updated to: `Register any package services.`

This aligns with the context of service providers within packages.