### PR TITLE
[12.x] Remove outdated phrasing

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -65,7 +65,7 @@ Laravel queues provide a unified queueing API across a variety of different queu
 Laravel's queue configuration options are stored in your application's `config/queue.php` configuration file. In this file, you will find connection configurations for each of the queue drivers that are included with the framework, including the database, [Amazon SQS](https://aws.amazon.com/sqs/), [Redis](https://redis.io), and [Beanstalkd](https://beanstalkd.github.io/) drivers, as well as a synchronous driver that will execute jobs immediately (for use during local development). A `null` queue driver is also included which discards queued jobs.
 
 > [!NOTE]
-> Laravel now offers Horizon, a beautiful dashboard and configuration system for your Redis powered queues. Check out the full [Horizon documentation](/docs/{{version}}/horizon) for more information.
+> Laravel Horizon is a beautiful dashboard and configuration system for your Redis powered queues. Check out the full [Horizon documentation](/docs/{{version}}/horizon) for more information.
 
 <a name="connections-vs-queues"></a>
 ### Connections vs. Queues


### PR DESCRIPTION
Description
---
The current phrasing made sense when **Horizon** was first introduced, but since Horizon has been part of Laravel for years, it no longer feels current. This makes the feature stable and keeps the tone clear and timeless.