### PR TITLE
[12.x] Remove outdated phrasing

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -450,9 +450,7 @@ public function handle(): void
 }
 ```
 
-While this code is valid, the implementation of the `handle` method becomes noisy since it is cluttered with Redis rate limiting logic. In addition, this rate limiting logic must be duplicated for any other jobs that we want to rate limit.
-
-Instead of rate limiting in the handle method, we could define a job middleware that handles rate limiting. Laravel does not have a default location for job middleware, so you are welcome to place job middleware anywhere in your application. In this example, we will place the middleware in an `app/Jobs/Middleware` directory:
+While this code is valid, the implementation of the `handle` method becomes noisy since it is cluttered with Redis rate limiting logic. In addition, this rate limiting logic must be duplicated for any other jobs that we want to rate limit. Instead of rate limiting in the handle method, we could define a job middleware that handles rate limiting.
 
 ```php
 <?php


### PR DESCRIPTION
Description
---
This PR updates the job middleware documentation to reflect the existence of the `make:job-middleware` command.

Previously, the docs mentioned that Laravel does not have a default location for job middleware, but since the framework now provides a `make:job-middleware` command, that sentence is outdated.

I updated the text to remove the reference to Laravel not having a default location, and also removed the extra empty line so the two sentences now flow together more naturally.

References
---
https://github.com/laravel/framework/pull/52965
https://github.com/laravel/docs/pull/10490