### PR TITLE
[12.x] MCP Tool Schema docs

### DIFF
--- a/mcp.md
+++ b/mcp.md
@@ -206,7 +206,7 @@ class CurrentWeatherTool extends Tool
     public function schema(JsonSchema $schema): array
     {
         return [
-            'location' => $schema->string()
+            'location' => $schema::string()
                 ->description('The location to get the weather for.')
                 ->required(),
         ];
@@ -308,11 +308,12 @@ class CurrentWeatherTool extends Tool
     public function schema(JsonSchema $schema): array
     {
         return [
-            'location' => $schema->string()
+            'location' => $schema::string()
                 ->description('The location to get the weather for.')
                 ->required(),
 
-            'units' => $schema->enum(['celsius', 'fahrenheit'])
+            'units' => $schema::array()
+                ->enum(['celsius', 'fahrenheit'])
                 ->description('The temperature units to use.')
                 ->default('celsius'),
         ];


### PR DESCRIPTION
* Replace the object call inside the schema docs to a static one
e.g.
https://github.com/laravel/framework/blob/12.x/src/Illuminate/JsonSchema/JsonSchema.php#L21-L24

* Replace the enum call for the schema docs to the rights syntax
e.g.
https://github.com/laravel/framework/blob/559976f75585e8a236699c4ff241a21dab3a517e/tests/JsonSchema/ArrayTypeTest.php#L57-L70