### PR TITLE
[13.x] Added note: teams prompt requires single-file components to be enabled

### DIFF
--- a/starter-kits.md
+++ b/starter-kits.md
@@ -456,6 +456,9 @@ RateLimiter::for('login', function ($request) {
 
 The React, Svelte, Vue, and Livewire starter kits may also be generated with team support. When the teams feature is enabled, each user belongs to one or more teams and has a current team. During registration, new users are automatically given a personal team. The starter kits also include team management screens for creating teams, switching between teams, inviting members, and updating team details.
 
+> [!NOTE]
+> The teams support prompt only appears if you answer **Yes** to the "Would you like to use single-file Livewire components?" prompt. Answering No will skip the teams prompt entirely.
+
 When a route is scoped to the current team, the current team's slug is included in the URL. For example, the dashboard route becomes `/{current_team}/dashboard`, while team management pages use routes such as `settings/teams/{team}`. When using the `{current_team}` and `{team}` route parameters, the starter kits automatically ensure that the authenticated user belongs to the requested team before allowing access to the route.
 
 To make generating team-aware URLs more convenient, the starter kits register URL defaults for the authenticated user's current team. This allows calls to helpers such as `route('dashboard')` to automatically include the current team's slug. When a user signs in, registers, or switches teams, the starter kits update the current team and refresh these URL defaults so generated links continue to use the correct team context.


### PR DESCRIPTION
Adding clarity for why the prompt wasn't showing.