### PR TITLE
[12.x] Improve queue:listen documentation

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1998,11 +1998,14 @@ php artisan queue:work -v
 
 Remember, queue workers are long-lived processes and store the booted application state in memory. As a result, they will not notice changes in your code base after they have been started. So, during your deployment process, be sure to [restart your queue workers](#queue-workers-and-deployment). In addition, remember that any static state created or modified by your application will not be automatically reset between jobs.
 
-Alternatively, you may run the `queue:listen` command. When using the `queue:listen` command, you don't have to manually restart the worker when you want to reload your updated code or reset the application state; however, this command is significantly less efficient than the `queue:work` command:
+Alternatively, you may run the `queue:listen` command. When using the `queue:listen` command, you don't have to manually restart the worker when you want to reload your updated code or reset the application state:
 
 ```shell
 php artisan queue:listen
 ```
+
+> [!NOTE]
+> The `queue:listen` command is significantly less efficient than the `queue:work` command because it reboots the application for every job. Therefore, it’s much slower and consumes more CPU and memory.
 
 <a name="running-multiple-queue-workers"></a>
 #### Running Multiple Queue Workers


### PR DESCRIPTION
Description
---
This PR updates the `queue:listen` documentation to clarify why the command is less efficient than `queue:work`.