### PR TITLE
fix 404 to `config/cors.php`

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -273,7 +273,7 @@ Even though never officially documented, previous Laravel releases allow you to 
 
 **Likelihood Of Impact: Medium**
 
-Cross-Origin Resource Sharing (CORS) support is now integrated by default. If you are using any third-party CORS libraries you are now advised to use the [new `cors` configuration file](https://github.com/laravel/laravel/blob/master/config/cors.php).
+Cross-Origin Resource Sharing (CORS) support is now integrated by default. If you are using any third-party CORS libraries you are now advised to use the [new `cors` configuration file](https://github.com/laravel/laravel/blob/7.x/config/cors.php).
 
 Next, install the underlying CORS library as a dependency of your application:
 


### PR DESCRIPTION
The link to the `cors.php` no longer exists on the `master` branch so I changed it to use the `7.x` branch instead.