### PR TITLE
queue:work --timeout has no effect when used with --once

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1719,6 +1719,9 @@ Sometimes, IO blocking processes such as sockets or outgoing HTTP connections ma
 > [!WARNING]
 > The [PCNTL](https://www.php.net/manual/en/book.pcntl.php) PHP extension must be installed in order to specify job timeouts. In addition, a job's "timeout" value should always be less than its ["retry after"](#job-expiration) value. Otherwise, the job may be re-attempted before it has actually finished executing or timed out.
 
+> [!WARNING]
+> The `--timeout` option has no effect when the `queue:work` command is invoked with the `--once` option. In this mode, the worker processes a single job and exits without registering the internal timeout handler used in daemon mode.
+
 <a name="failing-on-timeout"></a>
 #### Failing on Timeout
 

--- a/queues.md
+++ b/queues.md
@@ -1717,10 +1717,7 @@ class ProcessPodcast implements ShouldQueue
 Sometimes, IO blocking processes such as sockets or outgoing HTTP connections may not respect your specified timeout. Therefore, when using these features, you should always attempt to specify a timeout using their APIs as well. For example, when using [Guzzle](https://docs.guzzlephp.org), you should always specify a connection and request timeout value.
 
 > [!WARNING]
-> The [PCNTL](https://www.php.net/manual/en/book.pcntl.php) PHP extension must be installed in order to specify job timeouts. In addition, a job's "timeout" value should always be less than its ["retry after"](#job-expiration) value. Otherwise, the job may be re-attempted before it has actually finished executing or timed out.
-
-> [!WARNING]
-> The `--timeout` option has no effect when the `queue:work` command is invoked with the `--once` option. In this mode, the worker processes a single job and exits without registering the internal timeout handler used in daemon mode.
+> The [PCNTL](https://www.php.net/manual/en/book.pcntl.php) PHP extension must be installed in order to specify job timeouts. In addition, a job's "timeout" value should always be less than its ["retry after"](#job-expiration) value. Otherwise, the job may be re-attempted before it has actually finished executing or timed out. The `--timeout` option has no effect when the `queue:work` command is invoked with the `--once` option.
 
 <a name="failing-on-timeout"></a>
 #### Failing on Timeout


### PR DESCRIPTION
Hello :wave:,

### Description

The documentation currently implies that the `--timeout` option on `queue:work` works globally for the queue worker. However, when combining `--once` with `--timeout`, the timeout restriction is silently ignored.

I understand the design choice, but we had to debug this exact issue in production today, and to save other developers time, this PR aims to clarify this behavior in the official documentation. Note that this specifically applies to running individual workers via `--once`, and we are not using `queue:listen` (which handles timeouts differently).

### Technical Proof

This is because the logic for sending the SIGTERM comes from the [registerTimeoutHandler](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Queue/Worker.php#L292) method, which is called exclusively in [daemon](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Queue/Worker.php#L248) mode.

### Proposed solution

Add a warning note in the queue documentation under the `--timeout` section to clarify this behavior.