### PR TITLE
Adjust FastCGI buffer settings in deployment.md

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -82,10 +82,10 @@ server {
         fastcgi_pass unix:/var/run/php/php8.3-fpm.sock;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
-        fastcgi_hide_header X-Powered-By;
         fastcgi_buffer_size 32k;
         fastcgi_buffers 8 32k;
         fastcgi_busy_buffers_size 64k;
+        fastcgi_hide_header X-Powered-By;
     }
 
     location ~ /\.(?!well-known).* {

--- a/deployment.md
+++ b/deployment.md
@@ -83,6 +83,9 @@ server {
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
         fastcgi_hide_header X-Powered-By;
+        fastcgi_buffer_size 32k;
+        fastcgi_buffers 8 32k;
+        fastcgi_busy_buffers_size 64k;
     }
 
     location ~ /\.(?!well-known).* {


### PR DESCRIPTION
Increase FastCGI buffers
```
fastcgi_buffer_size 32k;
fastcgi_buffers 8 32k;
fastcgi_busy_buffers_size 64k;
```
Without this configs it throw `upstream sent too big header while reading response header from upstream` error on page refresh due to large headers.