### PR TITLE
[13.x] Add note on the limitations of the attributed `#[Scope]` variant

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1651,10 +1651,7 @@ Once the expected arguments have been added to your scope method's signature, yo
 $users = User::ofType('admin')->get();
 ```
 
-> [!WARNING]
-> Attributed scopes have to be `protected`, so the method can be called by Laravel's magic from outside, otherwise, you would have to pass the `Builder` inside if the method was `public`.\
-> When using the scope inside another model method, the `protected` method can be accessed or outside the model statically, you have to use `::query()` before calling the method, to make sure, it's called on the `Builder`, not the model for Laravel's magic to work.\
-> Another solution is to use the old way of writing scope without the attribute and instead with a `scope*` prefix before the actual scope method's name, so that there is no method with the scope's name and and Laravel's magic can work as intended.
+Attributed scope methods should be `protected`. When calling an attributed scope from within the model class, call the scope through a query builder instance, such as `static::query()->ofType('admin')`, to ensure the call is routed through Eloquent's scope handling.
 
 <a name="pending-attributes"></a>
 ### Pending Attributes

--- a/eloquent.md
+++ b/eloquent.md
@@ -1651,6 +1651,11 @@ Once the expected arguments have been added to your scope method's signature, yo
 $users = User::ofType('admin')->get();
 ```
 
+> [!WARNING]
+> Attributed scopes have to be `protected`, so the method can be called by Laravel's magic from outside, otherwise, you would have to pass the `Builder` inside if the method was `public`.\
+> When using the scope inside another model method, the `protected` method can be accessed or outside the model statically, you have to use `::query()` before calling the method, to make sure, it's called on the `Builder`, not the model for Laravel's magic to work.\
+> Another solution is to use the old way of writing scope without the attribute and instead with a `scope*` prefix before the actual scope method's name, so that there is no method with the scope's name and and Laravel's magic can work as intended.
+
 <a name="pending-attributes"></a>
 ### Pending Attributes
 


### PR DESCRIPTION
See https://github.com/laravel/framework/issues/55414#issuecomment-4638675296

TL;DR\
Due to the limitations of PHP as a language and its use in patterns of the framework, it is impossible to have protected attributed scopes accessed from outside the model as explained in the above issue.

The attributed scope works fine in most cases, but it does have its edge cases, so devs should be made aware of this when reading the docs, especially since the old prefixing variant was entirely scraped from this version's docs.

Thanks to: @siarheipashkevich, @decadence, @JackBayliss

This is a very rough write-up, I appreciate any hints on how to improve the wording.