### PR TITLE
[13.x] Fix two table of contents labels

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -31,7 +31,7 @@
     - [Anonymous Index Components](#anonymous-index-components)
     - [Data Properties / Attributes](#data-properties-attributes)
     - [Accessing Parent Data](#accessing-parent-data)
-    - [Anonymous Components Paths](#anonymous-component-paths)
+    - [Anonymous Component Paths](#anonymous-component-paths)
 - [Building Layouts](#building-layouts)
     - [Layouts Using Components](#layouts-using-components)
     - [Layouts Using Template Inheritance](#layouts-using-template-inheritance)

--- a/events.md
+++ b/events.md
@@ -26,7 +26,7 @@
     - [Registering Event Subscribers](#registering-event-subscribers)
 - [Testing](#testing)
     - [Faking a Subset of Events](#faking-a-subset-of-events)
-    - [Scoped Events Fakes](#scoped-event-fakes)
+    - [Scoped Event Fakes](#scoped-event-fakes)
 
 <a name="introduction"></a>
 ## Introduction


### PR DESCRIPTION
Two table of contents entries carry a stray plural on the first word, so the label in the sidebar does not match the section it points at.

| Page | Table of contents | Section heading | Anchor |
| --- | --- | --- | --- |
| `blade.md` | Anonymous **Components** Paths | Anonymous **Component** Paths | `#anonymous-component-paths` |
| `events.md` | Scoped **Events** Fakes | Scoped **Event** Fakes | `#scoped-event-fakes` |

In both cases the heading and the anchor already agree on the singular, so the label is the odd one out. Their neighbours in the same lists read the same way: `Anonymous Index Components`, `Writing Event Subscribers`, `Registering Event Subscribers`.

Only the link text changes. The anchors are untouched, so no existing link moves.

### How I checked

I walked every table of contents entry in the 105 pages and compared its label against the heading its anchor points at, which gave 2062 pairs. Most differences are deliberate shortenings, like `Conditional Classes` for a section called `Conditional Classes & Styles`, so I dropped every pair where one text contains the other. Of what was left, these two are the only ones where the label and the heading disagree on a singular versus plural noun.

`validation.md` also came up, but the opposite way round: there the heading and the label both read `Specifying Attributes in Language Files` and it is the older anchor that says `attribute`. That anchor is a live URL, so it is better left alone.

Ran the internal link check before and after: 4055 anchors and 4539 links, nothing broken either way.