### PR TITLE
[12.x] Replace $someCondition with $condition for consistency

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -2187,7 +2187,7 @@ use App\Models\Book;
 
 $books = Book::all();
 
-if ($someCondition) {
+if ($condition) {
     $books->load('author', 'publisher');
 }
 ```

--- a/queues.md
+++ b/queues.md
@@ -821,7 +821,7 @@ use Illuminate\Queue\Middleware\Skip;
 public function middleware(): array
 {
     return [
-        Skip::when($someCondition),
+        Skip::when($condition),
     ];
 }
 ```


### PR DESCRIPTION
Description
---
Most examples use the `$condition` variable to represent a conditional check. However, two examples use `$someCondition` instead. This PR updates those instances for consistency across the docs.