### PR TITLE
[13.x] Fix: casting an image to a string returns a data URI, not bytes

### DIFF
--- a/images.md
+++ b/images.md
@@ -258,10 +258,10 @@ $base64 = $image->toBase64();
 $dataUri = $image->toDataUri();
 ```
 
-An image instance may also be cast to a string to retrieve its processed bytes:
+An image instance may also be cast to a string to retrieve a data URI:
 
 ```php
-$bytes = (string) $image;
+$dataUri = (string) $image;
 ```
 
 <a name="storing-images"></a>


### PR DESCRIPTION
`(string) $image` returns a data URI, not raw bytes (`__toString()` → `toDataUri()`; `toBytes()` returns the bytes). Updates the sentence and the example variable name to match.