### PR TITLE
Add Scout 11.x where clause operators

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -818,10 +818,20 @@ use App\Models\Order;
 $orders = Order::search('Star Trek')->where('user_id', 1)->get();
 ```
 
-You can also do use the standard `=`, '!=`, `<`, `>`, `>=`, `<=` comparsion operators for more advanced queries:
+You can also use the standard `=`, `!=`, `<`, `>`, `>=`, `<=` comparsion operators to build more advanced queries:
 
-```
-Order::search('Star Trek')->where('amount', '>=', 42)->get();
+```php
+Order::search('Star Trek')->where('status', '=', 'completed')->get();
+
+Order::search('Star Trek')->where('is_refunded', '!=', true)->get();
+
+Order::search('Star Trek')->where('total_price', '>', 100)->get();
+
+Order::search('Star Trek')->where('shipping_cost', '<', 20)->get();
+
+Order::search('Star Trek')->where('created_at', '>=', now()->subDays(14)->toDateTimeString())->get();
+
+Order::search('Star Trek')->where('item_count', '<=', 5)->get();
 ```
 
 In addition, the `whereIn` method may be used to verify that a given column's value is contained within the given array:

--- a/scout.md
+++ b/scout.md
@@ -829,7 +829,7 @@ Order::search('Star Trek')->where('total_price', '>', 100)->get();
 
 Order::search('Star Trek')->where('shipping_cost', '<', 20)->get();
 
-Order::search('Star Trek')->where('created_at', '>=', now()->subDays(14)->toDateTimeString())->get();
+Order::search('Star Trek')->where('discount_percent', '>=', 10)->get();
 
 Order::search('Star Trek')->where('item_count', '<=', 5)->get();
 ```

--- a/scout.md
+++ b/scout.md
@@ -810,12 +810,18 @@ $orders = Order::search('Star Trek')
 <a name="where-clauses"></a>
 ### Where Clauses
 
-Scout allows you to add simple "where" clauses to your search queries. Currently, these clauses only support basic equality checks and are primarily useful for scoping search queries by an owner ID:
+Scout allows you to add "where" clauses to your search queries. For example, basic equality checks are useful for scoping search queries by an owner ID:
 
 ```php
 use App\Models\Order;
 
 $orders = Order::search('Star Trek')->where('user_id', 1)->get();
+```
+
+You can also do use the standard `=`, '!=`, `<`, `>`, `>=`, `<=` comparsion operators for more advanced queries:
+
+```
+Order::search('Star Trek')->where('amount', '>=', 42)->get();
 ```
 
 In addition, the `whereIn` method may be used to verify that a given column's value is contained within the given array:

--- a/scout.md
+++ b/scout.md
@@ -821,17 +821,14 @@ $orders = Order::search('Star Trek')->where('user_id', 1)->get();
 You can also use the standard `=`, `!=`, `<`, `>`, `>=`, `<=` comparsion operators to build more advanced queries:
 
 ```php
-Order::search('Star Trek')->where('status', '=', 'completed')->get();
-
-Order::search('Star Trek')->where('is_refunded', '!=', true)->get();
-
-Order::search('Star Trek')->where('total_price', '>', 100)->get();
-
-Order::search('Star Trek')->where('shipping_cost', '<', 20)->get();
-
-Order::search('Star Trek')->where('discount_percent', '>=', 10)->get();
-
-Order::search('Star Trek')->where('item_count', '<=', 5)->get();
+Order::search('Star Trek')
+  ->where('status', '=', 'completed')
+  ->where('is_refunded', '!=', true)
+  ->where('total_price', '>', 100)
+  ->where('shipping_cost', '<', 20)
+  ->where('discount_percent', '>=', 10)
+  ->where('item_count', '<=', 5)
+  ->get();
 ```
 
 In addition, the `whereIn` method may be used to verify that a given column's value is contained within the given array:

--- a/scout.md
+++ b/scout.md
@@ -818,7 +818,7 @@ use App\Models\Order;
 $orders = Order::search('Star Trek')->where('user_id', 1)->get();
 ```
 
-You can also use the standard `=`, `!=`, `<`, `>`, `>=`, `<=` comparsion operators to build more advanced queries:
+You may also use the `=`, `!=`, `<`, `>`, `>=`, `<=` comparsion operators to build more advanced queries:
 
 ```php
 Order::search('Star Trek')


### PR DESCRIPTION
Laravel Scout 11.x adds proper where clause operator support, which is really useful to know, so I've added it to the docs: https://github.com/laravel/scout/blob/11.x/UPGRADE.md#upgrading-to-110-from-10x