### PR TITLE
[12.x] Clarify that the Login event will not be dispatched on Auth once()

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -409,7 +409,7 @@ Auth::loginUsingId(1, remember: true);
 <a name="authenticate-a-user-once"></a>
 #### Authenticate a User Once
 
-You may use the `once` method to authenticate a user with the application for a single request. No sessions or cookies will be utilized when calling this method:
+You may use the `once` method to authenticate a user with the application for a single request. No sessions or cookies will be utilized when calling this method, and the `Login` event will not be dispatched:
 
 ```php
 if (Auth::once($credentials)) {


### PR DESCRIPTION
The fact that `auth()->once()` and `auth()->onceUsingId()` don't trigger `Login` event listener is not documented.

I wanted to update this in the code as well, and add tests showing that the event is not dispatched, but this documentation change was determined to be sufficient.

See https://github.com/laravel/framework/pull/56683