### PR TITLE
[12.x] Fix Arr::push example to show the actual result

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -972,7 +972,7 @@ $array = [];
 
 Arr::push($array, 'office.furniture', 'Desk');
 
-// $array: ['office' => ['furniture' => 'Desk']]
+// $array: ['office' => ['furniture' => ['Desk']]]
 ```
 
 <a name="method-array-query"></a>


### PR DESCRIPTION
Description
---
This PR updates the `Arr::push` documentation example to reflect the actual return value. Since `Arr::push` always appends the given value into an array, the corrected example should use the array form.

When I run this code I get:

```php
array:1 [
  "office" => array:1 [
    "furniture" => array:1 [
      0 => "Desk"
    ]
  ]
]
```