### PR TITLE
[13.x] Remove `prependCount` option from `Str::plural` docs

### DIFF
--- a/strings.md
+++ b/strings.md
@@ -1250,16 +1250,6 @@ $singular = Str::plural('child', 1);
 // child
 ```
 
-The `prependCount` argument may be provided to prefix the pluralized string with the formatted `$count`:
-
-```php
-use Illuminate\Support\Str;
-
-$label = Str::plural('car', 1000, prependCount: true);
-
-// 1,000 cars
-```
-
 <a name="method-str-plural-studly"></a>
 #### `Str::pluralStudly()` {.collection-method}
 


### PR DESCRIPTION
Since we now have [a dedicated `Str::counted` method](https://github.com/laravel/framework/pull/60649), there's no need to document the `prependCount` parameter on `Str::plural`. People should use `Str::counted` instead.