### PR TITLE
fix(precognition): correctly set file data for avatar

### DIFF
--- a/precognition.md
+++ b/precognition.md
@@ -330,13 +330,7 @@ If you are validating a subset of a form's inputs with Precognition, it can be u
     id="avatar"
     type="file"
     onChange={(e) => {
-        const files = e.target.files;
-
-        if (files === null || files.length === 0) {
-            return;
-        }
-
-        form.setData('avatar', files[0]);
+        form.setData('avatar', e.target.files[0);
 
         form.forgetError('avatar');
     }}


### PR DESCRIPTION
This pull request refactors the `onChange` handler for the avatar file input to correctly capture and set the `File` object in the form data instead of the input's string `value`.