### PR TITLE
Expand Laravel AI SDK documentation

### DIFF
--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -132,6 +132,8 @@ When using Amazon Bedrock, you may authenticate using an AWS bearer token, expli
 ],
 ```
 
+Credentials are resolved in priority order: a bearer token, then AssumeRole, then static IAM credentials, then the SDK's default credential provider chain. When `assume_role.arn` is set, the role is assumed using your static or default AWS credentials as the source, and the resulting temporary credentials are refreshed automatically before they expire.
+
 <a name="custom-base-urls"></a>
 ### Custom Base URLs
 

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -2195,12 +2195,12 @@ $response = Document::fromPath('/home/laravel/knowledge.txt')
 To scope options per provider, pass a closure that receives the current provider:
 
 ```php
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Files\Document;
-use Laravel\Ai\Providers\Provider;
 
 $response = Document::fromPath('/home/laravel/training.jsonl')
-    ->withProviderOptions(fn (Provider $provider) => match ($provider->driver()) {
-        'openai' => ['purpose' => 'fine-tune'],
+    ->withProviderOptions(fn (Lab|string $provider) => match ($provider) {
+        Lab::OpenAI => ['purpose' => 'fine-tune'],
         default => [],
     })
     ->put();

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -208,8 +208,8 @@ The AI SDK supports a variety of providers across its features. The following ta
 |---|---|
 | Text | OpenAI, OpenAI Compatible, Anthropic, Gemini, Azure, Bedrock, Groq, xAI, DeepSeek, Mistral, Ollama, OpenRouter |
 | Images | OpenAI, Gemini, xAI, Azure, Bedrock, OpenRouter |
-| TTS | OpenAI, ElevenLabs, Gemini |
-| STT | OpenAI, ElevenLabs, Mistral, Gemini |
+| TTS | OpenAI, ElevenLabs, Gemini, OpenRouter |
+| STT | OpenAI, ElevenLabs, Mistral, Gemini, OpenRouter |
 | Embeddings | OpenAI, Gemini, Azure, Bedrock, Cohere, Mistral, Jina, VoyageAI, Ollama, OpenRouter |
 | Reranking | Cohere, Jina, VoyageAI |
 | Files | OpenAI, Anthropic, Gemini, Azure |
@@ -1151,6 +1151,14 @@ To refine search results based on user location, use the `location` method:
 );
 ```
 
+If the provider returns citations for web search results, you may access them via the response's `meta` property:
+
+```php
+$response = (new ResearchAgent)->prompt('What changed in Laravel this week?');
+
+$citations = $response->meta->citations;
+```
+
 <a name="web-fetch"></a>
 #### Web Fetch
 
@@ -2001,6 +2009,14 @@ $response = Embeddings::for(['Napa Valley has great wine.'])
     ->generate();
 ```
 
+If global embedding caching is enabled, you may disable caching for a specific request by passing `0` to the `cache` method:
+
+```php
+$response = Embeddings::for(['Napa Valley has great wine.'])
+    ->cache(0)
+    ->generate();
+```
+
 The `toEmbeddings` Stringable method also accepts a `cache` argument:
 
 ```php
@@ -2009,6 +2025,9 @@ $embeddings = Str::of('Napa Valley has great wine.')->toEmbeddings(cache: true);
 
 // Cache for a specific duration...
 $embeddings = Str::of('Napa Valley has great wine.')->toEmbeddings(cache: 3600);
+
+// Disable caching for this request...
+$embeddings = Str::of('Napa Valley has great wine.')->toEmbeddings(cache: false);
 ```
 
 <a name="reranking"></a>

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -366,44 +366,58 @@ class SalesCoach implements Agent, Conversational
 
 When using the `RemembersConversations` trait, do not manually define a `messages` method in your agent class. If a `messages` method is present, it will take precedence over the trait's implementation and conversation history will not be loaded from the database.
 
-To start a new conversation for a user, call the `forUser` method before prompting:
+To start a new conversation for a participant, call the `forParticipant` method before prompting. The participant is typically an Eloquent model that represents the person or resource having the conversation:
 
 ```php
-$response = (new SalesCoach)->forUser($user)->prompt('Hello!');
+$response = (new SalesCoach)->forParticipant($user)->prompt('Hello!');
 
 $conversationId = $response->conversationId;
 ```
 
-The conversation ID is returned on the response and can be stored for future reference. If you would like to retrieve all of a user's conversations using Eloquent, you may add the `HasConversations` trait to your user model:
+If the participant is a user, you may use the `forUser` method as a convenience alias:
+
+```php
+$response = (new SalesCoach)->forUser($user)->prompt('Hello!');
+```
+
+The conversation ID is returned on the response and can be stored for future reference. If you would like to retrieve all of a participant's conversations using Eloquent, you may add the `HasConversations` trait to the participant model:
 
 ```php
 <?php
 
 namespace App\Models;
 
-use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Database\Eloquent\Model;
 use Laravel\Ai\Concerns\HasConversations;
 
-class User extends Authenticatable
+class Customer extends Model
 {
     use HasConversations;
 }
 ```
 
-Once the trait has been added to your model, you may retrieve and query the user's conversations via the `conversations` relationship:
+Once the trait has been added to your model, you may retrieve and query the participant's conversations via the `conversations` relationship:
 
 ```php
-$conversations = $user->conversations()
+$conversations = $customer->conversations()
     ->latest('updated_at')
     ->paginate(20);
 ```
 
-To continue an existing conversation, use the `continue` method:
+To continue an existing conversation, use the `continue` method and provide the participant using the `as` argument:
 
 ```php
 $response = (new SalesCoach)
-    ->continue($conversationId, as: $user)
+    ->continue($conversationId, as: $customer)
     ->prompt('Tell me more about that.');
+```
+
+If you would like to continue the participant's most recent conversation, use the `continueLastConversation` method:
+
+```php
+$response = (new SalesCoach)
+    ->continueLastConversation($customer)
+    ->prompt('What should we work on next?');
 ```
 
 When using the `RemembersConversations` trait, previous messages are automatically loaded and included in the conversation context when prompting. New messages (both user and assistant) are automatically stored after each interaction.

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -25,6 +25,7 @@
     - [Agent Configuration](#agent-configuration)
     - [Tool Choice](#tool-choice)
     - [Provider Options](#provider-options)
+    - [Pending Request Options](#pending-request-options)
 - [Summarization](#summarization)
 - [Images](#images)
 - [Audio (TTS)](#audio)
@@ -1601,6 +1602,43 @@ The `providerOptions` method receives the provider currently being used (`Lab` e
 
 The Anthropic example above also enables [prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) via `cache_control`.
 
+<a name="pending-request-options"></a>
+#### Pending Request Options
+
+Some pending operations also allow you to pass provider-specific options using the `withProviderOptions` method. For example, you may pass options when generating embeddings:
+
+```php
+use Laravel\Ai\Embeddings;
+
+$response = Embeddings::for(['Napa Valley has great wine.'])
+    ->withProviderOptions(['encoding_format' => 'float'])
+    ->generate();
+```
+
+You may also provide a closure that receives the provider currently being used. This is useful when a request may fail over between providers:
+
+```php
+use Laravel\Ai\Embeddings;
+use Laravel\Ai\Providers\Provider;
+
+$response = Embeddings::for(['Napa Valley has great wine.'])
+    ->withProviderOptions(fn (Provider $provider) => match ($provider->driver()) {
+        'openai' => ['encoding_format' => 'float'],
+        default => [],
+    })
+    ->generate();
+```
+
+Provider options may also be passed when generating transcriptions:
+
+```php
+use Laravel\Ai\Transcription;
+
+$transcript = Transcription::fromStorage('meeting.mp3')
+    ->withProviderOptions(['temperature' => 0])
+    ->generate();
+```
+
 <a name="summarization"></a>
 ## Summarization
 
@@ -2138,12 +2176,12 @@ $response = Document::fromPath('/home/laravel/knowledge.txt')
 To scope options per provider, pass a closure that receives the current provider:
 
 ```php
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Files\Document;
+use Laravel\Ai\Providers\Provider;
 
 $response = Document::fromPath('/home/laravel/training.jsonl')
-    ->withProviderOptions(fn (Lab|string $provider) => match ($provider) {
-        Lab::OpenAI => ['purpose' => 'fine-tune'],
+    ->withProviderOptions(fn (Provider $provider) => match ($provider->driver()) {
+        'openai' => ['purpose' => 'fine-tune'],
         default => [],
     })
     ->put();

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -112,7 +112,7 @@ XAI_API_KEY=
 
 The default models used for text, images, audio, transcription, and embeddings may also be configured in your application's `config/ai.php` configuration file.
 
-When using Amazon Bedrock, you may authenticate using an AWS bearer token, explicit AWS credentials, or the default AWS credential provider. If your application needs to assume a role before making Bedrock requests, configure the provider's `assume_role` options:
+When using Amazon Bedrock, you may authenticate using an AWS bearer token, AWS credentials, or the default AWS credential provider. If your application needs to assume a role before making Bedrock requests, configure the provider's `assume_role` options:
 
 ```php
 'bedrock' => [
@@ -132,7 +132,7 @@ When using Amazon Bedrock, you may authenticate using an AWS bearer token, expli
 ],
 ```
 
-Credentials are resolved in priority order: a bearer token, then AssumeRole, then static IAM credentials, then the SDK's default credential provider chain. When `assume_role.arn` is set, the role is assumed using your static or default AWS credentials as the source, and the resulting temporary credentials are refreshed automatically before they expire.
+Credentials are resolved in priority order: bearer token, AssumeRole, static AWS credentials, then the AWS SDK's default credentials. When `assume_role.arn` is set, the temporary credentials are refreshed automatically before they expire.
 
 <a name="custom-base-urls"></a>
 ### Custom Base URLs
@@ -403,7 +403,7 @@ class SalesCoach implements Agent, Conversational
 
 When using the `RemembersConversations` trait, do not manually define a `messages` method in your agent class. If a `messages` method is present, it will take precedence over the trait's implementation and conversation history will not be loaded from the database.
 
-To start a new conversation for a participant, call the `forParticipant` method before prompting. The participant may be any Eloquent model — conversations are scoped to both the model's class and its key, so a `User` and a `Team` that share an ID will never collide:
+To start a new conversation for a participant, call the `forParticipant` method before prompting. The participant is typically an Eloquent model, and conversations are scoped to both the model's class and key:
 
 ```php
 $response = (new SalesCoach)->forParticipant($team)->prompt('Hello!');
@@ -411,7 +411,7 @@ $response = (new SalesCoach)->forParticipant($team)->prompt('Hello!');
 $conversationId = $response->conversationId;
 ```
 
-Since a user is the most common participant, you may use the `forUser` method as a convenience alias:
+If the participant is a user, you may use the `forUser` method as a convenience alias:
 
 ```php
 $response = (new SalesCoach)->forUser($user)->prompt('Hello!');
@@ -433,17 +433,22 @@ class Team extends Model
 }
 ```
 
-Once the trait has been added to your model, you may retrieve and query the participant's conversations via the `conversations` relationship. Likewise, a conversation exposes its owning model via the `participant` relationship:
+Once the trait has been added to your model, you may retrieve and query the participant's conversations via the `conversations` relationship:
 
 ```php
 $conversations = $team->conversations()
     ->latest('updated_at')
     ->paginate(20);
 
-$conversation->participant; // The owning Team, User, etc...
 ```
 
-Since participants are stored using their morph class, you may wish to [enforce a morph map](/docs/{{version}}/eloquent-relationships#custom-polymorphic-types) so stored conversations survive model renames.
+Each conversation also exposes its owner via the `participant` relationship:
+
+```php
+$participant = $conversation->participant;
+```
+
+If you use multiple participant models, you may wish to [enforce a morph map](/docs/{{version}}/eloquent-relationships#custom-polymorphic-types) so stored conversation owners are not tied to class names.
 
 To continue an existing conversation, use the `continue` method and provide the participant using the `as` argument:
 
@@ -453,7 +458,7 @@ $response = (new SalesCoach)
     ->prompt('Tell me more about that.');
 ```
 
-The `continue` method trusts the given conversation ID and does not verify ownership. Like route model binding, authorization belongs in your application — for example, by resolving the ID through the participant's own conversations:
+The `continue` method does not verify that the given participant owns the conversation. If you need to authorize access to a conversation, resolve the ID through the participant's own conversations:
 
 ```php
 $conversationId = $team->conversations()->findOrFail($conversationId)->id;
@@ -843,7 +848,7 @@ public function tools(): iterable
 <a name="tool-approvals"></a>
 #### Tool Approvals
 
-Some tools perform sensitive actions that should be approved by a human before they are executed. To require approval before a tool executes, implement the `Approvable` interface and use the `InteractsWithApprovals` trait on the tool. Approvable tools require approval for every invocation by default:
+Some tools perform sensitive actions that should be approved before they are executed. To require approval, implement the `Approvable` interface and use the `InteractsWithApprovals` trait on the tool. Approvable tools require approval for every invocation by default:
 
 ```php
 <?php
@@ -890,7 +895,7 @@ class RefundCustomer implements Approvable, Tool
 }
 ```
 
-To determine whether approval is required based on the incoming tool request, define a `needsApproval` method on the tool. The method may return a boolean or an `Approval` instance containing the reason approval is required:
+To determine whether approval is required based on the incoming tool request, define a `needsApproval` method on the tool:
 
 ```php
 use Laravel\Ai\Approvals\Approval;
@@ -925,7 +930,7 @@ public function tools(): iterable
 ```
 
 > [!NOTE]
-> Approvable tools require an agent that stores its conversation history using the [`RemembersConversations` trait](#remembering-conversations), since paused tool calls are stored in and resumed from the conversation. Using an approvable tool on an agent that does not remember conversations will throw an `ApprovalNotResumableException`.
+> Approvable tools require an agent that stores conversation history using the [`RemembersConversations` trait](#remembering-conversations). Using an approvable tool on an agent that does not remember conversations will throw an `ApprovalNotResumableException`.
 
 <a name="inspecting-pending-approvals"></a>
 #### Inspecting Pending Approvals
@@ -939,15 +944,15 @@ $response = (new SalesCoach)
 
 if ($response->awaitingApproval()) {
     foreach ($response->pendingApprovals as $approval) {
-        $approval->id;        // The tool call ID...
-        $approval->tool;      // The tool's name...
-        $approval->arguments; // The tool call arguments...
-        $approval->reason;    // The reason approval is required, if any...
+        $approval->id;
+        $approval->tool;
+        $approval->arguments;
+        $approval->reason;
     }
 }
 ```
 
-Whenever an agent pauses for approval, a `Laravel\Ai\Events\ToolApprovalRequested` event is also dispatched. This event contains the pending approvals and the conversation ID, which is convenient when the agent was [queued](#queueing).
+Whenever an agent pauses for approval, a `Laravel\Ai\Events\ToolApprovalRequested` event is also dispatched. This event contains the pending approvals and the conversation ID.
 
 <a name="resuming-with-approval-decisions"></a>
 #### Resuming With Approval Decisions
@@ -975,7 +980,7 @@ Decisions::from([
 ]);
 ```
 
-Every pending tool call requires a decision. You may provide a `'*'` wildcard decision that applies to any tool calls without an explicit decision, or use the `approveAll` and `rejectAll` shortcuts. Decisions that do not match the conversation's pending tool calls will throw an `ApprovalMismatchException`:
+Every pending tool call requires a decision. You may provide a `'*'` wildcard decision for calls without an explicit decision, or use the `approveAll` and `rejectAll` shortcuts. Decisions that do not match the pending tool calls will throw an `ApprovalMismatchException`:
 
 ```php
 Decision::approveAll();
@@ -989,7 +994,7 @@ Decisions::from([
 Decisions::from(['tool_call_id' => true])->rejectRemaining();
 ```
 
-Approved tool results are recorded before generation continues, so a crash or retry will never execute an approved tool twice. However, since concurrent resumes may still reach a tool together, tools with external side effects may use the request's `toolCallId` method as an idempotency key when invoking external services.
+Tools with external side effects may use the request's `toolCallId` method as an idempotency key when invoking external services.
 
 <a name="streaming-tool-approvals"></a>
 #### Streaming Tool Approvals
@@ -1023,7 +1028,7 @@ return (new SalesCoach)
     ->stream(Decisions::from(['tool_call_id' => Decision::approve()]));
 ```
 
-When using the [Vercel AI SDK stream protocol](#streaming-using-the-vercel-ai-sdk-protocol), pauses are emitted as native `tool-approval-request` stream parts, and resumed tool calls emit their corresponding tool output parts.
+When using the [Vercel AI SDK stream protocol](#streaming-using-the-vercel-ai-sdk-protocol), pauses are emitted as `tool-approval-request` stream parts, and resumed tool calls emit their corresponding tool output parts.
 
 Approval decisions may also be passed to the `queue`, `broadcast`, `broadcastNow`, and `broadcastOnQueue` methods. When broadcasting, the `tool_approval_request` event is broadcast to your channels like any other stream event.
 
@@ -1578,7 +1583,7 @@ class ComplexReasoner implements Agent
 <a name="tool-choice"></a>
 #### Tool Choice
 
-If your agent has tools, you may use the `ToolChoice` attribute to control how the model uses them. The tool choice is mapped to each provider's native "tool choice" request field.
+If your agent has tools, you may use the `ToolChoice` attribute to control how the model uses them.
 
 **Supported providers:** OpenAI, Anthropic, Gemini, xAI, Groq, DeepSeek, Mistral, OpenRouter, OpenAI Compatible
 
@@ -1627,7 +1632,7 @@ class CustomerSupportAgent implements Agent, HasTools
 }
 ```
 
-To determine the tool choice at runtime based on the agent's own state, define a `toolChoice` method on the agent. The method takes precedence over the attribute, and returning `null` lets the model decide:
+To determine the tool choice at runtime, define a `toolChoice` method on the agent. This method takes precedence over the attribute, and returning `null` lets the model decide:
 
 ```php
 use Laravel\Ai\ToolChoice;
@@ -1643,10 +1648,10 @@ public function toolChoice(): ?ToolChoice
 }
 ```
 
-When tool calls are forced — using either the `required` mode or a specific tool — the requirement only applies to the first generation step. After the first step, the model may respond normally.
+When tool calls are forced using either the `required` mode or a specific tool, the requirement only applies to the first generation step. After the first step, the model may respond normally.
 
 > [!NOTE]
-> Anthropic cannot force tool use while extended thinking is enabled. Forcing a tool choice with thinking enabled throws an `InvalidArgumentException` instead of silently downgrading to `auto`.
+> Anthropic does not support forcing tool use while extended thinking is enabled. In this case, Laravel will throw an `InvalidArgumentException`.
 
 <a name="provider-options"></a>
 ### Provider Options
@@ -1707,7 +1712,7 @@ $response = Embeddings::for(['Napa Valley has great wine.'])
     ->generate();
 ```
 
-You may also provide a closure that receives the provider currently being used. This is useful when a request may fail over between providers:
+You may also provide a closure that receives the provider currently being used:
 
 ```php
 use Laravel\Ai\Embeddings;
@@ -1739,7 +1744,7 @@ $embeddings = Str::of('Napa Valley has great wine.')->toEmbeddings(
 );
 ```
 
-[Provider tools](#provider-tools) support `withProviderOptions` as well, allowing you to pass options onto the tool's payload. A flat array applies to every provider, while a closure receives the provider currently being used:
+[Provider tools](#provider-tools) support `withProviderOptions` as well. A flat array applies to every provider, while a closure may return options for a specific provider:
 
 ```php
 use Laravel\Ai\Enums\Lab;
@@ -2010,7 +2015,7 @@ $response = Embeddings::for([
 ```
 
 > [!NOTE]
-> File embeddings require a provider and model capable of embedding multimodal inputs. Gemini supports image, audio, document, and video inputs, while VoyageAI supports image and video inputs through its multimodal models. Providers that only support text embeddings throw an `InvalidArgumentException` when given file inputs.
+> File embeddings require a provider and model that support multimodal inputs. Gemini supports image, audio, document, and video inputs, while VoyageAI supports image and video inputs through its multimodal models.
 
 <a name="querying-embeddings"></a>
 ### Querying Embeddings

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1576,9 +1576,9 @@ class ComplexReasoner implements Agent
 <a name="tool-choice"></a>
 #### Tool Choice
 
-If your agent has tools, you may use the `ToolChoice` attribute to control how the model uses them.
+If your agent has tools, you may use the `ToolChoice` attribute to control how the model uses them. The tool choice is mapped to each provider's native "tool choice" request field.
 
-**Supported providers:** OpenAI, Anthropic, Gemini
+**Supported providers:** OpenAI, Anthropic, Gemini, xAI, Groq, DeepSeek, Mistral, OpenRouter, OpenAI Compatible
 
 ```php
 <?php
@@ -1625,7 +1625,26 @@ class CustomerSupportAgent implements Agent, HasTools
 }
 ```
 
+To determine the tool choice at runtime based on the agent's own state, define a `toolChoice` method on the agent. The method takes precedence over the attribute, and returning `null` lets the model decide:
+
+```php
+use Laravel\Ai\ToolChoice;
+
+/**
+ * Get the agent's tool choice.
+ */
+public function toolChoice(): ?ToolChoice
+{
+    return $this->readyToSave
+        ? ToolChoice::tool('save_payment')
+        : null;
+}
+```
+
 When tool calls are forced — using either the `required` mode or a specific tool — the requirement only applies to the first generation step. After the first step, the model may respond normally.
+
+> [!NOTE]
+> Anthropic cannot force tool use while extended thinking is enabled. Forcing a tool choice with thinking enabled throws an `InvalidArgumentException` instead of silently downgrading to `auto`.
 
 <a name="provider-options"></a>
 ### Provider Options

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1214,7 +1214,7 @@ To refine search results based on user location, use the `location` method:
 );
 ```
 
-If the provider returns citations for web search results, you may access them via the response's `meta` property:
+If the provider returns citations for web search results, you may access them via the response's `meta` property. When streaming, citations are emitted as `Citation` stream events as they arrive:
 
 ```php
 $response = (new ResearchAgent)->prompt('What happened in Laravel this week?');

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1154,7 +1154,7 @@ To refine search results based on user location, use the `location` method:
 If the provider returns citations for web search results, you may access them via the response's `meta` property:
 
 ```php
-$response = (new ResearchAgent)->prompt('What changed in Laravel this week?');
+$response = (new ResearchAgent)->prompt('What happened in Laravel this week?');
 
 $citations = $response->meta->citations;
 ```

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -82,6 +82,16 @@ You may define your AI provider credentials in your application's `config/ai.php
 
 ```ini
 ANTHROPIC_API_KEY=
+AWS_BEDROCK_REGION=
+AWS_BEARER_TOKEN_BEDROCK=
+AWS_USE_DEFAULT_CREDENTIALS=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_SESSION_TOKEN=
+AWS_BEDROCK_ASSUME_ROLE_ARN=
+AWS_BEDROCK_ASSUME_ROLE_SESSION_NAME=
+AWS_BEDROCK_ASSUME_ROLE_DURATION_SECONDS=
+AWS_BEDROCK_ASSUME_ROLE_EXTERNAL_ID=
 AZURE_OPENAI_API_KEY=
 COHERE_API_KEY=
 DEEPSEEK_API_KEY=
@@ -100,6 +110,26 @@ XAI_API_KEY=
 ```
 
 The default models used for text, images, audio, transcription, and embeddings may also be configured in your application's `config/ai.php` configuration file.
+
+When using Amazon Bedrock, you may authenticate using an AWS bearer token, explicit AWS credentials, or the default AWS credential provider. If your application needs to assume a role before making Bedrock requests, configure the provider's `assume_role` options:
+
+```php
+'bedrock' => [
+    'driver' => 'bedrock',
+    'region' => env('AWS_BEDROCK_REGION', 'us-east-1'),
+    'key' => env('AWS_BEARER_TOKEN_BEDROCK'),
+    'access_key_id' => env('AWS_ACCESS_KEY_ID'),
+    'secret_access_key' => env('AWS_SECRET_ACCESS_KEY'),
+    'session_token' => env('AWS_SESSION_TOKEN'),
+    'use_default_credential_provider' => env('AWS_USE_DEFAULT_CREDENTIALS', true),
+    'assume_role' => [
+        'arn' => env('AWS_BEDROCK_ASSUME_ROLE_ARN'),
+        'session_name' => env('AWS_BEDROCK_ASSUME_ROLE_SESSION_NAME'),
+        'duration_seconds' => env('AWS_BEDROCK_ASSUME_ROLE_DURATION_SECONDS'),
+        'external_id' => env('AWS_BEDROCK_ASSUME_ROLE_EXTERNAL_ID'),
+    ],
+],
+```
 
 <a name="custom-base-urls"></a>
 ### Custom Base URLs
@@ -577,6 +607,23 @@ $response = (new ImageAnalyzer)->prompt(
         Files\Image::fromPath('/home/laravel/photo.jpg') // Attach an image from a local path...
         $request->file('photo'), // Attach an uploaded file...
     ]
+);
+```
+
+When using Bedrock, the `S3Document` class may be used to reference a document stored in S3 without reading and sending the file contents from your application:
+
+```php
+use App\Ai\Agents\DocumentAnalyzer;
+use Laravel\Ai\Files\S3Document;
+
+$response = (new DocumentAnalyzer)->prompt(
+    'Summarize the attached report.',
+    attachments: [
+        new S3Document(
+            's3://company-reports/quarterly-report.pdf',
+            bucketOwner: '123456789012',
+        ),
+    ],
 );
 ```
 

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1615,7 +1615,7 @@ class CustomerSupportAgent implements Agent, HasTools
 }
 ```
 
-When a specific tool is required, the requirement only applies to the first generation step. After that tool has been called, the model may continue normally.
+When tool calls are forced — using either the `required` mode or a specific tool — the requirement only applies to the first generation step. After the first step, the model may respond normally.
 
 <a name="provider-options"></a>
 ### Provider Options

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1729,6 +1729,29 @@ $transcript = Transcription::fromStorage('meeting.mp3')
     ->generate();
 ```
 
+The `toEmbeddings` Stringable method accepts the same options via its `providerOptions` argument:
+
+```php
+$embeddings = Str::of('Napa Valley has great wine.')->toEmbeddings(
+    providerOptions: ['input_type' => 'search_query'],
+);
+```
+
+[Provider tools](#provider-tools) support `withProviderOptions` as well, allowing you to pass options onto the tool's payload. A flat array applies to every provider, while a closure receives the provider currently being used:
+
+```php
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Providers\Tools\WebSearch;
+
+(new WebSearch)->withProviderOptions(['search_context_size' => 'high']);
+
+(new WebSearch)->withProviderOptions(fn (Lab|string $provider) => match ($provider) {
+    Lab::OpenAI => ['search_context_size' => 'high'],
+    Lab::Anthropic => ['blocked_domains' => ['spam.com']],
+    default => [],
+});
+```
+
 <a name="summarization"></a>
 ## Summarization
 

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -831,25 +831,7 @@ public function tools(): iterable
 <a name="tool-approvals"></a>
 #### Tool Approvals
 
-Some tools perform sensitive actions that should be approved before they are executed. To require approval for a tool, use the `InteractsWithApprovals` trait on the tool class and call the `requireApproval` method when returning the tool from your agent:
-
-```php
-use App\Ai\Tools\DeleteCustomer;
-
-/**
- * Get the tools available to the agent.
- *
- * @return Tool[]
- */
-public function tools(): iterable
-{
-    return [
-        (new DeleteCustomer)->requireApproval('This tool deletes customer records.'),
-    ];
-}
-```
-
-You may also determine whether approval is required based on the incoming tool request by defining a `needsApproval` method on the tool:
+Some tools perform sensitive actions that should be approved by a human before they are executed. To require approval before a tool executes, implement the `Approvable` interface and use the `InteractsWithApprovals` trait on the tool. Approvable tools require approval for every invocation by default:
 
 ```php
 <?php
@@ -857,13 +839,13 @@ You may also determine whether approval is required based on the incoming tool r
 namespace App\Ai\Tools;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
-use Laravel\Ai\Approvals\Approval;
 use Laravel\Ai\Concerns\InteractsWithApprovals;
+use Laravel\Ai\Contracts\Approvable;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
 use Stringable;
 
-class RefundCustomer implements Tool
+class RefundCustomer implements Approvable, Tool
 {
     use InteractsWithApprovals;
 
@@ -884,16 +866,6 @@ class RefundCustomer implements Tool
     }
 
     /**
-     * Determine whether this tool call needs approval.
-     */
-    protected function needsApproval(Request $request): Approval|bool
-    {
-        return $request['amount_in_cents'] > 10000
-            ? Approval::required('Refunds over $100 require approval.')
-            : false;
-    }
-
-    /**
      * Get the tool's schema definition.
      */
     public function schema(JsonSchema $schema): array
@@ -906,7 +878,47 @@ class RefundCustomer implements Tool
 }
 ```
 
-When an agent reaches a tool call that requires approval, the response will pause before executing the tool. You may inspect the pending approvals on the response:
+To determine whether approval is required based on the incoming tool request, define a `needsApproval` method on the tool. The method may return a boolean or an `Approval` instance containing the reason approval is required:
+
+```php
+use Laravel\Ai\Approvals\Approval;
+use Laravel\Ai\Tools\Request;
+
+/**
+ * Determine whether the tool call needs approval.
+ */
+protected function needsApproval(Request $request): Approval|bool
+{
+    return $request['amount_in_cents'] > 10000
+        ? Approval::required('Refunds over $100 require approval.')
+        : false;
+}
+```
+
+Agents may override a tool's own approval requirement when registering the tool using the `requireApproval` and `withoutApproval` methods:
+
+```php
+/**
+ * Get the tools available to the agent.
+ *
+ * @return Tool[]
+ */
+public function tools(): iterable
+{
+    return [
+        (new RefundCustomer)->withoutApproval(),
+        (new SendEmail)->requireApproval('Review outgoing mail before it sends.'),
+    ];
+}
+```
+
+> [!NOTE]
+> Approvable tools require an agent that stores its conversation history using the [`RemembersConversations` trait](#remembering-conversations), since paused tool calls are stored in and resumed from the conversation. Using an approvable tool on an agent that does not remember conversations will throw an `ApprovalNotResumableException`.
+
+<a name="inspecting-pending-approvals"></a>
+#### Inspecting Pending Approvals
+
+When the model calls a tool that requires approval, the response pauses before the tool is executed. Tool calls in the same step that do not require approval are executed normally. You may inspect the pending approvals on the response:
 
 ```php
 $response = (new SalesCoach)
@@ -915,52 +927,93 @@ $response = (new SalesCoach)
 
 if ($response->awaitingApproval()) {
     foreach ($response->pendingApprovals as $approval) {
-        $approval->id;
-        $approval->tool;
-        $approval->arguments;
-        $approval->reason;
+        $approval->id;        // The tool call ID...
+        $approval->tool;      // The tool's name...
+        $approval->arguments; // The tool call arguments...
+        $approval->reason;    // The reason approval is required, if any...
     }
 }
 ```
 
-To continue the response, pass approval decisions back to the agent. Decisions are keyed by the pending approval ID:
+Whenever an agent pauses for approval, a `Laravel\Ai\Events\ToolApprovalRequested` event is also dispatched. This event contains the pending approvals and the conversation ID, which is convenient when the agent was [queued](#queueing).
+
+<a name="resuming-with-approval-decisions"></a>
+#### Resuming With Approval Decisions
+
+To resume a paused response, continue the conversation and pass approval decisions to the `prompt` method in place of a message. Decisions are keyed by the tool call ID and may approve, reject, or edit each pending tool call:
 
 ```php
 use Laravel\Ai\Approvals\Decision;
 use Laravel\Ai\Approvals\Decisions;
-
-$decisions = Decisions::from([
-    'tool_call_id' => Decision::approve(),
-]);
 
 $response = (new SalesCoach)
-    ->continue($response->conversationId, as: $user)
-    ->prompt($decisions);
+    ->continue($conversationId, as: $user)
+    ->prompt(Decisions::from([
+        'tool_call_id' => Decision::approve(),
+        'other_tool_call_id' => Decision::reject('The customer is not eligible for a refund.'),
+    ]));
 ```
 
-You may reject a tool call, provide edited arguments, or apply a default decision to any remaining tool calls:
+Booleans may be used as shorthand for approving or rejecting a tool call, while the `edit` decision executes the tool with revised arguments:
 
 ```php
-use Laravel\Ai\Approvals\Decision;
-use Laravel\Ai\Approvals\Decisions;
-
 Decisions::from([
-    'tool_call_id' => Decision::reject('The customer is not eligible for a refund.'),
+    'tool_call_id' => true,
+    'other_tool_call_id' => Decision::edit(['amount_in_cents' => 7500]),
 ]);
+```
 
-Decisions::from([
-    'tool_call_id' => Decision::edit(['amount_in_cents' => 7500]),
-]);
+Every pending tool call requires a decision. You may provide a `'*'` wildcard decision that applies to any tool calls without an explicit decision, or use the `approveAll` and `rejectAll` shortcuts. Decisions that do not match the conversation's pending tool calls will throw an `ApprovalMismatchException`:
 
+```php
 Decision::approveAll();
 Decision::rejectAll('Approval was not granted.');
 
 Decisions::from([
-    'tool_call_id' => Decision::approve(),
-])->rejectRemaining();
+    'tool_call_id' => Decision::edit(['amount_in_cents' => 7500]),
+    '*' => false,
+]);
+
+Decisions::from(['tool_call_id' => true])->rejectRemaining();
 ```
 
-Approval decisions may also be passed to `stream`, `queue`, `broadcast`, `broadcastNow`, and `broadcastOnQueue`. When resuming a paused response, continue the same conversation so Laravel can replay the approved tool results into the pending turn.
+Approved tool results are recorded before generation continues, so a crash or retry will never execute an approved tool twice. However, since concurrent resumes may still reach a tool together, tools with external side effects may use the request's `toolCallId` method as an idempotency key when invoking external services.
+
+<a name="streaming-tool-approvals"></a>
+#### Streaming Tool Approvals
+
+When streaming, a pause is emitted as a `ToolApprovalRequest` stream event (`tool_approval_request`) containing the pending approvals. Once the stream completes, the streamed response also exposes the pending approvals:
+
+```php
+use Illuminate\Http\Request;
+use Laravel\Ai\Responses\StreamedAgentResponse;
+
+Route::post('/chat/{conversationId}', function (Request $request, string $conversationId) {
+    return (new SalesCoach)
+        ->continue($conversationId, as: $request->user())
+        ->stream($request->input('message'))
+        ->then(function (StreamedAgentResponse $response) {
+            if ($response->awaitingApproval()) {
+                // $response->pendingApprovals...
+            }
+        });
+});
+```
+
+To resume a paused stream, pass the approval decisions to the `stream` method. The resumed stream emits the resolved tool results before continuing the model's response:
+
+```php
+use Laravel\Ai\Approvals\Decision;
+use Laravel\Ai\Approvals\Decisions;
+
+return (new SalesCoach)
+    ->continue($conversationId, as: $user)
+    ->stream(Decisions::from(['tool_call_id' => Decision::approve()]));
+```
+
+When using the [Vercel AI SDK stream protocol](#streaming-using-the-vercel-ai-sdk-protocol), pauses are emitted as native `tool-approval-request` stream parts, and resumed tool calls emit their corresponding tool output parts.
+
+Approval decisions may also be passed to the `queue`, `broadcast`, `broadcastNow`, and `broadcastOnQueue` methods. When broadcasting, the `tool_approval_request` event is broadcast to your channels like any other stream event.
 
 <a name="similarity-search"></a>
 #### Similarity Search
@@ -2874,6 +2927,8 @@ The Laravel AI SDK dispatches a variety of [events](/docs/{{version}}/events), i
 - `StoreCreated`
 - `StoringFile`
 - `StreamingAgent`
+- `ToolApprovalRequested`
+- `ToolApprovalResolved`
 - `ToolInvoked`
 - `TranscriptionGenerated`
 

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -15,6 +15,7 @@
     - [Broadcasting](#broadcasting)
     - [Queueing](#queueing)
     - [Tools](#tools)
+    - [Tool Approvals](#tool-approvals)
     - [File Storage Tools](#file-storage-tools)
     - [MCP Tools](#mcp-tools)
     - [Provider Tools](#provider-tools)
@@ -775,6 +776,140 @@ public function tools(): iterable
     ];
 }
 ```
+
+<a name="tool-approvals"></a>
+#### Tool Approvals
+
+Some tools perform sensitive actions that should be approved before they are executed. To require approval for a tool, use the `InteractsWithApprovals` trait on the tool class and call the `requireApproval` method when returning the tool from your agent:
+
+```php
+use App\Ai\Tools\DeleteCustomer;
+
+/**
+ * Get the tools available to the agent.
+ *
+ * @return Tool[]
+ */
+public function tools(): iterable
+{
+    return [
+        (new DeleteCustomer)->requireApproval('This tool deletes customer records.'),
+    ];
+}
+```
+
+You may also determine whether approval is required based on the incoming tool request by defining a `needsApproval` method on the tool:
+
+```php
+<?php
+
+namespace App\Ai\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Approvals\Approval;
+use Laravel\Ai\Concerns\InteractsWithApprovals;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Stringable;
+
+class RefundCustomer implements Tool
+{
+    use InteractsWithApprovals;
+
+    /**
+     * Get the description of the tool's purpose.
+     */
+    public function description(): Stringable|string
+    {
+        return 'Refund a customer order.';
+    }
+
+    /**
+     * Execute the tool.
+     */
+    public function handle(Request $request): Stringable|string
+    {
+        // ...
+    }
+
+    /**
+     * Determine whether this tool call needs approval.
+     */
+    protected function needsApproval(Request $request): Approval|bool
+    {
+        return $request['amount_in_cents'] > 10000
+            ? Approval::required('Refunds over $100 require approval.')
+            : false;
+    }
+
+    /**
+     * Get the tool's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'order_id' => $schema->string()->required(),
+            'amount_in_cents' => $schema->integer()->required(),
+        ];
+    }
+}
+```
+
+When an agent reaches a tool call that requires approval, the response will pause before executing the tool. You may inspect the pending approvals on the response:
+
+```php
+$response = (new SalesCoach)
+    ->forUser($user)
+    ->prompt('Refund order 123 for $150.');
+
+if ($response->awaitingApproval()) {
+    foreach ($response->pendingApprovals as $approval) {
+        $approval->id;
+        $approval->tool;
+        $approval->arguments;
+        $approval->reason;
+    }
+}
+```
+
+To continue the response, pass approval decisions back to the agent. Decisions are keyed by the pending approval ID:
+
+```php
+use Laravel\Ai\Approvals\Decision;
+use Laravel\Ai\Approvals\Decisions;
+
+$decisions = Decisions::from([
+    'tool_call_id' => Decision::approve(),
+]);
+
+$response = (new SalesCoach)
+    ->continue($response->conversationId, as: $user)
+    ->prompt($decisions);
+```
+
+You may reject a tool call, provide edited arguments, or apply a default decision to any remaining tool calls:
+
+```php
+use Laravel\Ai\Approvals\Decision;
+use Laravel\Ai\Approvals\Decisions;
+
+Decisions::from([
+    'tool_call_id' => Decision::reject('The customer is not eligible for a refund.'),
+]);
+
+Decisions::from([
+    'tool_call_id' => Decision::edit(['amount_in_cents' => 7500]),
+]);
+
+Decision::approveAll();
+Decision::rejectAll('Approval was not granted.');
+
+Decisions::from([
+    'tool_call_id' => Decision::approve(),
+])->rejectRemaining();
+```
+
+Approval decisions may also be passed to `stream`, `queue`, `broadcast`, `broadcastNow`, and `broadcastOnQueue`. When resuming a paused response, continue the same conversation so Laravel can replay the approved tool results into the pending turn.
 
 <a name="similarity-search"></a>
 #### Similarity Search
@@ -2042,6 +2177,24 @@ SalesCoach::fake([
 ```
 
 > **Note:** When `Agent::fake()` is invoked on an agent that returns structured output and fake output was not explicitly provided, Laravel will automatically generate fake data that matches your agent's defined output schema.
+
+You may also fake an agent response that is waiting for tool approval:
+
+```php
+use Laravel\Ai\Approvals\PendingApproval;
+use Laravel\Ai\Responses\AgentResponse;
+
+SalesCoach::fake([
+    AgentResponse::fakeAwaitingApproval([
+        new PendingApproval(
+            id: 'tool_call_id',
+            tool: 'refund_customer',
+            arguments: ['order_id' => '123', 'amount_in_cents' => 15000],
+            reason: 'Refunds over $100 require approval.',
+        ),
+    ]),
+]);
+```
 
 After prompting the agent, you may make assertions about the prompts that were received:
 

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -23,6 +23,7 @@
     - [Middleware](#middleware)
     - [Anonymous Agents](#anonymous-agents)
     - [Agent Configuration](#agent-configuration)
+    - [Tool Choice](#tool-choice)
     - [Provider Options](#provider-options)
 - [Images](#images)
 - [Audio (TTS)](#audio)
@@ -1387,6 +1388,7 @@ You may configure text generation options for an agent using PHP attributes. The
 - `Temperature`: The sampling temperature to use for generation (0.0 to 1.0).
 - `Timeout`: The HTTP timeout in seconds for agent requests (default: 60).
 - `TopP`: The nucleus sampling probability to use for generation (0.0 to 1.0).
+- `ToolChoice`: Controls whether and which tool the model should call.
 - `UseCheapestModel`: Use the provider's cheapest text model for cost optimization.
 - `UseSmartestModel`: Use the provider's most capable text model for complex tasks.
 
@@ -1402,6 +1404,7 @@ use Laravel\Ai\Attributes\Provider;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Attributes\Timeout;
 use Laravel\Ai\Attributes\TopP;
+use Laravel\Ai\ToolChoice;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
@@ -1413,6 +1416,7 @@ use Laravel\Ai\Promptable;
 #[Temperature(0.7)]
 #[Timeout(120)]
 #[TopP(0.9)]
+#[ToolChoice(ToolChoice::auto)]
 class SalesCoach implements Agent
 {
     use Promptable;
@@ -1448,6 +1452,60 @@ class ComplexReasoner implements Agent
 
 > [!NOTE]
 > The underlying model selected by `UseCheapestModel` and `UseSmartestModel` may change between releases of the Laravel AI SDK as providers release new models. Switching models can introduce behavioral changes, deprecated parameters, and significant cost differences. If you need a stable, predictable model and pricing, specify the model explicitly using the `Model` attribute.
+
+<a name="tool-choice"></a>
+#### Tool Choice
+
+If your agent has tools, you may use the `ToolChoice` attribute to control how the model uses them.
+
+**Supported providers:** OpenAI, Anthropic, Gemini
+
+```php
+<?php
+
+namespace App\Ai\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\ToolChoice;
+
+#[ToolChoice(ToolChoice::auto)]
+class CustomerSupportAgent implements Agent, HasTools
+{
+    use Promptable;
+
+    // ...
+}
+```
+
+The `auto` mode lets the model decide whether to call a tool, while `none` prevents tool calls and `required` requires the model to call a tool:
+
+```php
+#[ToolChoice(ToolChoice::none)]
+class CustomerSupportAgent implements Agent, HasTools
+{
+    // ...
+}
+
+#[ToolChoice(ToolChoice::required)]
+class CustomerSupportAgent implements Agent, HasTools
+{
+    // ...
+}
+```
+
+You may also require the model to call a specific tool by providing the tool's name:
+
+```php
+#[ToolChoice(ToolChoice::tool, 'lookup_order')]
+class CustomerSupportAgent implements Agent, HasTools
+{
+    // ...
+}
+```
+
+When a specific tool is required, the requirement only applies to the first generation step. After that tool has been called, the model may continue normally.
 
 <a name="provider-options"></a>
 ### Provider Options

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -25,6 +25,7 @@
     - [Agent Configuration](#agent-configuration)
     - [Tool Choice](#tool-choice)
     - [Provider Options](#provider-options)
+- [Summarization](#summarization)
 - [Images](#images)
 - [Audio (TTS)](#audio)
 - [Transcription (STT)](#transcription)
@@ -1552,6 +1553,37 @@ class SalesCoach implements Agent, HasProviderOptions
 The `providerOptions` method receives the provider currently being used (`Lab` enum or string), allowing you to return different options per provider. This is especially useful when using [failover](#failover), since each fallback provider can receive its own configuration.
 
 The Anthropic example above also enables [prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) via `cache_control`.
+
+<a name="summarization"></a>
+## Summarization
+
+The `Str::summarize` method may be used to quickly summarize text:
+
+```php
+use Illuminate\Support\Str;
+use Laravel\Ai\Enums\Lab;
+
+$summary = Str::summarize(
+    $article,
+    sentences: 3,
+    provider: Lab::Anthropic,
+);
+```
+
+You may also summarize a string using the `summarize` method available via Laravel's `Stringable` class:
+
+```php
+use Illuminate\Support\Str;
+use Laravel\Ai\Enums\Lab;
+
+$summary = Str::of($article)->summarize(
+    sentences: 5,
+    provider: Lab::OpenAI,
+    timeout: 120,
+);
+```
+
+For summaries that require custom instructions, tools, or conversation context, you should create a dedicated [agent](#agents).
 
 <a name="images"></a>
 ## Images

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -3,6 +3,7 @@
 - [Introduction](#introduction)
 - [Installation](#installation)
     - [Configuration](#configuration)
+        - [Bedrock](#bedrock)
     - [Custom Base URLs](#custom-base-urls)
     - [OpenAI-Compatible Providers](#openai-compatible-providers)
     - [Provider Support](#provider-support)
@@ -83,16 +84,6 @@ You may define your AI provider credentials in your application's `config/ai.php
 
 ```ini
 ANTHROPIC_API_KEY=
-AWS_BEDROCK_REGION=
-AWS_BEARER_TOKEN_BEDROCK=
-AWS_USE_DEFAULT_CREDENTIALS=
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-AWS_SESSION_TOKEN=
-AWS_BEDROCK_ASSUME_ROLE_ARN=
-AWS_BEDROCK_ASSUME_ROLE_SESSION_NAME=
-AWS_BEDROCK_ASSUME_ROLE_DURATION_SECONDS=
-AWS_BEDROCK_ASSUME_ROLE_EXTERNAL_ID=
 AZURE_OPENAI_API_KEY=
 COHERE_API_KEY=
 DEEPSEEK_API_KEY=
@@ -112,7 +103,23 @@ XAI_API_KEY=
 
 The default models used for text, images, audio, transcription, and embeddings may also be configured in your application's `config/ai.php` configuration file.
 
+<a name="bedrock"></a>
+#### Bedrock
+
 When using Amazon Bedrock, you may authenticate using an AWS bearer token, AWS credentials, or the default AWS credential provider. If your application needs to assume a role before making Bedrock requests, configure the provider's `assume_role` options:
+
+```ini
+AWS_BEDROCK_REGION=
+AWS_BEARER_TOKEN_BEDROCK=
+AWS_USE_DEFAULT_CREDENTIALS=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_SESSION_TOKEN=
+AWS_BEDROCK_ASSUME_ROLE_ARN=
+AWS_BEDROCK_ASSUME_ROLE_SESSION_NAME=
+AWS_BEDROCK_ASSUME_ROLE_DURATION_SECONDS=
+AWS_BEDROCK_ASSUME_ROLE_EXTERNAL_ID=
+```
 
 ```php
 'bedrock' => [
@@ -424,10 +431,10 @@ The conversation ID is returned on the response and can be stored for future ref
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 use Laravel\Ai\Concerns\HasConversations;
 
-class Team extends Model
+class User extends Authenticatable
 {
     use HasConversations;
 }
@@ -436,7 +443,7 @@ class Team extends Model
 Once the trait has been added to your model, you may retrieve and query the participant's conversations via the `conversations` relationship:
 
 ```php
-$conversations = $team->conversations()
+$conversations = $user->conversations()
     ->latest('updated_at')
     ->paginate(20);
 
@@ -454,7 +461,7 @@ To continue an existing conversation, use the `continue` method and provide the 
 
 ```php
 $response = (new SalesCoach)
-    ->continue($conversationId, as: $team)
+    ->continue($conversationId, as: $user)
     ->prompt('Tell me more about that.');
 ```
 
@@ -468,7 +475,7 @@ If you would like to continue the participant's most recent conversation, use th
 
 ```php
 $response = (new SalesCoach)
-    ->continueLastConversation($team)
+    ->continueLastConversation($user)
     ->prompt('What should we work on next?');
 ```
 
@@ -1224,7 +1231,7 @@ To refine search results based on user location, use the `location` method:
 If the provider returns citations for web search results, you may access them via the response's `meta` property. When streaming, citations are emitted as `Citation` stream events as they arrive:
 
 ```php
-$response = (new ResearchAgent)->prompt('What happened in Laravel this week?');
+$response = (new ResearchAgent)->prompt('What new Laravel features were released this week?');
 
 $citations = $response->meta->citations;
 ```

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -28,6 +28,7 @@
 - [Audio (TTS)](#audio)
 - [Transcription (STT)](#transcription)
 - [Embeddings](#embeddings)
+    - [File Embeddings](#file-embeddings)
     - [Querying Embeddings](#querying-embeddings)
     - [Caching Embeddings](#caching-embeddings)
 - [Reranking](#reranking)
@@ -1670,7 +1671,7 @@ Transcription::fromStorage('audio.mp3')
 <a name="embeddings"></a>
 ## Embeddings
 
-You may easily generate vector embeddings for any given string using the new `toEmbeddings` method available via Laravel's `Stringable` class:
+You may easily generate vector embeddings for any given string using the `toEmbeddings` method available via Laravel's `Stringable` class:
 
 ```php
 use Illuminate\Support\Str;
@@ -1698,6 +1699,28 @@ $response = Embeddings::for(['Napa Valley has great wine.'])
     ->dimensions(1536)
     ->generate(Lab::OpenAI, 'text-embedding-3-small');
 ```
+
+<a name="file-embeddings"></a>
+### File Embeddings
+
+The `Embeddings` class may also generate embeddings for file inputs, including documents, images, audio, and video. File inputs may be combined with strings in the same request:
+
+```php
+use Laravel\Ai\Embeddings;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Files;
+
+$response = Embeddings::for([
+    'Product onboarding materials.',
+    Files\Document::fromStorage('handbook.pdf'),
+    Files\Image::fromPath('/home/laravel/product.jpg'),
+    Files\Audio::fromUpload($request->file('call')),
+    Files\Video::fromUrl('https://example.com/demo.mp4'),
+])->generate(provider: Lab::Gemini);
+```
+
+> [!NOTE]
+> File embeddings depend on the selected provider and model. Gemini and VoyageAI provide models capable of embedding multimodal inputs.
 
 <a name="querying-embeddings"></a>
 ### Querying Embeddings
@@ -1909,6 +1932,21 @@ $stored = Document::fromString('Hello, World!', 'text/plain')->put();
 
 // Store an uploaded file...
 $stored = Document::fromUpload($request->file('document'))->put();
+```
+
+Features that accept file inputs, such as [embeddings](#file-embeddings), may also use audio and video file instances:
+
+```php
+use Laravel\Ai\Files\Audio;
+use Laravel\Ai\Files\Video;
+
+$audio = Audio::fromPath('/home/laravel/call.mp3');
+$audio = Audio::fromStorage('recordings/call.mp3');
+$audio = Audio::fromUpload($request->file('audio'));
+
+$video = Video::fromPath('/home/laravel/demo.mp4');
+$video = Video::fromUrl('https://example.com/demo.mp4');
+$video = Video::fromUpload($request->file('video'));
 ```
 
 Once a file has been stored, you may reference the file when generating text via agents instead of re-uploading the file:

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -2905,6 +2905,7 @@ $store->assertAdded(fn (StorableFile $file) => $file->content() === 'Hello, Worl
 The Laravel AI SDK dispatches a variety of [events](/docs/{{version}}/events), including:
 
 - `AddingFileToStore`
+- `AgentFailedOver`
 - `AgentPrompted`
 - `AgentStreamed`
 - `AudioGenerated`
@@ -2921,10 +2922,12 @@ The Laravel AI SDK dispatches a variety of [events](/docs/{{version}}/events), i
 - `ImageGenerated`
 - `InvokingTool`
 - `PromptingAgent`
+- `ProviderFailedOver`
 - `RemovingFileFromStore`
 - `Reranked`
 - `Reranking`
 - `StoreCreated`
+- `StoreDeleted`
 - `StoringFile`
 - `StreamingAgent`
 - `ToolApprovalRequested`

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1985,7 +1985,7 @@ $response = Embeddings::for([
 ```
 
 > [!NOTE]
-> File embeddings depend on the selected provider and model. Gemini and VoyageAI provide models capable of embedding multimodal inputs.
+> File embeddings require a provider and model capable of embedding multimodal inputs. Gemini supports image, audio, document, and video inputs, while VoyageAI supports image and video inputs through its multimodal models. Providers that only support text embeddings throw an `InvalidArgumentException` when given file inputs.
 
 <a name="querying-embeddings"></a>
 ### Querying Embeddings

--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -401,15 +401,15 @@ class SalesCoach implements Agent, Conversational
 
 When using the `RemembersConversations` trait, do not manually define a `messages` method in your agent class. If a `messages` method is present, it will take precedence over the trait's implementation and conversation history will not be loaded from the database.
 
-To start a new conversation for a participant, call the `forParticipant` method before prompting. The participant is typically an Eloquent model that represents the person or resource having the conversation:
+To start a new conversation for a participant, call the `forParticipant` method before prompting. The participant may be any Eloquent model — conversations are scoped to both the model's class and its key, so a `User` and a `Team` that share an ID will never collide:
 
 ```php
-$response = (new SalesCoach)->forParticipant($user)->prompt('Hello!');
+$response = (new SalesCoach)->forParticipant($team)->prompt('Hello!');
 
 $conversationId = $response->conversationId;
 ```
 
-If the participant is a user, you may use the `forUser` method as a convenience alias:
+Since a user is the most common participant, you may use the `forUser` method as a convenience alias:
 
 ```php
 $response = (new SalesCoach)->forUser($user)->prompt('Hello!');
@@ -425,33 +425,43 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Laravel\Ai\Concerns\HasConversations;
 
-class Customer extends Model
+class Team extends Model
 {
     use HasConversations;
 }
 ```
 
-Once the trait has been added to your model, you may retrieve and query the participant's conversations via the `conversations` relationship:
+Once the trait has been added to your model, you may retrieve and query the participant's conversations via the `conversations` relationship. Likewise, a conversation exposes its owning model via the `participant` relationship:
 
 ```php
-$conversations = $customer->conversations()
+$conversations = $team->conversations()
     ->latest('updated_at')
     ->paginate(20);
+
+$conversation->participant; // The owning Team, User, etc...
 ```
+
+Since participants are stored using their morph class, you may wish to [enforce a morph map](/docs/{{version}}/eloquent-relationships#custom-polymorphic-types) so stored conversations survive model renames.
 
 To continue an existing conversation, use the `continue` method and provide the participant using the `as` argument:
 
 ```php
 $response = (new SalesCoach)
-    ->continue($conversationId, as: $customer)
+    ->continue($conversationId, as: $team)
     ->prompt('Tell me more about that.');
+```
+
+The `continue` method trusts the given conversation ID and does not verify ownership. Like route model binding, authorization belongs in your application — for example, by resolving the ID through the participant's own conversations:
+
+```php
+$conversationId = $team->conversations()->findOrFail($conversationId)->id;
 ```
 
 If you would like to continue the participant's most recent conversation, use the `continueLastConversation` method:
 
 ```php
 $response = (new SalesCoach)
-    ->continueLastConversation($customer)
+    ->continueLastConversation($team)
     ->prompt('What should we work on next?');
 ```
 


### PR DESCRIPTION
## Summary

This PR updates the Laravel AI SDK documentation to cover current package usage for recently added and underdocumented APIs.

- Document polymorphic conversation participants, including `forParticipant`, `continueLastConversation`, and participant relationships. Related PR: laravel/ai#795.
- Document human-in-the-loop tool approvals, including approvable tools, approval decisions, streaming, queueing, broadcasting, and tests. Related PR: laravel/ai#773.
- Document file and multimodal embeddings, including audio, document, image, and video inputs. Related PR: laravel/ai#798.
- Document tool choice configuration and runtime `toolChoice` resolution. Related PR: laravel/ai#780.
- Document summarization helpers via `Str::summarize` and `Stringable::summarize`. Related PR: laravel/ai#800.
- Document Bedrock configuration, AssumeRole credentials, and S3 document references. Related PRs: laravel/ai#566, laravel/ai#476.
- Document provider options for pending requests, provider tools, and file uploads. Related PRs: laravel/ai#753, laravel/ai#717.
- Document web search citations and streaming citation events. Related PR: laravel/ai#738.
- Document per-request embedding cache disabling and update provider support coverage. Related PRs: laravel/ai#706, laravel/ai#559.