### PR TITLE
[12.x] Clean up redundant wording

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -3241,7 +3241,7 @@ defer(fn () => Metrics::reportOrder($order))->always();
 ```
 
 > [!WARNING]
-> If you have the [Swoole PHP extension](https://www.php.net/manual/en/book.swoole.php) installed, Laravel's `defer` function may conflict with Swoole's own global `defer` function, leading to web server errors. Make sure you call Laravel's `defer` helper by explicitly namespacing it: `use function Illuminate\Support\defer;`
+> If you have the [Swoole PHP extension](https://www.php.net/manual/en/book.swoole.php) installed, Laravel's `defer` function may conflict with Swoole's own global `defer` function, leading to web server errors. Make sure you call Laravel's `defer` helper by explicitly namespacing it.
 
 <a name="cancelling-deferred-functions"></a>
 #### Cancelling Deferred Functions


### PR DESCRIPTION
Before
---
The docs explanation about Swoole feels a bit repetitive.

After
---
The text now introduces the concept generally and leaves the example to demonstrate how to namespace the function. This keeps the section cleaner and easier to follow.