### PR TITLE
[12.x] Add Limit::perHour to route rate limiters

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -939,7 +939,7 @@ If you're assigning multiple rate limits segmented by identical `by` values, you
 ```php
 RateLimiter::for('uploads', function (Request $request) {
     return [
-        Limit::perMinute(10)->by('minute:'.$request->user()->id),
+        Limit::perHour(10)->by('hour:'.$request->user()->id),
         Limit::perDay(1000)->by('day:'.$request->user()->id),
     ];
 });


### PR DESCRIPTION
Description
---
Most of the examples in the rate limiting documentation demonstrate the `Limit::perMinute` method. To add more variety and show that other intervals are also available, I updated **only** the final example to use `Limit::perHour` instead of `Limit::perMinute`.