### PR TITLE
Remove duplicate event:list mention from events docs

### DIFF
--- a/events.md
+++ b/events.md
@@ -134,12 +134,6 @@ public function boot(): void
 }
 ```
 
-The `event:list` command may be used to list all of the listeners registered within your application:
-
-```shell
-php artisan event:list
-```
-
 <a name="closure-listeners"></a>
 ### Closure Listeners
 


### PR DESCRIPTION
The event:list command is mentioned twice in the Laravel 12 events documentation — once at the end of the Event Discovery section and again immediately after the Manually Registering Events section. Both instances contain identical text and code. This PR removes the second occurrence to avoid redundancy and keep the documentation concise.