### PR TITLE
[13.x] Expand HTTP exceptions section with abort message, headers, and conditional helpers

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -474,6 +474,20 @@ Some exceptions describe HTTP error codes from the server. For example, this may
 abort(404);
 ```
 
+You may also provide the exception's response text and custom HTTP response headers that should be sent to the browser:
+
+```php
+abort(403, 'Unauthorized.', $headers);
+```
+
+The `abort_if` and `abort_unless` [helpers](/docs/{{version}}/helpers#method-abort-if) provide a convenient way to throw HTTP exceptions when a given condition is met:
+
+```php
+abort_if(! Auth::user()->isAdmin(), 403);
+
+abort_unless(Auth::user()->isAdmin(), 403);
+```
+
 <a name="custom-http-error-pages"></a>
 ### Custom HTTP Error Pages
 


### PR DESCRIPTION
This PR expands the HTTP Exceptions section in `errors.md` to include:

- `abort()` usage with a custom message and response headers
- `abort_if()` and `abort_unless()` conditional helpers with a cross-reference to the helpers documentation

Currently, the HTTP Exceptions section only shows `abort(404)` — the most basic usage. Developers reading this section have no indication they can pass a custom message, headers, or use conditional abort helpers without navigating to a separate page.

The `helpers.md` page documents these features, but `errors.md` is the primary landing page for developers searching for HTTP error handling — adding a brief mention with a cross-reference improves discoverability.