### PR TITLE
[13.x] Fix the session cookie name in the upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -94,11 +94,11 @@ Or, if you are using [Laravel Herd's](https://herd.laravel.com) bundled copy of 
 
 **Likelihood Of Impact: Low**
 
-Laravel's default cache and Redis key prefixes now use hyphenated suffixes.
+Laravel's default cache and Redis key prefixes now use hyphenated suffixes. The default session cookie name is now generated using `Str::snake` rather than `Str::slug`, but it keeps its underscore suffix and is therefore unchanged for typical application names.
 
 In most applications, this change will not apply because application-level configuration files already define these values. This primarily affects applications that rely on framework-level fallback configuration when corresponding application config values are not present.
 
-If your application relies on these generated defaults, cache keys and session cookie names may change after upgrading:
+If your application relies on these generated defaults, cache and Redis keys may change after upgrading:
 
 ```php
 // Laravel <= 12.x
@@ -109,10 +109,12 @@ Str::slug((string) env('APP_NAME', 'laravel'), '_').'_session';
 // Laravel >= 13.x
 Str::slug((string) env('APP_NAME', 'laravel')).'-cache-';
 Str::slug((string) env('APP_NAME', 'laravel')).'-database-';
-Str::slug((string) env('APP_NAME', 'laravel')).'-session';
+Str::snake((string) env('APP_NAME', 'laravel')).'_session';
 ```
 
-To retain previous behavior, explicitly configure `CACHE_PREFIX`, `REDIS_PREFIX`, and `SESSION_COOKIE` in your environment.
+Because `Str::snake` and the previous `Str::slug(..., '_')` resolve to the same value for most application names, the session cookie name — and therefore existing user sessions — will typically be unaffected.
+
+To retain the previous cache and Redis key prefixes, explicitly configure `CACHE_PREFIX` and `REDIS_PREFIX` in your environment. The session cookie name is unchanged for most applications; if your application name resolves to a different value under `Str::snake`, you may also set `SESSION_COOKIE`.
 
 <a name="store-and-repository-contracts-touch"></a>
 #### `Store` and `Repository` Contracts: `touch`


### PR DESCRIPTION
The "Cache Prefixes and Session Cookie Names" section of the 13.x upgrade guide states that the default session cookie name now uses a hyphenated `-session` suffix. That part is inaccurate.

laravel/framework#56172 hyphenated the cache (`-cache-`) and Redis (`-database-`) prefixes, but it deliberately kept the session cookie underscore-based — see laravel/framework@4f8ee55a442656b9a128d0333ad67185e8ddea18, which sets the default to:

```php
Str::snake((string) env('APP_NAME', 'laravel')).'_session'
```

Since `Str::snake` and the previous `Str::slug(..., '_')` produce the same value for typical application names, the session cookie name — and therefore existing user sessions — is unchanged on upgrade. This corrects the example and clarifies that only the cache and Redis prefixes are affected.