### PR TITLE
Improve Stringable::whenIsUuid() example

### DIFF
--- a/strings.md
+++ b/strings.md
@@ -3806,12 +3806,13 @@ The `whenIsUuid` method invokes the given closure if the string is a valid UUID.
 ```php
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
+use Ramsey\Uuid\UuidFactory;
 
-$string = Str::of('a0a2a2d2-0b87-4a18-83f2-2529882be2de')->whenIsUuid(function (Stringable $string) {
-    return $string->substr(0, 8);
+$node = Str::of('a0a2a2d2-0b87-1a18-83f2-2529882be2de')->whenIsUuid(function (Stringable $string) {
+    return wordwrap((new UuidFactory)->fromString($string)->getFields()->getNode()->toString(), 2, ':', true);
 });
 
-// 'a0a2a2d2'
+// '25:29:88:2b:e2:de'
 ```
 
 <a name="method-fluent-str-when-test"></a>


### PR DESCRIPTION
The old example
* wasn't very descriptive: It extracted the `time_low` part but didn't indicate this anywhere, let alone it looked like a pretty random choice
* didn't treat the UUID as such: It didn't properly parse it (we should strive to show best practices)

The new example
* actually does something with the passed UUID: It formats the extracted UUID segment as it would be expected as a standalone value