### PR TITLE
[13.x] Document the DatabaseRefreshed command

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -1615,11 +1615,11 @@ For convenience, each migration operation will dispatch an [event](/docs/{{versi
 | ------------------------------------------------ | ------------------------------------------------ |
 | `Illuminate\Database\Events\DatabaseRefreshed`   | The `migrate:refresh` command has finished.      |
 | `Illuminate\Database\Events\MigrationsStarted`   | A batch of migrations is about to be executed.   |
-| `Illuminate\Database\Events\MigrationsEnded`     | A batch of migrations has finished executing.    |
+| `Illuminate\Database\Events\MigrationsEnded`     | A batch of migrations has finished.              |
 | `Illuminate\Database\Events\MigrationStarted`    | A single migration is about to be executed.      |
-| `Illuminate\Database\Events\MigrationEnded`      | A single migration has finished executing.       |
+| `Illuminate\Database\Events\MigrationEnded`      | A single migration has finished.                 |
 | `Illuminate\Database\Events\NoPendingMigrations` | A migration command found no pending migrations. |
-| `Illuminate\Database\Events\SchemaDumped`        | A database schema dump has completed.            |
+| `Illuminate\Database\Events\SchemaDumped`        | A database schema dump has finished.             |
 | `Illuminate\Database\Events\SchemaLoaded`        | An existing database schema dump has loaded.     |
 
 </div>

--- a/migrations.md
+++ b/migrations.md
@@ -1613,6 +1613,7 @@ For convenience, each migration operation will dispatch an [event](/docs/{{versi
 
 | Class                                            | Description                                      |
 | ------------------------------------------------ | ------------------------------------------------ |
+| `Illuminate\Database\Events\DatabaseRefreshed`   | The `migrate:refresh` command has finished.      |
 | `Illuminate\Database\Events\MigrationsStarted`   | A batch of migrations is about to be executed.   |
 | `Illuminate\Database\Events\MigrationsEnded`     | A batch of migrations has finished executing.    |
 | `Illuminate\Database\Events\MigrationStarted`    | A single migration is about to be executed.      |


### PR DESCRIPTION
I regularly run the `migrate:refresh` in local. When that command finishes execution, I also want to empty my local file storage.

I have no idea about the `Illuminate\Database\Events\DatabaseRefreshed` event till I read the source code.