### PR TITLE
Add v13 upgrade guide dependency item for Laravel Boost

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -69,6 +69,7 @@ You should update the following dependencies in your application's `composer.jso
 - `laravel/tinker` to `^3.0`
 - `phpunit/phpunit` to `^12.0`
 - `pestphp/pest` to `^4.0`
+- `laravel/boost` to `^2.0`
 
 </div>
 


### PR DESCRIPTION
Laravel Boost's 1.x branch doesn't support Laravel 13.x - attempting to upgrade from 12.x to 13.x with a dependency on `"laravel/boost": "^1.0"` fails.

The 2.x branch of Boost depends on `"illuminate/support": "^11.45.3|^12.41.1|^13.0"`.

Folks running Laravel 11.x (supported until last week) or 12.x (still supported) below those minor versions, with Laravel Boost, will run into this issue.

As a first-party package, it warrants a mention in the upgrade guide.