### PR TITLE
Document Vite font optimization

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -714,7 +714,7 @@ Grouped imports are also supported with both function and const modifiers, allow
 <a name="fonts"></a>
 ### Fonts
 
-When using [Laravel's Vite font optimization](/docs/{{version}}/vite#working-with-fonts), you may use the `@fonts` directive to render the configured font preload links and inline font CSS in your application's layout:
+When using [Laravel's Vite font optimization](/docs/{{version}}/vite#working-with-fonts), you may use the `@fonts` directive to render your configured font preload links and inline font CSS in your application's layout:
 
 ```blade
 <!doctype html>
@@ -726,7 +726,7 @@ When using [Laravel's Vite font optimization](/docs/{{version}}/vite#working-wit
 </head>
 ```
 
-The `@fonts` directive renders all font families configured in your `vite.config.js` file. The directive should typically be placed in the `<head>` of your application's root layout before the content that uses those fonts.
+The `@fonts` directive renders all font families configured in your `vite.config.js` file. The directive should typically be placed in the `<head>` of your application's root layout before any content that uses those fonts.
 
 If a page only needs some of your configured fonts, you may pass one or more font aliases to the directive:
 
@@ -738,7 +738,7 @@ If a page only needs some of your configured fonts, you may pass one or more fon
 @fonts(['sans', 'mono'])
 ```
 
-Font aliases are configured using the `alias` option when defining fonts in your Vite configuration. Under the hood, the `@fonts` directive calls the `fonts` method provided by the `Vite` facade, which may also be invoked directly:
+Font aliases are configured using the `alias` option when defining fonts in your Vite configuration. The `@fonts` directive calls the `fonts` method provided by the `Vite` facade, which may also be invoked directly:
 
 ```blade
 {{ Vite::fonts(['sans', 'mono']) }}

--- a/blade.md
+++ b/blade.md
@@ -15,6 +15,7 @@
     - [Including Subviews](#including-subviews)
     - [The `@once` Directive](#the-once-directive)
     - [Raw PHP](#raw-php)
+    - [Fonts](#fonts)
     - [Comments](#comments)
 - [Components](#components)
     - [Rendering Components](#rendering-components)
@@ -708,6 +709,39 @@ Grouped imports are also supported with both function and const modifiers, allow
 ```blade
 @use(function App\Helpers\{format_currency, format_date})
 @use(const App\Constants\{MAX_ATTEMPTS, DEFAULT_TIMEOUT})
+```
+
+<a name="fonts"></a>
+### Fonts
+
+When using [Laravel's Vite font optimization](/docs/{{version}}/vite#working-with-fonts), you may use the `@fonts` directive to render the configured font preload links and inline font CSS in your application's layout:
+
+```blade
+<!doctype html>
+<head>
+    {{-- ... --}}
+
+    @fonts
+    @vite('resources/js/app.js')
+</head>
+```
+
+The `@fonts` directive renders all font families configured in your `vite.config.js` file. The directive should typically be placed in the `<head>` of your application's root layout before the content that uses those fonts.
+
+If a page only needs some of your configured fonts, you may pass one or more font aliases to the directive:
+
+```blade
+{{-- Load a single font alias... --}}
+@fonts('sans')
+
+{{-- Load multiple font aliases... --}}
+@fonts(['sans', 'mono'])
+```
+
+Font aliases are configured using the `alias` option when defining fonts in your Vite configuration. Under the hood, the `@fonts` directive calls the `fonts` method provided by the `Vite` facade, which may also be invoked directly:
+
+```blade
+{{ Vite::fonts(['sans', 'mono']) }}
 ```
 
 <a name="comments"></a>

--- a/vite.md
+++ b/vite.md
@@ -15,6 +15,10 @@
   - [Inertia](#inertia)
   - [URL Processing](#url-processing)
 - [Working With Stylesheets](#working-with-stylesheets)
+- [Working With Fonts](#working-with-fonts)
+  - [Font Providers](#font-providers)
+  - [Local Fonts](#local-fonts)
+  - [Font Options](#font-options)
 - [Working With Blade and Routes](#working-with-blade-and-routes)
   - [Processing Static Assets With Vite](#blade-processing-static-assets)
   - [Refreshing on Save](#blade-refreshing-on-save)
@@ -473,6 +477,115 @@ composer run dev
 
 Your application's CSS may be placed within the `resources/css/app.css` file.
 
+<a name="working-with-fonts"></a>
+## Working With Fonts
+
+The Laravel Vite plugin can self-host and optimize fonts for your application. When fonts are configured, the plugin resolves the requested font files, emits them as Vite assets, generates font CSS, and writes a font manifest that may be consumed by Blade's [`@fonts` directive](/docs/{{version}}/blade#fonts).
+
+To configure fonts, import one or more provider helpers from `laravel-vite-plugin/fonts` and add them to the Laravel plugin's `fonts` option:
+
+```js
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+import { google } from 'laravel-vite-plugin/fonts';
+
+export default defineConfig({
+    plugins: [
+        laravel({
+            input: 'resources/js/app.js',
+            fonts: [
+                google('Inter', {
+                    alias: 'sans',
+                    weights: [400, 500, 600, 700],
+                    styles: ['normal', 'italic'],
+                    subsets: ['latin'],
+                    display: 'swap',
+                    preload: [
+                        { weight: 400 },
+                        { weight: 700 },
+                    ],
+                    fallbacks: ['system-ui', 'sans-serif'],
+                }),
+            ],
+        }),
+    ],
+});
+```
+
+In this example, the `Inter` font will be available through the `sans` alias. The plugin will generate a `--font-sans` CSS variable and a `.font-sans` utility class that applies the generated font stack.
+
+<a name="font-providers"></a>
+### Font Providers
+
+The Laravel Vite plugin includes provider helpers for Google Fonts, Bunny Fonts, Fontsource, and local fonts:
+
+```js
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+import { bunny, fontsource, google, local } from 'laravel-vite-plugin/fonts';
+
+export default defineConfig({
+    plugins: [
+        laravel({
+            input: 'resources/js/app.js',
+            fonts: [
+                google('Inter', { alias: 'sans' }),
+                bunny('Figtree', { alias: 'body' }),
+                fontsource('JetBrains Mono', { alias: 'mono' }),
+                local('Brand Sans', {
+                    alias: 'brand',
+                    src: 'resources/fonts/brand-sans',
+                }),
+            ],
+        }),
+    ],
+});
+```
+
+The `fontsource` provider reads fonts from an installed Fontsource package. By default, the package name is derived from the font family, such as `@fontsource/jetbrains-mono`. If your application uses a different package name, you may specify it using the `package` option.
+
+<a name="local-fonts"></a>
+### Local Fonts
+
+When using local fonts, the `src` option may point to a single font file, a directory, or a glob pattern. The plugin will discover supported font files and infer their weight and style from the filenames:
+
+```js
+local('Brand Sans', {
+    alias: 'brand',
+    src: 'resources/fonts/brand-sans/*.woff2',
+})
+```
+
+If you need full control over the available variants, you may define them explicitly using the `variants` option:
+
+```js
+local('Brand Sans', {
+    alias: 'brand',
+    variants: [
+        { src: 'resources/fonts/BrandSans-Regular.woff2', weight: 400 },
+        { src: 'resources/fonts/BrandSans-Italic.woff2', weight: 400, style: 'italic' },
+        { src: ['resources/fonts/BrandSans-Bold.woff2', 'resources/fonts/BrandSans-Bold.ttf'], weight: 700 },
+    ],
+})
+```
+
+<a name="font-options"></a>
+### Font Options
+
+Depending on the provider, font definitions may accept several options that allow you to customize the generated font CSS:
+
+- `alias` defines the name used by Blade's `@fonts` directive and defaults to a slug of the font family.
+- `variable` defines the generated CSS variable and defaults to `--font-{alias}`.
+- `weights` defines the remote or Fontsource font weights that should be resolved and defaults to `[400]`.
+- `styles` defines the remote or Fontsource font styles that should be resolved and defaults to `['normal']`.
+- `subsets` defines the remote or Fontsource font subsets that should be resolved and defaults to `['latin']`.
+- `display` defines the `font-display` value and defaults to `swap`.
+- `preload` controls which WOFF2 font variants should be preloaded. This option may be `true`, `false`, or an array of `{ weight, style }` selectors.
+- `fallbacks` defines additional fallback fonts that should be appended to the generated font stack.
+- `optimizedFallbacks` attempts to generate metric-adjusted fallback font faces using the optional `fontaine` package and defaults to `true`.
+
+Local fonts are resolved from the `src` or `variants` options described above instead of using `weights`, `styles`, and `subsets`.
+
 <a name="working-with-blade-and-routes"></a>
 ## Working With Blade and Routes
 
@@ -481,7 +594,7 @@ Your application's CSS may be placed within the `resources/css/app.css` file.
 
 When referencing assets in your JavaScript or CSS, Vite automatically processes and versions them. In addition, when building Blade based applications, Vite can also process and version static assets that you reference solely in Blade templates.
 
-However, in order to accomplish this, you need to make Vite aware of your assets by specifying them in the plugin's `assets` option. For example, if you want to process and version all images stored in `resources/images` and all fonts stored in `resources/fonts`, you should add the following to your Vite configuration:
+However, in order to accomplish this, you need to make Vite aware of your assets by specifying them in the plugin's `assets` option. This option is intended for static files that you want to reference directly with `Vite::asset`; if you want Laravel to generate font CSS and preload links, use the [`fonts` option](#working-with-fonts) instead. For example, if you want to process and version all images stored in `resources/images` and all fonts stored in `resources/fonts`, you should add the following to your Vite configuration:
 
 ```js
 laravel({

--- a/vite.md
+++ b/vite.md
@@ -574,6 +574,8 @@ local('Brand Sans', {
 
 Depending on the provider, font definitions may accept several options that allow you to customize the generated font CSS:
 
+<div class="content-list" markdown="1">
+
 - `alias` defines the name used by Blade's `@fonts` directive and defaults to a slug of the font family.
 - `variable` defines the generated CSS variable and defaults to `--font-{alias}`.
 - `weights` defines the remote or Fontsource font weights that should be resolved and defaults to `[400]`.
@@ -583,6 +585,8 @@ Depending on the provider, font definitions may accept several options that allo
 - `preload` controls which WOFF2 font variants should be preloaded. This option may be `true`, `false`, or an array of `{ weight, style }` selectors.
 - `fallbacks` defines additional fallback fonts that should be appended to the generated font stack.
 - `optimizedFallbacks` attempts to generate metric-adjusted fallback font faces using the optional `fontaine` package and defaults to `true`.
+
+</div>
 
 Local fonts are resolved from the `src` or `variants` options described above instead of using `weights`, `styles`, and `subsets`.
 

--- a/vite.md
+++ b/vite.md
@@ -480,7 +480,7 @@ Your application's CSS may be placed within the `resources/css/app.css` file.
 <a name="working-with-fonts"></a>
 ## Working With Fonts
 
-The Laravel Vite plugin can self-host and optimize fonts for your application. When fonts are configured, the plugin resolves the requested font files, emits them as Vite assets, generates font CSS, and writes a font manifest that may be consumed by Blade's [`@fonts` directive](/docs/{{version}}/blade#fonts).
+The Laravel Vite plugin can serve optimized, self-hosted fonts for your application. When fonts are configured, the plugin resolves the requested font files, emits them as Vite assets, generates font CSS, and writes a font manifest that may be consumed by Blade's [`@fonts` directive](/docs/{{version}}/blade#fonts).
 
 To configure fonts, import one or more provider helpers from `laravel-vite-plugin/fonts` and add them to the Laravel plugin's `fonts` option:
 
@@ -547,7 +547,7 @@ The `fontsource` provider reads fonts from an installed Fontsource package. By d
 <a name="local-fonts"></a>
 ### Local Fonts
 
-When using local fonts, the `src` option may point to a single font file, a directory, or a glob pattern. The plugin will discover supported font files and infer their weight and style from the filenames:
+When using local fonts, the `src` option may point to a single font file, a directory, or a glob pattern. The plugin will discover supported font files and infer their weight and style from their filenames:
 
 ```js
 local('Brand Sans', {
@@ -592,9 +592,11 @@ Local fonts are resolved from the `src` or `variants` options described above in
 <a name="blade-processing-static-assets"></a>
 ### Processing Static Assets With Vite
 
-When referencing assets in your JavaScript or CSS, Vite automatically processes and versions them. In addition, when building Blade based applications, Vite can also process and version static assets that you reference solely in Blade templates.
+When referencing assets in your JavaScript or CSS, Vite automatically processes and versions them. In addition, when building Blade-based applications, Vite can also process and version static assets that you reference solely in Blade templates.
 
-However, in order to accomplish this, you need to make Vite aware of your assets by specifying them in the plugin's `assets` option. This option is intended for static files that you want to reference directly with `Vite::asset`; if you want Laravel to generate font CSS and preload links, use the [`fonts` option](#working-with-fonts) instead. For example, if you want to process and version all images stored in `resources/images` and all fonts stored in `resources/fonts`, you should add the following to your Vite configuration:
+However, to accomplish this, you need to make Vite aware of your assets by specifying them in the plugin's `assets` option. This option is intended for static files that you want to reference directly with `Vite::asset`. If you want Laravel to generate font CSS and preload links, use the [`fonts` option](#working-with-fonts) instead.
+
+For example, if you want to process and version all images stored in `resources/images` and all fonts stored in `resources/fonts`, you should add the following to your Vite configuration:
 
 ```js
 laravel({


### PR DESCRIPTION
Laravel now has Vite font optimization support through laravel/vite-plugin#348 and laravel/framework#59584, so the docs should explain how to configure fonts and render them from Blade.

This adds Vite documentation for font providers, local fonts, and font options, plus Blade documentation for the @fonts directive and alias-based loading.