### PR TITLE
[13.x] Fix boost chapter order in TOC to reflect section headlines

### DIFF
--- a/boost.md
+++ b/boost.md
@@ -2,8 +2,8 @@
 
 - [Introduction](#introduction)
 - [Installation](#installation)
-    - [Keeping Boost Resources Updated](#keeping-boost-resources-updated)
     - [Set Up Your Agents](#set-up-your-agents)
+    - [Keeping Boost Resources Updated](#keeping-boost-resources-updated)
 - [MCP Server](#mcp-server)
     - [Available MCP Tools](#available-mcp-tools)
     - [Manually Registering the MCP Server](#manually-registering-the-mcp-server)


### PR DESCRIPTION
<img width="862" height="459" alt="grafik" src="https://github.com/user-attachments/assets/35cc8635-d511-4708-939a-ea03819e3eee" />
