### PR TITLE
[12.x] Update queues.md - warn constructor-based queue assignment does not work for event listeners

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1207,6 +1207,9 @@ class ProcessPodcast implements ShouldQueue
 }
 ```
 
+> [!WARNING]
+> Constructor-based queue assignment via `onQueue` only works for job classes. For [queued event listeners](/docs/{{version}}/events#customizing-the-queue-connection-queue-name), define a `viaQueue` method or a `$queue` property on the listener class instead.
+
 <a name="dispatching-to-a-particular-connection"></a>
 #### Dispatching to a Particular Connection
 


### PR DESCRIPTION
This PR adds a warning to the queue documentation noting that constructor-based queue assignment via `onQueue` does not work
  for queued event listeners — only for job classes.

  Related issue 12.x: laravel/framework#59483 -> if issue is resolved there, this mr can be closed
  Fixed in 13.x by: laravel/framework#59468

  ### Context

  Laravel's event dispatcher instantiates listeners without calling the constructor when resolving queue configuration. This
  means `$this->onQueue()` in a listener constructor is silently ignored. The docs currently show this pattern without noting
  the limitation.

  ### Approach

  - Add a `[!WARNING]` callout after the `onQueue` constructor example in `queues.md`, directing users to define a `viaQueue`
  method or `$queue` property on their listener class instead.