### PR TITLE
Recommend Passport for MCP servers when choosing an authentication stack

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -103,7 +103,7 @@ Next, if your application offers an API that will be consumed by third parties, 
 
 If you are building a single-page application (SPA) that will be powered by a Laravel backend, you should use [Laravel Sanctum](/docs/{{version}}/sanctum). When using Sanctum, you will either need to [manually implement your own backend authentication routes](#authenticating-users) or utilize [Laravel Fortify](/docs/{{version}}/fortify) as a headless authentication backend service that provides routes and controllers for features such as registration, password reset, email verification, and more.
 
-Passport may be chosen when your application absolutely needs all of the features provided by the OAuth2 specification.
+Passport may be chosen when your application absolutely needs all of the features provided by the OAuth2 specification. Additionally, if you are building an [MCP server](/docs/{{version}}/mcp) that will be accessed by AI clients, you should use Passport, as MCP clients typically expect to [authenticate using OAuth](/docs/{{version}}/mcp#oauth).
 
 And, if you would like to get started quickly, we are pleased to recommend [our application starter kits](/docs/{{version}}/starter-kits) as a quick way to start a new Laravel application that already uses our preferred authentication stack of Laravel's built-in authentication services.
 


### PR DESCRIPTION
The ["Summary & Choosing Your Stack"](https://laravel.com/docs/13.x/authentication#summary-choosing-your-stack) section covers monoliths, third-party APIs, and SPAs, but not MCP servers. 

Now that Laravel ships first-party MCP support, developers building an MCP server land on this page and the general advice ("Sanctum should be preferred when possible") points them the wrong way - remote AI clients expect the OAuth flow that [the MCP documentation already recommends](https://laravel.com/docs/13.x/mcp#oauth) via Passport.