### PR TITLE
Document command class support for Artisan methods

### DIFF
--- a/artisan.md
+++ b/artisan.md
@@ -774,13 +774,13 @@ Route::post('/user/{user}/mail', function (string $user) {
 });
 ```
 
-You may also pass the entire Artisan command to the `call` method as a string:
+Alternatively, you may pass the entire Artisan command to the `call` method as a string:
 
 ```php
 Artisan::call('mail:send 1 --queue=default');
 ```
 
-Alternatively, you may pass the command class to the `call` method:
+Additionally, you may pass the command class to the `call` method:
 
 ```php
 $exitCode = Artisan::call(SendEmails::class, [
@@ -833,7 +833,7 @@ Route::post('/user/{user}/mail', function (string $user) {
 });
 ```
 
-Alternatively, You may also pass the command class to the `queue` method:
+Alternatively, you may also pass the command class to the `queue` method:
 
 ```php
 Artisan::queue(SendEmails::class, [
@@ -868,7 +868,7 @@ public function handle(): void
 }
 ```
 
-Alternatively, you may pass the command class to the `call` method:
+Alternatively, you may also pass the command class to the `call` method:
 
 ```php
 $this->call(SendEmails::class, [

--- a/artisan.md
+++ b/artisan.md
@@ -774,10 +774,18 @@ Route::post('/user/{user}/mail', function (string $user) {
 });
 ```
 
-Alternatively, you may pass the entire Artisan command to the `call` method as a string:
+You may also pass the entire Artisan command to the `call` method as a string:
 
 ```php
 Artisan::call('mail:send 1 --queue=default');
+```
+
+Alternatively, you may pass the command class to the `call` method:
+
+```php
+$exitCode = Artisan::call(SendEmails::class, [
+    'user' => 1, '--queue' => 'default'
+]);
 ```
 
 <a name="passing-array-values"></a>
@@ -825,6 +833,14 @@ Route::post('/user/{user}/mail', function (string $user) {
 });
 ```
 
+Alternatively, You may also pass the command class to the `queue` method:
+
+```php
+Artisan::queue(SendEmails::class, [
+    'user' => 1, '--queue' => 'default'
+]);
+```
+
 Using the `onConnection` and `onQueue` methods, you may specify the connection or queue the Artisan command should be dispatched to:
 
 ```php
@@ -836,7 +852,7 @@ Artisan::queue('mail:send', [
 <a name="calling-commands-from-other-commands"></a>
 ### Calling Commands From Other Commands
 
-Sometimes you may wish to call other commands from an existing Artisan command. You may do so using the `call` method. This `call` method accepts the command name and an array of command arguments / options:
+Sometimes you may wish to call other commands from an existing Artisan command. You may do so using the `call` method. This `call` method accepts the command's signature or command class, and an array of command arguments / options:
 
 ```php
 /**
@@ -852,10 +868,21 @@ public function handle(): void
 }
 ```
 
+Alternatively, you may pass the command class to the `call` method:
+
+```php
+$this->call(SendEmails::class, [
+    'user' => 1, '--queue' => 'default'
+]);
+```
+
 If you would like to call another console command and suppress all of its output, you may use the `callSilently` method. The `callSilently` method has the same signature as the `call` method:
 
 ```php
 $this->callSilently('mail:send', [
+    'user' => 1, '--queue' => 'default'
+]);
+$this->callSilently(SendEmails::class, [
     'user' => 1, '--queue' => 'default'
 ]);
 ```

--- a/console-tests.md
+++ b/console-tests.md
@@ -13,11 +13,15 @@ In addition to simplifying HTTP testing, Laravel provides a simple API for testi
 <a name="success-failure-expectations"></a>
 ## Success / Failure Expectations
 
-To get started, let's explore how to make assertions regarding an Artisan command's exit code. To accomplish this, we will use the `artisan` method to invoke an Artisan command from our test. Then, we will use the `assertExitCode` method to assert that the command completed with a given exit code:
+To get started, let's explore how to make assertions regarding an Artisan command's exit code. To accomplish this, we will use the `artisan` method to invoke an Artisan command from our test. The `artisan` method accepts either the command's signature or command class. Then, we will use the `assertExitCode` method to assert that the command completed with a given exit code:
 
 ```php tab=Pest
 test('console command', function () {
     $this->artisan('inspire')->assertExitCode(0);
+});
+
+test('console command using command class', function () {
+    $this->artisan(InspireCommand::class)->assertExitCode(0);
 });
 ```
 
@@ -28,6 +32,14 @@ test('console command', function () {
 public function test_console_command(): void
 {
     $this->artisan('inspire')->assertExitCode(0);
+}
+
+/**
+ * Test a console command using command class.
+ */
+public function test_console_command_using_command_class(): void
+{
+    $this->artisan(InspireCommand::class)->assertExitCode(0);
 }
 ```
 


### PR DESCRIPTION
This PR updates the documentation to reflect that `Artisan::call`, `Artisan::queue`, and `$this->call` methods now support passing the command class directly, in addition to the command signature. The code example for the console test is also updated.

I discovered this behavior was not previously documented and traced it back to the implementation in this framework PR: https://github.com/laravel/framework/pull/56530.

edited:
I apologize for missing the previous discussion on this topic in https://github.com/laravel/docs/pull/10683#issuecomment-3160555631, but I still believe documenting this is helpful for users, as it provides a type-safe and refactor-friendly alternative to string-based signatures, significantly reducing potential runtime errors.