### PR TITLE
Update Enum Type Example Usage

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -686,12 +686,12 @@ The `enum` method creates a `ENUM` equivalent column with the given valid values
 $table->enum('difficulty', ['easy', 'hard']);
 ```
 
-Of course, you may use the `Enum::cases()` method instead of manually defining an array of allowed values:
+Alternatively, you can use an existing enum instead of manually defining an array of allowed values:
 
 ```php
 use App\Enums\Difficulty;
 
-$table->enum('difficulty', Difficulty::cases());
+$table->enum('difficulty', array_map(fn ($case) => $case->value, Difficulty::cases()));
 ```
 
 <a name="column-method-float"></a>


### PR DESCRIPTION
The example usage of defining a column based off an enum gives the following error:

```
  Object of class Modules\Pack\Enums\MessageEmailStatus could not be converted to string

  at vendor/laravel/framework/src/Illuminate/Database/Grammar.php:235
    231▕         if (is_array($value)) {
    232▕             return implode(', ', array_map([$this, __FUNCTION__], $value));
    233▕         }
    234▕ 
  ➜ 235▕         return "'$value'";
    236▕     }
    237▕ 
    238▕     /**
    239▕      * Escapes a value for safe SQL embedding.
```

I've adjusted the documentation to demonstrate passing the value of the enum, which works as expected