### PR TITLE
[13.x] Fix double space typo in http-client timeout section

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -251,7 +251,7 @@ The `timeout` method may be used to specify the maximum number of seconds to wai
 $response = Http::timeout(3)->get(/* ... */);
 ```
 
-If the given timeout is exceeded, an instance of `Illuminate\Http\Client\ConnectionException` will  be thrown.
+If the given timeout is exceeded, an instance of `Illuminate\Http\Client\ConnectionException` will be thrown.
 
 You may specify the maximum number of seconds to wait while trying to connect to a server using the `connectTimeout` method. The default is 10 seconds:
 


### PR DESCRIPTION
Fix minor typographical error where "will  be thrown" had an extra space in the timeout documentation.