### PR TITLE
Add throwIfServerError and throwIfClientError to HTTP client response

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -375,10 +375,10 @@ $response->throwIfStatus(403);
 // Throw an exception unless the response has a specific status code...
 $response->throwUnlessStatus(200);
 
-// Throw an exception if a server error occurred (status >500)
+// Throw an exception if a server error occurred (status >500)...
 $response->throwIfServerError();
 
-// Throw an exception if a client error occurred (status >400 and <500)
+// Throw an exception if a client error occurred (status >400 and <500)...
 $response->throwIfClientError();
 
 return $response['user']['id'];

--- a/http-client.md
+++ b/http-client.md
@@ -375,6 +375,12 @@ $response->throwIfStatus(403);
 // Throw an exception unless the response has a specific status code...
 $response->throwUnlessStatus(200);
 
+// Throw an exception if a server error occurred (status >500)
+$response->throwIfServerError();
+
+// Throw an exception if a client error occurred (status >400 and <500)
+$response->throwIfClientError();
+
 return $response['user']['id'];
 ```
 


### PR DESCRIPTION
This PR adds documentation for the `throwIfServerError` and `throwIfClientError` methods on the HTTP client error handling.

They were introduced in Laravel 9.x (laravel/framework#45704) but are not currently documented.