### PR TITLE
Fix command syntax for mcp:inspector

### DIFF
--- a/mcp.md
+++ b/mcp.md
@@ -1238,7 +1238,7 @@ You may run the inspector for any registered server:
 
 ```shell
 # Web server...
-php artisan mcp:inspector /mcp/weather
+php artisan mcp:inspector mcp/weather
 
 # Local server named "weather"...
 php artisan mcp:inspector weather


### PR DESCRIPTION
With the leading `/`, you get the error that the server cannot be found.