### PR TITLE
[13.x] Adjust Queue::route order

### DIFF
--- a/queues.md
+++ b/queues.md
@@ -1524,7 +1524,7 @@ You may also route multiple job classes at once by passing an array to the `rout
 
 ```php
 Queue::route([
-    ProcessPodcast::class => ['podcasts', 'redis'], // Queue and connection
+    ProcessPodcast::class => ['redis', 'podcasts'], // Connection and queue
     ProcessVideo::class => 'videos', // Queue only (uses default connection)
 ]);
 ```


### PR DESCRIPTION
Connection is first as indicated via:

https://github.com/laravel/framework/blob/3adfccdb611f0f26dd16a7ec7e442340693a4b86/src/Illuminate/Queue/QueueRoutes.php#L39-L41

^ The first item is the connection