### PR TITLE
[12.x] Document client credentials token ID collision risk

### DIFF
--- a/passport.md
+++ b/passport.md
@@ -973,6 +973,9 @@ Route::get('/orders', function (Request $request) {
 })->middleware(EnsureClientIsResourceOwner::using('servers:read', 'servers:create'));
 ```
 
+> [!WARNING]
+> The [underlying OAuth2 server](https://oauth2.thephpleague.com/database-setup/#:~:text=Please%20note%20that,the%20bearer%20token.) sets the token's `sub` claim to the client's identifier for client credentials tokens. By default, Passport uses UUIDs for clients, so this cannot collide with a user's integer primary key. However, if you have set `Passport::$clientUuids` to `false`, a client credentials token may inadvertently resolve a user whose ID matches the client's ID. Applications using integer client IDs should ensure client credentials routes are protected by the `EnsureClientIsResourceOwner` middleware and are not shared with user-authenticated routes.
+
 <a name="retrieving-tokens"></a>
 ### Retrieving Tokens
 

--- a/passport.md
+++ b/passport.md
@@ -974,7 +974,7 @@ Route::get('/orders', function (Request $request) {
 ```
 
 > [!WARNING]
-> The [underlying OAuth2 server](https://oauth2.thephpleague.com/database-setup/#:~:text=Please%20note%20that,the%20bearer%20token.) sets the token's `sub` claim to the client's identifier for client credentials tokens. By default, Passport uses UUIDs for clients, so this cannot collide with a user's integer primary key. However, if you have set `Passport::$clientUuids` to `false`, a client credentials token may inadvertently resolve a user whose ID matches the client's ID. Applications using integer client IDs should ensure client credentials routes are protected by the `EnsureClientIsResourceOwner` middleware and are not shared with user-authenticated routes.
+> The [underlying OAuth2 server](https://oauth2.thephpleague.com/database-setup/#:~:text=Please%20note%20that,the%20bearer%20token.) sets the token's `sub` claim to the client's identifier for client credentials tokens. By default, Passport uses UUIDs for clients, so this cannot collide with a user's integer primary key. However, if you have set `Passport::$clientUuids` to `false`, a client credentials token may inadvertently resolve a user whose ID matches the client's ID. In such cases, using this middleware cannot guarantee that the incoming token is a client credentials token.
 
 <a name="retrieving-tokens"></a>
 ### Retrieving Tokens


### PR DESCRIPTION
Same as https://github.com/laravel/docs/pull/11139 on targeted on 12.x