### PR TITLE
fix: update retryUntil() return type from DateTime to DateTimeInterface

### DIFF
--- a/events.md
+++ b/events.md
@@ -685,15 +685,15 @@ class SendShipmentNotification implements ShouldQueue
 }
 ```
 
-As an alternative to defining how many times a listener may be attempted before it fails, you may define a time at which the listener should no longer be attempted. This allows a listener to be attempted any number of times within a given time frame. To define the time at which a listener should no longer be attempted, add a `retryUntil` method to your listener class. This method should return a `DateTime` instance:
+As an alternative to defining how many times a listener may be attempted before it fails, you may define a time at which the listener should no longer be attempted. This allows a listener to be attempted any number of times within a given time frame. To define the time at which a listener should no longer be attempted, add a `retryUntil` method to your listener class. This method should return a `DateTimeInterface` instance:
 
 ```php
-use DateTime;
+use DateTimeInterface;
 
 /**
  * Determine the time at which the listener should timeout.
  */
-public function retryUntil(): DateTime
+public function retryUntil(): DateTimeInterface
 {
     return now()->plus(minutes: 5);
 }


### PR DESCRIPTION
in [events.md](https://github.com/laravel/docs/blob/13.x/events.md) line `688`, it says:

> Add a `retryUntil` method to your listener class. This method should return a `DateTime` instance:

```php
use DateTime;

/**
 * Determine the time at which the listener should timeout.
 */
public function retryUntil(): DateTime
{
    return now()->plus(minutes: 5);
}
```

However, this is not proper for the latest versions of Laravel. By default, `now()` returns an instance of `Carbon\CarbonImmutable` (or its parent `CarbonInterface`) and `CarbonInterface` extends the `\DateTimeInterface`, **not** `DateTime`.
<img width="996" height="300" alt="image" src="https://github.com/user-attachments/assets/2230b602-2386-4c43-9215-843f8983a501" />

As a result, using `DateTime` as the return type may cause a fatal error:

> Return value must be of type DateTime, Carbon\CarbonImmutable returned

See issue [#745](https://github.com/laravel/boost/issues/745) in [laravel/boost](https://github.com/laravel/boost). because the `retryUntil` method _don't always_ return a `DateTime` instance, but we _can be sure_ that the returned object **always implements** `DateTimeInterface`.

So, the correct (and better) return type would be:

```php
public function retryUntil(): DateTimeInterface
```

I've added a fix regarding this in laravel-boost in PR [#748](https://github.com/laravel/boost/pull/748), which was merged.
This PR updates the official doc accordingly, which would **help prevent** confusion and runtime errors. and this tiny change can encourage **alignment** with Laravel’s internal expectations, following best practices (programming to an interface), as well as keeping the method **compatible** with **both** `DateTime` and `CarbonImmutable` return types.

Thanks.