### PR TITLE
Edit collections#method-crossjoin: cross joins give combinations, not permutations

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -631,7 +631,7 @@ $counted->all();
 <a name="method-crossjoin"></a>
 #### `crossJoin()` {.collection-method}
 
-The `crossJoin` method cross joins the collection's values among the given arrays or collections, returning a Cartesian product with all possible permutations:
+The `crossJoin` method cross joins the collection's values among the given arrays or collections, returning a Cartesian product with all possible combinations:
 
 ```php
 $collection = collect([1, 2]);


### PR DESCRIPTION
A very small gripe. The cross join/cartesian product gives you _combinations_, not permutations. If it gave you permutations then it would give you `[1, 'a']` and `['a', 1]` as separate things.