### PR TITLE
Wrap docs tables in overflow-auto to fix mobile overflow

### DIFF
--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -125,6 +125,8 @@ Custom base URLs are supported for the following providers: OpenAI, Anthropic, G
 
 The AI SDK supports a variety of providers across its features. The following table summarizes which providers are available for each feature:
 
+<div class="overflow-auto">
+
 | Feature | Providers |
 |---|---|
 | Text | OpenAI, Anthropic, Gemini, Azure, Bedrock, Groq, xAI, DeepSeek, Mistral, Ollama, OpenRouter |
@@ -134,6 +136,8 @@ The AI SDK supports a variety of providers across its features. The following ta
 | Embeddings | OpenAI, Gemini, Azure, Bedrock, Cohere, Mistral, Jina, VoyageAI, Ollama, OpenRouter |
 | Reranking | Cohere, Jina, VoyageAI |
 | Files | OpenAI, Anthropic, Gemini |
+
+</div>
 
 The `Laravel\Ai\Enums\Lab` enum may be used to reference providers throughout your code instead of using plain strings:
 

--- a/boost.md
+++ b/boost.md
@@ -127,6 +127,8 @@ Laravel Boost provides an MCP (Model Context Protocol) server that exposes tools
 <a name="available-mcp-tools"></a>
 ### Available MCP Tools
 
+<div class="overflow-auto">
+
 | Name                 | Notes                                                                                                       |
 | -------------------- | ----------------------------------------------------------------------------------------------------------- |
 | Application Info     | Read PHP & Laravel versions, database engine, list of ecosystem packages with versions, and Eloquent models |
@@ -138,6 +140,8 @@ Laravel Boost provides an MCP (Model Context Protocol) server that exposes tools
 | Last Error           | Read the last error from the application's log files                                                        |
 | Read Log Entries     | Read the last N log entries                                                                                 |
 | Search Docs          | Query the Laravel hosted documentation API service to retrieve documentation based on installed packages    |
+
+</div>
 
 <a name="manually-registering-the-mcp-server"></a>
 ### Manually Registering the MCP Server
@@ -172,6 +176,8 @@ AI guidelines are composable instruction files that are loaded upfront to provid
 
 Laravel Boost includes AI guidelines for the following packages and frameworks. The `core` guidelines provide generic, generalized advice to the AI for the given package that is applicable across all versions.
 
+<div class="overflow-auto">
+
 | Package           | Versions Supported     |
 | ----------------- | ---------------------- |
 | Core & Boost      | core                   |
@@ -194,6 +200,8 @@ Laravel Boost includes AI guidelines for the following packages and frameworks. 
 | Livewire Volt     | core                   |
 | Wayfinder         | core                   |
 | Enforce Tests     | conditional            |
+
+</div>
 
 > **Note:** To keep your AI guidelines up-to-date, see the [Keeping Boost Resources Updated](#keeping-boost-resources-updated) section.
 
@@ -243,6 +251,8 @@ When you run `boost:install` and select skills as a feature, skills are automati
 <a name="available-skills"></a>
 ### Available Skills
 
+<div class="overflow-auto">
+
 | Skill                      | Package        |
 | -------------------------- | -------------- |
 | fluxui-development         | Flux UI        |
@@ -257,6 +267,8 @@ When you run `boost:install` and select skills as a feature, skills are automati
 | tailwindcss-development    | Tailwind CSS   |
 | volt-development           | Volt           |
 | wayfinder-development      | Wayfinder      |
+
+</div>
 
 > **Note:** To keep your skills up-to-date, see the [Keeping Boost Resources Updated](#keeping-boost-resources-updated) section.
 
@@ -315,11 +327,15 @@ Laravel Boost provides two distinct ways to give AI agents context about your ap
 
 **Skills** are activated on-demand when working on specific tasks, containing detailed patterns for particular domains (like Livewire components or Pest tests). Loading skills only when relevant reduces context bloat and improves code quality.
 
+<div class="overflow-auto">
+
 | Aspect      | Guidelines                        | Skills                           |
 | ----------- | --------------------------------- | -------------------------------- |
 | **Loaded**  | Upfront, always present           | On-demand, when relevant         |
 | **Scope**   | Broad, foundational               | Focused, task-specific           |
 | **Purpose** | Core conventions & best practices | Detailed implementation patterns |
+
+</div>
 
 <a name="documentation-api"></a>
 ## Documentation API
@@ -327,6 +343,8 @@ Laravel Boost provides two distinct ways to give AI agents context about your ap
 Laravel Boost includes a Documentation API that provides AI agents with access to an extensive knowledge base containing over 17,000 pieces of Laravel-specific information. The API uses semantic search with embeddings to deliver precise, context-aware results.
 
 The `Search Docs` MCP tool allows agents to query the Laravel hosted documentation API service to retrieve documentation based on your installed packages. Boost's AI guidelines and skills will automatically instruct your coding agent to use this API.
+
+<div class="overflow-auto">
 
 | Package           | Versions Supported |
 | ----------------- | ------------------ |
@@ -338,6 +356,8 @@ The `Search Docs` MCP tool allows agents to query the Laravel hosted documentati
 | Nova              | 4.x, 5.x           |
 | Pest              | 3.x, 4.x           |
 | Tailwind CSS      | 3.x, 4.x           |
+
+</div>
 
 <a name="extending-boost"></a>
 ## Extending Boost

--- a/mcp.md
+++ b/mcp.md
@@ -482,12 +482,16 @@ class CurrentWeatherTool extends Tool
 
 Available annotations include:
 
+<div class="overflow-auto">
+
 | Annotation         | Type    | Description                                                                                  |
 | ------------------ | ------- | -------------------------------------------------------------------------------------------- |
 | `#[IsReadOnly]`    | boolean | Indicates the tool does not modify its environment.                                          |
 | `#[IsDestructive]` | boolean | Indicates the tool may perform destructive updates (only meaningful when not read-only).     |
 | `#[IsIdempotent]`  | boolean | Indicates repeated calls with same arguments have no additional effect (when not read-only). |
 | `#[IsOpenWorld]`   | boolean | Indicates the tool may interact with external entities.                                      |
+
+</div>
 
 Annotation values can be explicitly set using boolean arguments:
 
@@ -1243,11 +1247,15 @@ class UserDashboardResource extends Resource
 
 Available annotations include:
 
+<div class="overflow-auto">
+
 | Annotation        | Type          | Description                                                                 |
 | ----------------- | ------------- | --------------------------------------------------------------------------- |
 | `#[Audience]`     | Role or array | Specifies the intended audience (`Role::User`, `Role::Assistant`, or both). |
 | `#[Priority]`     | float         | A numerical score between 0.0 and 1.0 indicating resource importance.       |
 | `#[LastModified]` | string        | An ISO 8601 timestamp showing when the resource was last updated.           |
+
+</div>
 
 <a name="conditional-resource-registration"></a>
 ### Conditional Resource Registration

--- a/starter-kits.md
+++ b/starter-kits.md
@@ -354,6 +354,8 @@ All starter kits use [Laravel Fortify](/docs/{{version}}/fortify) to handle auth
 
 Fortify automatically registers the following authentication routes based on the features that are enabled in your application's `config/fortify.php` configuration file:
 
+<div class="overflow-auto">
+
 | Route                              | Method | Description                         |
 | ---------------------------------- | ------ | ----------------------------------- |
 | `/login`                           | `GET`    | Display login form                  |
@@ -372,6 +374,8 @@ Fortify automatically registers the following authentication routes based on the
 | `/user/confirm-password`           | `POST`   | Confirm password                    |
 | `/two-factor-challenge`            | `GET`    | Display 2FA challenge form          |
 | `/two-factor-challenge`            | `POST`   | Verify 2FA code                     |
+
+</div>
 
 The `php artisan route:list` Artisan command can be used to display all of the routes in your application.
 
@@ -403,11 +407,15 @@ When using the [React](#react), [Svelte](#svelte) or [Vue](#vue) starter kits, y
 
 When a user registers or resets their password, Fortify invokes action classes located in your application's `app/Actions/Fortify` directory:
 
+<div class="overflow-auto">
+
 | File                          | Description                           |
 | ----------------------------- | ------------------------------------- |
 | `CreateNewUser.php`           | Validates and creates new users       |
 | `ResetUserPassword.php`       | Validates and updates user passwords  |
 | `PasswordValidationRules.php` | Defines password validation rules     |
+
+</div>
 
 For example, to customize your application's registration logic, you should edit the `CreateNewUser` action:
 


### PR DESCRIPTION
Wraps wide tables in `<div class="overflow-auto">` so they scroll instead of
being clipped on mobile, matching the pattern already used in `facades.md` and
others. Purely additive — no content changed.