### PR TITLE
Add link to Prism documentation for agent SSE output

### DIFF
--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -410,7 +410,7 @@ $response = (new ImageAnalyzer)->prompt(
 <a name="streaming"></a>
 ### Streaming
 
-You may stream an agent's response by invoking the `stream` method. The returned `StreamableAgentResponse` may be returned from a route to automatically send a streaming response (SSE) to the client:
+You may stream an agent's response by invoking the `stream` method. The returned `StreamableAgentResponse` may be returned from a route to automatically send a [streaming response (SSE)](https://prismphp.com/core-concepts/streaming-output.html#server-sent-events-sse) to the client:
 
 ```php
 use App\Ai\Agents\SalesCoach;


### PR DESCRIPTION
After using `$agent->stream($prompt)` to stream the agent's response to the browser, I was a bit lost on where I could find more information on what exactly is being sent and how I could process it.

This PR adds a link to the relevant page of the Prism documentation.

Of course, I'm open to other ideas on how we could word this in the documentation.