### PR TITLE
[12.x] Use Str::plural

### DIFF
--- a/rate-limiting.md
+++ b/rate-limiting.md
@@ -103,11 +103,12 @@ When a key has no more attempts left, the `availableIn` method returns the numbe
 
 ```php
 use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
 
 if (RateLimiter::tooManyAttempts('send-message:'.$user->id, $perMinute = 5)) {
     $seconds = RateLimiter::availableIn('send-message:'.$user->id);
 
-    return 'You may try again in '.$seconds.' seconds.';
+    return 'You may try again in '.$seconds.' '.Str::plural('second', $seconds).'.';
 }
 
 RateLimiter::increment('send-message:'.$user->id);


### PR DESCRIPTION
Description
---
This fixes the messages so that we don't have messages that say "1 seconds" instead it will say "1 second".