### PR TITLE
[12.x] Fix indentation for consistency

### DIFF
--- a/rate-limiting.md
+++ b/rate-limiting.md
@@ -44,7 +44,7 @@ $executed = RateLimiter::attempt(
 );
 
 if (! $executed) {
-  return 'Too many messages sent!';
+    return 'Too many messages sent!';
 }
 ```
 


### PR DESCRIPTION
Description
---
We use four spaces for indentation throughout the documentation.