### PR TITLE
[12.x] add a `$` when referencing a class property

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -122,7 +122,7 @@ php artisan make:command SendEmails
 <a name="command-structure"></a>
 ### Command Structure
 
-After generating your command, you should define appropriate values for the `signature` and `description` properties of the class. These properties will be used when displaying your command on the `list` screen. The `signature` property also allows you to define [your command's input expectations](#defining-input-expectations). The `handle` method will be called when your command is executed. You may place your command logic in this method.
+After generating your command, you should define appropriate values for the `signature` and `description` properties of the class. These properties will be used when displaying your command on the `list` screen. The `$signature` property also allows you to define [your command's input expectations](#defining-input-expectations). The `handle` method will be called when your command is executed. You may place your command logic in this method.
 
 Let's take a look at an example command. Note that we are able to request any dependencies we need via the command's `handle` method. The Laravel [service container](/docs/{{version}}/container) will automatically inject all dependencies that are type-hinted in this method's signature:
 
@@ -292,7 +292,7 @@ public function isolationLockExpiresAt(): DateTimeInterface|DateInterval
 <a name="defining-input-expectations"></a>
 ## Defining Input Expectations
 
-When writing console commands, it is common to gather input from the user through arguments or options. Laravel makes it very convenient to define the input you expect from the user using the `signature` property on your commands. The `signature` property allows you to define the name, arguments, and options for the command in a single, expressive, route-like syntax.
+When writing console commands, it is common to gather input from the user through arguments or options. Laravel makes it very convenient to define the input you expect from the user using the `$signature` property on your commands. The `$signature` property allows you to define the name, arguments, and options for the command in a single, expressive, route-like syntax.
 
 <a name="arguments"></a>
 ### Arguments

--- a/billing.md
+++ b/billing.md
@@ -2502,7 +2502,7 @@ if ($user->subscription('default')->hasIncompletePayment()) {
 }
 ```
 
-You can derive the specific status of an incomplete payment by inspecting the `payment` property on the exception instance:
+You can derive the specific status of an incomplete payment by inspecting the `$payment` property on the exception instance:
 
 ```php
 use Laravel\Cashier\Exceptions\IncompletePayment;

--- a/broadcasting.md
+++ b/broadcasting.md
@@ -1539,7 +1539,7 @@ Once you have added the `BroadcastsEvents` trait to your model and defined your 
 
 First, use the `private` method to retrieve an instance of a channel, then call the `listen` method to listen for a specified event. Typically, the channel name given to the `private` method should correspond to Laravel's [model broadcasting conventions](#model-broadcasting-conventions).
 
-Once you have obtained a channel instance, you may use the `listen` method to listen for a particular event. Since model broadcast events are not associated with an "actual" event within your application's `App\Events` directory, the [event name](#model-broadcasting-event-conventions) must be prefixed with a `.` to indicate it does not belong to a particular namespace. Each model broadcast event has a `model` property which contains all of the broadcastable properties of the model:
+Once you have obtained a channel instance, you may use the `listen` method to listen for a particular event. Since model broadcast events are not associated with an "actual" event within your application's `App\Events` directory, the [event name](#model-broadcasting-event-conventions) must be prefixed with a `.` to indicate it does not belong to a particular namespace. Each model broadcast event has a `$model` property which contains all of the broadcastable properties of the model:
 
 ```js
 Echo.private(`App.Models.User.${this.user.id}`)

--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -109,7 +109,7 @@ protected static function newFactory()
 }
 ```
 
-Then, define a `model` property on the corresponding factory:
+Then, define a `$model` property on the corresponding factory:
 
 ```php
 use App\Administration\Flight;

--- a/eloquent-mutators.md
+++ b/eloquent-mutators.md
@@ -827,7 +827,7 @@ $user->save();
 
 When attributes that are cast to value objects are resolved, they are cached by Eloquent. Therefore, the same object instance will be returned if the attribute is accessed again.
 
-If you would like to disable the object caching behavior of custom cast classes, you may declare a public `withoutObjectCaching` property on your custom cast class:
+If you would like to disable the object caching behavior of custom cast classes, you may declare a public `$withoutObjectCaching` property on your custom cast class:
 
 ```php
 class AsAddress implements CastsAttributes

--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -1001,7 +1001,7 @@ class RoleUser extends Pivot
 <a name="custom-pivot-models-and-incrementing-ids"></a>
 #### Custom Pivot Models and Incrementing IDs
 
-If you have defined a many-to-many relationship that uses a custom pivot model, and that pivot model has an auto-incrementing primary key, you should ensure your custom pivot model class defines an `incrementing` property that is set to `true`.
+If you have defined a many-to-many relationship that uses a custom pivot model, and that pivot model has an auto-incrementing primary key, you should ensure your custom pivot model class defines an `$incrementing` property that is set to `true`.
 
 ```php
 /**
@@ -2562,7 +2562,7 @@ $user->roles()->updateExistingPivot($roleId, [
 
 When a model defines a `belongsTo` or `belongsToMany` relationship to another model, such as a `Comment` which belongs to a `Post`, it is sometimes helpful to update the parent's timestamp when the child model is updated.
 
-For example, when a `Comment` model is updated, you may want to automatically "touch" the `updated_at` timestamp of the owning `Post` so that it is set to the current date and time. To accomplish this, you may add a `touches` property to your child model containing the names of the relationships that should have their `updated_at` timestamps updated when the child model is updated:
+For example, when a `Comment` model is updated, you may want to automatically "touch" the `updated_at` timestamp of the owning `Post` so that it is set to the current date and time. To accomplish this, you may add a `$touches` property to your child model containing the names of the relationships that should have their `updated_at` timestamps updated when the child model is updated:
 
 ```php
 <?php

--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -180,7 +180,7 @@ When invoking the `toResourceCollection` method, Laravel will attempt to locate 
 <a name="preserving-collection-keys"></a>
 #### Preserving Collection Keys
 
-When returning a resource collection from a route, Laravel resets the collection's keys so that they are in numerical order. However, you may add a `preserveKeys` property to your resource class indicating whether a collection's original keys should be preserved:
+When returning a resource collection from a route, Laravel resets the collection's keys so that they are in numerical order. However, you may add a `$preserveKeys` property to your resource class indicating whether a collection's original keys should be preserved:
 
 ```php
 <?php
@@ -200,7 +200,7 @@ class UserResource extends JsonResource
 }
 ```
 
-When the `preserveKeys` property is set to `true`, collection keys will be preserved when the collection is returned from a route or controller:
+When the `$preserveKeys` property is set to `true`, collection keys will be preserved when the collection is returned from a route or controller:
 
 ```php
 use App\Http\Resources\UserResource;

--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -108,7 +108,7 @@ class User extends Model
 > [!NOTE]
 > To hide relationships, add the relationship's method name to your Eloquent model's `$hidden` property.
 
-Alternatively, you may use the `visible` property to define an "allow list" of attributes that should be included in your model's array and JSON representation. All attributes that are not present in the `$visible` array will be hidden when the model is converted to an array or JSON:
+Alternatively, you may use the `$visible` property to define an "allow list" of attributes that should be included in your model's array and JSON representation. All attributes that are not present in the `$visible` array will be hidden when the model is converted to an array or JSON:
 
 ```php
 <?php
@@ -178,7 +178,7 @@ class User extends Model
 }
 ```
 
-If you would like the accessor to always be appended to your model's array and JSON representations, you may add the attribute name to the `appends` property of your model. Note that attribute names are typically referenced using their "snake case" serialized representation, even though the accessor's PHP method is defined using "camel case":
+If you would like the accessor to always be appended to your model's array and JSON representations, you may add the attribute name to the `$appends` property of your model. Note that attribute names are typically referenced using their "snake case" serialized representation, even though the accessor's PHP method is defined using "camel case":
 
 ```php
 <?php

--- a/eloquent.md
+++ b/eloquent.md
@@ -128,7 +128,7 @@ class Flight extends Model
 
 After glancing at the example above, you may have noticed that we did not tell Eloquent which database table corresponds to our `Flight` model. By convention, the "snake case", plural name of the class will be used as the table name unless another name is explicitly specified. So, in this case, Eloquent will assume the `Flight` model stores records in the `flights` table, while an `AirTrafficController` model would store records in an `air_traffic_controllers` table.
 
-If your model's corresponding database table does not fit this convention, you may manually specify the model's table name by defining a `table` property on the model:
+If your model's corresponding database table does not fit this convention, you may manually specify the model's table name by defining a `$table` property on the model:
 
 ```php
 <?php
@@ -766,7 +766,7 @@ $flight = Flight::create([
 ]);
 ```
 
-However, before using the `create` method, you will need to specify either a `fillable` or `guarded` property on your model class. These properties are required because all Eloquent models are protected against mass assignment vulnerabilities by default. To learn more about mass assignment, please consult the [mass assignment documentation](#mass-assignment).
+However, before using the `create` method, you will need to specify either a `$fillable` or `$guarded` property on your model class. These properties are required because all Eloquent models are protected against mass assignment vulnerabilities by default. To learn more about mass assignment, please consult the [mass assignment documentation](#mass-assignment).
 
 <a name="updates"></a>
 ### Updates
@@ -924,7 +924,7 @@ $flight = Flight::create([
 ]);
 ```
 
-However, before using the `create` method, you will need to specify either a `fillable` or `guarded` property on your model class. These properties are required because all Eloquent models are protected against mass assignment vulnerabilities by default.
+However, before using the `create` method, you will need to specify either a `$fillable` or `$guarded` property on your model class. These properties are required because all Eloquent models are protected against mass assignment vulnerabilities by default.
 
 A mass assignment vulnerability occurs when a user passes an unexpected HTTP request field and that field changes a column in your database that you did not expect. For example, a malicious user might send an `is_admin` parameter through an HTTP request, which is then passed to your model's `create` method, allowing the user to escalate themselves to an administrator.
 
@@ -963,7 +963,7 @@ $flight->fill(['name' => 'Amsterdam to Frankfurt']);
 <a name="mass-assignment-json-columns"></a>
 #### Mass Assignment and JSON Columns
 
-When assigning JSON columns, each column's mass assignable key must be specified in your model's `$fillable` array. For security, Laravel does not support updating nested JSON attributes when using the `guarded` property:
+When assigning JSON columns, each column's mass assignable key must be specified in your model's `$fillable` array. For security, Laravel does not support updating nested JSON attributes when using the `$guarded` property:
 
 ```php
 /**

--- a/queues.md
+++ b/queues.md
@@ -1273,12 +1273,12 @@ public function retryUntil(): DateTime
 If both `retryUntil` and `tries` are defined, Laravel gives precedence to the `retryUntil` method.
 
 > [!NOTE]
-> You may also define a `tries` property or `retryUntil` method on your [queued event listeners](/docs/{{version}}/events#queued-event-listeners) and [queued notifications](/docs/{{version}}/notifications#queueing-notifications).
+> You may also define a `$tries` property or `retryUntil` method on your [queued event listeners](/docs/{{version}}/events#queued-event-listeners) and [queued notifications](/docs/{{version}}/notifications#queueing-notifications).
 
 <a name="max-exceptions"></a>
 #### Max Exceptions
 
-Sometimes you may wish to specify that a job may be attempted many times, but should fail if the retries are triggered by a given number of unhandled exceptions (as opposed to being released by the `release` method directly). To accomplish this, you may define a `maxExceptions` property on your job class:
+Sometimes you may wish to specify that a job may be attempted many times, but should fail if the retries are triggered by a given number of unhandled exceptions (as opposed to being released by the `release` method directly). To accomplish this, you may define a `$maxExceptions` property on your job class:
 
 ```php
 <?php
@@ -2164,7 +2164,7 @@ Using the `--backoff` option, you may specify how many seconds Laravel should wa
 php artisan queue:work redis --tries=3 --backoff=3
 ```
 
-If you would like to configure how many seconds Laravel should wait before retrying a job that has encountered an exception on a per-job basis, you may do so by defining a `backoff` property on your job class:
+If you would like to configure how many seconds Laravel should wait before retrying a job that has encountered an exception on a per-job basis, you may do so by defining a `$backoff` property on your job class:
 
 ```php
 /**
@@ -2302,7 +2302,7 @@ php artisan queue:flush
 
 When injecting an Eloquent model into a job, the model is automatically serialized before being placed on the queue and re-retrieved from the database when the job is processed. However, if the model has been deleted while the job was waiting to be processed by a worker, your job may fail with a `ModelNotFoundException`.
 
-For convenience, you may choose to automatically delete jobs with missing models by setting your job's `deleteWhenMissingModels` property to `true`. When this property is set to `true`, Laravel will quietly discard the job without raising an exception:
+For convenience, you may choose to automatically delete jobs with missing models by setting your job's `$deleteWhenMissingModels` property to `true`. When this property is set to `true`, Laravel will quietly discard the job without raising an exception:
 
 ```php
 /**

--- a/validation.md
+++ b/validation.md
@@ -429,7 +429,7 @@ public function after(): array
 <a name="request-stopping-on-first-validation-rule-failure"></a>
 #### Stopping on the First Validation Failure
 
-By adding a `stopOnFirstFailure` property to your request class, you may inform the validator that it should stop validating all attributes once a single validation failure has occurred:
+By adding a `$stopOnFirstFailure` property to your request class, you may inform the validator that it should stop validating all attributes once a single validation failure has occurred:
 
 ```php
 /**


### PR DESCRIPTION
consistently prefix with a `$` when referencing a class property.

this is a follow up to #10645

I explicitly only added the prefix when we were directly referencing and showing an example of a PHP class.  I did not add the prefix when referencing a javascript property of an object, or when the example showed the calling code of the property from an instantiated object (`$model->property`).

if I'm being honest, I think the previous PR went the wrong direction, and instead we should *remove* all the `$` prefixes. it feels like the `$` is implied for all PHP class properties. we also get this inconsistency, because it becomes largely context dependent on what *type* of property we're referencing, and _how_ we're showing it in the example. but I'll obviously leave that up to maintainers to decide on.