### PR TITLE
[13.x] Added docs for valet reading composer.json

### DIFF
--- a/valet.md
+++ b/valet.md
@@ -122,6 +122,8 @@ php=php@8.2
 
 Once this file has been created, you may simply execute the `valet use` command and the command will determine the site's preferred PHP version by reading the file.
 
+Alternatively Valet listens to the php requirement in your `composer.json`, executing the `valet use` or `valet isolate` command will determine the site's preferred PHP version using the php require.
+
 > [!WARNING]
 > Valet only serves one PHP version at a time, even if you have multiple PHP versions installed.
 


### PR DESCRIPTION
Docs for: https://github.com/laravel/valet/pull/1554

> This PR adds support to fall back to the php version defined in the composer.json
Due to using composer/semver all combination of php requirements are possible (though the match is not exact as we only care about the x.x version, no patch versions)
>
>Requirements like ^8.3, 8.3, <8.5, >=8.4 are all supported.
Priority is still given to the valetrc files, and we pick the lowest matching version so ^8.3 could not suddenly switch to 8.6 once it comes out.
This is the same way [rectorphp/rector](https://github.com/rectorphp/rector/blob/a6a70cce35f29cb34a7874a518caf48b7f8d5fc5/src/Configuration/RectorConfigBuilder.php#L388) handles php constraints.