### PR TITLE
Fix duplicate anchor name in notifications.md

### DIFF
--- a/notifications.md
+++ b/notifications.md
@@ -1843,7 +1843,7 @@ Notification::assertSentTo(
 );
 ```
 
-<a name="on-demand-notifications"></a>
+<a name="testing-on-demand-notifications"></a>
 #### On-Demand Notifications
 
 If the code you are testing sends [on-demand notifications](#on-demand-notifications), you can test that the on-demand notification was sent via the `assertSentOnDemand` method:


### PR DESCRIPTION
In https://laravel.com/docs/13.x/notifications, the "On-Demand Notifications"
subsection under "Testing" has the same anchor name as the main "On-Demand
Notifications" section, which makes it impossible to deep-link.

Renamed from: `<a name="on-demand-notifications"></a>`
to: `<a name="testing-on-demand-notifications"></a>`
