### PR TITLE
Fixed string utility examples

### DIFF
--- a/strings.md
+++ b/strings.md
@@ -3053,9 +3053,9 @@ The `remove` method removes the given value or array of values from the string:
 ```php
 use Illuminate\Support\Str;
 
-$string = Str::of('Arkansas is quite beautiful!')->remove('quite');
+$string = Str::of('Arkansas is quite beautiful!')->remove('quite ');
 
-// Arkansas is  beautiful!
+// Arkansas is beautiful!
 ```
 
 You may also pass `false` as a second parameter to ignore case when removing strings.

--- a/strings.md
+++ b/strings.md
@@ -3055,7 +3055,7 @@ use Illuminate\Support\Str;
 
 $string = Str::of('Arkansas is quite beautiful!')->remove('quite');
 
-// Arkansas is beautiful!
+// Arkansas is  beautiful!
 ```
 
 You may also pass `false` as a second parameter to ignore case when removing strings.
@@ -3567,7 +3567,7 @@ use Illuminate\Support\Str;
 
 $string = Str::of('Foo Bar')->ucsplit();
 
-// collect(['Foo', 'Bar'])
+// collect(['Foo ', 'Bar'])
 ```
 
 <a name="method-fluent-str-unwrap"></a>


### PR DESCRIPTION
Some of the documentation examples are incorrect and make it seem like there's additional hidden functionality for removing whitespace.

I tested them in artisan tinker:

```
> Str::of('Arkansas is quite beautiful!')->remove('quite')
= Illuminate\Support\Stringable {#7012
    value: "Arkansas is  beautiful!",
  }

> Str::of('Foo Bar')->ucsplit()
= Illuminate\Support\Collection {#7005
    all: [
      "Foo ",
      "Bar",
    ],
  }
```