### PR TITLE
[12.x] Fix withHeartbeat example

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -4338,7 +4338,7 @@ The `withHeartbeat` method allows you to execute a callback at regular time inte
 use Carbon\CarbonInterval;
 use Illuminate\Support\Facades\Cache;
 
-$lock = Cache::lock('generate-reports', CarbonInterval::minutes(5));
+$lock = Cache::lock('generate-reports', seconds: 60 * 5);
 
 if ($lock->get()) {
     try {


### PR DESCRIPTION
Description
---
When I run this code on a fresh Laravel installation (latest version) I get this error:

```sh
Object of class Carbon\CarbonInterval could not be converted to int
```