### PR TITLE
[9.x] docs: update supervisor start commands for fresh installs

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1696,11 +1696,8 @@ In this example, the `numprocs` directive will instruct Supervisor to run eight 
 Once the configuration file has been created, you may update the Supervisor configuration and start the processes using the following commands:
 
 ```shell
-sudo supervisorctl reread
-
-sudo supervisorctl update
-
-sudo supervisorctl start laravel-worker:*
+sudo systemctl enable supervisor
+sudo systemctl start supervisor
 ```
 
 For more information on Supervisor, consult the [Supervisor documentation](http://supervisord.org/index.html).


### PR DESCRIPTION
Currently, the docs instruct users to run `supervisorctl` commands immediately after installation. Since the Supervisor daemon isn't actually running yet on a fresh install, this throws errors such as `error: <class 'FileNotFoundError'>, [Errno 2] No such file or directory: file: /usr/lib/python3/dist-packages/supervisor/xmlrpc.py line: 557` and `unix:///var/run/supervisor.sock no such file` respectively. This PR replaces those commands with `systemctl enable` and `systemctl start` to properly boot the daemon.