### PR TITLE
Document passing arrays as fake responses for structured agents

### DIFF
--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1897,6 +1897,14 @@ SalesCoach::fake(function (AgentPrompt $prompt) {
 
 > **Note:** When `Agent::fake()` is invoked on an agent that returns structured output, Laravel will automatically generate fake data that matches your agent's defined output schema.
 
+When faking an agent that returns structured output, you may also provide arrays as responses. The agent will return a structured response containing the given data:
+
+```php
+SalesCoach::fake([
+    ['score' => 87],
+]);
+```
+
 After prompting the agent, you may make assertions about the prompts that were received:
 
 ```php

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1895,15 +1895,15 @@ SalesCoach::fake(function (AgentPrompt $prompt) {
 });
 ```
 
-> **Note:** When `Agent::fake()` is invoked on an agent that returns structured output, Laravel will automatically generate fake data that matches your agent's defined output schema.
-
-When faking an agent that returns structured output, you may also provide arrays as responses. The agent will return a structured response containing the given data:
+When faking an agent that returns structured output, you may provide arrays as responses. The agent will return a structured response containing the given data:
 
 ```php
 SalesCoach::fake([
     ['score' => 87],
 ]);
 ```
+
+> **Note:** When `Agent::fake()` is invoked on an agent that returns structured output and fake output was not explicitly provided, Laravel will automatically generate fake data that matches your agent's defined output schema.
 
 After prompting the agent, you may make assertions about the prompts that were received:
 


### PR DESCRIPTION
The Testing section notes that `Agent::fake()` auto-generates schema-matching data for structured output agents, but doesn't mention that you may also pass explicit arrays as fake responses - useful for deterministic assertions. This behavior is covered by the SDK's own tests (`AgentFakeTest` exercises arrays, closures returning arrays, and `StructuredTextResponse` instances).

This gap is not hypothetical: while planning a migration to the SDK, an AI assistant working from the current documentation repeatedly concluded that faking structured output wasn't supported at all, and only reading the SDK's tests proved otherwise. Documenting the array form keeps both readers and AI tooling from reaching the same wrong conclusion.

Adds a short example based on the existing `SalesCoach` agent.