### PR TITLE
[13.x] Add `Min` to the list of available validation rules for Files

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1161,6 +1161,7 @@ Below is a list of all available validation rules and their function:
 [File](#rule-file)
 [Image](#rule-image)
 [Max](#rule-max)
+[Min](#rule-min)
 [MIME Types](#rule-mimetypes)
 [MIME Type By File Extension](#rule-mimes)
 [Size](#rule-size)


### PR DESCRIPTION
Adds `Min` to the list of available validation rules for files.

The `min` rule documentation already specifies support for file validation, but the file validation rules list didn't include a link to that rule.

PR for `12.x` docs: https://github.com/laravel/docs/pull/11256