### PR TITLE
[13.x] Add missing code block language tags

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -283,7 +283,7 @@ $array = Arr::add(['name' => 'Desk', 'price' => null], 'price', 100);
 
 The `Arr::array` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not an `array`:
 
-```
+```php
 use Illuminate\Support\Arr;
 
 $array = ['name' => 'Joe', 'languages' => ['PHP', 'Ruby']];
@@ -302,7 +302,7 @@ $value = Arr::array($array, 'name');
 
 The `Arr::boolean` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `boolean`:
 
-```
+```php
 use Illuminate\Support\Arr;
 
 $array = ['name' => 'Joe', 'available' => true];
@@ -520,7 +520,7 @@ $flattened = Arr::flatten($array);
 
 The `Arr::float` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `float`:
 
-```
+```php
 use Illuminate\Support\Arr;
 
 $array = ['name' => 'Joe', 'balance' => 123.45];
@@ -657,7 +657,7 @@ $contains = Arr::hasAny($array, ['category', 'product.discount']);
 
 The `Arr::integer` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not an `int`:
 
-```
+```php
 use Illuminate\Support\Arr;
 
 $array = ['name' => 'Joe', 'age' => 42];
@@ -1286,7 +1286,7 @@ $sorted = Arr::sortRecursiveDesc($array);
 
 The `Arr::string` method retrieves a value from a deeply nested array using "dot" notation (just as [Arr::get()](#method-array-get) does), but throws an `InvalidArgumentException` if the requested value is not a `string`:
 
-```
+```php
 use Illuminate\Support\Arr;
 
 $array = ['name' => 'Joe', 'languages' => ['PHP', 'Ruby']];

--- a/starter-kits.md
+++ b/starter-kits.md
@@ -584,7 +584,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
 You may want to customize the default email template to better align with your application's branding. To modify this template, you should publish the email views to your application with the following command:
 
-```
+```shell
 php artisan vendor:publish --tag=laravel-mail
 ```
 


### PR DESCRIPTION
Six fenced code blocks are missing their language, so they render as plain unhighlighted text next to identical blocks that are highlighted.

### `helpers.md`

The five typed `Arr` retrieval helpers all share the same shape, the same opening sentence, and the same `use Illuminate\Support\Arr;` first line, and all five were added without a language on the fence:

| Method | Line |
| --- | --- |
| `Arr::array()` | 286 |
| `Arr::boolean()` | 305 |
| `Arr::float()` | 523 |
| `Arr::integer()` | 660 |
| `Arr::string()` | 1289 |

They are the only bare fences on the page. The other 245 blocks in `helpers.md` are tagged `php`, including `Arr::add()` immediately above `Arr::array()`.

### `starter-kits.md`

`php artisan vendor:publish --tag=laravel-mail` on line 587 is missing `shell`. That exact command appears 22 times across the docs and every other occurrence uses `shell`, including the three other command blocks in this same file at lines 38, 518 and 524.

### What I checked

I walked the fences in all 105 pages and found 10 bare ones out of 5854. Six are the ones above. The other four are deliberate and left alone: a bare file path in `boost.md`, and three `GET /api/...` request lines in `eloquent-resources.md`, which are the only three request examples in the docs and are already consistent with each other.

I also ran the five `helpers.md` snippets through `php -l` to confirm the `php` tag is right, and all five report no syntax errors. The fence count is unchanged at 5854 after the edit, and the internal link check still passes with 4055 anchors and nothing broken.