### PR TITLE
[13.x] Document partial indexes and soft-delete uniqueness

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -1183,6 +1183,9 @@ Schema::table('flights', function (Blueprint $table) {
 
 Now, when you call the `delete` method on the model, the `deleted_at` column will be set to the current date and time. However, the model's database record will be left in the table. When querying a model that uses soft deletes, the soft deleted models will automatically be excluded from all query results.
 
+> [!WARNING]
+> Soft-deleted rows remain in the table, so a standard unique index still treats them as conflicts. If you need uniqueness only among non-deleted rows (for example, allowing an email to be reused after soft deletion), use a [partial unique index](/docs/{{version}}/migrations#partial-indexes) such as `$table->unique('email')->whereNull('deleted_at')`. Validation rules like `Rule::unique()->whereNull('deleted_at')` only protect at the application layer.
+
 To determine if a given model instance has been soft deleted, you may use the `trashed` method:
 
 ```php

--- a/migrations.md
+++ b/migrations.md
@@ -1485,15 +1485,17 @@ When using PostgreSQL, this adds the `CONCURRENTLY` option to the index creation
 <a name="partial-indexes"></a>
 ### Partial Indexes
 
-PostgreSQL, SQLite, and SQL Server support "partial" (or "filtered") indexes that only include rows matching a given predicate. You may define a partial index by chaining `where`, `whereNull`, or `whereNotNull` onto an index definition:
+PostgreSQL, SQLite, and SQL Server support "partial" (or "filtered") indexes that only include rows matching a given predicate. You may define a partial index by chaining `where`, `whereNull`, `whereNotNull`, or `whereRaw` onto an `index` or `unique` definition:
 
 ```php
 $table->unique('email')->whereNull('deleted_at');
 
 $table->index('status')->where('active', true);
 
-$table->unique('email')->where('deleted_at is null');
+$table->unique('email')->whereRaw('deleted_at is null');
 ```
+
+The `where` method follows query builder semantics: a single column argument or a `null` value compiles to an `IS NULL` predicate. Use `whereRaw` when you need a raw SQL fragment.
 
 This is especially useful when combining unique indexes with Eloquent [soft deletes](/docs/{{version}}/eloquent#soft-deleting). A normal unique index still sees soft-deleted rows, so re-creating a deleted email or business key fails. A partial unique index that excludes deleted rows allows a new active row while still enforcing uniqueness among non-deleted rows:
 
@@ -1511,8 +1513,8 @@ Schema::create('posts', function (Blueprint $table) {
 > [!WARNING]
 > MySQL and MariaDB do not support partial indexes. Attempting to compile a partial index on those drivers will throw a `RuntimeException`. Application-level validation such as `Rule::unique()->whereNull('deleted_at')` does not replace a database unique constraint.
 
-> [!NOTE]
-> On PostgreSQL, partial unique indexes are created as indexes (not table constraints). Drop them with `dropIndex` rather than `dropUnique`:
+> [!WARNING]
+> On PostgreSQL, partial unique indexes are created as indexes (not table constraints). Always drop them with `dropIndex` rather than `dropUnique` — `dropUnique` emits `DROP CONSTRAINT` and will fail for partial unique indexes:
 >
 > ```php
 > $table->dropIndex('posts_user_id_slug_unique');

--- a/migrations.md
+++ b/migrations.md
@@ -1513,11 +1513,11 @@ Schema::create('posts', function (Blueprint $table) {
 > [!WARNING]
 > MySQL and MariaDB do not support partial indexes. Attempting to compile a partial index on those drivers will throw a `RuntimeException`. Application-level validation such as `Rule::unique()->whereNull('deleted_at')` does not replace a database unique constraint.
 
-> [!WARNING]
-> On PostgreSQL, partial unique indexes are created as indexes (not table constraints). Always drop them with `dropIndex` rather than `dropUnique` — `dropUnique` emits `DROP CONSTRAINT` and will fail for partial unique indexes:
+> [!NOTE]
+> On PostgreSQL, partial unique indexes are created as indexes (not table constraints). `dropUnique()` detects this and emits `DROP INDEX` when needed, so you can drop either form with:
 >
 > ```php
-> $table->dropIndex('posts_user_id_slug_unique');
+> $table->dropUnique('posts_user_id_slug_unique');
 > ```
 
 <a name="renaming-indexes"></a>

--- a/migrations.md
+++ b/migrations.md
@@ -19,6 +19,7 @@
     - [Dropping Columns](#dropping-columns)
 - [Indexes](#indexes)
     - [Creating Indexes](#creating-indexes)
+    - [Partial Indexes](#partial-indexes)
     - [Renaming Indexes](#renaming-indexes)
     - [Dropping Indexes](#dropping-indexes)
     - [Foreign Key Constraints](#foreign-key-constraints)
@@ -1480,6 +1481,42 @@ $table->string('email')->unique()->online();
 ```
 
 When using PostgreSQL, this adds the `CONCURRENTLY` option to the index creation statement. When using SQL Server, this adds the `WITH (online = on)` option.
+
+<a name="partial-indexes"></a>
+### Partial Indexes
+
+PostgreSQL, SQLite, and SQL Server support "partial" (or "filtered") indexes that only include rows matching a given predicate. You may define a partial index by chaining `where`, `whereNull`, or `whereNotNull` onto an index definition:
+
+```php
+$table->unique('email')->whereNull('deleted_at');
+
+$table->index('status')->where('active', true);
+
+$table->unique('email')->where('deleted_at is null');
+```
+
+This is especially useful when combining unique indexes with Eloquent [soft deletes](/docs/{{version}}/eloquent#soft-deleting). A normal unique index still sees soft-deleted rows, so re-creating a deleted email or business key fails. A partial unique index that excludes deleted rows allows a new active row while still enforcing uniqueness among non-deleted rows:
+
+```php
+Schema::create('posts', function (Blueprint $table) {
+    $table->id();
+    $table->foreignId('user_id');
+    $table->string('slug');
+    $table->softDeletes();
+
+    $table->unique(['user_id', 'slug'])->whereNull('deleted_at');
+});
+```
+
+> [!WARNING]
+> MySQL and MariaDB do not support partial indexes. Attempting to compile a partial index on those drivers will throw a `RuntimeException`. Application-level validation such as `Rule::unique()->whereNull('deleted_at')` does not replace a database unique constraint.
+
+> [!NOTE]
+> On PostgreSQL, partial unique indexes are created as indexes (not table constraints). Drop them with `dropIndex` rather than `dropUnique`:
+>
+> ```php
+> $table->dropIndex('posts_user_id_slug_unique');
+> ```
 
 <a name="renaming-indexes"></a>
 ### Renaming Indexes


### PR DESCRIPTION
## Summary
- Document partial indexes (`where` / `whereNull` / `whereNotNull`) in the migrations guide
- Warn about SoftDeletes + unique indexes in the Eloquent soft deleting docs
- Companion to https://github.com/laravel/framework/pull/61007


Made with [Cursor](https://cursor.com)