### PR TITLE
[13.x] Fix stray markdown asterisks

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -27,7 +27,7 @@ The `debug` option in your `config/app.php` configuration file determines how mu
 During local development, you should set the `APP_DEBUG` environment variable to `true`.
 
 > [!WARNING]
-> In your production environment, the value of `APP_DEBUG` should always be `false`. If the value is set to `true` in production, you risk exposing sensitive configuration values to your application's end users.**
+> In your production environment, the value of `APP_DEBUG` should always be `false`. If the value is set to `true` in production, you risk exposing sensitive configuration values to your application's end users.
 
 <a name="handling-exceptions"></a>
 ## Handling Exceptions


### PR DESCRIPTION
Description
---
Remove the extra `**` left at the end of the warning block introduced in #11083.