### PR TITLE
[12.x] change wording on Horizon connection note

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -57,7 +57,7 @@ php artisan horizon:install
 After publishing Horizon's assets, its primary configuration file will be located at `config/horizon.php`. This configuration file allows you to configure the queue worker options for your application. Each configuration option includes a description of its purpose, so be sure to thoroughly explore this file.
 
 > [!WARNING]
-> Horizon uses a Redis connection named `horizon` internally. This Redis connection name is reserved and should not be assigned to another Redis connection in the `database.php` configuration file or as the value of the `use` option in the `horizon.php` configuration file.
+> Horizon uses a Redis connection named `horizon` internally. This Redis connection name is reserved and cannot be assigned to another Redis connection in the `database.php` configuration file or as the value of the `use` option in the `horizon.php` configuration file.
 
 <a name="environments"></a>
 #### Environments


### PR DESCRIPTION
Since [Horizon now forbids naming the connection `'horizon'`](https://github.com/laravel/horizon/issues/1616), the docs now reflect that.