### PR TITLE
Remove deprecated MCP tools from documentation

### DIFF
--- a/boost.md
+++ b/boost.md
@@ -121,23 +121,17 @@ Laravel Boost provides an MCP (Model Context Protocol) server that exposes tools
 <a name="available-mcp-tools"></a>
 ### Available MCP Tools
 
-| Name                       | Notes                                                                                                       |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Application Info           | Read PHP & Laravel versions, database engine, list of ecosystem packages with versions, and Eloquent models |
-| Browser Logs               | Read logs and errors from the browser                                                                       |
-| Database Connections       | Inspect available database connections, including the default connection                                    |
-| Database Query             | Execute a query against the database                                                                        |
-| Database Schema            | Read the database schema                                                                                    |
-| Get Absolute URL           | Convert relative path URIs to absolute so agents generate valid URLs                                        |
-| Get Config                 | Get a value from the configuration files using "dot" notation                                               |
-| Last Error                 | Read the last error from the application's log files                                                        |
-| List Artisan Commands      | Inspect the available Artisan commands                                                                      |
-| List Available Config Keys | Inspect the available configuration keys                                                                    |
-| List Available Env Vars    | Inspect the available environment variable keys                                                             |
-| List Routes                | Inspect the application's routes                                                                            |
-| Read Log Entries           | Read the last N log entries                                                                                 |
-| Search Docs                | Query the Laravel hosted documentation API service to retrieve documentation based on installed packages    |
-| Tinker                     | Execute arbitrary code within the context of the application                                                |
+| Name                 | Notes                                                                                                       |
+| -------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Application Info     | Read PHP & Laravel versions, database engine, list of ecosystem packages with versions, and Eloquent models |
+| Browser Logs         | Read logs and errors from the browser                                                                       |
+| Database Connections | Inspect available database connections, including the default connection                                    |
+| Database Query       | Execute a query against the database                                                                        |
+| Database Schema      | Read the database schema                                                                                    |
+| Get Absolute URL     | Convert relative path URIs to absolute so agents generate valid URLs                                        |
+| Last Error           | Read the last error from the application's log files                                                        |
+| Read Log Entries     | Read the last N log entries                                                                                 |
+| Search Docs          | Query the Laravel hosted documentation API service to retrieve documentation based on installed packages    |
 
 <a name="manually-registering-the-mcp-server"></a>
 ### Manually Registering the MCP Server

--- a/boost.md
+++ b/boost.md
@@ -174,10 +174,10 @@ Laravel Boost includes AI guidelines for the following packages and frameworks. 
 | Flux UI           | core, free, pro        |
 | Folio             | core                   |
 | Herd              | core                   |
-| Inertia Laravel   | core, 1.x, 2.x         |
-| Inertia React     | core, 1.x, 2.x         |
-| Inertia Vue       | core, 1.x, 2.x         |
-| Inertia Svelte    | core, 1.x, 2.x         |
+| Inertia Laravel   | core, 1.x, 2.x, 3.x    |
+| Inertia React     | core, 1.x, 2.x, 3.x    |
+| Inertia Vue       | core, 1.x, 2.x, 3.x    |
+| Inertia Svelte    | core, 1.x, 2.x, 3.x    |
 | MCP               | core                   |
 | Pennant           | core                   |
 | Pest              | core, 3.x, 4.x         |


### PR DESCRIPTION
Six MCP tools were removed from Laravel Boost in laravel/boost#629 as they were thin wrappers around Artisan commands that agents can invoke directly via shell.

### Approach

- Removes the six deprecated tools (Get Config, List Artisan Commands, List Available Config Keys, List Available Env Vars, List Routes, Tinker) from the Available MCP Tools table