### PR TITLE
[13.x] Add prependToPriorityList and appendToPriorityList methods

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -396,6 +396,24 @@ Rarely, you may need your middleware to execute in a specific order but not have
 })
 ```
 
+If you would like to add middleware to the existing priority list without replacing it, you may use the `prependToPriorityList` or `appendToPriorityList` methods. The `prependToPriorityList` method inserts the given middleware before another middleware, while the `appendToPriorityList` method inserts it after another middleware:
+
+```php
+->withMiddleware(function (Middleware $middleware): void {
+    $middleware->prependToPriorityList(
+        before: \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        prepend: \App\Http\Middleware\EnsureTokenIsValid::class,
+    );
+
+    $middleware->appendToPriorityList(
+        after: \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        append: \App\Http\Middleware\EnsureUserIsSubscribed::class,
+    );
+})
+```
+
+The `before` and `after` arguments may also be an array of middleware classes.
+
 <a name="middleware-parameters"></a>
 ## Middleware Parameters
 


### PR DESCRIPTION
Hello there!

While reading the middleware documentation, I accidentally noticed that the `appendToPriorityList` and `prependToPriorityList` methods are not documented in the [Sorting Middleware](https://laravel.com/docs/13.x/middleware#sorting-middleware) section.

The only existing reference is an example of `prependToPriorityList` in [URL Defaults and Middleware Priority](https://laravel.com/docs/13.x/urls#url-defaults-middleware-priority). Although that example demonstrates a specific use case, it may be difficult to discover when looking for information about middleware sorting, and `appendToPriorityList` is not mentioned there.

These methods were introduced in Laravel 11 through [laravel/framework#53326](https://github.com/laravel/framework/pull/53326) and remain available in Laravel 13.

This PR documents both methods in the [Sorting Middleware](https://laravel.com/docs/13.x/middleware#sorting-middleware) section, where readers are more likely to look for ways to customize the middleware priority list without replacing it entirely.

Please feel free to let me know if any changes are needed. I would be happy to improve this contribution or submit corresponding updates for previous documentation versions if appropriate.

Thank you for your time.