### PR TITLE
[13.x] Document model-per-provider failover and failover-triggering exceptions

### DIFF
--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1768,10 +1768,7 @@ $image = Image::of('A donut sitting on the kitchen counter')
 
 Failover only occurs when a `FailoverableException` is thrown — such as a rate limit (`RateLimitedException`), an overloaded or unavailable provider (`ProviderOverloadedException`), or insufficient credits (`InsufficientCreditsException`). Ordinary errors, like a validation or bad request error, will not trigger failover.
 
-> [!WARNING]
-> When you pass a plain list of providers, such as `[Lab::OpenAI, Lab::Anthropic]`, each provider uses its **default model**. The model defined via the `#[Model]` attribute (or `model()` method) on your agent is **not** applied to providers listed this way.
-
-To specify a particular model for each provider in the failover chain, pass an associative array keyed by the provider, using the `Lab` enum's `value` as the key (enum cases cannot be used directly as PHP array keys):
+When you pass a plain list of providers, such as `[Lab::OpenAI, Lab::Anthropic]`, each provider uses its default model. To specify a particular model for each provider in the failover chain, pass an associative array keyed by the provider, using the `Lab` enum's `value` as the key (enum cases cannot be used directly as PHP array keys):
 
 ```php
 use Laravel\Ai\Enums\Lab;
@@ -1784,9 +1781,6 @@ $response = (new SalesCoach)->prompt(
     ],
 );
 ```
-
-The first entry is the primary provider / model, and each subsequent entry is tried in order if the previous one fails over. You may listen for the `Laravel\Ai\Events\AgentFailedOver` event to log or monitor each failover that occurs.
-
 
 <a name="testing"></a>
 ## Testing

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1754,6 +1754,7 @@ When prompting or generating other media, you may provide an array of providers 
 
 ```php
 use App\Ai\Agents\SalesCoach;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Image;
 
 $response = (new SalesCoach)->prompt(
@@ -1764,6 +1765,28 @@ $response = (new SalesCoach)->prompt(
 $image = Image::of('A donut sitting on the kitchen counter')
     ->generate(provider: [Lab::Gemini, Lab::xAI]);
 ```
+
+Failover only occurs when a `FailoverableException` is thrown — such as a rate limit (`RateLimitedException`), an overloaded or unavailable provider (`ProviderOverloadedException`), or insufficient credits (`InsufficientCreditsException`). Ordinary errors, like a validation or bad request error, will not trigger failover.
+
+> [!WARNING]
+> When you pass a plain list of providers, such as `[Lab::OpenAI, Lab::Anthropic]`, each provider uses its **default model**. The model defined via the `#[Model]` attribute (or `model()` method) on your agent is **not** applied to providers listed this way.
+
+To specify a particular model for each provider in the failover chain, pass an associative array keyed by the provider, using the `Lab` enum's `value` as the key (enum cases cannot be used directly as PHP array keys):
+
+```php
+use Laravel\Ai\Enums\Lab;
+
+$response = (new SalesCoach)->prompt(
+    'Analyze this sales transcript...',
+    provider: [
+        Lab::Gemini->value => 'gemini-3-flash-preview',
+        Lab::DeepSeek->value => 'deepseek-v4-pro',
+    ],
+);
+```
+
+The first entry is the primary provider / model, and each subsequent entry is tried in order if the previous one fails over. You may listen for the `Laravel\Ai\Events\AgentFailedOver` event to log or monitor each failover that occurs.
+
 
 <a name="testing"></a>
 ## Testing


### PR DESCRIPTION
This PR expands the **Failover** section with two clarifications that are
currently missing:

1. **Model per provider.** A plain list like `[Lab::OpenAI, Lab::Anthropic]`
   makes each provider fall back to its *default* model — the agent's
   `#[Model]` attribute (or `model()` method) is not applied. This isn't
   documented, and it's surprising. I added the associative-array form
   (`Lab::Gemini->value => 'gemini-3-flash-preview'`) for specifying a model
   per provider, and noted that enum cases can't be used directly as array keys.

2. **Which exceptions trigger failover.** Documented that failover only happens
   on a `FailoverableException` (rate limit, overloaded provider, insufficient
   credits) and not on ordinary errors, plus the `AgentFailedOver` event for
   monitoring.

Docs-only change.