### PR TITLE
[12.x] Improve Artisan console docs

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -651,15 +651,15 @@ $name = $this->choice(
     'What is your name?',
     ['Taylor', 'Dayle'],
     $defaultIndex,
-    $maxAttempts = null,
-    $allowMultipleSelections = false
+    attempts: null,
+    multiple: false
 );
 ```
 
 <a name="writing-output"></a>
 ### Writing Output
 
-To send output to the console, you may use the `line`, `info`, `comment`, `question`, `warn`, and `error` methods. Each of these methods will use appropriate ANSI colors for their purpose. For example, let's display some general information to the user. Typically, the `info` method will display in the console as green colored text:
+To send output to the console, you may use the `line`, `info`, `comment`, `question`, `warn`, `alert` and `error` methods. Each of these methods will use appropriate ANSI colors for their purpose. For example, let's display some general information to the user. Typically, the `info` method will display in the console as green colored text:
 
 ```php
 /**


### PR DESCRIPTION
This PR improves the Artisan console documentation by:

- Correcting the usage of the `choice()` method parameters
- Adding the missing `alert()` method to the console output methods list