### PR TITLE
Document dropForeignIdFor behavior change in upgrade guide

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -29,6 +29,7 @@
 - [Carbon 3](#carbon-3)
 - [Concurrency Result Index Mapping](#concurrency-result-index-mapping)
 - [Container Class Dependency Resolution](#container-class-dependency-resolution)
+- [Dropping Foreign Key Constraints](#drop-foreign-for)
 - [Image Validation Now Excludes SVGs](#image-validation)
 - [Local Filesystem Disk Default Root Path](#local-filesystem-disk-default-root-path)
 - [Multi-Schema Database Inspecting](#multi-schema-database-inspecting)
@@ -181,6 +182,24 @@ $tables = Schema::getTableListing(schema: 'main', schemaQualified: false);
 ```
 
 The `db:table` and `db:show` commands now output the results of all schemas on MySQL, MariaDB, and SQLite, just like PostgreSQL and SQL Server.
+
+<a name="drop-foreign-for"></a>
+#### Dropping Foreign Key Constraints
+
+**Likelihood Of Impact: Low**
+
+To improve consistency the `Blueprint::dropForeignIdFor()` method now drops the column created by `Blueprint::foreignIdFor()` instead of dropping the foreign key constraint. To drop the foreign key constraint use one of the following:
+
+```php
+// Drops foreign key constraint and column
+$table->dropConstrainedForeignIdFor(User::class);
+
+// Drops just the foreign key constraint based on the column name
+$table->dropForeign(['user_id']);
+
+// Drops the foreign key constraint based on the exact index name
+$table->dropForeign('examples_user_id_index');
+```
 
 <a name="database-constructor-signature-changes"></a>
 #### Database Constructor Signature Changes


### PR DESCRIPTION
[laravel/framework#54102](https://github.com/laravel/framework/pull/54102) was a fix to make the behavior of `dropForeignIdFor` mirror the behavior of `foreignIdFor`.  This is a good change but isn't really documented anywhere easy to find.  The docs don't mention the function and the api auto documentation doesn't reflect any change, I had to dig into the source code and compare to figure out what was going on.

I lost a few hours trying to figure out why our migrations were suddenly breaking when upgrading from 11x to 12x, so I think it'd be good to have in the upgrade guide.