### PR TITLE
[13.x] Document client credentials token ID collision risk

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -991,6 +991,9 @@ $response = Http::asForm()->post('https://passport-app.test/oauth/token', [
 return $response->json()['access_token'];
 ```
 
+> [!WARNING]
+> The underlying OAuth2 server sets the token's `sub` claim to the client's identifier for client credentials tokens. By default, Passport uses UUIDs for clients, so this cannot collide with a user's integer primary key. However, if you have set `Passport::$clientUuids` to `false`, a client credentials token may inadvertently resolve a user whose ID matches the client's ID. Applications using integer client IDs should ensure client credentials routes are protected by the `EnsureClientIsResourceOwner` middleware and are not shared with user-authenticated routes.
+
 <a name="personal-access-tokens"></a>
 ## Personal Access Tokens
 

--- a/passport.md
+++ b/passport.md
@@ -974,7 +974,7 @@ Route::get('/orders', function (Request $request) {
 ```
 
 > [!WARNING]
-> The [underlying OAuth2 server](https://oauth2.thephpleague.com/database-setup/#:~:text=Please%20note%20that,the%20bearer%20token.) sets the token's `sub` claim to the client's identifier for client credentials tokens. By default, Passport uses UUIDs for clients, so this cannot collide with a user's integer primary key. However, if you have set `Passport::$clientUuids` to `false`, a client credentials token may inadvertently resolve a user whose ID matches the client's ID. Applications using integer client IDs should ensure client credentials routes are protected by the `EnsureClientIsResourceOwner` middleware and are not shared with user-authenticated routes.
+> The [underlying OAuth2 server](https://oauth2.thephpleague.com/database-setup/#:~:text=Please%20note%20that,the%20bearer%20token.) sets the token's `sub` claim to the client's identifier for client credentials tokens. By default, Passport uses UUIDs for clients, so this cannot collide with a user's integer primary key. However, if you have set `Passport::$clientUuids` to `false`, a client credentials token may inadvertently resolve a user whose ID matches the client's ID. In such cases, using this middleware cannot guarantee that the incoming token is a client credentials token.
 
 <a name="retrieving-tokens"></a>
 ### Retrieving Tokens

--- a/passport.md
+++ b/passport.md
@@ -973,6 +973,9 @@ Route::get('/orders', function (Request $request) {
 })->middleware(EnsureClientIsResourceOwner::using('servers:read', 'servers:create'));
 ```
 
+> [!WARNING]
+> The [underlying OAuth2 server](https://oauth2.thephpleague.com/database-setup/#:~:text=Please%20note%20that,the%20bearer%20token.) sets the token's `sub` claim to the client's identifier for client credentials tokens. By default, Passport uses UUIDs for clients, so this cannot collide with a user's integer primary key. However, if you have set `Passport::$clientUuids` to `false`, a client credentials token may inadvertently resolve a user whose ID matches the client's ID. Applications using integer client IDs should ensure client credentials routes are protected by the `EnsureClientIsResourceOwner` middleware and are not shared with user-authenticated routes.
+
 <a name="retrieving-tokens"></a>
 ### Retrieving Tokens
 
@@ -990,9 +993,6 @@ $response = Http::asForm()->post('https://passport-app.test/oauth/token', [
 
 return $response->json()['access_token'];
 ```
-
-> [!WARNING]
-> The underlying OAuth2 server sets the token's `sub` claim to the client's identifier for client credentials tokens. By default, Passport uses UUIDs for clients, so this cannot collide with a user's integer primary key. However, if you have set `Passport::$clientUuids` to `false`, a client credentials token may inadvertently resolve a user whose ID matches the client's ID. Applications using integer client IDs should ensure client credentials routes are protected by the `EnsureClientIsResourceOwner` middleware and are not shared with user-authenticated routes.
 
 <a name="personal-access-tokens"></a>
 ## Personal Access Tokens


### PR DESCRIPTION
When using the `client_credentials` grant with integer client IDs, the token's `sub` claim can match a user's primary key, causing unintended user resolution. This adds a warning to the Passport docs explaining the risk and how to avoid it.

CC @hafezdivandari