### PR TITLE
Seperate unique job warnings

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -310,7 +310,7 @@ If a job receives a collection or array of Eloquent models instead of a single m
 > Unique jobs require a cache driver that supports [locks](/docs/{{version}}/cache#atomic-locks). Currently, the `memcached`, `redis`, `dynamodb`, `database`, `file`, and `array` cache drivers support atomic locks. 
 
 > [!WARNING]
-> In addition, unique job constraints do not apply to jobs within batches.
+> Unique job constraints do not apply to jobs within batches.
 
 Sometimes, you may want to ensure that only one instance of a specific job is on the queue at any point in time. You may do so by implementing the `ShouldBeUnique` interface on your job class. This interface does not require you to define any additional methods on your class:
 


### PR DESCRIPTION
This is a gotcha and easily read over. Pulling it in its own warning message should make it more visible while scanning the page.