### PR TITLE
Fix email sender address retrieval method

### DIFF
--- a/mail.md
+++ b/mail.md
@@ -1541,7 +1541,7 @@ class MailchimpTransport extends AbstractTransport
         $email = MessageConverter::toEmail($message->getOriginalMessage());
 
         $this->client->messages->send(['message' => [
-            'from_email' => $email->getFrom(),
+            'from_email' => collect($email->getFrom())->first()->getAddress(),
             'to' => collect($email->getTo())->map(function (Address $email) {
                 return ['email' => $email->getAddress(), 'type' => 'to'];
             })->all(),


### PR DESCRIPTION
I suppose there was a change on Symphony side some time ago (did not look at it).
To make the example work I need to adjust how to retrieve the from email address (which comes from MAIL_FROM_ADDRESS eventually. Otherwise mailchimp has an empty string and the mail been rejected.
```
{
    "message": {
        "from_email": [
            {} <===== 
        ],
        "to": [
            {
                "email": "david.tourrel@timesofmalta.com",
                "type": "to"
            }
        ],
        "subject": "Verify your email address",
        "text": "<Mail Content>"
    },
    "key": "<key>"
}
```

Hope this help
David