### PR TITLE
[13.x] Clarify the two makeSearchableUsing methods

### DIFF
--- a/scout.md
+++ b/scout.md
@@ -846,6 +846,9 @@ public function makeSearchableUsing(Collection $models): Collection
 }
 ```
 
+> [!NOTE]
+> The model's `makeSearchableUsing` method should not be confused with the `Scout::makeSearchableUsing` method, which [determines the job class](#unique-jobs) Scout dispatches when indexing records.
+
 <a name="conditionally-updating-the-search-index"></a>
 #### Conditionally Updating the Search Index
 


### PR DESCRIPTION
Hi, I finally noticed that there are 2 methods with same name, `makeSearchableUsing`. It took me a couple of headaches to work out the difference. Maybe a small note helps to "polish" this amazing doc, without giving the same headache to other devs.