### PR TITLE
Remove mention of $count in Factory Sequence documentation

### DIFF
--- a/eloquent-factories.md
+++ b/eloquent-factories.md
@@ -319,12 +319,14 @@ $users = User::factory()
     ->create();
 ```
 
-Within a sequence closure, you may access the `$index` or `$count` properties on the sequence instance that is injected into the closure. The `$index` property contains the number of iterations through the sequence that have occurred thus far, while the `$count` property contains the total number of times the sequence will be invoked:
+Within a sequence closure, you may access the `$index` property on the sequence instance that is injected into the closure. The `$index` property contains the number of iterations through the sequence that have occurred thus far:
 
 ```php
 $users = User::factory()
     ->count(10)
-    ->sequence(fn (Sequence $sequence) => ['name' => 'Name '.$sequence->index])
+    ->state(new Sequence(
+        fn (Sequence $sequence) => ['name' => 'Name '.$sequence->index],
+    ))
     ->create();
 ```
 


### PR DESCRIPTION
The following description of `$count` in a `Sequence` callback:

> the `$count` property contains the total number of times the sequence will be invoked

is incorrect.

`$count` [is equal to the number of parameters passed to the constructor](https://github.com/laravel/framework/blob/66a4cab8e1fb52ba75fde126ab62cc6ed6935bc9/src/Illuminate/Database/Eloquent/Factories/Sequence.php#L35-L39).

`$count` is not useful for `Sequence`s with a callback passed to the constructor, as, if there is only one callback passed, `$count` will always be `1`. If two callbacks were passed to the constructor, it would be `2`, and so on. 

In tinker:
```
> User::factory()->count(3)->sequence(fn($s)=> ['name'=>$s->count])->make()->pluck('name')
= Illuminate\Support\Collection {#6526
    all: [
      1,
      1,
      1,
    ],
  }
```

The primary use for `$count` is one internal to the Sequence class logic, when multiple arguments are passed to the sequence constructor and the count is used to modulo the index to avoid accessing values beyond the size of the arguments array. It's hard to imagine scenarios where this value would be particularly useful as a public property, but concealing it from the documentation will at least help people avoid using it mistakenly.

I also updated the code snippet to use the syntax `->state(new Sequence(` rather than `->sequence(`, as that latter concept is first introduced in the lines below this snippet.