### PR TITLE
Add Laravel Boost to upgrade guide note

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -47,7 +47,7 @@
 #### Estimated Upgrade Time: 10 Minutes
 
 > [!NOTE]
-> We attempt to document every possible breaking change. Since some of these breaking changes are in obscure parts of the framework only a portion of these changes may actually affect your application. To save time, you may use [Laravel Shift](https://laravelshift.com) or [Laravel Boost](https://github.com/laravel/boost). Shift is a community-maintained service that automates Laravel upgrades. Boost is a first-party MCP server that provides your AI assistant with guided upgrade prompts — once installed in any Laravel 12 application, simply use the `/upgrade-laravel-13` slash command in Claude Code, Cursor, Opencode, Gemini or VS Code to begin the upgrade to Laravel 13.
+> We attempt to document every possible breaking change. Since some of these breaking changes are in obscure parts of the framework only a portion of these changes may actually affect your application. To save time, you may use [Laravel Shift](https://laravelshift.com) or [Laravel Boost](https://github.com/laravel/boost). Shift is a community-maintained service that automates Laravel upgrades. Boost is a first-party MCP server that provides your AI assistant with guided upgrade prompts — once installed in any Laravel 12 application, simply use the `/upgrade-laravel-13` slash command in Claude Code, Cursor, OpenCode, Gemini or VS Code to begin the upgrade to Laravel 13.
 
 <a name="updating-dependencies"></a>
 ### Updating Dependencies

--- a/upgrade.md
+++ b/upgrade.md
@@ -47,7 +47,7 @@
 #### Estimated Upgrade Time: 10 Minutes
 
 > [!NOTE]
-> We attempt to document every possible breaking change. Since some of these breaking changes are in obscure parts of the framework only a portion of these changes may actually affect your application. To save time, consider using [Shift](https://laravelshift.com) — a community-maintained service that automates Laravel upgrades.
+> We attempt to document every possible breaking change. Since some of these breaking changes are in obscure parts of the framework only a portion of these changes may actually affect your application. To save time, you may use [Laravel Shift](https://laravelshift.com) or [Laravel Boost](https://github.com/laravel/boost). Shift is a community-maintained service that automates Laravel upgrades. Boost is a first-party MCP server that provides your AI assistant with guided upgrade prompts — once installed in any Laravel 12 application, simply use the `/upgrade-laravel-13` slash command in Claude Code, Cursor, Opencode, Gemini or VS Code to begin the upgrade to Laravel 13.
 
 <a name="updating-dependencies"></a>
 ### Updating Dependencies

--- a/upgrade.md
+++ b/upgrade.md
@@ -1,6 +1,7 @@
 # Upgrade Guide
 
 - [Upgrading To 13.0 From 12.x](#upgrade-13.0)
+    - [Upgrading With AI](#upgrading-with-ai)
 
 <a name="high-impact-changes"></a>
 ## High Impact Changes
@@ -47,7 +48,12 @@
 #### Estimated Upgrade Time: 10 Minutes
 
 > [!NOTE]
-> We attempt to document every possible breaking change. Since some of these breaking changes are in obscure parts of the framework only a portion of these changes may actually affect your application. To save time, you may use [Laravel Shift](https://laravelshift.com) or [Laravel Boost](https://github.com/laravel/boost). Shift is a community-maintained service that automates Laravel upgrades. Boost is a first-party MCP server that provides your AI assistant with guided upgrade prompts — once installed in any Laravel 12 application, simply use the `/upgrade-laravel-13` slash command in Claude Code, Cursor, OpenCode, Gemini or VS Code to begin the upgrade to Laravel 13.
+> We attempt to document every possible breaking change. Since some of these breaking changes are in obscure parts of the framework only a portion of these changes may actually affect your application. To save time, you may use [Shift](https://laravelshift.com). Shift is a community-maintained service that automates Laravel upgrades.
+
+<a name="upgrading-with-ai"></a>
+### Upgrading With AI
+
+You can automate your upgrade using [Laravel Boost](https://github.com/laravel/boost). Boost is a first-party MCP server that provides your AI assistant with guided upgrade prompts — once installed in any Laravel 12 application, use the `/upgrade-laravel-13` slash command in Claude Code, Cursor, OpenCode, Gemini. or VS Code to begin the upgrade to Laravel 13.
 
 <a name="updating-dependencies"></a>
 ### Updating Dependencies

--- a/upgrade.md
+++ b/upgrade.md
@@ -1,7 +1,7 @@
 # Upgrade Guide
 
 - [Upgrading To 13.0 From 12.x](#upgrade-13.0)
-    - [Upgrading With AI](#upgrading-with-ai)
+    - [Upgrading Using AI](#upgrading-using-ai)
 
 <a name="high-impact-changes"></a>
 ## High Impact Changes
@@ -50,8 +50,8 @@
 > [!NOTE]
 > We attempt to document every possible breaking change. Since some of these breaking changes are in obscure parts of the framework only a portion of these changes may actually affect your application. To save time, you may use [Shift](https://laravelshift.com). Shift is a community-maintained service that automates Laravel upgrades.
 
-<a name="upgrading-with-ai"></a>
-### Upgrading With AI
+<a name="upgrading-using-ai"></a>
+### Upgrading Using AI
 
 You can automate your upgrade using [Laravel Boost](https://github.com/laravel/boost). Boost is a first-party MCP server that provides your AI assistant with guided upgrade prompts — once installed in any Laravel 12 application, use the `/upgrade-laravel-13` slash command in Claude Code, Cursor, OpenCode, Gemini. or VS Code to begin the upgrade to Laravel 13.
 


### PR DESCRIPTION
The upgrade guide note currently only mentions Laravel Shift for automating upgrades. This adds Laravel Boost as an additional option — a first-party MCP server that provides AI-guided upgrade prompts via the `/upgrade-laravel-13` slash command in Claude Code, Cursor, and VS Code.
