### PR TITLE
Correct demonstration URL in route helper example

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -462,7 +462,7 @@ Route::get('/user/{id}/profile', function (string $id) {
 
 $url = route('profile', ['id' => 1, 'photos' => 'yes']);
 
-// /user/1/profile?photos=yes
+// http://example.com/user/1/profile?photos=yes
 ```
 
 > [!NOTE]


### PR DESCRIPTION
The example for the route helper currently shows a relative URL:

```
// /user/1/profile?photos=yes
```

However, the route helper returns an absolute URL by default, since the third parameter is not set to false. The corrected example should be:

```
// http://example.com/user/1/profile?photos=yes
```

This change ensures the documentation matches the actual behavior of the route helper.