### PR TITLE
Fix invalid validation rule and array method call in AI SDK docs (Human Tool Approval)

### DIFF
--- a/ai-sdk.md
+++ b/ai-sdk.md
@@ -1695,14 +1695,14 @@ Route::post('/chat/{conversation}', function (Request $request, Conversation $co
     Gate::authorize('view', $conversation);
 
     $validated = $request->validate([
-        'message' => ['nullable', 'string', 'required_without:decisions', 'prohibited_with:decisions'],
-        'decisions' => ['nullable', 'array', 'required_without:message', 'prohibited_with:message'],
+        'message' => ['nullable', 'string', 'required_without:decisions', 'prohibits:decisions'],
+        'decisions' => ['nullable', 'array', 'required_without:message', 'prohibits:message'],
         'decisions.*.action' => ['required_with:decisions', Rule::in(['approve', 'reject'])],
         'decisions.*.result' => ['nullable', 'string'],
     ]);
 
     $prompt = isset($validated['decisions'])
-        ? Decisions::from($validated->collect('decisions')->map(
+        ? Decisions::from(collect($validated['decisions'])->map(
             fn (array $decision) => match ($decision['action']) {
                 'approve' => Decision::approve(),
                 'reject' => Decision::reject($decision['result'] ?? null),


### PR DESCRIPTION
### Summary
This PR fixes two issues in the code example under **AI SDK > Human Tool Approval > Complete Approval Flow**:

1. **Invalid method call:** `$request->validate()` returns a plain PHP `array`, so calling `$validated->collect()` raises `Call to a member function collect() on array`. Changed to `collect($validated['decisions'])`.
2. **Invalid validation rule:** `prohibited_with` is not a valid Laravel validation rule. Replaced with the actual rule, `prohibits`.