### PR TITLE
Remove beta notice for automatic eager loading

### DIFF
--- a/eloquent-relationships.md
+++ b/eloquent-relationships.md
@@ -2249,9 +2249,6 @@ $activities = ActivityFeed::with('parentable')
 <a name="automatic-eager-loading"></a>
 ### Automatic Eager Loading
 
-> [!WARNING]
-> This feature is currently in beta in order to gather community feedback. The behavior and functionality of this feature may change even on patch releases.
-
 In many cases, Laravel can automatically eager load the relationships you access. To enable automatic eager loading, you should invoke the `Model::automaticallyEagerLoadRelationships` method within the `boot` method of your application's `AppServiceProvider`:
 
 ```php


### PR DESCRIPTION
The Laravel 13.x docs still mark automatic eager loading as beta. We’d like to use it in production, but the warning about changes in patch releases makes us hesitant.

I’m opening this small PR to remove the notice and let Taylor make the call. If the feature is ready, this can be merged. If it isn’t, feel free to close it and we’ll hold off for now.
