### PR TITLE
Fix grammar in cache testing callout

### DIFF
--- a/cache.md
+++ b/cache.md
@@ -396,7 +396,7 @@ cache()->remember('users', $seconds, function () {
 ```
 
 > [!NOTE]
-> When testing call to the global `cache` function, you may use the `Cache::shouldReceive` method just as if you were [testing the facade](/docs/{{version}}/mocking#mocking-facades).
+> When testing calls to the global `cache` function, you may use the `Cache::shouldReceive` method just as if you were [testing the facade](/docs/{{version}}/mocking#mocking-facades).
 
 <a name="atomic-locks"></a>
 ## Atomic Locks


### PR DESCRIPTION
### Corrects Grammar in Cache Documentation

This pull request resolves a minor grammatical error in the cache documentation.

The original sentence in the callout read:

> When testing call to the global cache function, you may use the Cache::shouldReceive method just as if you were testing a facade.

This has been updated to use the plural form, "calls", which is grammatically correct. The corrected sentence now reads:

> When testing calls to the global cache function, you may use the Cache::shouldReceive method just as if you were testing a facade.

This change improves the clarity and overall quality of the documentation.