### PR TITLE
Add warning about messages() method conflict with RemembersConversati…

### DIFF
--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -316,7 +316,7 @@ class SalesCoach implements Agent, Conversational
 }
 ```
 
-> **Note:** When using `RemembersConversations`, do not define a `messages()` method in your agent class. If a `messages()` method is present, it will take precedence over the trait's implementation and conversation history will not be loaded from the database. The `make:agent` Artisan command generates a `messages()` method by default — remove it when adding `RemembersConversations` to your agent.
+When using the `RemembersConversations` trait, do not manually define a `messages` method in your agent class. If a `messages` method is present, it will take precedence over the trait's implementation and conversation history will not be loaded from the database.
 
 To start a new conversation for a user, call the `forUser` method before prompting:
 

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -316,6 +316,8 @@ class SalesCoach implements Agent, Conversational
 }
 ```
 
+> **Note:** When using `RemembersConversations`, do not define a `messages()` method in your agent class. If a `messages()` method is present, it will take precedence over the trait's implementation and conversation history will not be loaded from the database. The `make:agent` Artisan command generates a `messages()` method by default — remove it when adding `RemembersConversations` to your agent.
+
 To start a new conversation for a user, call the `forUser` method before prompting:
 
 ```php


### PR DESCRIPTION
When using the RemembersConversations trait, defining a messages() method 
in the agent class causes PHP to silently prioritize the class method over 
the trait's implementation, resulting in conversation history never being 
loaded from the database.

This is a common pitfall because the make:agent Artisan command generates 
a messages() method by default. Developers adding RemembersConversations 
to an existing agent may not realize they need to remove it.

Confirmed via ReflectionMethod:
- Agent with messages(): method resolves to the agent class → trait ignored
- Agent without messages(): method resolves to RemembersConversations.php → works correctly