### PR TITLE
Document the release date of Laravel 13

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -28,7 +28,7 @@ For all Laravel releases, bug fixes are provided for 18 months and security fixe
 | 10      | 8.1 - 8.3 | February 14th, 2023 | August 6th, 2024    | February 4th, 2025   |
 | 11      | 8.2 - 8.4 | March 12th, 2024    | September 3rd, 2025 | March 12th, 2026     |
 | 12      | 8.2 - 8.5 | February 24th, 2025 | August 13th, 2026   | February 24th, 2027  |
-| 13      | 8.3 - 8.5 | Q1 2026             | Q3 2027             | Q1 2028              |
+| 13      | 8.3 - 8.5 | March 17th, 2026    | Q3 2027             | March 17th, 2028     |
 
 </div>
 


### PR DESCRIPTION
This continues from #11111.

At least we may start with the release date of Laravel 13, which is 17 March. We then add 2 years to it to obtain the date of EOL.

It's unclear how "18 months" will be calculated, so the bugfix deadline is left ambiguous for future clarification.