### PR TITLE
[12.x] Fix order of sections in packages docs

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -136,21 +136,6 @@ public function register(): void
 > [!WARNING]
 > This method only merges the first level of the configuration array. If your users partially define a multi-dimensional configuration array, the missing options will not be merged.
 
-<a name="routes"></a>
-### Routes
-
-If your package contains routes, you may load them using the `loadRoutesFrom` method. This method will automatically determine if the application's routes are cached and will not load your routes file if the routes have already been cached:
-
-```php
-/**
- * Bootstrap any package services.
- */
-public function boot(): void
-{
-    $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
-}
-```
-
 <a name="migrations"></a>
 ### Migrations
 
@@ -165,6 +150,21 @@ public function boot(): void
     $this->publishesMigrations([
         __DIR__.'/../database/migrations' => database_path('migrations'),
     ]);
+}
+```
+
+<a name="routes"></a>
+### Routes
+
+If your package contains routes, you may load them using the `loadRoutesFrom` method. This method will automatically determine if the application's routes are cached and will not load your routes file if the routes have already been cached:
+
+```php
+/**
+ * Bootstrap any package services.
+ */
+public function boot(): void
+{
+    $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
 }
 ```
 


### PR DESCRIPTION
Description
---
This PR corrects the order of the "Migrations" and "Routes" sections in the packages docs. Previously, the main content displayed "Routes" before "Migrations", which did not match the order shown in the right sidebar (table of contents). The sections are now reordered to ensure consistency between the sidebar and the main documentation content.

Note
---
While the changes may not be immediately obvious, I only reversed the order of the two sections.