### PR TITLE
[12.x] Clarify safety of rolling back open transactions in queue workers

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -2869,3 +2869,6 @@ Queue::looping(function () {
     }
 });
 ```
+
+> [!NOTE]
+> If you have multiple running workers, rolling back a transaction opened in worker A does not affect other transactions opened in worker B because each worker is a separate PHP process with its own memory space and database connection.


### PR DESCRIPTION
Description
---
This PR adds clarification to the queue worker documentation, explaining why it is safe to roll back any transactions left open by a previously failed job.

Since each queue worker runs as a separate PHP process with its own memory space and database connection, one worker’s rollback will never interfere with transactions opened by another worker.