### PR TITLE
[13.x] Mention Sockudo in broadcasting documentation

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -5,10 +5,12 @@
 - [Server Side Installation](#server-side-installation)
     - [Reverb](#reverb)
     - [Pusher Channels](#pusher-channels)
+    - [Sockudo](#sockudo)
     - [Ably](#ably)
 - [Client Side Installation](#client-side-installation)
     - [Reverb](#client-reverb)
     - [Pusher Channels](#client-pusher-channels)
+    - [Sockudo](#client-sockudo)
     - [Ably](#client-ably)
 - [Concept Overview](#concept-overview)
     - [Using an Example Application](#using-example-application)
@@ -56,6 +58,8 @@ The core concepts behind broadcasting are simple: clients connect to named chann
 #### Supported Drivers
 
 By default, Laravel includes three server-side broadcasting drivers for you to choose from: [Laravel Reverb](https://reverb.laravel.com), [Pusher Channels](https://pusher.com/channels), and [Ably](https://ably.com).
+
+Self-hosted servers that implement the Pusher Channels protocol, such as [Sockudo](https://github.com/sockudo/sockudo), may also be used with Laravel's Pusher driver.
 
 > [!NOTE]
 > Before diving into event broadcasting, make sure you have read Laravel's documentation on [events and listeners](/docs/{{version}}/events).
@@ -148,9 +152,6 @@ PUSHER_APP_CLUSTER="mt1"
 
 The `config/broadcasting.php` file's `pusher` configuration also allows you to specify additional `options` that are supported by Channels, such as the cluster.
 
-> [!NOTE]
-> If you prefer to self-host your broadcasting infrastructure, [Sockudo](https://github.com/sockudo/sockudo) is an open-source server that implements the Pusher Channels protocol. It works with Laravel's existing Pusher driver and Laravel Echo by pointing the Pusher host, port, scheme, and application credentials at your Sockudo instance.
-
 Then, set the `BROADCAST_CONNECTION` environment variable to `pusher` in your application's `.env` file:
 
 ```ini
@@ -158,6 +159,17 @@ BROADCAST_CONNECTION=pusher
 ```
 
 Finally, you are ready to install and configure [Laravel Echo](#client-side-installation), which will receive the broadcast events on the client-side.
+
+<a name="sockudo"></a>
+### Sockudo
+
+[Sockudo](https://github.com/sockudo/sockudo) is an open-source, self-hosted server that implements the Pusher Channels protocol. Laravel does not include a dedicated Sockudo driver; instead, select Pusher when running the broadcasting installer:
+
+```shell
+php artisan install:broadcasting --pusher
+```
+
+After installing Sockudo, point the Pusher host, port, scheme, and application credentials in your `.env` file at your Sockudo instance. For installation and deployment options, consult the [Sockudo documentation](https://sockudo.io/docs/getting-started/installation).
 
 <a name="ably"></a>
 ### Ably
@@ -409,6 +421,11 @@ window.Echo = new Echo({
     client: new Pusher(options.key, options)
 });
 ```
+
+<a name="client-sockudo"></a>
+### Sockudo
+
+Since Sockudo implements the Pusher Channels protocol, it uses Echo's `pusher` broadcaster. Follow the [Pusher Channels client installation instructions](#client-pusher-channels), then set the `wsHost`, `wsPort`, `wssPort`, `forceTLS`, and `enabledTransports` options to connect to your Sockudo instance.
 
 <a name="client-ably"></a>
 ### Ably

--- a/broadcasting.md
+++ b/broadcasting.md
@@ -148,6 +148,9 @@ PUSHER_APP_CLUSTER="mt1"
 
 The `config/broadcasting.php` file's `pusher` configuration also allows you to specify additional `options` that are supported by Channels, such as the cluster.
 
+> [!NOTE]
+> If you prefer to self-host your broadcasting infrastructure, [Sockudo](https://github.com/sockudo/sockudo) is an open-source server that implements the Pusher Channels protocol. It works with Laravel's existing Pusher driver and Laravel Echo by pointing the Pusher host, port, scheme, and application credentials at your Sockudo instance.
+
 Then, set the `BROADCAST_CONNECTION` environment variable to `pusher` in your application's `.env` file:
 
 ```ini


### PR DESCRIPTION
## Summary

- list Sockudo beside Reverb, Pusher Channels, and Ably in the server-side and client-side navigation
- add dedicated server-side and client-side Sockudo sections
- clarify that Sockudo works through Laravel's existing Pusher driver and Laravel Echo configuration

## Context

This is a deliberately smaller follow-up to https://github.com/laravel/docs/pull/10421. That proposal was closed while Sockudo was still new and production feedback was limited. Unlike the earlier proposal, this change does not present Sockudo as a built-in Laravel driver or duplicate the Pusher installation instructions.

Since then, Sockudo has progressed to [v4.7.0](https://github.com/sockudo/sockudo/releases/tag/v4.7.0), with 777 stars and 54 forks as of July 28, 2026. Multiple companies and teams are already using Sockudo in production, with public community reports including:

- a [production Redis deployment](https://github.com/sockudo/sockudo/issues/51) exercising Pusher-compatible behavior
- a [Laravel integration report](https://github.com/sockudo/sockudo/issues/130) where the user changed only the WebSocket server image, then confirmed the compatibility fix worked
- a [three-replica Docker Swarm deployment](https://github.com/sockudo/sockudo/issues/120) using Redis for horizontal scaling

Sockudo ecosystem adoption also includes [NautilusTrader](https://github.com/nautechsystems/nautilus_trader), whose `nautilus-network` crate enables its `transport-sockudo` feature by default and depends on `sockudo-ws`. Its [Deribit integration documentation](https://nautilustrader.io/docs/latest/integrations/deribit/) identifies Sockudo as the default Rust WebSocket backend when that feature is enabled. This is adoption of the Sockudo WebSocket crate rather than evidence of a Sockudo realtime server deployment.

Independent coverage has also grown:

- [WebSockets with Pusher - Real-time Events, Notifications with Laravel & TanStack Start](https://nikuscs.com/blog/08-websockets-pusher/) includes a dedicated Sockudo section and Laravel Echo integration
- [5 Awesome Soketi Alternatives](https://sliplane.io/blog/5-awesome-soketi-alternatives) compares Sockudo with Pusher, Centrifugo, Ably, and Mercure
- [Sockudo - The 100K+ Connection Rust WebSocket Server](https://www.blog.brightcoding.dev/2025/10/21/%F0%9F%9A%80-sockudo-the-100k%2B-connection-rust-websocket-server) provides a long-form overview of Sockudo's architecture, scaling, security, and monitoring
- [Startup-ul săptămânii #1: Sockudo](https://www.mobilissimo.ro/articole-diverse/startup-ul-saptamanii-1-sockudo-roiectul-open-source-care-vrea-sa-reduca-dependenta-dezvoltatorilor-de-serviciile-externe-pentru-comunicatii-in-timp-real) profiles Sockudo as a self-hosted Pusher-compatible project
- [Rust Daily: sockudo-ws ultra-low-latency WebSocket library](https://rustcc.cn/article?id=fc37b833-f69b-4eec-a793-7bef1535f6ab) covers the WebSocket engine used by Sockudo

## Impact

Laravel users who want to self-host can discover Sockudo at the same navigation level as the other broadcasting options, without implying that Laravel ships or directly maintains a Sockudo driver.

## Validation

- `git diff --check`
- reviewed against the Pusher server and client configuration documented on the `13.x` branch
