### PR TITLE
[10.x] Clarify Redis cache tags fix in Laravel `12.30.0`

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -131,7 +131,7 @@ The `registerPolicies` method of the `AuthServiceProvider` is now invoked automa
 
 **Likelihood Of Impact: Medium**
 
-Usage of `Cache::tags()` is only recommended for applications using Memcached. If you are using Redis as your application's cache driver, you should consider moving to Memcached or using an alternative solution.
+Usage of `Cache::tags()` is only recommended for applications using Memcached. If you are using Redis as your application's cache driver, you should consider moving to Memcached or upgrade your application to Laravel [12.30.0](https://github.com/laravel/framework/pull/57098).
 
 ### Database
 


### PR DESCRIPTION
This PR updates the 9 to 10 upgrade guide to clarify the status of Redis cache tags across Laravel versions.

Currently, the upgrade guide warns users that cache tags is only recommended when using Memcached, and discourages Redis: https://github.com/laravel/docs/pull/9286

## Why?
This small clarification helps developers upgrading from Laravel 9 avoid unnecessary driver migrations, while making it clear that flush Redis tags are supported again starting from `12.30.0`: https://github.com/laravel/framework/pull/57098