### PR TITLE
[12.x] Documents `Pint/phpdoc_type_annotations_only`

### DIFF
--- a/pint.md
+++ b/pint.md
@@ -154,10 +154,10 @@ In addition to PHP CS Fixer rules, Pint provides custom rules prefixed with `Pin
 
 This rule removes all comments and docblock prose from your code, keeping only lines that contain `@` annotations such as `@param`, `@return`, `@var`, `@phpstan-type`, etc:
 
-```diff
+```php
 /**
--* Get the posts for the user.
--*
+ * Get the posts for the user. [tl! remove]
+ * [tl! remove]
  * @return HasMany<Post, $this>
  */
 public function posts(): HasMany

--- a/pint.md
+++ b/pint.md
@@ -163,7 +163,7 @@ This rule removes all comments and docblock prose from your code, keeping only l
 public function posts(): HasMany
 ```
 
-Single-line comments and block comments without `@` annotations are removed entirely. If you would like to keep a specific comment, you may prefix it with `@note`, `@warning`, or `@important`:
+Single-line comments and block comments without `@` annotations are removed entirely. If you would like to keep a specific comment, you may prefix it with `@note`, `@warning`, or `@todo`:
 
 ```php
 // @note This comment will be preserved.

--- a/pint.md
+++ b/pint.md
@@ -6,6 +6,7 @@
 - [Configuring Pint](#configuring-pint)
     - [Presets](#presets)
     - [Rules](#rules)
+        - [Custom Rules](#custom-rules)
     - [Excluding Files / Folders](#excluding-files-or-folders)
 - [Continuous Integration](#continuous-integration)
     - [GitHub Actions](#running-tests-on-github-actions)
@@ -143,6 +144,56 @@ However, if you wish, you may enable or disable specific rules in your `pint.jso
 ```
 
 Pint is built on top of [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer). Therefore, you may use any of its rules to fix code style issues in your project: [PHP CS Fixer Configurator](https://mlocati.github.io/php-cs-fixer-configurator).
+
+<a name="custom-rules"></a>
+#### Custom Rules
+
+In addition to PHP CS Fixer rules, Pint provides custom rules prefixed with `Pint/`. These rules are not enabled by default and can be enabled in your `pint.json` file.
+
+<a name="phpdoc-type-annotations-only"></a>
+##### `Pint/phpdoc_type_annotations_only`
+
+The `Pint/phpdoc_type_annotations_only` rule removes all comments and docblock prose from your code, keeping only lines that contain `@` annotations (such as `@param`, `@return`, `@var`, `@phpstan-type`, etc.).
+
+For example, the following docblock:
+
+```php
+/**
+ * Get the posts for the user.
+ *
+ * @return HasMany<Post, $this>
+ */
+public function posts(): HasMany
+```
+
+Would become:
+
+```php
+/**
+ * @return HasMany<Post, $this>
+ */
+public function posts(): HasMany
+```
+
+Single-line comments and block comments without `@` annotations are removed entirely. If you would like to keep a specific comment, you may prefix it with `@note`, `@warning`, or `@important`:
+
+```php
+// @note This comment will be preserved.
+```
+
+To enable this rule, add it to your `pint.json` file:
+
+```json
+{
+    "preset": "laravel",
+    "rules": {
+        "Pint/phpdoc_type_annotations_only": true
+    }
+}
+```
+
+> [!NOTE]
+> This rule automatically skips files in the `config` directory, as configuration files typically rely on comments for documentation.
 
 <a name="excluding-files-or-folders"></a>
 ### Excluding Files / Folders

--- a/pint.md
+++ b/pint.md
@@ -147,14 +147,12 @@ Pint is built on top of [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fi
 <a name="custom-rules"></a>
 #### Custom Rules
 
-In addition to PHP CS Fixer rules, Pint provides custom rules prefixed with `Pint/`. These rules are not enabled by default and can be enabled in your `pint.json` file.
+In addition to PHP CS Fixer rules, Pint provides custom rules prefixed with `Pint/`. These rules are not enabled by default, but you may enable them in your `pint.json` file.
 
 <a name="phpdoc-type-annotations-only"></a>
 ##### `Pint/phpdoc_type_annotations_only`
 
-The `Pint/phpdoc_type_annotations_only` rule removes all comments and docblock prose from your code, keeping only lines that contain `@` annotations (such as `@param`, `@return`, `@var`, `@phpstan-type`, etc.).
-
-For example:
+This rule removes all comments and docblock prose from your code, keeping only lines that contain `@` annotations such as `@param`, `@return`, `@var`, `@phpstan-type`, etc:
 
 ```diff
 /**

--- a/pint.md
+++ b/pint.md
@@ -6,7 +6,6 @@
 - [Configuring Pint](#configuring-pint)
     - [Presets](#presets)
     - [Rules](#rules)
-        - [Custom Rules](#custom-rules)
     - [Excluding Files / Folders](#excluding-files-or-folders)
 - [Continuous Integration](#continuous-integration)
     - [GitHub Actions](#running-tests-on-github-actions)
@@ -155,21 +154,12 @@ In addition to PHP CS Fixer rules, Pint provides custom rules prefixed with `Pin
 
 The `Pint/phpdoc_type_annotations_only` rule removes all comments and docblock prose from your code, keeping only lines that contain `@` annotations (such as `@param`, `@return`, `@var`, `@phpstan-type`, etc.).
 
-For example, the following docblock:
+For example:
 
-```php
+```diff
 /**
- * Get the posts for the user.
- *
- * @return HasMany<Post, $this>
- */
-public function posts(): HasMany
-```
-
-Would become:
-
-```php
-/**
+-* Get the posts for the user.
+-*
  * @return HasMany<Post, $this>
  */
 public function posts(): HasMany


### PR DESCRIPTION
This pull request documents this new feature: https://github.com/laravel/pint/pull/427.