### PR TITLE
[12.x] Add toPrettyJson to Eloquent Serialization

### DIFF
--- a/eloquent-serialization.md
+++ b/eloquent-serialization.md
@@ -63,6 +63,16 @@ return $user->toJson();
 return $user->toJson(JSON_PRETTY_PRINT);
 ```
 
+For convenience, you may use the `toPrettyJson` method to convert a model into a formatted JSON string using the `JSON_PRETTY_PRINT` option:
+
+```php
+use App\Models\User;
+
+$user = User::find(1);
+
+return $user->toPrettyJson();
+```
+
 Alternatively, you may cast a model or collection to a string, which will automatically call the `toJson` method on the model or collection:
 
 ```php


### PR DESCRIPTION
See: https://github.com/laravel/framework/pull/56697

I used the same tone that we used here: #10765

Note
---
I didn't remove the example:

```php
return $user->toJson(JSON_PRETTY_PRINT);
```

Because it's a way for documenting things. Also, the current docs state:

https://github.com/laravel/docs/blob/90032baf5391094038f32f2428680ac4a0420ee3/eloquent-serialization.md?plain=1#L54C174-L54C307