### PR TITLE
[12.x] Correct import statement for Eloquent Builder

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -2127,7 +2127,7 @@ Sometimes you may wish to eager load a relationship but also specify additional 
 
 ```php
 use App\Models\User;
-use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Builder;
 
 $users = User::with(['posts' => function (Builder $query) {
     $query->where('title', 'like', '%code%');


### PR DESCRIPTION
## Description
This PR corrects the import statement for the `Builder` class in the eager loading documentation.

The example should import `Illuminate\Database\Eloquent\Builder` class, not the contract.