### PR TITLE
Update description of starter kits in frontend.md

### DIFF
--- a/frontend.md
+++ b/frontend.md
@@ -160,7 +160,7 @@ If you're concerned about diving into Inertia because your application requires 
 <a name="inertia-starter-kits"></a>
 ### Starter Kits
 
-If you would like to build your frontend using Inertia and React / Svelte / Vue, you can leverage our [React, Svelte, or Vue application starter kits](/docs/{{version}}/starter-kits) to jump-start your application's development. Both of these starter kits scaffold your application's backend and frontend authentication flow using Inertia, React / Svelte / Vue, [Tailwind](https://tailwindcss.com), and [Vite](https://vitejs.dev) so that you can start building your next big idea.
+If you would like to build your frontend using Inertia and React / Svelte / Vue, you can leverage our [React, Svelte, or Vue application starter kits](/docs/{{version}}/starter-kits) to jump-start your application's development. All of these starter kits scaffold your application's backend and frontend authentication flow using Inertia, React / Svelte / Vue, [Tailwind](https://tailwindcss.com), and [Vite](https://vitejs.dev) so that you can start building your next big idea.
 
 <a name="bundling-assets"></a>
 ## Bundling Assets


### PR DESCRIPTION
Now there's three starter kits, and not two, it doesn't make sense to say "Both of these starter kits..."