### PR TITLE
[12.x] Consistent batch naming across examples

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -2758,7 +2758,7 @@ Bus::fake();
 // ...
 
 Bus::assertBatched(function (PendingBatch $batch) {
-    return $batch->name == 'import-csv' &&
+    return $batch->name == 'Import CSV' &&
            $batch->jobs->count() === 10;
 });
 ```


### PR DESCRIPTION
Description
---
It’s reasonable to choose one of two approaches for consistent documentation. Laravel docs uses the **Pascal Case** with spaces, which I think is better for queue reporting dashboards.

See
---
https://laravel.com/docs/12.x/queues#naming-batches
https://laravel.com/docs/12.x/queues#queueing-closures