### PR TITLE
[12.x] clarify dispatch behavior when using beforeCommit() with ShouldQueueAfterCommit interface

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -994,6 +994,9 @@ Likewise, if the `after_commit` configuration option is set to `true`, you may i
 ProcessPodcast::dispatch($podcast)->beforeCommit();
 ```
 
+> [!WARNING]
+> The `beforeCommit()` method takes precedence over the `ShouldQueueAfterCommit` interface. This means even if a job implements `ShouldQueueAfterCommit`, calling `beforeCommit()` will force it to be dispatched immediately without waiting for open database transactions to get committed. So use this carefully to avoid unexpected behavior.
+
 <a name="job-chaining"></a>
 ### Job Chaining
 


### PR DESCRIPTION
This little update is added in support of the changes made in ([framework#56445](https://github.com/laravel/framework/pull/56445)). It will give developers more clarity about the behavior of job dispatching when using the `beforeCommit()` method alongside the `ShouldQueueAfterCommit` interface.

The will be helpful for devs to ensure more predictable and intentional dispatch timing.