### PR TITLE
[12.x] Synchronous driver is the default driver in testing

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -2626,7 +2626,7 @@ Queue::assertClosurePushed(function (CallQueuedClosure $job) {
 <a name="faking-a-subset-of-jobs"></a>
 ### Faking a Subset of Jobs
 
-If you only need to fake specific jobs while allowing your other jobs to execute normally (synchronous driver), you may pass the class names of the jobs that should be faked to the `fake` method:
+If you only need to fake specific jobs while allowing your other jobs to execute normally, you may pass the class names of the jobs that should be faked to the `fake` method:
 
 ```php tab=Pest
 test('orders can be shipped', function () {


### PR DESCRIPTION
Description
---
This PR clarifies that the synchronous driver is the default queue driver when running tests.