### PR TITLE
[12x.] Add `0` option for disabling `LongWaitDetectedNotification` in Horizon docs

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -653,6 +653,9 @@ You may configure how many seconds are considered a "long wait" within your appl
 ],
 ```
 
+> [!NOTE]
+> Setting a queue's threshold to `0` will disable long wait notifications for that queue.
+
 <a name="metrics"></a>
 ## Metrics
 


### PR DESCRIPTION
This PR updates the Horizon documentation to clarify that setting a queue’s wait threshold to `0` disables `LongWaitDetectedNotification`.

This is based on the way Horizon filters long waits:

https://github.com/laravel/horizon/blob/a5c29dfdb56555f59a0f13f4ba8fe003c98c6101/src/Listeners/MonitorWaitTimes.php#L54-L57

