### PR TITLE
Clarify YEAR column limitations in migrations.md

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -1199,6 +1199,8 @@ The `year` method creates a `YEAR` equivalent column:
 ```php
 $table->year('birth_year');
 ```
+> [!WARNING]
+> The year method creates the `YEAR` equivalent column, but **limited in range**. YEAR accepts input values in a variety of formats, but always in the range '1901' to '2155'. Years previous to '1901' are not accepted by MySQL.
 
 <a name="column-modifiers"></a>
 ### Column Modifiers

--- a/migrations.md
+++ b/migrations.md
@@ -1200,7 +1200,7 @@ The `year` method creates a `YEAR` equivalent column:
 $table->year('birth_year');
 ```
 > [!WARNING]
-> The year method creates the `YEAR` equivalent column, but **limited in range**. YEAR accepts input values in a variety of formats, but always in the range '1901' to '2155'. Years previous to '1901' are not accepted by MySQL.
+> **When using the MySQL engine:** The year method creates the `YEAR` equivalent column, but **limited in range**. YEAR accepts input values in a variety of formats, but always in the range '1901' to '2155'. Years previous to '1901' are not accepted.
 
 <a name="column-modifiers"></a>
 ### Column Modifiers


### PR DESCRIPTION
Added a warning about the range limitation of the YEAR column in MySQL. This warning is important to clarify the **limitations** of this type. In many cases, especially in historical projects or projects dealing with **dates before 1901**, for instance, a company established since 1828, the `integer` type should be used.
In these cases, instead of ```$table->year('founded');``` use `$table->unsignedInteger('founded');` to keep your data coherent.