### PR TITLE
Document HTTP idempotency middleware

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -6,6 +6,7 @@
     - [Single Action Controllers](#single-action-controllers)
 - [Controller Middleware](#controller-middleware)
     - [Middleware Attributes](#middleware-attributes)
+    - [Idempotent attribute](#idempotent-attribute)
     - [Authorization Attributes](#authorization-attributes)
 - [Resource Controllers](#resource-controllers)
     - [Partial Resource Routes](#restful-partial-resource-routes)
@@ -221,6 +222,82 @@ class UserController
     }
 }
 ```
+
+<a name="idempotent-attribute"></a>
+### Idempotent Attribute
+
+If you need to make write-oriented controller actions safely retryable, you may use Laravel's `#[Idempotent]` attribute. This attribute applies the `Illuminate\Routing\Middleware\Idempotent` middleware to the controller action, allowing Laravel to replay the original response when the same idempotency key is submitted more than once.
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Routing\Attributes\Controllers\Idempotent;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Idempotent]
+class OrderController
+{
+    public function store(): Response
+    {
+        // ...
+    }
+}
+```
+
+Like the route middleware, the attribute expects an `Idempotency-Key` header by default and only manages `POST`, `PUT`, and `PATCH` requests.
+
+You may place the attribute on individual methods or on the controller class itself. Method-level attributes are merged with class-level attributes:
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Routing\Attributes\Controllers\Idempotent;
+
+#[Idempotent]
+class OrderController
+{
+    #[Idempotent(ttl: 600, scope: 'ip', header: 'X-Idempotency-Key')]
+    public function store()
+    {
+        // ...
+    }
+
+    public function update()
+    {
+        // ...
+    }
+}
+```
+
+The `#[Idempotent]` attribute accepts the same `ttl`, `required`, `scope`, and `header` options as the route middleware. In addition, since it extends Laravel's controller middleware attribute, you may limit the attribute to selected methods using the `only` and `except` arguments:
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Routing\Attributes\Controllers\Idempotent;
+
+#[Idempotent(except: ['store'])]
+class OrderController
+{
+    public function store()
+    {
+        // ...
+    }
+
+    public function update()
+    {
+        // ...
+    }
+}
+```
+
+For more information about configuring idempotency behavior, including custom headers and request scopes, check out the [idempotent requests middleware documentation](/docs/{{version}}/middleware#idempotent-requests).
 
 <a name="authorization-attributes"></a>
 ### Authorization Attributes

--- a/middleware.md
+++ b/middleware.md
@@ -7,6 +7,7 @@
     - [Assigning Middleware to Routes](#assigning-middleware-to-routes)
     - [Middleware Groups](#middleware-groups)
     - [Middleware Aliases](#middleware-aliases)
+    - [Idempotent requests](#idempotent-requests)
     - [Sorting Middleware](#sorting-middleware)
 - [Middleware Parameters](#middleware-parameters)
 - [Terminable Middleware](#terminable-middleware)
@@ -363,6 +364,7 @@ For convenience, some of Laravel's built-in middleware are aliased by default. F
 | `cache.headers`    | `Illuminate\Http\Middleware\SetCacheHeaders`                                                                  |
 | `can`              | `Illuminate\Auth\Middleware\Authorize`                                                                        |
 | `guest`            | `Illuminate\Auth\Middleware\RedirectIfAuthenticated`                                                          |
+| `idempotent`       | `Illuminate\Routing\Middleware\Idempotent`                                                                    |
 | `password.confirm` | `Illuminate\Auth\Middleware\RequirePassword`                                                                  |
 | `precognitive`     | `Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests`                                            |
 | `signed`           | `Illuminate\Routing\Middleware\ValidateSignature`                                                             |
@@ -371,6 +373,59 @@ For convenience, some of Laravel's built-in middleware are aliased by default. F
 | `verified`         | `Illuminate\Auth\Middleware\EnsureEmailIsVerified`                                                            |
 
 </div>
+
+<a name="idempotent-requests"></a>
+### Idempotent requests
+
+Laravel includes an `Illuminate\Routing\Middleware\Idempotent` middleware that helps you safely retry `POST`, `PUT`, and `PATCH` requests without performing the same work twice. When two requests use the same idempotency key and the same request payload, Laravel will return the original response instead of executing your route again.
+
+To get started, attach the middleware to the routes that create or update data:
+
+```php
+use Illuminate\Routing\Middleware\Idempotent;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/orders', StoreOrderController::class)
+    ->middleware(Idempotent::class);
+```
+
+By default, the middleware expects an `Idempotency-Key` header on the request. If the header is missing, Laravel will return a `400` response. When the same key is sent again with the same request data, the cached response will be replayed and the response will include an `Idempotency-Replayed: true` header.
+
+> [!NOTE]
+> The idempotency middleware uses Laravel's cache system to store responses and acquire locks. Therefore, your application should use a cache driver that supports [atomic locks](/docs/{{version}}/cache#atomic-locks).
+
+If you need to customize the middleware's behavior, you may use the `Idempotent::using` helper when assigning the middleware:
+
+```php
+use Illuminate\Routing\Middleware\Idempotent;
+
+Route::post('/orders', StoreOrderController::class)
+    ->middleware(Idempotent::using(
+        ttl: 600,
+        required: false,
+        scope: 'ip',
+        header: 'X-Idempotency-Key',
+    ));
+```
+
+The middleware accepts four options:
+
+<div class="overflow-auto">
+
+| Option | Description |
+| --- | --- |
+| `ttl` | The number of seconds the stored response should remain available. The default is `86400` seconds. |
+| `required` | Determines whether the idempotency header is required. When `false`, requests without the header pass through normally. |
+| `scope` | Controls how keys are segmented. Supported values are `user`, `ip`, and `global`. |
+| `header` | The header name Laravel should inspect for the client-provided idempotency key. |
+
+</div>
+
+When using the default `user` scope, keys are isolated per authenticated user. Guest requests automatically fall back to the request IP address. The `ip` scope always segments by client IP address, while the `global` scope reuses the same key across all users and IP addresses.
+
+If the same key is reused with different request data, Laravel will return a `422` response. If a second matching request arrives while the first request is still being processed, Laravel will return a `409` response with a `Retry-After: 1` header so the client may try again shortly.
+
+Idempotency fingerprints include the request method, route, query string, payload, and content type. JSON payloads are normalized before hashing, so equivalent JSON objects with different key ordering are still treated as the same request.
 
 <a name="sorting-middleware"></a>
 ### Sorting Middleware


### PR DESCRIPTION
This PR documents Laravel's new HTTP idempotency support so developers can understand when to use it and how to configure it.

Companion framework PR: https://github.com/laravel/framework/pull/59304

### Approach

- document route middleware usage, replay behavior, and configuration options
- document the `#[Idempotent]` controller attribute and how it maps to middleware options
- surface the feature in the built-in middleware alias reference