### PR TITLE
Boost tool name - upgrade-laravel-13 vs upgrade-laravel-v13

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -53,7 +53,7 @@
 <a name="upgrading-using-ai"></a>
 ### Upgrading Using AI
 
-You can automate your upgrade using [Laravel Boost](https://github.com/laravel/boost). Boost is a first-party MCP server that provides your AI assistant with guided upgrade prompts — once installed in any Laravel 12 application, use the `/upgrade-laravel-13` slash command in Claude Code, Cursor, OpenCode, Gemini. or VS Code to begin the upgrade to Laravel 13.
+You can automate your upgrade using [Laravel Boost](https://github.com/laravel/boost). Boost is a first-party MCP server that provides your AI assistant with guided upgrade prompts — once installed in any Laravel 12 application, use the `/upgrade-laravel-v13` slash command in Claude Code, Cursor, OpenCode, Gemini. or VS Code to begin the upgrade to Laravel 13.
 
 <a name="updating-dependencies"></a>
 ### Updating Dependencies


### PR DESCRIPTION
Think the tool name is upgrade-laravel-v13 ? 


See

https://github.com/laravel/boost/blob/83309fb975750f22f902da76b95b420d45f839f2/src/Mcp/Prompts/UpgradeLaravelv13/UpgradeLaravelV13.php#L18