### PR TITLE
[12.x] Clarify behavior of `--hours` in `queue:flush` command

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -2366,6 +2366,12 @@ To delete all of your failed jobs from the `failed_jobs` table, you may use the 
 php artisan queue:flush
 ```
 
+By default, this command deletes all failed job records regardless of age. However, you may provide the `--hours` option to delete only jobs that failed at or before the given number of hours ago. For example, the following command will delete all jobs that failed 48 hours ago or earlier:
+
+```shell
+php artisan queue:flush --hours=48
+```
+
 <a name="ignoring-missing-models"></a>
 ### Ignoring Missing Models
 


### PR DESCRIPTION
## Why?

The `queue:flush` command supports an optional `--hours` parameter, but the existing docs do not mention it. While we generally avoid documenting all options for every command, the `--hours` behavior for `flush` is **different from `--hours` in `queue:prune-failed`**, which could easily confuse developers.

- `queue:flush --hours=N` deletes jobs **at or before N hours ago**.
- `queue:prune-failed --hours=N` deletes jobs **older than N hours**.

Because of this subtle difference, it is important to clarify it in the docs to prevent unexpected deletions.

## Changes

- Added a short section to the `queue:flush` command documentation highlighting that `--hours` exists and explaining its inclusive behavior.
- Included an example for clarity.
