### PR TITLE
[12.x] Expand HTTP exceptions section with abort message, headers, and conditional helpers

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -469,9 +469,20 @@ use Throwable;
 ## HTTP Exceptions
 
 Some exceptions describe HTTP error codes from the server. For example, this may be a "page not found" error (404), an "unauthorized error" (401), or even a developer generated 500 error. In order to generate such a response from anywhere in your application, you may use the `abort` helper:
-
 ```php
 abort(404);
+```
+
+You may also provide the exception's response text and custom HTTP response headers that should be sent to the browser:
+```php
+abort(403, 'Unauthorized.', $headers);
+```
+
+The `abort_if` and `abort_unless` [helpers](/docs/{{version}}/helpers#method-abort-if) provide a convenient way to throw HTTP exceptions when a given condition is met:
+```php
+abort_if(! Auth::user()->isAdmin(), 403);
+
+abort_unless(Auth::user()->isAdmin(), 403);
 ```
 
 <a name="custom-http-error-pages"></a>

--- a/http-client.md
+++ b/http-client.md
@@ -251,7 +251,7 @@ The `timeout` method may be used to specify the maximum number of seconds to wai
 $response = Http::timeout(3)->get(/* ... */);
 ```
 
-If the given timeout is exceeded, an instance of `Illuminate\Http\Client\ConnectionException` will  be thrown.
+If the given timeout is exceeded, an instance of `Illuminate\Http\Client\ConnectionException` will be thrown.
 
 You may specify the maximum number of seconds to wait while trying to connect to a server using the `connectTimeout` method. The default is 10 seconds:
 


### PR DESCRIPTION
This PR expands the HTTP Exceptions section in `errors.md` to include:

- `abort()` usage with a custom message and response headers
- `abort_if()` and `abort_unless()` conditional helpers with a cross-reference to the helpers documentation

Currently, the HTTP Exceptions section only shows `abort(404)` — the most basic usage. Developers reading this section have no indication they can pass a custom message, headers, or use conditional abort helpers without navigating to a separate page.

Also fixes a minor double-space typo in `http-client.md` timeout section.