### PR TITLE
[13.x] Clarify SIGTERM behavior

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -863,7 +863,7 @@ $this->callSilently('mail:send', [
 <a name="signal-handling"></a>
 ## Signal Handling
 
-As you may know, operating systems allow signals to be sent to running processes. For example, the `SIGTERM` signal is how operating systems ask a program to terminate. If you wish to listen for signals in your Artisan console commands and execute code when they occur, you may use the `trap` method:
+As you may know, operating systems allow signals to be sent to running processes. For example, the `SIGTERM` signal is how operating systems ask a program to terminate gracefully. If you wish to listen for signals in your Artisan console commands and execute code when they occur, you may use the `trap` method:
 
 ```php
 /**


### PR DESCRIPTION
Description
---
This PR updates the **Signal Handling** section in the Artisan documentation to clarify that **SIGTERM** requests a process to terminate **gracefully**. Unlike the **SIGKILL** which cause it to terminate immediately.

See
---
https://en.wikipedia.org/wiki/Signal_(IPC)#SIGTERM