### PR TITLE
docs: add Nginx config example for handling CORS preflight in Laravel

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -77,6 +77,11 @@ server {
 
     error_page 404 /index.php;
 
+    # If you want to handle cors in the application instead of Nginx
+    if ($request_method = OPTIONS) {
+        rewrite ^ /index.php last;
+    }
+
     location ~ ^/index\.php(/|$) {
         fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;


### PR DESCRIPTION
Added an example to the Nginx configuration in the documentation showing how to forward OPTIONS requests to Laravel.   This ensures that CORS preflight requests are handled by the application instead of Nginx:

    # If you want to handle cors in the application instead of Nginx
    if ($request_method = OPTIONS) {
        rewrite ^ /index.php last;
    }