### PR TITLE
Fix unreachable code in Queueing example

### DIFF
--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -496,7 +496,7 @@ use Laravel\Ai\Responses\AgentResponse;
 use Throwable;
 
 Route::post('/coach', function (Request $request) {
-    return (new SalesCoach)
+    (new SalesCoach)
         ->queue($request->input('transcript'))
         ->then(function (AgentResponse $response) {
             // ...


### PR DESCRIPTION
The second return in the example is never executed, and returning a `QueuedAgentResponse` is useless in an HTTP response. This PR removes the first return to make the route behave correctly.