### PR TITLE
[13.x] Document database query logging

### DIFF
--- a/database.md
+++ b/database.md
@@ -6,6 +6,7 @@
 - [Running SQL Queries](#running-queries)
     - [Using Multiple Database Connections](#using-multiple-database-connections)
     - [Listening for Query Events](#listening-for-query-events)
+    - [Logging Queries](#logging-queries)
     - [Monitoring Cumulative Query Time](#monitoring-cumulative-query-time)
 - [Database Transactions](#database-transactions)
 - [Connecting to the Database CLI](#connecting-to-the-database-cli)
@@ -329,6 +330,50 @@ class AppServiceProvider extends ServiceProvider
     }
 }
 ```
+
+### Logging Queries
+
+Laravel can log all the queries that have been executed for debugging. To start capturing, call the `enableQueryLog` on the `DB` facade, then `getQueryLog` to retreive the results:
+
+```php
+DB::enableQueryLog();
+
+DB::select('select * from `books` where `id` = ?', [1]);
+
+$queries = DB::getQueryLog();
+
+// [
+//     [
+//         'query'    => 'select * from `books` where `id` = ?',
+//         'bindings' => [1],
+//         'time'     => 0.34,
+//     ],
+// ]
+```
+
+You can also get the raw SQL queries using `getRawQueryLog`:
+
+```php
+$queries = DB::getRawQueryLog();
+
+// [
+//     [
+//         'raw_query' => 'select * from `books` where `id` = 1',
+//         'time'      => 0.34,
+//     ],
+// ]
+```
+
+To clear the log without disabling it, call `flushQueryLog`. To stop capturing altogether, call `disableQueryLog`:
+
+```php
+DB::flushQueryLog();
+
+DB::disableQueryLog();
+```
+
+> [!NOTE]
+> You can also log the queries on a specific connection: `DB::connection('mysql-replica')->enableQueryLog()`.
 
 <a name="monitoring-cumulative-query-time"></a>
 ### Monitoring Cumulative Query Time

--- a/database.md
+++ b/database.md
@@ -90,7 +90,7 @@ To see how read / write connections should be configured, let's look at this exa
 ```php
 'mysql' => [
     'driver' => 'mysql',
-    
+
     'read' => [
         'host' => [
             '192.168.1.1',
@@ -103,7 +103,7 @@ To see how read / write connections should be configured, let's look at this exa
         ],
     ],
     'sticky' => true,
-    
+
     'port' => env('DB_PORT', '3306'),
     'database' => env('DB_DATABASE', 'laravel'),
     'username' => env('DB_USERNAME', 'root'),
@@ -334,7 +334,7 @@ class AppServiceProvider extends ServiceProvider
 <a name="logging-queries"></a>
 ### Logging Queries
 
-Laravel can log all the queries that have been executed for debugging. To start capturing, call the `enableQueryLog` on the `DB` facade, then `getQueryLog` to retreive the results:
+Laravel can log all the queries that have been executed for debugging. To start capturing, call `enableQueryLog` on the `DB` facade, then `getQueryLog` to retrieve the results:
 
 ```php
 DB::enableQueryLog();
@@ -352,7 +352,7 @@ $queries = DB::getQueryLog();
 // ]
 ```
 
-You can also get the raw SQL queries using `getRawQueryLog`:
+You can also retrieve the raw queries using `getRawQueryLog`:
 
 ```php
 $queries = DB::getRawQueryLog();
@@ -365,7 +365,7 @@ $queries = DB::getRawQueryLog();
 // ]
 ```
 
-To clear the log without disabling it, call `flushQueryLog`. To stop capturing altogether, call `disableQueryLog`:
+To clear the log without disabling it, call `flushQueryLog`, or to stop capturing entirely, call `disableQueryLog`:
 
 ```php
 DB::flushQueryLog();
@@ -373,8 +373,8 @@ DB::flushQueryLog();
 DB::disableQueryLog();
 ```
 
-> [!NOTE]
-> You can also log the queries on a specific connection: `DB::connection('mysql-replica')->enableQueryLog()`.
+> [!WARNING]
+> Query logging stores all executed queries in memory. You should only enable it for local development and debugging.
 
 <a name="monitoring-cumulative-query-time"></a>
 ### Monitoring Cumulative Query Time

--- a/database.md
+++ b/database.md
@@ -334,7 +334,7 @@ class AppServiceProvider extends ServiceProvider
 <a name="logging-queries"></a>
 ### Logging Queries
 
-Laravel can log all the queries that have been executed for debugging. To start capturing, call `enableQueryLog` on the `DB` facade, then `getQueryLog` to retrieve the results:
+Laravel can log all the database queries that have been executed. To start capturing, call the `DB` facade's `enableQueryLog` method, execute some queries, and then call `getQueryLog` to retrieve the results:
 
 ```php
 DB::enableQueryLog();

--- a/database.md
+++ b/database.md
@@ -331,6 +331,7 @@ class AppServiceProvider extends ServiceProvider
 }
 ```
 
+<a name="logging-queries"></a>
 ### Logging Queries
 
 Laravel can log all the queries that have been executed for debugging. To start capturing, call the `enableQueryLog` on the `DB` facade, then `getQueryLog` to retreive the results:

--- a/database.md
+++ b/database.md
@@ -90,7 +90,7 @@ To see how read / write connections should be configured, let's look at this exa
 ```php
 'mysql' => [
     'driver' => 'mysql',
-
+    
     'read' => [
         'host' => [
             '192.168.1.1',
@@ -103,7 +103,7 @@ To see how read / write connections should be configured, let's look at this exa
         ],
     ],
     'sticky' => true,
-
+    
     'port' => env('DB_PORT', '3306'),
     'database' => env('DB_DATABASE', 'laravel'),
     'username' => env('DB_USERNAME', 'root'),

--- a/database.md
+++ b/database.md
@@ -334,7 +334,7 @@ class AppServiceProvider extends ServiceProvider
 <a name="logging-queries"></a>
 ### Logging Queries
 
-Laravel can log all the database queries that have been executed. To start capturing, call the `DB` facade's `enableQueryLog` method, execute some queries, and then call `getQueryLog` to retrieve the results:
+Laravel can log every database query that has been executed. To start capturing, call the `DB` facade's `enableQueryLog` method, execute some queries, and then call `getQueryLog` to retrieve the results:
 
 ```php
 DB::enableQueryLog();
@@ -365,7 +365,7 @@ $queries = DB::getRawQueryLog();
 // ]
 ```
 
-To clear the log without disabling it, call `flushQueryLog`, or to stop capturing entirely, call `disableQueryLog`:
+To clear the log, call `flushQueryLog`, or to stop capturing entirely, call `disableQueryLog`:
 
 ```php
 DB::flushQueryLog();


### PR DESCRIPTION
I find database query logging really useful for local development debugging, particularly the `getRawQueries()` method. 

I figured it would be nice to document some of this stuff, to save others having to dig around in the codebase to find it.