### PR TITLE
docs(ai-sdk): correct environment variable for custom base URL

### DIFF
--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -105,7 +105,7 @@ You may configure custom base URLs by adding a `url` parameter to your provider 
     'openai' => [
         'driver' => 'openai',
         'key' => env('OPENAI_API_KEY'),
-        'url' => env('OPENAI_BASE_URL'),
+        'url' => env('OPENAI_URL'),
     ],
 
     'anthropic' => [


### PR DESCRIPTION
The AI SDK documentation incorrectly referenced `OPENAI_BASE_URL` for the custom provider URL configuration.
The actual environment variable used in the `config/ai.php` file is `OPENAI_URL`.

Fixes the example in the \"Custom Base URLs\" section.