### PR TITLE
[12.x] Enhance the FailOnException middleware example

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1470,13 +1470,12 @@ use App\Models\User;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\FailOnException;
 use Illuminate\Support\Facades\Http;
 
 class SyncChatHistory implements ShouldQueue
 {
-    use InteractsWithQueue;
+    use Queueable;
 
     public $tries = 3;
 


### PR DESCRIPTION
Description
---
This code was newly introduced in #10508 and it uses the `InteractsWithQueue` trait which we do not use it throw the whole `queues.md` docs, so I think we should use the `Queueable` trait -which is already imported- for consistency with the job class generated by Artisan command.