### PR TITLE
Add pgvector extension information to vector colum description

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -1179,6 +1179,12 @@ The `vector` method creates a `vector` equivalent column:
 $table->vector('embedding', dimensions: 100);
 ```
 
+When utilizing PostgreSQL, the `pgvector` extension must be loaded before `vector` columns can be created:
+
+```php
+Schema::ensureVectorExtensionExists();
+```
+
 <a name="column-method-year"></a>
 #### `year()` {.collection-method}
 


### PR DESCRIPTION
Using the `vector` column type requires loading the `pgvector` extension through `Schema::ensureVectorExtensionExists()` when using PostgreSQL. This pull request adds this bit of information to the description of the `vector` column.

- The Laravel AI SDK docs state this requirement correctly: [link](https://laravel.com/docs/12.x/ai-sdk#querying-embeddings)
- The `ensureVectorExtensionExists()` method is found [here](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Database/Schema/Builder.php#L646-L655) (i.e. it is part of Laravel's core, not the AI SDK)
- PostgreSQL is the only database engine that requires/supports loading extensions. The other engines either have native or emulated support, and loading the extension is not required there.