### PR TITLE
Remove reference to dusk browser in Pest tests

### DIFF
--- a/dusk.md
+++ b/dusk.md
@@ -164,7 +164,6 @@ The `DatabaseMigrations` trait will run your database migrations before each tes
 <?php
 
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
 
 pest()->use(DatabaseMigrations::class);
 
@@ -200,7 +199,6 @@ The `DatabaseTruncation` trait will migrate your database on the first test in o
 <?php
 
 use Illuminate\Foundation\Testing\DatabaseTruncation;
-use Laravel\Dusk\Browser;
 
 pest()->use(DatabaseTruncation::class);
 
@@ -358,7 +356,6 @@ To get started, let's write a test that verifies we can log into our application
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
 
 pest()->use(DatabaseMigrations::class);
 
@@ -2481,7 +2478,6 @@ Once the component has been defined, we can easily select a date within the date
 <?php
 
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Laravel\Dusk\Browser;
 use Tests\Browser\Components\DatePicker;
 
 pest()->use(DatabaseMigrations::class);


### PR DESCRIPTION
Remove unnecessary references to dusk browser in Pest test examples. I've confirmed this isn't required locally:
```
<?php

use Illuminate\Foundation\Testing\DatabaseTruncation;

pest()->use(DatabaseTruncation::class);

beforeEach(function () {
    $this->seed();
});

it('title is as expected', function () {
    $page = visit('/');
 
    $page->assertTitle('My Page Title');
});
```