### PR TITLE
[12.x] update `newCollection` override to account for automatic eager loading

### DIFF
--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -335,7 +335,13 @@ class User extends Model
      */
     public function newCollection(array $models = []): Collection
     {
-        return new UserCollection($models);
+        $collection = new UserCollection($models);
+
+        if (Model::isAutomaticallyEagerLoadingRelationships()) {
+            $collection->withRelationshipAutoloading();
+        }
+
+        return $collection;
     }
 }
 ```


### PR DESCRIPTION
due to the new "automatic eager loading" feature, and the changes made here:

https://github.com/laravel/framework/commit/5548f956a64fa620356ae96880418901d358787d

the programmer needs to also include these changes when using the `newCollection()` method override for a custom collection, if they want the automatic eager loading feature to work correctly.

as much as I hate to say it, it might be time to remove the documentation for the `newCollection()` method override option, and instead just document the Attribute option.