### PR TITLE
[12.x] Fix incorrect default retry info in Horizon docs

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -179,7 +179,7 @@ You can define the maximum number of attempts a job can consume within a supervi
 
 Adjusting the `tries` option is essential when using middlewares such as `WithoutOverlapping` or `RateLimited` because they consume attempts. To handle this, adjust the `tries` configuration value either at the supervisor level or by defining the `$tries` property on the job class.
 
-If you don’t set the `tries` option, Horizon defaults to a single attempt, unless the job class defines `$tries`, which takes precedence over the Horizon configuration.
+If you don’t set the `tries` option, Horizon retries indefinitely, unless the job class defines `$tries`, which takes precedence over the Horizon configuration.
 
 Setting `tries` or `$tries` to 0 allows unlimited attempts, which is ideal when the number of attempts is uncertain. To prevent endless failures, you can limit the number of exceptions allowed by setting the `$maxExceptions` property on the job class.
 


### PR DESCRIPTION
This PR fixes a small misleading detail about how Horizon handles retries when the `$tries` option is omitted. In such cases, Horizon retries indefinitely, as opposed to the current docs which state it defaults to 1.

You can test this easily by: 
- Creating a fresh Laravel app
- Installing Horizon
- Omitting the `$tries` option
- Dispatching any job that throws an exception in its `handle()` method

You will see that the job is retried indefinitely instead of being marked as failed after the first attempt.

For reference, here is where the default behavior is defined if no tries are set:
- https://github.com/laravel/horizon/blob/5.x/src/Console/SupervisorCommand.php#L36
- https://github.com/laravel/horizon/blob/5.x/src/SupervisorOptions.php#L213