### PR TITLE
[12.x] Fix Cancelling Batches example

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1799,6 +1799,8 @@ public function handle(): void
 {
     if ($this->user->exceedsImportLimit()) {
         $this->batch()->cancel();
+
+        return;
     }
 
     if ($this->batch()->cancelled()) {

--- a/queues.md
+++ b/queues.md
@@ -1798,7 +1798,7 @@ Sometimes you may need to cancel a given batch's execution. This can be accompli
 public function handle(): void
 {
     if ($this->user->exceedsImportLimit()) {
-        return $this->batch()->cancel();
+        $this->batch()->cancel();
     }
 
     if ($this->batch()->cancelled()) {


### PR DESCRIPTION
Description
---
The current example uses `return` with the job's `handle()` method which returns `void`, this causes a PHP error:

```sh
A void method must not return a value
```

The example is updated to simply call `cancel()` without returning its result. This makes the code matches the actual method signature.