### PR TITLE
[13.x] Document named results and task timeouts for Concurrency::run()

### DIFF
--- a/concurrency.md
+++ b/concurrency.md
@@ -2,6 +2,8 @@
 
 - [Introduction](#introduction)
 - [Running Concurrent Tasks](#running-concurrent-tasks)
+- [Named Results](#named-results)
+- [Task Timeouts](#task-timeouts)
 - [Deferring Concurrent Tasks](#deferring-concurrent-tasks)
 
 <a name="introduction"></a>
@@ -49,6 +51,48 @@ Or, to change the default concurrency driver, you should publish the `concurrenc
 
 ```shell
 php artisan config:publish concurrency
+```
+
+<a name="named-results"></a>
+## Named Results
+
+If you would like to access concurrent task results by name rather than by position, you may provide an associative array of closures. Each result will be returned using the same key as its corresponding closure:
+
+```php
+use Illuminate\Support\Facades\Concurrency;
+use Illuminate\Support\Facades\DB;
+
+$results = Concurrency::run([
+    'users' => fn () => DB::table('users')->count(),
+    'orders' => fn () => DB::table('orders')->count(),
+]);
+
+$userCount = $results['users'];
+$orderCount = $results['orders'];
+```
+
+<a name="task-timeouts"></a>
+## Task Timeouts
+
+When using the `process` driver (the default), you may specify a maximum number of seconds a concurrent task is allowed to run before it is terminated by providing a timeout to the `run` method:
+
+```php
+use Illuminate\Support\Facades\Concurrency;
+use Illuminate\Support\Facades\DB;
+
+[$userCount, $orderCount] = Concurrency::run([
+    fn () => DB::table('users')->count(),
+    fn () => DB::table('orders')->count(),
+], timeout: 30);
+```
+
+You may also provide a `CarbonInterval` instance if you prefer a more expressive timeout definition:
+
+```php
+use Carbon\CarbonInterval;
+use Illuminate\Support\Facades\Concurrency;
+
+Concurrency::run([...], timeout: CarbonInterval::seconds(30));
 ```
 
 <a name="deferring-concurrent-tasks"></a>

--- a/concurrency.md
+++ b/concurrency.md
@@ -2,8 +2,8 @@
 
 - [Introduction](#introduction)
 - [Running Concurrent Tasks](#running-concurrent-tasks)
-- [Named Results](#named-results)
-- [Task Timeouts](#task-timeouts)
+    - [Named Results](#named-results)
+    - [Task Timeouts](#task-timeouts)
 - [Deferring Concurrent Tasks](#deferring-concurrent-tasks)
 
 <a name="introduction"></a>
@@ -54,7 +54,7 @@ php artisan config:publish concurrency
 ```
 
 <a name="named-results"></a>
-## Named Results
+### Named Results
 
 If you would like to access concurrent task results by name rather than by position, you may provide an associative array of closures. Each result will be returned using the same key as its corresponding closure:
 
@@ -72,7 +72,7 @@ $orderCount = $results['orders'];
 ```
 
 <a name="task-timeouts"></a>
-## Task Timeouts
+### Task Timeouts
 
 When using the `process` driver (the default), you may specify a maximum number of seconds a concurrent task is allowed to run before it is terminated by providing a timeout to the `run` method:
 
@@ -89,10 +89,11 @@ use Illuminate\Support\Facades\DB;
 You may also provide a `CarbonInterval` instance if you prefer a more expressive timeout definition:
 
 ```php
-use Carbon\CarbonInterval;
 use Illuminate\Support\Facades\Concurrency;
 
-Concurrency::run([...], timeout: CarbonInterval::seconds(30));
+use function Illuminate\Support\seconds;
+
+Concurrency::run([...], timeout: seconds(30));
 ```
 
 <a name="deferring-concurrent-tasks"></a>


### PR DESCRIPTION
The `Concurrency::run()` method supports two features that are currently undocumented:

**Named results** — an associative array of closures can be passed to `run()`, and results are returned using the same keys. Works across all three drivers (`process`, `fork`, `sync`).

**Task timeouts** — the default `process` driver accepts a `timeout` argument (integer seconds or `CarbonInterval` instance), after which a task is terminated.

Both are defined in the `Driver` contract:
https://github.com/laravel/framework/blob/13.x/src/Illuminate/Contracts/Concurrency/Driver.php

```php
public function run(Closure|array $tasks, CarbonInterval|int|null $timeout = null): array;
```

Timeout is applied in `ProcessDriver`:
https://github.com/laravel/framework/blob/13.x/src/Illuminate/Concurrency/ProcessDriver.php

Named keys are preserved in all drivers — via `pool->as($key)` in `ProcessDriver` and `array_combine($keys, $results)` in `ForkDriver`:
https://github.com/laravel/framework/blob/13.x/src/Illuminate/Concurrency/ForkDriver.php