### PR TITLE
[12.x] Fix incorrect usage of Process::pipe()

### DIFF
--- a/processes.md
+++ b/processes.md
@@ -219,7 +219,7 @@ Laravel also allows you to assign string keys to each process within a pipeline 
 $result = Process::pipe(function (Pipe $pipe) {
     $pipe->as('first')->command('cat example.txt');
     $pipe->as('second')->command('grep -i "laravel"');
-})->start(function (string $type, string $output, string $key) {
+}, function (string $type, string $output, string $key) {
     // ...
 });
 ```


### PR DESCRIPTION
Description
---
When I run this code for the first time, I encounter the following error:

```php
Call to undefined method Illuminate\Process\ProcessResult::start()
```

As stated in the docs, the closure should be passed as the second argument to the pipe method. See: https://github.com/laravel/docs/blob/d640df584c1a06656e4518074a08acc5ca7a1560/processes.md?plain=1#L205C52-L205C102