### PR TITLE
Update controllers.md to correct HasMiddleware documentation

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -114,11 +114,10 @@ Or, you may find it convenient to specify middleware within your controller clas
 
     namespace App\Http\Controllers;
 
-    use App\Http\Controllers\Controller;
     use Illuminate\Routing\Controllers\HasMiddleware;
     use Illuminate\Routing\Controllers\Middleware;
 
-    class UserController extends Controller implements HasMiddleware
+    class UserController implements HasMiddleware
     {
         /**
          * Get the middleware that should be assigned to the controller.


### PR DESCRIPTION
There is a note just under this section that states that the `Illuminate\Routing\Controllers\HasMiddleware` contract cannot be used in conjunction with ` App\Http\Controllers\Controller`, yet the example itself has the class extending `Controller`.

I can confirm that if the class extends `Controller` you will get an error:

"Cannot make non static method Illuminate\Routing\Controller::middleware() static in class App\Http\Controllers\ArticleController"

This correction is applicable to documentation for Laravel 11.x and up.