### PR TITLE
Document Horizon worker options and metrics snapshot trimming

### DIFF
--- a/horizon.md
+++ b/horizon.md
@@ -255,12 +255,12 @@ In addition to `tries`, `timeout`, and `backoff`, each supervisor accepts severa
 
 <div class="content-list" markdown="1">
 
-- `memory` defines the maximum amount of memory, in megabytes, that a single worker process may consume before it is restarted. Defaults to `128`.
-- `maxJobs` defines the number of jobs a worker should process before restarting. A value of `0` indicates that workers should not be restarted based on the number of jobs processed. Defaults to `0`.
-- `maxTime` defines the number of seconds a worker should run before restarting. A value of `0` indicates that workers should not be restarted based on time. Defaults to `0`.
-- `sleep` defines the number of seconds a worker should wait when no job is available before polling the queue for new jobs again. Defaults to `3`.
-- `rest` defines the number of seconds to pause between processing each job. Defaults to `0`.
-- `nice` defines the "niceness" (scheduling priority) of the worker processes. A higher value gives the process a lower priority. Defaults to `0`.
+- `memory` defines the maximum amount of memory, in megabytes, that a single worker process may consume before it is restarted. By default, this value is `128`.
+- `maxJobs` defines the number of jobs a worker should process before restarting. A value of `0` indicates that workers should not be restarted based on the number of jobs processed. By default, this value is `0`.
+- `maxTime` defines the number of seconds a worker should run before restarting. A value of `0` indicates that workers should not be restarted based on time. By default, this value is `0`.
+- `sleep` defines the number of seconds a worker should wait when no job is available before polling the queue for new jobs again. By default, this value is `3`.
+- `rest` defines the number of seconds to pause between processing each job. By default, this value is `0`.
+- `nice` defines the "niceness" (scheduling priority) of the worker processes. A higher value gives the process a lower priority. By default, this value is `0`.
 
 </div>
 
@@ -744,7 +744,7 @@ use Illuminate\Support\Facades\Schedule;
 Schedule::command('horizon:snapshot')->everyFiveMinutes();
 ```
 
-You may configure how many of these snapshots are retained for display in the metrics graphs using the `metrics` configuration option within your application's `config/horizon.php` configuration file. The `trim_snapshots` option controls how many `job` and `queue` snapshots are kept:
+You may configure how many snapshots Horizon retains for its metrics graphs using the `metrics.trim_snapshots` option in your application's `config/horizon.php` configuration file. Because this option limits the number of snapshots rather than their age, the retention period depends on how frequently the `horizon:snapshot` command runs:
 
 ```php
 'metrics' => [

--- a/horizon.md
+++ b/horizon.md
@@ -7,6 +7,7 @@
     - [Max Job Attempts](#max-job-attempts)
     - [Job Timeout](#job-timeout)
     - [Job Backoff](#job-backoff)
+    - [Worker Options](#worker-options)
     - [Silenced Jobs](#silenced-jobs)
 - [Balancing Strategies](#balancing-strategies)
     - [Auto Balancing](#auto-balancing)
@@ -230,6 +231,38 @@ You may also configure "exponential" backoffs by using an array for the `backoff
     ],
 ],
 ```
+
+<a name="worker-options"></a>
+### Worker Options
+
+In addition to `tries`, `timeout`, and `backoff`, each supervisor accepts several other options that control how its worker processes behave and when they are automatically restarted. Periodically restarting workers is a good practice for long-running processes, as it helps guard against memory leaks:
+
+```php
+'environments' => [
+    'production' => [
+        'supervisor-1' => [
+            // ...
+            'memory' => 128,
+            'maxJobs' => 1000,
+            'maxTime' => 3600,
+            'sleep' => 3,
+            'rest' => 0,
+            'nice' => 0,
+        ],
+    ],
+],
+```
+
+<div class="content-list" markdown="1">
+
+- `memory` defines the maximum amount of memory, in megabytes, that a single worker process may consume before it is restarted. Defaults to `128`.
+- `maxJobs` defines the number of jobs a worker should process before restarting. A value of `0` indicates that workers should not be restarted based on the number of jobs processed. Defaults to `0`.
+- `maxTime` defines the number of seconds a worker should run before restarting. A value of `0` indicates that workers should not be restarted based on time. Defaults to `0`.
+- `sleep` defines the number of seconds a worker should wait when no job is available before polling the queue for new jobs again. Defaults to `3`.
+- `rest` defines the number of seconds to pause between processing each job. Defaults to `0`.
+- `nice` defines the "niceness" (scheduling priority) of the worker processes. A higher value gives the process a lower priority. Defaults to `0`.
+
+</div>
 
 <a name="silenced-jobs"></a>
 ### Silenced Jobs
@@ -709,6 +742,17 @@ Horizon includes a metrics dashboard which provides information regarding your j
 use Illuminate\Support\Facades\Schedule;
 
 Schedule::command('horizon:snapshot')->everyFiveMinutes();
+```
+
+You may configure how many of these snapshots are retained for display in the metrics graphs using the `metrics` configuration option within your application's `config/horizon.php` configuration file. The `trim_snapshots` option controls how many `job` and `queue` snapshots are kept:
+
+```php
+'metrics' => [
+    'trim_snapshots' => [
+        'job' => 24,
+        'queue' => 24,
+    ],
+],
 ```
 
 If you would like to delete all metric data, you can invoke the `horizon:clear-metrics` Artisan command:

--- a/horizon.md
+++ b/horizon.md
@@ -7,7 +7,7 @@
     - [Max Job Attempts](#max-job-attempts)
     - [Job Timeout](#job-timeout)
     - [Job Backoff](#job-backoff)
-    - [Worker Options](#worker-options)
+    - [Other Worker Options](#other-worker-options)
     - [Silenced Jobs](#silenced-jobs)
 - [Balancing Strategies](#balancing-strategies)
     - [Auto Balancing](#auto-balancing)
@@ -232,8 +232,8 @@ You may also configure "exponential" backoffs by using an array for the `backoff
 ],
 ```
 
-<a name="worker-options"></a>
-### Worker Options
+<a name="other-worker-options"></a>
+### Other Worker Options
 
 In addition to `tries`, `timeout`, and `backoff`, each supervisor accepts several other options that control how its worker processes behave and when they are automatically restarted. Periodically restarting workers is a good practice for long-running processes, as it helps guard against memory leaks:
 


### PR DESCRIPTION
The Horizon config docs already cover `tries`, `timeout`, and `backoff`, but the rest of the supervisor worker options aren't documented, so today you have to dig through the published `config/horizon.php` stub to find them. Felt the docs should cover these since they're all config driven and easy to miss.

This adds a short Worker Options section for `memory`, `maxJobs`, `maxTime`, `sleep`, `rest`, and `nice`, plus a note on the `metrics.trim_snapshots` option.