### PR TITLE
Document caveats of UseCheapestModel and UseSmartestModel

### DIFF
--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1110,6 +1110,9 @@ class ComplexReasoner implements Agent
 }
 ```
 
+> [!WARNING]
+> The underlying model selected by `UseCheapestModel` and `UseSmartestModel` may change between releases of the Laravel AI SDK as providers release new models. Switching models can introduce behavioral changes, deprecated parameters, and significant cost differences. If you need a stable, predictable model and pricing, specify the model explicitly using the `Model` attribute.
+
 <a name="provider-options"></a>
 ### Provider Options
 

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1110,7 +1110,7 @@ class ComplexReasoner implements Agent
 }
 ```
 
-> [!WARNING]
+> [!NOTE]
 > The underlying model selected by `UseCheapestModel` and `UseSmartestModel` may change between releases of the Laravel AI SDK as providers release new models. Switching models can introduce behavioral changes, deprecated parameters, and significant cost differences. If you need a stable, predictable model and pricing, specify the model explicitly using the `Model` attribute.
 
 <a name="provider-options"></a>


### PR DESCRIPTION
The `UseCheapestModel` and `UseSmartestModel` attributes don't currently call out that the underlying model can change between SDK releases, which can shift behavior, prompting, and cost.
