### PR TITLE
Document Anthropic prompt caching in AI SDK provider options

### DIFF
--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1016,6 +1016,7 @@ class SalesCoach implements Agent, HasProviderOptions
             ],
             Lab::Anthropic => [
                 'thinking' => ['budget_tokens' => 1024],
+                'cache_control' => ['type' => 'ephemeral'],
             ],
             default => [],
         };
@@ -1024,6 +1025,8 @@ class SalesCoach implements Agent, HasProviderOptions
 ```
 
 The `providerOptions` method receives the provider currently being used (`Lab` enum or string), allowing you to return different options per provider. This is especially useful when using [failover](#failover), since each fallback provider can receive its own configuration.
+
+The Anthropic example above also enables [prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) via `cache_control`.
 
 <a name="images"></a>
 ## Images


### PR DESCRIPTION
Documents how to enable [Anthropic prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) through the AI SDK. This has come up repeatedly in laravel/ai issues/PRs (most recently [laravel/ai#119](https://github.com/laravel/ai/issues/119)) and saves users from going down the rabbit hole of building gateway overrides when the SDK already supports it via `providerOptions`.

### Approach

Rather than adding a new provider-specific subsection (the docs don't currently have provider-specific sections, and adding one for a single option felt heavy), the existing `SalesCoach` provider options example is extended to show `cache_control` alongside the existing `thinking` option for Anthropic, with a one-liner below the example pointing at Anthropic's prompt caching docs.