### PR TITLE
[12.x] Update GH Action syntax to use `tools` parameter for Pint

### DIFF
--- a/pint.md
+++ b/pint.md
@@ -206,11 +206,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: json, dom, curl, libxml, mbstring
-          coverage: none
-
-      - name: Install Pint
-        run: composer global require laravel/pint
+          tools: pint
 
       - name: Run Pint
         run: pint


### PR DESCRIPTION
The `shivammathur/setup-php` action supports a `tools` parameter where we can specify Pint.

https://github.com/shivammathur/setup-php?tab=readme-ov-file#wrench-tools-support

This keeps the workflow tidy, and actually gives us a speed boost because it downloads the .phar directly, skipping dependency resolution and autoload generation.