### PR TITLE
[12.x] Clarify `withinTransactions()`

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -3370,7 +3370,7 @@ $user = Pipeline::send($user)
     ->thenReturn();
 ```
 
-The `withinTransactions` method may be invoked on the pipeline to automatically invoke each step of the pipeline within a database transaction:
+The `withinTransactions` method may be invoked on the pipeline to automatically invoke each step of the pipeline within a single database transaction:
 
 ```php
 $user = Pipeline::send($user)


### PR DESCRIPTION
Just wanted to make sure it was super obvious that it's a solitary transaction, not many DB transactions, as the name may imply.