### PR TITLE
do not need to use Vite because it is aliased

### DIFF
--- a/vite.md
+++ b/vite.md
@@ -231,8 +231,6 @@ If needed, you may also specify the build path of your compiled assets when invo
 Sometimes it may be necessary to include the raw content of assets rather than linking to the versioned URL of the asset. For example, you may need to include asset content directly into your page when passing HTML content to a PDF generator. You may output the content of Vite assets using the `content` method provided by the `Vite` facade:
 
 ```blade
-@use('Illuminate\Support\Facades\Vite')
-
 <!doctype html>
 <head>
     {{-- ... --}}


### PR DESCRIPTION
We do not need to import the `Vite` facade using the `@use` directive, because it is already aliased in:
```php
Illuminate\Support\Facades::defaultAliases();
```

See: https://github.com/laravel/framework/blob/3093ff3a61f88225f16fec35dda65e1e7c0867a4/src/Illuminate/Support/Facades/Facade.php#L321