### PR TITLE
[13.x] Bug fix branch latest is 13.x

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -83,7 +83,7 @@ Informal discussion regarding bugs, new features, and implementation of existing
 <a name="which-branch"></a>
 ## Which Branch?
 
-**All** bug fixes should be sent to the latest version that supports bug fixes (currently `12.x`). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
+**All** bug fixes should be sent to the latest version that supports bug fixes (currently `13.x`). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
 
 **Minor** features that are **fully backward compatible** with the current release may be sent to the latest stable branch (currently `13.x`).
 


### PR DESCRIPTION
https://github.com/laravel/docs/pull/11187 changed this to 12.x which has confused me...

The text says: "bug fixes should be sent to the latest version that supports bug fixes"



<img width="732" height="246" alt="image" src="https://github.com/user-attachments/assets/db1b9ecc-5e81-4c97-af92-3fbf4b28e265" />



The latest version to support bug fixes is 13.x, which is until 2027.

12.x is not the latest... so fixes go to 13.x, which can get backported afaik.

Am I missing something crazy here? or perhaps it needs rewording..


