### PR TITLE
Document two-factor authentication rate limiting

### DIFF
--- a/fortify.md
+++ b/fortify.md
@@ -216,6 +216,22 @@ By default, Fortify will throttle authentication attempts using the `EnsureLogin
 
 Some applications may require a different approach to throttling authentication attempts, such as throttling by IP address alone. Therefore, Fortify allows you to specify your own [rate limiter](/docs/{{version}}/routing#rate-limiting) via the `fortify.limiters.login` configuration option. Of course, this configuration option is located in your application's `config/fortify.php` configuration file.
 
+If your application uses two-factor authentication, you should also rate limit the two-factor challenge endpoint. You may specify your own [rate limiter](/docs/{{version}}/routing#rate-limiting) via the `fortify.limiters.two-factor` configuration option:
+
+    'limiters' => [
+        'login' => 'login',
+        'two-factor' => 'two-factor',
+    ],
+
+Then, define the corresponding rate limiter in your application's `FortifyServiceProvider`:
+
+    use Illuminate\Cache\RateLimiting\Limit;
+    use Illuminate\Support\Facades\RateLimiter;
+
+    RateLimiter::for('two-factor', function (Request $request) {
+        return Limit::perMinute(5)->by($request->session()->get('login.id'));
+    });
+
 > [!NOTE]
 > Utilizing a mixture of throttling, [two-factor authentication](/docs/{{version}}/fortify#two-factor-authentication), and an external web application firewall (WAF) will provide the most robust defense for your legitimate application users.
 

--- a/fortify.md
+++ b/fortify.md
@@ -218,19 +218,23 @@ Some applications may require a different approach to throttling authentication 
 
 If your application uses two-factor authentication, you should also rate limit the two-factor challenge endpoint. You may specify your own [rate limiter](/docs/{{version}}/routing#rate-limiting) via the `fortify.limiters.two-factor` configuration option:
 
-    'limiters' => [
-        'login' => 'login',
-        'two-factor' => 'two-factor',
-    ],
+```php
+'limiters' => [
+    'login' => 'login',
+    'two-factor' => 'two-factor',
+],
+```
 
 Then, define the corresponding rate limiter in your application's `FortifyServiceProvider`:
 
-    use Illuminate\Cache\RateLimiting\Limit;
-    use Illuminate\Support\Facades\RateLimiter;
+```php
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
 
-    RateLimiter::for('two-factor', function (Request $request) {
-        return Limit::perMinute(5)->by($request->session()->get('login.id'));
-    });
+RateLimiter::for('two-factor', function (Request $request) {
+    return Limit::perMinute(5)->by($request->session()->get('login.id'));
+});
+```
 
 > [!NOTE]
 > Utilizing a mixture of throttling, [two-factor authentication](/docs/{{version}}/fortify#two-factor-authentication), and an external web application firewall (WAF) will provide the most robust defense for your legitimate application users.


### PR DESCRIPTION
## Summary

Documents the `fortify.limiters.two-factor` configuration option in the Authentication Throttling section. This option already exists in the route definitions and is included in the published stubs for new installations, but is not currently mentioned in the documentation.

## Changes

- Adds guidance on configuring rate limiting for the two-factor challenge endpoint
- Includes config snippet and `RateLimiter::for()` example matching the existing `FortifyServiceProvider` stub

## Context

The `fortify.limiters.two-factor` config key was added in [laravel/fortify@8609af2](https://github.com/laravel/fortify/commit/8609af2) (Dec 2020) and is included in the published stubs for new installations. However, it has never been documented, meaning developers who installed Fortify before this change — or who didn't regenerate their config — may not know the option exists.

Related issues and PRs:
- laravel/fortify#171 — Original report that surfaced the missing 2FA rate limiting
- laravel/fortify#179 — Initial rate limiting PR by @driesvints
- laravel/fortify#190 — Request to mark older versions as vulnerable
- laravel/fortify#191 — Request to mention the config update in release notes
- laravel/fortify#651 — Recent attempt to add configurable per-feature rate limiters (declined)