### PR TITLE
Fix security email address in contribution guidelines

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -108,7 +108,7 @@ We encourage contributors to familiarize themselves with the existing codebase, 
 <a name="security-vulnerabilities"></a>
 ## Security Vulnerabilities
 
-If you discover a security vulnerability within Laravel, please send an email to Taylor Otwell at <a href="mailto:taylor@laravel.com">taylor@laravel.com</a>. All security vulnerabilities will be promptly addressed.
+If you discover a security vulnerability within Laravel, please email our security team at <a href="mailto:security@laravel.com">security@laravel.com</a>. All security vulnerabilities will be promptly addressed.
 
 <a name="coding-style"></a>
 ## Coding Style


### PR DESCRIPTION
The contribution guidelines instructed to email Taylor directly about security vulnerabilities. I was advised by @jbrooksuk that there's a dedicated security email address they should be directed to instead.