### PR TITLE
[12.x] Add admonition to error handling flag on production

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -27,7 +27,7 @@ The `debug` option in your `config/app.php` configuration file determines how mu
 During local development, you should set the `APP_DEBUG` environment variable to `true`.
 
 > [!WARNING]
-> In your production environment, this value should always be `false`. If the value is set to `true` in production, you risk exposing sensitive configuration values to your application's end users.**
+> In your production environment, the value of `APP_DEBUG` should always be `false`. If the value is set to `true` in production, you risk exposing sensitive configuration values to your application's end users.**
 
 <a name="handling-exceptions"></a>
 ## Handling Exceptions

--- a/errors.md
+++ b/errors.md
@@ -24,7 +24,10 @@ The `$exceptions` object provided to the `withExceptions` closure is an instance
 
 The `debug` option in your `config/app.php` configuration file determines how much information about an error is actually displayed to the user. By default, this option is set to respect the value of the `APP_DEBUG` environment variable, which is stored in your `.env` file.
 
-During local development, you should set the `APP_DEBUG` environment variable to `true`. **In your production environment, this value should always be `false`. If the value is set to `true` in production, you risk exposing sensitive configuration values to your application's end users.**
+During local development, you should set the `APP_DEBUG` environment variable to `true`.
+
+> [!WARNING]
+> In your production environment, this value should always be `false`. If the value is set to `true` in production, you risk exposing sensitive configuration values to your application's end users.**
 
 <a name="handling-exceptions"></a>
 ## Handling Exceptions


### PR DESCRIPTION
Instead of bold, we can now use admonitions to better highlight important sections.

| Before | After |
| ------ | ----- |
| <img width="659" height="347" alt="image" src="https://github.com/user-attachments/assets/9e6d5942-5515-4a67-ab75-b8f479ad0751" /> | <img width="670" height="444" alt="image" src="https://github.com/user-attachments/assets/408b7c23-4386-4fec-93c9-18067d31cecd" /> |

✅ Visually easily distinguishable
✅ Consistent with other places in the docs