### PR TITLE
[12.x] fix: correct link reference for Resources section in MCP documentation

### DIFF
--- a/mcp.md
+++ b/mcp.md
@@ -22,7 +22,7 @@
     - [Prompt Dependency Injection](#prompt-dependency-injection)
     - [Conditional Prompt Registration](#conditional-prompt-registration)
     - [Prompt Responses](#prompt-responses)
-- [Resources](#creating-resources)
+- [Resources](#resources)
     - [Creating Resources](#creating-resources)
     - [Resource URI and MIME Type](#resource-uri-and-mime-type)
     - [Resource Request](#resource-request)


### PR DESCRIPTION
Fix: Redirect to the Resources Section Instead of Create Resources

The issue is that when clicking on the **Resources** navigation link, it incorrectly redirects to the **Create Resources** section. The expected behavior is that it should redirect to the main Resources section instead.

https://github.com/user-attachments/assets/58773790-0990-4deb-82b0-10f7b7ad1cc4

