### PR TITLE
[12.x] Enhance trimming section with 'keep' key details

### DIFF
--- a/pulse.md
+++ b/pulse.md
@@ -521,6 +521,22 @@ In general, the more entries you have for a particular metric, the lower you can
 
 Pulse will automatically trim its stored entries once they are outside of the dashboard window. Trimming occurs when ingesting data using a lottery system which may be customized in the Pulse [configuration file](#configuration).
 
+The `keep` key specifies how often the trim will occur. By default, the interval is `7 days`, which is also the minimum value. You can customize this setting using a human-friendly format in the pattern `number unit`, where the unit can be `seconds`, `minutes`, `hours`, `days`, `months`, or `years`. For example, the trim will occur every 2 months:
+
+```
+    'ingest' => [
+        ....
+        'trim' => [
+            'lottery' => [1, 1_000],
+            'keep' => '2 months',
+        ],
+        ....
+    ],
+```
+
+> [!NOTE]
+> If you want a more customized/advanced interval, the `keep` key uses the `Carbon::fromString` behind the scenes.
+
 <a name="pulse-exceptions"></a>
 ### Handling Pulse Exceptions
 


### PR DESCRIPTION
Context: I needed to extend the pulse trimming interval but I didn't find much information on the web. And the value is too implicit (at least for me), which made me consulting the underlying implementation.

In the [pulse/src/Storage/DatabaseStorage.php](https://github.com/laravel/pulse/blob/1.x/src/Storage/DatabaseStorage.php) on line `130`, the interval is created using the `CarbonInterval::fromString`.

And in "...which is also the minimum value" part is confirmed in the line `134`, when it checks if the `before` var is less than `7 days`, if it is the `before` is set to `7 days`.

```
    /**
     * Trim the storage.
     */
    public function trim(): void
    {
        $now = CarbonImmutable::now();

        $keep = $this->config->get('pulse.storage.trim.keep') ?? '7 days';

        $before = $now->subMilliseconds(
            (int) CarbonInterval::fromString($keep)->totalMilliseconds
        );

        if ($now->subDays(7)->isAfter($before)) {
            $before = $now->subDays(7);
        }
        ....
```

English is not my native language, so I'd appreciate it if anyone could help me with my grammar. :D
