### PR TITLE
Shouldn't it be resend/resend-laravel instead of resend/resend-php?

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -135,7 +135,7 @@ This way you are also able to set up multiple Postmark mailers with different me
 To use the [Resend](https://resend.com/) driver, install Resend's PHP SDK via Composer:
 
 ```shell
-composer require resend/resend-php
+composer require resend/resend-laravel
 ```
 
 Next, set the `default` option in your application's `config/mail.php` configuration file to `resend`. After configuring your application's default mailer, ensure that your `config/services.php` configuration file contains the following options:


### PR DESCRIPTION
I looked at the documentation on Resend ... and they use: composer require resend/resend-laravel

https://resend.com/docs/send-with-laravel/

