### PR TITLE
[12.x] Fix outdated URLs in Queues

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -114,7 +114,7 @@ In order to use the `redis` queue driver, you should configure a Redis database 
 
 **Redis Cluster**
 
-If your Redis queue connection uses a Redis Cluster, your queue names must contain a [key hash tag](https://redis.io/docs/reference/cluster-spec/#hash-tags). This is required in order to ensure all of the Redis keys for a given queue are placed into the same hash slot:
+If your Redis queue connection uses a Redis Cluster, your queue names must contain a [key hash tag](https://redis.io/docs/latest/develop/using-commands/keyspace/#hashtags). This is required in order to ensure all of the Redis keys for a given queue are placed into the same hash slot:
 
 ```php
 'redis' => [


### PR DESCRIPTION
Description
---
This PR updates one outdated and broken URL in the Laravel queues docs to point to the correct location.