### PR TITLE
[13.x] Fix two out-of-sync table of contents labels

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -13,7 +13,7 @@
 - [Retrieving Models](#retrieving-models)
     - [Collections](#collections)
     - [Chunking Results](#chunking-results)
-    - [Chunk Using Lazy Collections](#chunking-using-lazy-collections)
+    - [Chunking Using Lazy Collections](#chunking-using-lazy-collections)
     - [Cursors](#cursors)
     - [Advanced Subqueries](#advanced-subqueries)
 - [Retrieving Single Models / Aggregates](#retrieving-single-models)

--- a/passport.md
+++ b/passport.md
@@ -20,7 +20,7 @@
     - [Creating the Client](#creating-a-auth-pkce-grant-client)
     - [Requesting Tokens](#requesting-auth-pkce-grant-tokens)
 - [Device Authorization Grant](#device-authorization-grant)
-    - [Creating a Device Code Grant Client](#creating-a-device-authorization-grant-client)
+    - [Creating a Device Authorization Grant Client](#creating-a-device-authorization-grant-client)
     - [Requesting Tokens](#requesting-device-authorization-grant-tokens)
 - [Password Grant](#password-grant)
     - [Creating a Password Grant Client](#creating-a-password-grant-client)


### PR DESCRIPTION
Two table of contents entries used a label that does not match the heading and anchor they point to. In both cases the heading and anchor agree, and only the visible label text is out of sync, so the fix changes the label text and leaves every anchor untouched, meaning no links change.

**`eloquent.md`**

The entry reads `Chunk Using Lazy Collections`, but the section heading is `Chunking Using Lazy Collections`, its anchor is `#chunking-using-lazy-collections`, and the two in-page links to it (in the `cursor` method notes) both read `Chunking`. Updated the label to `Chunking Using Lazy Collections`.

**`passport.md`**

The entry reads `Creating a Device Code Grant Client`, but its heading is `Creating a Device Authorization Grant Client` and its anchor is `#creating-a-device-authorization-grant-client`. The parent entry and heading are both `Device Authorization Grant`. (The `device_code` wording elsewhere on the page is the OAuth request attribute, which is a different thing from the grant's name.) Updated the label to `Creating a Device Authorization Grant Client`.

Diff is 2 files, +2 -2, label text only.
