### PR TITLE
[12.x] Add documentation for `doesnt_contain` rule

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1042,6 +1042,7 @@ Below is a list of all available validation rules and their function:
 [Array](#rule-array)
 [Between](#rule-between)
 [Contains](#rule-contains)
+[Doesnt Contain](#rule-doesnt-contain)
 [Distinct](#rule-distinct)
 [In Array](#rule-in-array)
 [In Array Keys](#rule-in-array-keys)
@@ -1373,6 +1374,24 @@ Validator::make($data, [
         'required',
         'array',
         Rule::contains(['admin', 'editor']),
+    ],
+]);
+```
+
+<a name="rule-doesnt-contain"></a>
+#### doesnt_contain:_foo_,_bar_,...
+
+The field under validation must be an array that does not contain all of the given parameter values. Since this rule often requires you to `implode` an array, the `Rule::doesntContain` method may be used to fluently construct the rule:
+
+```php
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+
+Validator::make($data, [
+    'roles' => [
+        'required',
+        'array',
+        Rule::doesntContain(['admin', 'editor']),
     ],
 ]);
 ```


### PR DESCRIPTION
This PR documents the new `doesnt_contain` validation rule introduced in https://github.com/laravel/framework/pull/56467