### PR TITLE
[12.x] Added the $flags parameter to the method signature for Illuminate\Http\Client\Response::json()

### DIFF
--- a/http-client.md
+++ b/http-client.md
@@ -40,7 +40,7 @@ The `get` method returns an instance of `Illuminate\Http\Client\Response`, which
 
 ```php
 $response->body() : string;
-$response->json($key = null, $default = null) : mixed;
+$response->json($key = null, $default = null, $flags = null) : mixed;
 $response->object() : object;
 $response->collect($key = null) : Illuminate\Support\Collection;
 $response->resource() : resource;


### PR DESCRIPTION
Noticed that this parameter that was added in Laravel 12 was missing from the documentation for the `Illuminate\Http\Client\Response::json()` method