### PR TITLE
[12.x] Fix namespace declaration and correct PHPDoc in job class example

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -301,7 +301,6 @@ In certain cases, you may want to define a specific "key" that makes the job uni
 
 namespace App\Jobs;
 
-use App\Models\Product;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 

--- a/queues.md
+++ b/queues.md
@@ -299,6 +299,8 @@ In certain cases, you may want to define a specific "key" that makes the job uni
 ```php
 <?php
 
+namespace App\Jobs;
+
 use App\Models\Product;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -308,7 +310,7 @@ class UpdateSearchIndex implements ShouldQueue, ShouldBeUnique
     /**
      * The product instance.
      *
-     * @var \App\Product
+     * @var \App\Models\Product
      */
     public $product;
 


### PR DESCRIPTION
Description
---
This PR enhances the `UpdateSearchIndex` job example by:

- Adding the missing namespace.
- Correcting the @var PHPDoc annotation to reflect the correct model namespace.
- Remove the unused import.

These changes improve clarity and ensure the example accurately represents standard Laravel application structure.