### PR TITLE
[12.x] PhpRedis Retry & Backoff configuration docs

### DIFF
--- a/redis.md
+++ b/redis.md
@@ -212,8 +212,8 @@ In addition to the default configuration options, PhpRedis supports the followin
 
 <a name="retry-and-backoff-configuration"></a>
 #### Retry and Backoff Configuration
-The `retry_interval`, `max_retries`, `backoff_algorithm`, `backoff_base`, and `backoff_cap` options may be used to configure how the PhpRedis client should attempt to reconnect to a Redis server.   
-The following backoff algorithms are supported: `default`, `decorrelated_jitter`, `equal_jitter`, `exponential`, `uniform`, and `constant`.
+
+The `retry_interval`, `max_retries`, `backoff_algorithm`, `backoff_base`, and `backoff_cap` options may be used to configure how the PhpRedis client should attempt to reconnect to a Redis server. The following backoff algorithms are supported: `default`, `decorrelated_jitter`, `equal_jitter`, `exponential`, `uniform`, and `constant`:
 
 ```php
 'default' => [


### PR DESCRIPTION
I wasn't sure if we should remove the earlier mention to the retry options:

>In addition to the default configuration options, PhpRedis supports the following additional connection parameters: `name`, `persistent`, `persistent_id`, `prefix`, `read_timeout`, `retry_interval`, `max_retries`, `backoff_algorithm`, `backoff_base`, `backoff_cap`, `timeout`, and `context`. You may add any of these options to your Redis server configuration in the `config/database.php` configuration file:   