### PR TITLE
[12.x] Format

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -537,7 +537,7 @@ In the example above, we defined an hourly rate limit; however, you may easily d
 return Limit::perMinute(50)->by($job->user->id);
 ```
 
-Once you have defined your rate limit, you may attach the rate limiter to your job using the `Illuminate\Queue\Middleware\RateLimited` middleware. Each time the job exceeds the rate limit, this middleware will release the job back to the queue with an appropriate delay based on the rate limit duration.
+Once you have defined your rate limit, you may attach the rate limiter to your job using the `Illuminate\Queue\Middleware\RateLimited` middleware. Each time the job exceeds the rate limit, this middleware will release the job back to the queue with an appropriate delay based on the rate limit duration:
 
 ```php
 use Illuminate\Queue\Middleware\RateLimited;


### PR DESCRIPTION
Description
---
This PR updates the punctuation to follow the Laravel documentation style guide. When a sentence introduces a code block, it should end with a colon (:) instead of a period (.).