### PR TITLE
Add 'PasswordResetLinkSent' event to authentication

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -825,19 +825,20 @@ Laravel dispatches a variety of [events](/docs/{{version}}/events) during the au
 
 <div class="overflow-auto">
 
-| Event Name                                   |
-| -------------------------------------------- |
-| `Illuminate\Auth\Events\Registered`          |
-| `Illuminate\Auth\Events\Attempting`          |
-| `Illuminate\Auth\Events\Authenticated`       |
-| `Illuminate\Auth\Events\Login`               |
-| `Illuminate\Auth\Events\Failed`              |
-| `Illuminate\Auth\Events\Validated`           |
-| `Illuminate\Auth\Events\Verified`            |
-| `Illuminate\Auth\Events\Logout`              |
-| `Illuminate\Auth\Events\CurrentDeviceLogout` |
-| `Illuminate\Auth\Events\OtherDeviceLogout`   |
-| `Illuminate\Auth\Events\Lockout`             |
-| `Illuminate\Auth\Events\PasswordReset`       |
+| Event Name                                     |
+| ---------------------------------------------- |
+| `Illuminate\Auth\Events\Registered`            |
+| `Illuminate\Auth\Events\Attempting`            |
+| `Illuminate\Auth\Events\Authenticated`         |
+| `Illuminate\Auth\Events\Login`                 |
+| `Illuminate\Auth\Events\Failed`                |
+| `Illuminate\Auth\Events\Validated`             |
+| `Illuminate\Auth\Events\Verified`              |
+| `Illuminate\Auth\Events\Logout`                |
+| `Illuminate\Auth\Events\CurrentDeviceLogout`   |
+| `Illuminate\Auth\Events\OtherDeviceLogout`     |
+| `Illuminate\Auth\Events\Lockout`               |
+| `Illuminate\Auth\Events\PasswordReset`         |
+| `Illuminate\Auth\Events\PasswordResetLinkSent` |
 
 </div>


### PR DESCRIPTION
This PR adds missing `PasswordResetLinkSent` to the authentication events list.