### PR TITLE
[12.x] Improve consistency and clarity

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -2201,7 +2201,7 @@ For more information on Supervisor, consult the [Supervisor documentation](http:
 
 Sometimes your queued jobs will fail. Don't worry, things don't always go as planned! Laravel includes a convenient way to [specify the maximum number of times a job should be attempted](#max-job-attempts-and-timeout). After an asynchronous job has exceeded this number of attempts, it will be inserted into the `failed_jobs` database table. [Synchronously dispatched jobs](/docs/{{version}}/queues#synchronous-dispatching) that fail are not stored in this table and their exceptions are immediately handled by the application.
 
-A migration to create the `failed_jobs` table is typically already present in new Laravel applications. However, if your application does not contain a migration for this table, you may use the `make:queue-failed-table` command to create the migration:
+A migration to create the `failed_jobs` table is already present in new Laravel applications. However, if your application does not contain a migration for this table, you may use the `make:queue-failed-table` command to create the migration:
 
 ```shell
 php artisan make:queue-failed-table


### PR DESCRIPTION
Description
---
Removing the word "typically" makes the statement more direct and consistent with similar documentation phrasing.

See
---
https://github.com/search?q=repo%3Alaravel%2Fdocs+%22is+already%22&type=code