### PR TITLE
[12.x] Fix anchor format for toPrettyJson

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -230,7 +230,7 @@ For the majority of the remaining collection documentation, we'll discuss each m
 [times](#method-times)
 [toArray](#method-toarray)
 [toJson](#method-tojson)
-[toPrettyJson](#method-toprettyjson)
+[toPrettyJson](#method-to-pretty-json)
 [transform](#method-transform)
 [undot](#method-undot)
 [union](#method-union)
@@ -3334,7 +3334,7 @@ $collection->toJson();
 // '{"name":"Desk", "price":200}'
 ```
 
-<a name="method-toprettyjson"></a>
+<a name="method-to-pretty-json"></a>
 #### `toPrettyJson()` {.collection-method}
 
 The `toPrettyJson` method converts the collection into a formatted JSON string using the `JSON_PRETTY_PRINT` option:


### PR DESCRIPTION
Description
---
This PR updates the recently added `toPrettyJson` link to use the slug format.

In the past, I attempted a full unification, but that PR was closed due to the broad impact on existing links across the web. This PR limits the change to only this new method, which was **just merged a few hours ago**.

Currently, the documentation contains a mix of anchor formats. I think we can stick with the slug format for new methods to ensure future consistency.