### PR TITLE
Update API documentation link to 13.x

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -110,4 +110,4 @@
     - [Socialite](/docs/{{version}}/socialite)
     - [Telescope](/docs/{{version}}/telescope)
     - [Valet](/docs/{{version}}/valet)
-- [API Documentation](https://api.laravel.com/docs/12.x)
+- [API Documentation](https://api.laravel.com/docs/13.x)


### PR DESCRIPTION
The "API Documentation" link in `documentation.md` pointed to `https://api.laravel.com/docs/12.x` on the 13.x branch. This updates it to point to the 13.x API documentation.