### PR TITLE
Fix newline formatting in MCP docs example

### DIFF
--- a/mcp.md
+++ b/mcp.md
@@ -591,7 +591,7 @@ public function handle(Request $request): array
 
     return [
         Response::text('Weather Summary: Sunny, 72°F'),
-        Response::text('**Detailed Forecast**\n- Morning: 65°F\n- Afternoon: 78°F\n- Evening: 70°F')
+        Response::text("**Detailed Forecast**\n- Morning: 65°F\n- Afternoon: 78°F\n- Evening: 70°F")
     ];
 }
 ```


### PR DESCRIPTION
Correct newline formatting in MCP documentation example by replacing single‑quoted strings with double‑quoted ones so `\n` is interpreted properly.