### PR TITLE
[13.x] Fix the heading level of groupByRaw

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -363,7 +363,7 @@ $orders = DB::table('orders')
 ```
 
 <a name="groupbyraw"></a>
-### `groupByRaw`
+#### `groupByRaw`
 
 The `groupByRaw` method may be used to provide a raw string as the value of the `group by` clause:
 


### PR DESCRIPTION
The **Raw Methods** section in `queries.md` introduces its contents with "you may also use the following methods to insert a raw expression into various parts of your query", then documents five of them. Four are level 4 headings, but `groupByRaw` is a level 3:

```
## Raw Expressions
### Raw Methods
####  `selectRaw`
####  `whereRaw / orWhereRaw`
####  `havingRaw / orHavingRaw`
####  `orderByRaw`
###   `groupByRaw`     <- one level up
## Joins
```

So `groupByRaw` renders as a sibling of **Raw Methods** rather than as one of the methods inside it, even though it is documented exactly like `orderByRaw` right above it.

This changes `###` to `####` on that one heading. The `<a name="groupbyraw"></a>` anchor is untouched, so existing links to `#groupbyraw` keep working, and none of the five raw methods are listed in the table of contents, so nothing needs to be added there either.

I checked the other 104 pages for the same thing. Grouping every run of consecutive headings whose text is purely a method name in backticks and comparing the levels within each run, this is the only group in the docs that is not uniform.