### PR TITLE
[13.x] Add the missing anchor for the WorkOS configuration section

### DIFF
--- a/starter-kits.md
+++ b/starter-kits.md
@@ -19,6 +19,7 @@
     - [Rate Limiting](#rate-limiting)
 - [Teams](#teams)
 - [WorkOS AuthKit Authentication](#workos)
+    - [Configuring Your WorkOS Starter Kit](#configuring-your-workos-starter-kit)
 - [Inertia SSR](#inertia-ssr)
 - [Community Maintained Starter Kits](#community-maintained-starter-kits)
 - [Frequently Asked Questions](#faqs)
@@ -488,6 +489,7 @@ Using WorkOS as your authentication provider [requires a WorkOS account](https:/
 
 To use WorkOS AuthKit as your application's authentication provider, select the WorkOS option when creating your new starter kit powered application via `laravel new`.
 
+<a name="configuring-your-workos-starter-kit"></a>
 ### Configuring Your WorkOS Starter Kit
 
 After creating a new application using a WorkOS powered starter kit, you should set the `WORKOS_CLIENT_ID`, `WORKOS_API_KEY`, and `WORKOS_REDIRECT_URL` environment variables in your application's `.env` file. These variables should match the values provided to you in the WorkOS dashboard for your application:


### PR DESCRIPTION
`starter-kits.md` has 23 headings. Twenty two of them are preceded by an `<a name="...">` anchor and appear in the page's table of contents. `Configuring Your WorkOS Starter Kit` has neither, so nothing can link to it and it does not show up in the sidebar.

```
<a name="workos"></a>
## WorkOS AuthKit Authentication
...
### Configuring Your WorkOS Starter Kit     <- no anchor
...
<a name="inertia-ssr"></a>
### Inertia SSR
```

The anchor name follows what the rest of the docs do with these headings: of the 34 headings that start with `Configuring`, 32 use the full heading text lowercased and hyphenated, so this one becomes `configuring-your-workos-starter-kit`.

The table of contents entry is indented under `WorkOS AuthKit Authentication` because the section is a level 3 heading inside that level 2 section, which is how the page already lists `React`, `Svelte`, `Vue` and `Livewire` under `Available Starter Kits`, and `Rate Limiting` under `Authentication`.

### How I checked

I walked every level 2 and level 3 heading across the 105 pages, 2088 in total, and looked for the ones with no anchor above them. Eleven came back. Ten are the `Laravel\Pennant\Events\...` headings in `pennant.md`, which sit under a single `Events` section that is itself anchored and listed, so they are a flat list rather than sections you navigate to. This is the only standalone one.

Anchors go from 4055 to 4056 and the internal link check still reports nothing broken.

This does not conflict with #11337, which touches a fenced code block much further down the same file. I merged the two branches locally to confirm.