### PR TITLE
[12.x] Clarify parameter types in assertRanTimes method docs

### DIFF
--- a/processes.md
+++ b/processes.md
@@ -623,7 +623,7 @@ use Illuminate\Support\Facades\Process;
 Process::assertRanTimes('ls -la', times: 3);
 ```
 
-The `assertRanTimes` method also accepts a closure, which will receive an instance of a process and a process result, allowing you to inspect the process' configured options. If this closure returns `true` and the process was invoked the specified number of times, the assertion will "pass":
+The `assertRanTimes` method also accepts a closure, which will receive an instance of `PendingProcess` and `ProcessResult`, allowing you to inspect the process' configured options. If this closure returns `true` and the process was invoked the specified number of times, the assertion will "pass":
 
 ```php
 Process::assertRanTimes(function (PendingProcess $process, ProcessResult $result) {


### PR DESCRIPTION
Description
---
This PR improves the clarity of the `assertRanTimes()` method documentation by specifying the concrete types of the parameters passed to the closure: `PendingProcess` and `ProcessResult`. This makes it clearer to developers what to expect and aligns with Laravel’s standard of using class names where applicable.