### PR TITLE
[13.x] Add reference to AI repository in contributions guide

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -27,6 +27,7 @@ The Laravel source code is managed on GitHub, and there are repositories for eac
 
 <div class="content-list" markdown="1">
 
+- [Laravel AI](https://github.com/laravel/ai)
 - [Laravel Application](https://github.com/laravel/laravel)
 - [Laravel Art](https://github.com/laravel/art)
 - [Laravel Boost](https://github.com/laravel/boost)

--- a/contributions.md
+++ b/contributions.md
@@ -27,7 +27,7 @@ The Laravel source code is managed on GitHub, and there are repositories for eac
 
 <div class="content-list" markdown="1">
 
-- [Laravel AI](https://github.com/laravel/ai)
+- [Laravel AI SDK](https://github.com/laravel/ai)
 - [Laravel Application](https://github.com/laravel/laravel)
 - [Laravel Art](https://github.com/laravel/art)
 - [Laravel Boost](https://github.com/laravel/boost)


### PR DESCRIPTION
This PR adds the missing `laravel/ai` repository to the list of official Laravel projects in the Contributions Guide. 
