### PR TITLE
Add starter kit docs for teams support

### DIFF
--- a/starter-kits.md
+++ b/starter-kits.md
@@ -13,6 +13,7 @@
     - [Vue](#vue-customization)
     - [Livewire](#livewire-customization)
 - [Authentication](#authentication)
+    - [Teams](#teams)
     - [Enabling and Disabling Features](#enabling-and-disabling-features)
     - [Customizing User Creation and Password Reset](#customizing-actions)
     - [Two-Factor Authentication](#two-factor-authentication)
@@ -350,6 +351,17 @@ To change your authentication layout, modify the layout that is used by your app
 ## Authentication
 
 All starter kits use [Laravel Fortify](/docs/{{version}}/fortify) to handle authentication. Fortify provides routes, controllers, and logic for login, registration, password reset, email verification, and more.
+
+<a name="teams"></a>
+### Teams
+
+The React, Svelte, Vue, and Livewire starter kits may also be generated with team support. When the teams feature is enabled, each user belongs to one or more teams and has a current team. During registration, new users are automatically given a personal team. The starter kits also include team management screens for creating teams, switching between teams, inviting members, and updating team details.
+
+When a route is scoped to the current team, the current team's slug is included in the URL. For example, the dashboard route becomes `/{current_team}/dashboard`, while team management pages use routes such as `settings/teams/{team}`. The starter kits automatically ensure that the authenticated user belongs to the requested team before allowing access to the route.
+
+To make generating team-aware URLs more convenient, the starter kits register URL defaults for the authenticated user's current team. This allows calls to helpers such as `route('dashboard')` to automatically include the current team's slug. When a user signs in, registers, or switches teams, the starter kits update the current team and refresh these URL defaults so generated links continue to use the correct team context.
+
+When creating or renaming a team, the starter kits also prevent users from choosing reserved names that could produce unsafe or conflicting route segments. For example, names that would collide with route prefixes such as `settings`, `login`, or `dashboard` may not be used.
 
 Fortify automatically registers the following authentication routes based on the features that are enabled in your application's `config/fortify.php` configuration file:
 

--- a/starter-kits.md
+++ b/starter-kits.md
@@ -13,11 +13,11 @@
     - [Vue](#vue-customization)
     - [Livewire](#livewire-customization)
 - [Authentication](#authentication)
-    - [Teams](#teams)
     - [Enabling and Disabling Features](#enabling-and-disabling-features)
     - [Customizing User Creation and Password Reset](#customizing-actions)
     - [Two-Factor Authentication](#two-factor-authentication)
     - [Rate Limiting](#rate-limiting)
+- [Teams](#teams)
 - [WorkOS AuthKit Authentication](#workos)
 - [Inertia SSR](#inertia-ssr)
 - [Community Maintained Starter Kits](#community-maintained-starter-kits)
@@ -352,17 +352,6 @@ To change your authentication layout, modify the layout that is used by your app
 
 All starter kits use [Laravel Fortify](/docs/{{version}}/fortify) to handle authentication. Fortify provides routes, controllers, and logic for login, registration, password reset, email verification, and more.
 
-<a name="teams"></a>
-### Teams
-
-The React, Svelte, Vue, and Livewire starter kits may also be generated with team support. When the teams feature is enabled, each user belongs to one or more teams and has a current team. During registration, new users are automatically given a personal team. The starter kits also include team management screens for creating teams, switching between teams, inviting members, and updating team details.
-
-When a route is scoped to the current team, the current team's slug is included in the URL. For example, the dashboard route becomes `/{current_team}/dashboard`, while team management pages use routes such as `settings/teams/{team}`. The starter kits automatically ensure that the authenticated user belongs to the requested team before allowing access to the route.
-
-To make generating team-aware URLs more convenient, the starter kits register URL defaults for the authenticated user's current team. This allows calls to helpers such as `route('dashboard')` to automatically include the current team's slug. When a user signs in, registers, or switches teams, the starter kits update the current team and refresh these URL defaults so generated links continue to use the correct team context.
-
-When creating or renaming a team, the starter kits also prevent users from choosing reserved names that could produce unsafe or conflicting route segments. For example, names that would collide with route prefixes such as `settings`, `login`, or `dashboard` may not be used.
-
 Fortify automatically registers the following authentication routes based on the features that are enabled in your application's `config/fortify.php` configuration file:
 
 | Route                              | Method | Description                         |
@@ -461,6 +450,17 @@ RateLimiter::for('login', function ($request) {
     return Limit::perMinute(5)->by($request->email.$request->ip());
 });
 ```
+
+<a name="teams"></a>
+## Teams
+
+The React, Svelte, Vue, and Livewire starter kits may also be generated with team support. When the teams feature is enabled, each user belongs to one or more teams and has a current team. During registration, new users are automatically given a personal team. The starter kits also include team management screens for creating teams, switching between teams, inviting members, and updating team details.
+
+When a route is scoped to the current team, the current team's slug is included in the URL. For example, the dashboard route becomes `/{current_team}/dashboard`, while team management pages use routes such as `settings/teams/{team}`. When using the `{current_team}` and `{team}` route parameters, the starter kits automatically ensure that the authenticated user belongs to the requested team before allowing access to the route.
+
+To make generating team-aware URLs more convenient, the starter kits register URL defaults for the authenticated user's current team. This allows calls to helpers such as `route('dashboard')` to automatically include the current team's slug. When a user signs in, registers, or switches teams, the starter kits update the current team and refresh these URL defaults so generated links continue to use the correct team context.
+
+When creating or renaming a team, the starter kits also prevent users from choosing reserved names that could produce unsafe or conflicting route segments. For example, names that would collide with route prefixes such as `settings`, `login`, or `dashboard` may not be used.
 
 <a name="workos"></a>
 ## WorkOS AuthKit Authentication


### PR DESCRIPTION
Starter kit users need a short explanation of how the Teams variant works so they can understand the current team context used throughout the app.

### Approach

- add a Teams subsection under the starter kit authentication docs
- explain personal teams, team-scoped URLs, and automatic URL defaults
- document the reserved team-name validation that avoids route conflicts