### PR TITLE
[13.x] Document session serialization configuration

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -30,6 +30,7 @@
 <div class="content-list" markdown="1">
 
 - [Cache Prefixes and Session Cookie Names](#cache-prefixes-and-session-cookie-names)
+- [Session `serialization` Configuration](#session-serialization-configuration)
 - [Collection Model Serialization Restores Eager-Loaded Relations](#collection-model-serialization-restores-eager-loaded-relations)
 - [`Container::call` and Nullable Class Defaults](#containercall-and-nullable-class-defaults)
 - [Domain Route Registration Precedence](#domain-route-registration-precedence)
@@ -141,6 +142,20 @@ The default application `cache` configuration now includes a `serializable_class
 ```
 
 If your application previously relied on unserializing arbitrary cached objects, you will need to migrate that usage to explicit class allow-lists or to non-object cache payloads (such as arrays).
+
+<a name="cache"></a>
+### Session
+
+<a name="session-serialization-configuration"></a>
+#### Session `serialization` Configuration
+
+**Likelihood Of Impact: Low**
+
+To help prevent PHP deserialization gadget chain attacks, the default skeleton now sets the session `serialization` option to `json` in the `config/session.php` file.
+
+If you are upgrading an existing application and syncing your configuration files with the Laravel 13 skeleton, updating this value from `php` to `json` will invalidate all active user sessions.
+
+If you wish to seamlessly maintain active sessions during your upgrade, you should ensure this value remains set to `php`. However, if your application does not store PHP objects in the session and you are comfortable requiring your users to re-authenticate, we recommend updating this value to `json` for improved security.
 
 <a name="container"></a>
 ### Container

--- a/upgrade.md
+++ b/upgrade.md
@@ -30,7 +30,6 @@
 <div class="content-list" markdown="1">
 
 - [Cache Prefixes and Session Cookie Names](#cache-prefixes-and-session-cookie-names)
-- [Session `serialization` Configuration](#session-serialization-configuration)
 - [Collection Model Serialization Restores Eager-Loaded Relations](#collection-model-serialization-restores-eager-loaded-relations)
 - [`Container::call` and Nullable Class Defaults](#containercall-and-nullable-class-defaults)
 - [Domain Route Registration Precedence](#domain-route-registration-precedence)
@@ -40,6 +39,7 @@
 - [Pagination Bootstrap View Names](#pagination-bootstrap-view-names)
 - [Polymorphic Pivot Table Name Generation](#polymorphic-pivot-table-name-generation)
 - [`QueueBusy` Event Property Rename](#queuebusy-event-property-rename)
+- [Session `serialization` Configuration](#session-serialization-configuration)
 - [`Str` Factories Reset Between Tests](#str-factories-reset-between-tests)
 
 </div>
@@ -142,20 +142,6 @@ The default application `cache` configuration now includes a `serializable_class
 ```
 
 If your application previously relied on unserializing arbitrary cached objects, you will need to migrate that usage to explicit class allow-lists or to non-object cache payloads (such as arrays).
-
-<a name="cache"></a>
-### Session
-
-<a name="session-serialization-configuration"></a>
-#### Session `serialization` Configuration
-
-**Likelihood Of Impact: Low**
-
-To help prevent PHP deserialization gadget chain attacks, the default skeleton now sets the session `serialization` option to `json` in the `config/session.php` file.
-
-If you are upgrading an existing application and syncing your configuration files with the Laravel 13 skeleton, updating this value from `php` to `json` will invalidate all active user sessions.
-
-If you wish to seamlessly maintain active sessions during your upgrade, you should ensure this value remains set to `php`. However, if your application does not store PHP objects in the session and you are comfortable requiring your users to re-authenticate, we recommend updating this value to `json` for improved security.
 
 <a name="container"></a>
 ### Container
@@ -375,6 +361,20 @@ If you maintain custom queue driver implementations of this contract, add implem
 Routes with an explicit domain are now prioritized before non-domain routes in route matching.
 
 This allows catch-all subdomain routes to behave consistently even when non-domain routes are registered earlier. If your application relied on previous registration precedence between domain and non-domain routes, review route matching behavior.
+
+<a name="session"></a>
+### Session
+
+<a name="session-serialization-configuration"></a>
+#### Session `serialization` Configuration
+
+**Likelihood Of Impact: Low**
+
+To help prevent PHP deserialization gadget chain attacks, the default application skeleton now sets the session `serialization` option to `json` in the `config/session.php` file.
+
+If you are upgrading an existing application and syncing your configuration files with the Laravel 13 skeleton, updating this value from `php` to `json` will invalidate all active user sessions.
+
+If you wish to seamlessly maintain active sessions during your upgrade, you should ensure this value remains set to `php`. However, if your application does not store PHP objects in the session and you are comfortable requiring your users to re-authenticate, we recommend updating this value to `json` for improved security.
 
 <a name="scheduling"></a>
 ### Scheduling


### PR DESCRIPTION
Just adding a quick note to the upgrade guide about the new `json` session serialization default in the v13 skeleton.

When developers sync their config files during an upgrade, they'll naturally pick up this new setting. If an existing app switches from `php` to `json`, all active sessions are invalidated, which means everyone gets logged out after deployment.

I think it's worth documenting this so developers know what to expect and can either keep using `php` or plan for users to sign in again after the upgrade.