### PR TITLE
[12.x] Add Limit::perHour to route rate limiters

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -893,7 +893,7 @@ Since rate limiter callbacks receive the incoming HTTP request instance, you may
 RateLimiter::for('uploads', function (Request $request) {
     return $request->user()->vipCustomer()
         ? Limit::none()
-        : Limit::perMinute(100);
+        : Limit::perHour(10);
 });
 ```
 


### PR DESCRIPTION
Description
---
Most of the examples in the rate limiting documentation demonstrate the `Limit::perMinute` method. To add more variety and show that other intervals are also available, I updated **only** one example to use `Limit::perHour` instead of `Limit::perMinute`.

---

Rework of: #10753 but with another example.