### PR TITLE
[12.x] Add the same comment inside the then callback

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1669,7 +1669,7 @@ Bus::batch([
         new SendPodcastReleaseNotification(2),
     ],
 ])->then(function (Batch $batch) {
-    // ...
+    // All jobs completed successfully...
 })->dispatch();
 ```
 


### PR DESCRIPTION
Description
---
This PR adds the missing comment inside the `then()` method in the **Chains and Batches** example for consistency with the other code snippets. In all the examples that use the `then()` method, the same comment is included; except in this one.