### PR TITLE
Update attribute type annotation in eloquent.md

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -409,7 +409,7 @@ class Flight extends Model
     /**
      * The model's default values for attributes.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $attributes = [
         'options' => '[]',


### PR DESCRIPTION
Update the `$attributes` example so that the docblock type matches the one in `HasAttributes` from the framework.