### PR TITLE
[13.x] Mention faking DNS lookups in the email rule docs

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1691,6 +1691,22 @@ $request->validate([
 ]);
 ```
 
+The `dns` validator performs a real DNS lookup to confirm the address's domain has a valid MX record. It does not determine whether an individual mailbox exists.
+
+Since your tests should not rely on live DNS lookups, you may use the `Validator::fakeDnsLookups` method to [fake DNS lookups](#rule-active-url) while any other requested validations, such as `rfc`, continue to run:
+
+```php
+use Illuminate\Support\Facades\Validator;
+
+Validator::fakeDnsLookups();
+```
+
+This allows your application to keep using its existing validation rules while testing:
+
+```php
+'email' => ['required', 'email:rfc,dns'],
+```
+
 > [!WARNING]
 > The `dns` and `spoof` validators require the PHP `intl` extension.
 


### PR DESCRIPTION
`Validator::fakeDnsLookups()` is currently only documented under the [`active_url`](https://laravel.com/docs/13.x/validation#rule-active-url) rule, even though it also applies to `email:dns`. Developers whose email validation tests fail because of live DNS lookups are unlikely to look under `active_url` for the fix.

This adds a short paragraph to the `email` rule section that clarifies the `dns` validator performs a real DNS lookup (of the domain's MX record — not of an individual mailbox), and points to the existing explanation rather than repeating it.