### PR TITLE
[13.x] Make attributed `#[Scope]` usage reflect the actual state of the feature

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1638,7 +1638,7 @@ class User extends Model
      * Scope a query to only include users of a given type.
      */
     #[Scope]
-    protected function ofType(Builder $query, string $type): void
+    public function ofType(Builder $query, string $type): void
     {
         $query->where('type', $type);
     }

--- a/eloquent.md
+++ b/eloquent.md
@@ -1638,7 +1638,7 @@ class User extends Model
      * Scope a query to only include users of a given type.
      */
     #[Scope]
-    public function ofType(Builder $query, string $type): void
+    protected function ofType(Builder $query, string $type): void
     {
         $query->where('type', $type);
     }
@@ -1648,7 +1648,7 @@ class User extends Model
 Once the expected arguments have been added to your scope method's signature, you may pass the arguments when calling the scope:
 
 ```php
-$users = User::ofType('admin')->get();
+$users = User::query()->ofType('admin')->get();
 ```
 
 <a name="pending-attributes"></a>


### PR DESCRIPTION
See https://github.com/laravel/framework/issues/55414#issuecomment-4638675296

TL;DR\
Due to the limitations of PHP as a language and its use in patterns of the framework, it is impossible to have protected attributed scopes accessed from outside the model as explained in the above issue.

The example, as it is in the docs right now, doesn't work.

Thanks to: @siarheipashkevich, @decadence, @JackBayliss
