### PR TITLE
[12.x] Align example method order with second example

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -278,11 +278,9 @@ After making a test request to your application, the `dump`, `dumpHeaders`, and 
 test('basic test', function () {
     $response = $this->get('/');
 
-    $response->dumpHeaders();
-
-    $response->dumpSession();
-
     $response->dump();
+    $response->dumpHeaders();
+    $response->dumpSession();
 });
 ```
 
@@ -302,11 +300,9 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->dumpHeaders();
-
-        $response->dumpSession();
-
         $response->dump();
+        $response->dumpHeaders();
+        $response->dumpSession();
     }
 }
 ```


### PR DESCRIPTION
Description
---
This PR makes the method order and formatting consistent with the second example in the "Debugging Responses" section.

See
---
https://github.com/laravel/docs/blob/43bbd494256950e6cb3b2b3b83a03a5a284aff07/http-tests.md?plain=1#L318-L322