### PR TITLE
Update Spatie's Laravel Query Builder link

### DIFF
--- a/eloquent-resources.md
+++ b/eloquent-resources.md
@@ -902,7 +902,7 @@ return User::all()
 Laravel ships with `JsonApiResource`, a resource class that produces responses compliant with the [JSON:API specification](https://jsonapi.org/). It extends the standard `JsonResource` class and automatically handles resource object structure, relationships, sparse fieldsets, includes, and sets the `Content-Type` header to `application/vnd.api+json`.
 
 > [!NOTE]
-> Laravel's JSON:API resources handle the serialization of your responses. If you also need to parse incoming JSON:API query parameters such as filters and sorts, [Spatie's Laravel Query Builder](https://spatie.be/docs/laravel-query-builder/v6/introduction) is a great companion package.
+> Laravel's JSON:API resources handle the serialization of your responses. If you also need to parse incoming JSON:API query parameters such as filters and sorts, [Spatie's Laravel Query Builder](https://spatie.be/docs/laravel-query-builder) is a great companion package.
 
 <a name="generating-jsonapi-resources"></a>
 ### Generating JSON:API Resources


### PR DESCRIPTION
Spatie's Laravel Query released a new version, v7.  The current link redirect to an older version (v6). 

Instead of manually bumping the documentation URL for every major release, this PR uses the top-level redirect URL that will alwasy redirect the laster version.

I have confirmed that Spatie top redirect url always redirect to the latest package version. 

Examples:
- [https://spatie.be/docs/laravel-query-builder](https://spatie.be/docs/laravel-query-builder)
- [https://spatie.be/docs/laravel-sitemap](https://spatie.be/docs/laravel-sitemap)