### PR TITLE
[12.x] Update Redis documentation URLs

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -13,7 +13,7 @@
 <a name="introduction"></a>
 ## Introduction
 
-[Redis](https://redis.io) is an open source, advanced key-value store. It is often referred to as a data structure server since keys can contain [strings](https://redis.io/docs/data-types/strings/), [hashes](https://redis.io/docs/data-types/hashes/), [lists](https://redis.io/docs/data-types/lists/), [sets](https://redis.io/docs/data-types/sets/), and [sorted sets](https://redis.io/docs/data-types/sorted-sets/).
+[Redis](https://redis.io) is an open source, advanced key-value store. It is often referred to as a data structure server since keys can contain [strings](https://redis.io/docs/latest/develop/data-types/strings/), [hashes](https://redis.io/docs/latest/develop/data-types/hashes/), [lists](https://redis.io/docs/latest/develop/data-types/lists/), [sets](https://redis.io/docs/latest/develop/data-types/sets/), and [sorted sets](https://redis.io/docs/latest/develop/data-types/sorted-sets/).
 
 Before using Redis with Laravel, we encourage you to install and use the [PhpRedis](https://github.com/phpredis/phpredis) PHP extension via PECL. The extension is more complex to install compared to "user-land" PHP packages but may yield better performance for applications that make heavy use of Redis. If you are using [Laravel Sail](/docs/{{version}}/sail), this extension is already installed in your application's Docker container.
 


### PR DESCRIPTION
**Summary**

The documentation for Redis has moved causing the current links to the various data type sections to land on a 404 page.

The 10, 11, 12, and master documentation is all affected.

Prior to version 10 the URLs pointed to https://redis.io/topics/data-types which contains a brief summary of the various data types, and has a redirect in place to the current documenation.

Version 10 onwards has moved to pointing directly to the more in-depth explanation of a specific data type, for example, https://redis.io/docs/latest/develop/data-types/strings/.

**Changes**

Updated the documentation to point directly to the in-depth explanation of a specific data type.

I haven't updated the remaining documentation yet as I wasn't sure which links were preferred.