### PR TITLE
[13.x] Remove stale link from contribution guide table of contents

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -2,7 +2,6 @@
 
 - [Bug Reports](#bug-reports)
 - [Support Questions](#support-questions)
-- [Core Development Discussion](#core-development-discussion)
 - [Which Branch?](#which-branch)
 - [Compiled Assets](#compiled-assets)
 - [AI-Generated Contributions](#ai-generated-contributions)


### PR DESCRIPTION
Removes the invalid link that remained in the table of contents.