### PR TITLE
Document MCP Apps support

### DIFF
--- a/mcp.md
+++ b/mcp.md
@@ -1328,23 +1328,23 @@ return Response::error('Unable to fetch weather data for the specified location.
 <a name="apps"></a>
 ## Apps
 
-Laravel MCP supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview), an extension of the Model Context Protocol that allows a tool to render a fully interactive HTML application inside a sandboxed iframe in the host. This lets you build dashboards, forms, visualizations, and other rich experiences that go beyond plain text responses.
+Laravel MCP supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview), an extension of the Model Context Protocol that allows tools to render interactive HTML applications within sandboxed iframes in supported hosts. This allows you to build dashboards, forms, visualizations, and other rich experiences that go beyond plain text responses.
 
-An MCP App consists of two pieces working together:
+An MCP app consists of two parts working together:
 
-- An **App Resource** that returns the self-contained HTML for your application.
-- A **Tool** that is linked to the App Resource using the `#[RendersApp]` attribute. When the tool is called, the host fetches and renders the linked resource.
+- An **app resource** that returns the self-contained HTML for your application.
+- A **tool** that is linked to the app resource using the `#[RendersApp]` attribute. When the tool is called, the host fetches and renders the linked resource.
 
 <a name="creating-app-resources"></a>
 ### Creating App Resources
 
-You can create an App Resource using the `make:mcp-app-resource` Artisan command:
+You may create an app resource using the `make:mcp-app-resource` Artisan command:
 
 ```shell
 php artisan make:mcp-app-resource WeatherDashboardApp
 ```
 
-This command generates two files: a PHP class in `app/Mcp/Resources` and a Blade view in `resources/views/mcp`. The view name is automatically inferred from the class name (for example, `WeatherDashboardApp` maps to `mcp.weather-dashboard-app`):
+This command creates two files: a PHP class in `app/Mcp/Resources` and a Blade view in `resources/views/mcp`. The view name is automatically inferred from the class name. For example, `WeatherDashboardApp` maps to `mcp.weather-dashboard-app`:
 
 ```php
 <?php
@@ -1373,9 +1373,9 @@ class WeatherDashboardApp extends AppResource
 }
 ```
 
-`AppResource` extends the base `Resource` class and automatically configures the `ui://` URI scheme and the `text/html;profile=mcp-app` MIME type required by the MCP Apps specification. Like any other resource, you must register it on your server's `$resources` array.
+`AppResource` extends the base `Resource` class and automatically configures the `ui://` URI scheme and the `text/html;profile=mcp-app` MIME type required by the MCP Apps specification. Like any other resource, you must register it in your server's `$resources` array.
 
-The generated Blade view uses the `<x-mcp::app>` component, which produces a complete HTML document with the client-side MCP SDK pre-bundled and ready to use. There is no need to install npm packages, configure Vite, or bundle JavaScript:
+The generated Blade view uses the `<x-mcp::app>` component, which renders a complete HTML document with the client-side MCP SDK bundled and ready to use:
 
 ```blade
 <x-mcp::app :title="$title">
@@ -1397,12 +1397,12 @@ The generated Blade view uses the `<x-mcp::app>` component, which produces a com
 </x-mcp::app>
 ```
 
-The `createMcpApp` global is provided by the inlined SDK and handles connecting the iframe to the server, applying host theming, and exposing helpers such as `callServerTool`, `sendMessage`, `openLink`, and event callbacks. For the full client-side API, refer to the [MCP Apps specification](https://modelcontextprotocol.io/extensions/apps/overview).
+The `createMcpApp` global is provided by the bundled SDK and handles connecting the iframe to the server, applying host theming, and exposing helpers such as `callServerTool`, `sendMessage`, `openLink`, and event callbacks. For the full client-side API, refer to the [MCP Apps specification](https://modelcontextprotocol.io/extensions/apps/overview).
 
 <a name="rendering-apps-from-tools"></a>
 ### Rendering Apps From Tools
 
-To display an App Resource, link a tool to it using the `#[RendersApp]` attribute. When the tool is called, the tool listing is enriched with the resource's URI and the host renders the app in a sandboxed iframe:
+To display an app resource, link a tool to it using the `#[RendersApp]` attribute. When the tool is called, Laravel MCP includes the resource's URI in the tool metadata so the host can render the app in a sandboxed iframe:
 
 ```php
 <?php
@@ -1433,7 +1433,7 @@ Laravel MCP automatically advertises the `io.modelcontextprotocol/ui` capability
 <a name="app-tool-visibility"></a>
 ### App Tool Visibility
 
-Each `#[RendersApp]` tool can limit who is allowed to invoke it via the `visibility` argument. This is useful for exposing private "app-only" tools that the UI calls to load or refresh data without making those tools visible to the model:
+Each `#[RendersApp]` tool can limit who may invoke it via the `visibility` argument. This is useful for exposing private, app-only tools that the UI calls to load or refresh data without making those tools visible to the model:
 
 ```php
 use Laravel\Mcp\Server\Attributes\RendersApp;
@@ -1446,12 +1446,12 @@ class GetWeatherData extends Tool
 }
 ```
 
-The `Visibility` enum has two cases, `Model` and `App`, and defaults to both. Use `[Visibility::App]` for backend actions the UI calls directly, or `[Visibility::Model]` to hide the tool from the UI.
+The `Visibility` enum has two cases, `Model` and `App`, and defaults to both. Use `[Visibility::App]` for backend actions the UI calls directly, or `[Visibility::Model]` to make a tool unavailable to the UI.
 
 <a name="app-configuration"></a>
 ### App Configuration
 
-The `#[AppMeta]` attribute on your App Resource configures the iframe's Content Security Policy, browser permissions, and any library scripts that should be included in the view's `<head>`:
+The `#[AppMeta]` attribute on your app resource configures the iframe's Content Security Policy, browser permissions, and any library scripts that should be included in the view's `<head>`:
 
 ```php
 use Laravel\Mcp\Server\Attributes\AppMeta;
@@ -1469,14 +1469,14 @@ class WeatherDashboardApp extends AppResource
 }
 ```
 
-The `Library` enum includes pre-configured CDN scripts for common front-end libraries (`Library::Tailwind`, `Library::Alpine`), and their CDN origins are automatically merged into the CSP. The `Permission` enum covers browser permissions such as `Camera`, `Microphone`, `Geolocation`, and `ClipboardWrite`.
+The `Library` enum includes pre-configured CDN scripts for common front-end libraries, such as `Library::Tailwind` and `Library::Alpine`, and their CDN origins are automatically merged into the CSP. The `Permission` enum covers browser permissions such as `Camera`, `Microphone`, `Geolocation`, and `ClipboardWrite`.
 
 For computed or dynamic configuration, override the `appMeta` method on your resource using the fluent `AppMeta`, `Csp`, and `Permissions` builders from the `Laravel\Mcp\Server\Ui` namespace.
 
 <a name="building-apps-with-boost"></a>
 ### Building Apps With Boost
 
-Laravel MCP ships with a dedicated [Boost](/docs/{{version}}/boost) skill reference for building MCP Apps. If you have [Laravel Boost](/docs/{{version}}/boost) installed, your AI coding agent can invoke the `mcp-development` skill and ask it to scaffold a complete App Resource, Blade view, and linked tool for you. This is the fastest way to go from idea to a working app without having to memorize the full MCP Apps protocol surface.
+Laravel MCP includes a dedicated [Boost](/docs/{{version}}/boost) skill reference for building MCP Apps. If you have [Laravel Boost](/docs/{{version}}/boost) installed, your AI coding agent can invoke the `mcp-development` skill and ask it to scaffold an app resource, Blade view, and linked tool for you.
 
 For the complete protocol reference, including the full client-side API and schema details, see the official [MCP Apps documentation](https://modelcontextprotocol.io/extensions/apps/overview).
 

--- a/mcp.md
+++ b/mcp.md
@@ -32,6 +32,12 @@
     - [Resource Annotations](#resource-annotations)
     - [Conditional Resource Registration](#conditional-resource-registration)
     - [Resource Responses](#resource-responses)
+- [Apps](#apps)
+    - [Creating App Resources](#creating-app-resources)
+    - [Rendering Apps From Tools](#rendering-apps-from-tools)
+    - [App Tool Visibility](#app-tool-visibility)
+    - [App Configuration](#app-configuration)
+    - [Building Apps With Boost](#building-apps-with-boost)
 - [Metadata](#metadata)
 - [Authentication](#authentication)
     - [OAuth 2.1](#oauth)
@@ -1318,6 +1324,161 @@ To indicate an error occurred during resource retrieval, use the `error()` metho
 ```php
 return Response::error('Unable to fetch weather data for the specified location.');
 ```
+
+<a name="apps"></a>
+## Apps
+
+Laravel MCP supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview), an extension of the Model Context Protocol that allows a tool to render a fully interactive HTML application inside a sandboxed iframe in the host. This lets you build dashboards, forms, visualizations, and other rich experiences that go beyond plain text responses.
+
+An MCP App consists of two pieces working together:
+
+- An **App Resource** that returns the self-contained HTML for your application.
+- A **Tool** that is linked to the App Resource using the `#[RendersApp]` attribute. When the tool is called, the host fetches and renders the linked resource.
+
+<a name="creating-app-resources"></a>
+### Creating App Resources
+
+You can create an App Resource using the `make:mcp-app-resource` Artisan command:
+
+```shell
+php artisan make:mcp-app-resource WeatherDashboardApp
+```
+
+This command generates two files: a PHP class in `app/Mcp/Resources` and a Blade view in `resources/views/mcp`. The view name is automatically inferred from the class name (for example, `WeatherDashboardApp` maps to `mcp.weather-dashboard-app`):
+
+```php
+<?php
+
+namespace App\Mcp\Resources;
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\AppMeta;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\AppResource;
+
+#[Description('An interactive weather dashboard.')]
+#[AppMeta]
+class WeatherDashboardApp extends AppResource
+{
+    /**
+     * Handle the app resource request.
+     */
+    public function handle(Request $request): Response
+    {
+        return Response::view('mcp.weather-dashboard-app', [
+            'title' => $this->title(),
+        ]);
+    }
+}
+```
+
+`AppResource` extends the base `Resource` class and automatically configures the `ui://` URI scheme and the `text/html;profile=mcp-app` MIME type required by the MCP Apps specification. Like any other resource, you must register it on your server's `$resources` array.
+
+The generated Blade view uses the `<x-mcp::app>` component, which produces a complete HTML document with the client-side MCP SDK pre-bundled and ready to use. There is no need to install npm packages, configure Vite, or bundle JavaScript:
+
+```blade
+<x-mcp::app :title="$title">
+    <x-slot:head>
+        <script type="module">
+        createMcpApp(async (app) => {
+            document.getElementById('run-btn').addEventListener('click', async () => {
+                const result = await app.callServerTool('get-weather-data', {});
+                document.getElementById('output').textContent = result.content[0]?.text ?? '';
+            });
+        });
+        </script>
+    </x-slot:head>
+
+    <div id="app">
+        <button id="run-btn">Refresh</button>
+        <p id="output"></p>
+    </div>
+</x-mcp::app>
+```
+
+The `createMcpApp` global is provided by the inlined SDK and handles connecting the iframe to the server, applying host theming, and exposing helpers such as `callServerTool`, `sendMessage`, `openLink`, and event callbacks. For the full client-side API, refer to the [MCP Apps specification](https://modelcontextprotocol.io/extensions/apps/overview).
+
+<a name="rendering-apps-from-tools"></a>
+### Rendering Apps From Tools
+
+To display an App Resource, link a tool to it using the `#[RendersApp]` attribute. When the tool is called, the tool listing is enriched with the resource's URI and the host renders the app in a sandboxed iframe:
+
+```php
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Mcp\Resources\WeatherDashboardApp;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\RendersApp;
+use Laravel\Mcp\Server\Tool;
+
+#[RendersApp(resource: WeatherDashboardApp::class)]
+class ShowWeatherDashboard extends Tool
+{
+    /**
+     * Handle the tool request.
+     */
+    public function handle(Request $request): Response
+    {
+        return Response::text('Weather dashboard loaded.');
+    }
+}
+```
+
+Laravel MCP automatically advertises the `io.modelcontextprotocol/ui` capability whenever any `AppResource` is registered, so no additional server configuration is required.
+
+<a name="app-tool-visibility"></a>
+### App Tool Visibility
+
+Each `#[RendersApp]` tool can limit who is allowed to invoke it via the `visibility` argument. This is useful for exposing private "app-only" tools that the UI calls to load or refresh data without making those tools visible to the model:
+
+```php
+use Laravel\Mcp\Server\Attributes\RendersApp;
+use Laravel\Mcp\Server\Ui\Enums\Visibility;
+
+#[RendersApp(resource: WeatherDashboardApp::class, visibility: [Visibility::App])]
+class GetWeatherData extends Tool
+{
+    // ...
+}
+```
+
+The `Visibility` enum has two cases, `Model` and `App`, and defaults to both. Use `[Visibility::App]` for backend actions the UI calls directly, or `[Visibility::Model]` to hide the tool from the UI.
+
+<a name="app-configuration"></a>
+### App Configuration
+
+The `#[AppMeta]` attribute on your App Resource configures the iframe's Content Security Policy, browser permissions, and any library scripts that should be included in the view's `<head>`:
+
+```php
+use Laravel\Mcp\Server\Attributes\AppMeta;
+use Laravel\Mcp\Server\Ui\Enums\Library;
+use Laravel\Mcp\Server\Ui\Enums\Permission;
+
+#[AppMeta(
+    connectDomains: ['https://api.weather.com'],
+    permissions: [Permission::Geolocation],
+    libraries: [Library::Tailwind, Library::Alpine],
+)]
+class WeatherDashboardApp extends AppResource
+{
+    // ...
+}
+```
+
+The `Library` enum includes pre-configured CDN scripts for common front-end libraries (`Library::Tailwind`, `Library::Alpine`), and their CDN origins are automatically merged into the CSP. The `Permission` enum covers browser permissions such as `Camera`, `Microphone`, `Geolocation`, and `ClipboardWrite`.
+
+For computed or dynamic configuration, override the `appMeta` method on your resource using the fluent `AppMeta`, `Csp`, and `Permissions` builders from the `Laravel\Mcp\Server\Ui` namespace.
+
+<a name="building-apps-with-boost"></a>
+### Building Apps With Boost
+
+Laravel MCP ships with a dedicated [Boost](/docs/{{version}}/boost) skill reference for building MCP Apps. If you have [Laravel Boost](/docs/{{version}}/boost) installed, your AI coding agent can invoke the `mcp-development` skill and ask it to scaffold a complete App Resource, Blade view, and linked tool for you. This is the fastest way to go from idea to a working app without having to memorize the full MCP Apps protocol surface.
+
+For the complete protocol reference, including the full client-side API and schema details, see the official [MCP Apps documentation](https://modelcontextprotocol.io/extensions/apps/overview).
 
 <a name="metadata"></a>
 ## Metadata


### PR DESCRIPTION
Adds documentation for MCP Apps support, which shipped in laravel/mcp#196. 