### PR TITLE
add $forcewrapping documentation

### DIFF
--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -428,6 +428,77 @@ class AppServiceProvider extends ServiceProvider
 > [!WARNING]
 > The `withoutWrapping` method only affects the outermost response and will not remove `data` keys that you manually add to your own resource collections.
 
+<a name="force-wrapping"></a>
+#### Force Wrapping
+
+In some cases, you may want to ensure that your resource response is always wrapped in the configured wrapper key, even when the resource data already contains that key. This commonly occurs when working with model attributes that match the wrapper name (usually `data`).
+
+By default, if your resource array contains a key that matches the wrapper, Laravel will skip the wrapping to avoid double-wrapping. However, this can lead to inconsistent API responses depending on your model's structure.
+
+To force consistent wrapping behavior, you may set the `$forceWrapping` static property to `true` on your resource class:
+
+```php
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TaskResource extends JsonResource
+{
+    /**
+     * The "data" wrapper that should be applied.
+     *
+     * @var string|null
+     */
+    public static $wrap = 'data';
+
+    /**
+     * Whether to force wrapping even if the wrapper key exists in resource data.
+     *
+     * @var bool
+     */
+    public static $forceWrapping = true;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'data' => $this->data, // This won't prevent wrapping anymore
+        ];
+    }
+}
+```
+
+With `$forceWrapping` set to `true`, your response will be consistently wrapped regardless of the model's attributes:
+
+```json
+{
+    "data": {
+        "id": 1,
+        "title": "Task Title",
+        "data": "some model data"
+    }
+}
+```
+
+Without `$forceWrapping`, the same resource might return an inconsistent response structure:
+
+```json
+{
+    "id": 1,
+    "title": "Task Title",
+    "data": "some model data"
+}
+```
+
 <a name="wrapping-nested-resources"></a>
 #### Wrapping Nested Resources
 


### PR DESCRIPTION
### Docs: Add $forceWrapping property usage to resource data wrapping section

#### Summary

This PR updates the [Eloquent API Resources - Data Wrapping](https://laravel.com/docs/eloquent-resources#data-wrapping) documentation to include details about the new $forceWrapping static property introduced in [laravel/framework#56736](https://github.com/laravel/framework/pull/56736).

#### Motivation

Laravel's resource response wrapping can behave inconsistently when the resource's toArray() output includes a top-level key that matches the wrapper (typically data). In such cases, Laravel skips wrapping to avoid nesting the data key twice. While this behavior is intentional, it leads to unpredictable API responses based on the model's attributes.

To resolve this, Laravel now supports an opt-in $forceWrapping property on JsonResource, allowing developers to **explicitly force wrapping**, even if the wrapper key already exists in the resource data.

#### Changes

*   Adds a new subsection: **Force Wrapping** under the existing [#data-wrapping](https://laravel.com/docs/eloquent-resources#data-wrapping) heading.
    
*   Documents how and why to use the $forceWrapping static property.
    
*   Provides a complete usage example with before/after output to demonstrate the impact of enabling $forceWrapping.
    

#### Benefits

*   Helps developers write **more predictable and stable API responses**.
    
*   Encourages explicit behavior over implicit side effects.
    
*   Reduces bugs caused by model attributes accidentally colliding with the wrapper key.
    
*   Highlights a **backward-compatible feature** that aligns with Laravel’s expressive resource design.