### PR TITLE
Clarify that HasUuids generates UUIDv7 identifiers and fix example UUID

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -228,10 +228,10 @@ class Article extends Model
 
 $article = Article::create(['title' => 'Traveling to Europe']);
 
-$article->id; // "8f8e8478-9035-4d23-b9a7-62f4d2612ce5"
+$article->id; // "018f2b5c-6a7f-7b12-9d6f-2f8a4e0c9c11"
 ```
 
-By default, The `HasUuids` trait will generate ["ordered" UUIDs](/docs/{{version}}/strings#method-str-ordered-uuid) for your models. These UUIDs are more efficient for indexed database storage because they can be sorted lexicographically.
+By default, the `HasUuids` trait will generate [UUIDv7](/docs/{{version}}/strings#method-str-uuid7) identifiers for your models. These UUIDs are more efficient for indexed database storage because they can be sorted lexicographically.
 
 You can override the UUID generation process for a given model by defining a `newUniqueId` method on the model. In addition, you may specify which columns should receive UUIDs by defining a `uniqueIds` method on the model:
 


### PR DESCRIPTION
This PR updates the `HasUuids` documentation to clarify that it generates UUIDv7 identifiers by default.

It also replaces the example UUID (which was UUIDv4) with a UUIDv7 example and adds a link to the `Str::uuid7` documentation.