### PR TITLE
[12.x] Add note about TTY mode support

### DIFF
--- a/processes.md
+++ b/processes.md
@@ -133,8 +133,8 @@ The `tty` method may be used to enable TTY mode for your process. TTY mode conne
 Process::forever()->tty()->run('vim');
 ```
 
-> [!NOTE]
-> TTY mode is not supported on Windows platform.
+> [!WARNING]
+> TTY mode is not supported on Windows.
 
 <a name="process-output"></a>
 ### Process Output


### PR DESCRIPTION
Description
---
This PR clarifies that TTY mode is not supported on Windows platform, allowing readers to spot the limitation immediately while reading.