### PR TITLE
Change Laravel Sail default Node version from 22 to 24

### DIFF
--- a/sail.md
+++ b/sail.md
@@ -428,7 +428,7 @@ sail up
 <a name="sail-node-versions"></a>
 ## Node Versions
 
-Sail installs Node 22 by default. To change the Node version that is installed when building your images, you may update the `build.args` definition of the `laravel.test` service in your application's `compose.yaml` file:
+Sail installs Node 24 by default. To change the Node version that is installed when building your images, you may update the `build.args` definition of the `laravel.test` service in your application's `compose.yaml` file:
 
 ```yaml
 build:


### PR DESCRIPTION
The current documentation mentions Laravel Sail installs Node 24 by default.

However, the upstream repository `laravel/sail` bumped [Node LTS from 22 to 24](https://github.com/laravel/sail/commit/3b47cce6833949075296077db67df2b9da9025f6) back in November 2025.

This pull request aligns the documentation with the canonical Dockerfile(s).