### PR TITLE
Change bug fix branch version from 13.x to 12.x

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -83,7 +83,7 @@ Informal discussion regarding bugs, new features, and implementation of existing
 <a name="which-branch"></a>
 ## Which Branch?
 
-**All** bug fixes should be sent to the latest version that supports bug fixes (currently `13.x`). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
+**All** bug fixes should be sent to the latest version that supports bug fixes (currently `12.x`). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
 
 **Minor** features that are **fully backward compatible** with the current release may be sent to the latest stable branch (currently `13.x`).
 


### PR DESCRIPTION
This part was wrongly updated on this PR : https://github.com/laravel/docs/pull/11102/changes

[Support policy](https://laravel.com/docs/13.x/releases#support-policy) refers to `12.x` for oldest version which allow bug fixes.