### PR TITLE
Typo fix

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -688,7 +688,7 @@ class ProviderIsUp
 <a name="throttling-exceptions"></a>
 ### Throttling Exceptions
 
-Laravel includes a `Illuminate\Queue\Middleware\ThrottlesExceptions` middleware that allows you to throttle exceptions. Once the job throws a given number of exceptions, all further attempts to execute the job are delayed until a specified time interval lapses. This middleware is particularly useful for jobs that interact with third-party services that are unstable.
+Laravel includes an `Illuminate\Queue\Middleware\ThrottlesExceptions` middleware that allows you to throttle exceptions. Once the job throws a given number of exceptions, all further attempts to execute the job are delayed until a specified time interval lapses. This middleware is particularly useful for jobs that interact with third-party services that are unstable.
 
 For example, let's imagine a queued job that interacts with a third-party API that begins throwing exceptions. To throttle exceptions, you can return the `ThrottlesExceptions` middleware from your job's `middleware` method. Typically, this middleware should be paired with a job that implements [time based attempts](#time-based-attempts):
 


### PR DESCRIPTION
The indefinite article was incorrect (“an” had been written as “a”), so I’ve fixed it.

``` Before
Laravel includes a `Illuminate\Queue\Middleware\ThrottlesExceptions`
```

``` After
Laravel includes an `Illuminate\Queue\Middleware\ThrottlesExceptions`
```