### PR TITLE
[13.x] fix typo in Upgrading Using AI

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -53,7 +53,7 @@
 <a name="upgrading-using-ai"></a>
 ### Upgrading Using AI
 
-You can automate your upgrade using [Laravel Boost](https://github.com/laravel/boost). Boost is a first-party MCP server that provides your AI assistant with guided upgrade prompts — once installed in any Laravel 12 application, use the `/upgrade-laravel-v13` slash command in Claude Code, Cursor, OpenCode, Gemini. or VS Code to begin the upgrade to Laravel 13.
+You can automate your upgrade using [Laravel Boost](https://github.com/laravel/boost). Boost is a first-party MCP server that provides your AI assistant with guided upgrade prompts — once installed in any Laravel 12 application, use the `/upgrade-laravel-v13` slash command in Claude Code, Cursor, OpenCode, Gemini, or VS Code to begin the upgrade to Laravel 13.
 
 <a name="updating-dependencies"></a>
 ### Updating Dependencies


### PR DESCRIPTION
replace ``Gemini. or VS Code`` with ``Gemini, or VS Code``