### PR TITLE
Correct session cookie default in 13.x upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -94,7 +94,7 @@ Or, if you are using [Laravel Herd's](https://herd.laravel.com) bundled copy of 
 
 **Likelihood Of Impact: Low**
 
-Laravel's default cache and Redis key prefixes now use hyphenated suffixes. In addition, the default session cookie name now uses `Str::snake(...)` for the application name.
+Laravel's default cache and Redis key prefixes now use hyphenated suffixes.
 
 In most applications, this change will not apply because application-level configuration files already define these values. This primarily affects applications that rely on framework-level fallback configuration when corresponding application config values are not present.
 
@@ -109,7 +109,7 @@ Str::slug((string) env('APP_NAME', 'laravel'), '_').'_session';
 // Laravel >= 13.x
 Str::slug((string) env('APP_NAME', 'laravel')).'-cache-';
 Str::slug((string) env('APP_NAME', 'laravel')).'-database-';
-Str::snake((string) env('APP_NAME', 'laravel')).'_session';
+Str::slug((string) env('APP_NAME', 'laravel')).'-session';
 ```
 
 To retain previous behavior, explicitly configure `CACHE_PREFIX`, `REDIS_PREFIX`, and `SESSION_COOKIE` in your environment.


### PR DESCRIPTION
To reflect current 13.x default. It looks like the slug-to-snake change (along with hyphen-to-underscore) was committed in https://github.com/laravel/laravel/commit/dd473eaddc824aeada037f0dc702a3b68a51946c but later reverted in https://github.com/laravel/laravel/commit/902200e7aac4af7efff60ed7ee958932b83ff2e4