### PR TITLE
[12.x] Clean up redundant wording

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -2794,7 +2794,7 @@ $this->assertEmpty($batch->added);
 
 Sometimes, you may need to test that a queued job [releases itself back onto the queue](#manually-releasing-a-job). Or, you may need to test that the job deleted itself. You may test these queue interactions by instantiating the job and invoking the `withFakeQueueInteractions` method.
 
-Once the job's queue interactions have been faked, you may invoke the `handle` method on the job. After invoking the job, various assertion methods are available to verify its queue interactions:
+Once the job's queue interactions have been faked, you may invoke the `handle` method on the job. After invoking the job, various assertion methods are available to verify the job's queue interactions:
 
 ```php
 use App\Exceptions\CorruptedAudioException;

--- a/queues.md
+++ b/queues.md
@@ -2794,7 +2794,7 @@ $this->assertEmpty($batch->added);
 
 Sometimes, you may need to test that a queued job [releases itself back onto the queue](#manually-releasing-a-job). Or, you may need to test that the job deleted itself. You may test these queue interactions by instantiating the job and invoking the `withFakeQueueInteractions` method.
 
-Once the job's queue interactions have been faked, you may invoke the `handle` method on the job. After invoking the job, the `assertReleased`, `assertDeleted`, `assertNotDeleted`, `assertFailed`, `assertFailedWith`, and `assertNotFailed` methods may be used to make assertions against the job's queue interactions:
+Once the job's queue interactions have been faked, you may invoke the `handle` method on the job. After invoking the job, various assertion methods are available to verify its queue interactions:
 
 ```php
 use App\Exceptions\CorruptedAudioException;


### PR DESCRIPTION
Summary
---
This PR updates the queue interactions testing documentation to remove redundant method name repetition.

Before
---
The docs listed all assertion methods in the text and repeated them in the example.

After
---
The text now introduces the concept generally and leaves the example to demonstrate the available methods. This keeps the section cleaner, easier to maintain, and consistent with other areas of the documentation.