### PR TITLE
Clarify skipping validation rules for empty string

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -3113,3 +3113,6 @@ php artisan make:rule Uppercase --implicit
 
 > [!WARNING]
 > An "implicit" rule only _implies_ that the attribute is required. Whether it actually invalidates a missing or empty attribute is up to you.
+
+> [!NOTE]
+> As mentioned in [a note on optional fields](#a-note-on-optional-fields), when using [Form Request Validation](#form-request-validation), empty strings are converted to `null` by the `ConvertEmptyStringsToNull` middleware. Therefore, they will be passed to the validation rules as `null` , and the rules will not be skipped.

--- a/validation.md
+++ b/validation.md
@@ -3115,4 +3115,4 @@ php artisan make:rule Uppercase --implicit
 > An "implicit" rule only _implies_ that the attribute is required. Whether it actually invalidates a missing or empty attribute is up to you.
 
 > [!NOTE]
-> As mentioned in [a note on optional fields](#a-note-on-optional-fields), when using [Form Request Validation](#form-request-validation), empty strings are converted to `null` by the `ConvertEmptyStringsToNull` middleware. Therefore, they will be passed to the validation rules as `null` , and the rules will not be skipped.
+> As mentioned in [a note on optional fields](#a-note-on-optional-fields), when using [Form Request Validation](#form-request-validation), empty strings are converted to `null` by the `ConvertEmptyStringsToNull` middleware. Therefore, they will be passed to the validation rules as `null`, and the rules will not be skipped.


### PR DESCRIPTION
[Implicit Rules](https://laravel.com/docs/13.x/validation#implicit-rules) explanation says that empty string will skip the validation rules and the example shows it as well.

But, this case is valid when the user uses `Validator::make()`. If the user uses rules in the **FormRequest**, the middleware will convert empty string to `null`, and then the validation rules won't be skipped, and custom rules, even without `--implicit`, will be run. So, to clarify this to the users, in this PR I added a small note about this.