### PR TITLE
Update branch references from 12.x to 13.x in contribution guide

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -83,7 +83,7 @@ Informal discussion regarding bugs, new features, and implementation of existing
 <a name="which-branch"></a>
 ## Which Branch?
 
-**All** bug fixes should be sent to the latest version that supports bug fixes (currently `12.x`). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
+**All** bug fixes should be sent to the latest version that supports bug fixes (currently `13.x`). Bug fixes should **never** be sent to the `master` branch unless they fix features that exist only in the upcoming release.
 
 **Minor** features that are **fully backward compatible** with the current release may be sent to the latest stable branch (currently `13.x`).
 


### PR DESCRIPTION
Hello Laravel Team! While submitting a change to the framework I saw that the "Which Branch" section of the contribution guide still referenced `12.x` as the current branch for bug fixes.
Since this is the `13.x` documentation branch, these references have been updated accordingly to match the pattern used in previous versions of the documentation (e.g. 11v docs referenced current 11.x for bug fixes, as well as 12v docs referenced 12.x).