### PR TITLE
[12.x] add warning about Horizon timeout killing long jobs during auto-scaling

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -198,7 +198,9 @@ Similarly, you can set a `timeout` value at the supervisor level, which specifie
     ],
 ],
 ```
-
+> [!WARNING]  
+> When using the `auto` balancing strategy, Horizon will consider in-progress workers as “hanging” and force-kill them after the Horizon timeout during scale down. Always ensure the Horizon timeout is greater than any job-level timeout, otherwise jobs may be terminated mid-execution.
+ 
 > [!WARNING]
 > The `timeout` value should always be at least a few seconds shorter than the `retry_after` value defined in your `config/queue.php` configuration file. Otherwise, your jobs may be processed twice.
 


### PR DESCRIPTION
Our team recently encountered a production incident where some long-running jobs were failing silently, without any exceptions being thrown. After investigation, we traced the issue back to Horizon’s downscaling logic.  

In our case, the jobs had a class-defined timeout of 10 minutes, while the Horizon timeout was set to the default of 60 seconds.  

With regular queue workers (without scaling), this is not an issue because the [job-defined timeout is always respected](https://github.com/laravel/framework/blob/905c93a926117ca4ac02d6b22f3b5722db274e2f/src/Illuminate/Queue/Worker.php#L262). However, when using Horizon’s autoscaling, the worker is considered "stuck" after the Horizon timeout rather than the job-level timeout (since Horizon does not know which job is running). The worker is then [forcefully killed](https://github.com/laravel/horizon/blob/a5c29dfdb56555f59a0f13f4ba8fe003c98c6101/src/ProcessPool.php#L268) without any exception or event being raised.  

We believe the current documentation does not make this behavior clear enough, and we propose adding a warning to highlight the interaction between Horizon timeouts and autoscaling, so that others can avoid similar issues.