### PR TITLE
[13.x] Document updates to readable encrypted environment files

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -184,6 +184,21 @@ When decrypting environment files, Laravel automatically detects which format wa
 > [!NOTE]
 > When using the `--readable` option, comments, and blank lines from the original environment file are not included in the encrypted output.
 
+<a name="incremental-encryption"></a>
+#### Incremental Encryption
+
+To update a readable encrypted environment file without re-encrypting unchanged values, use the `--incremental` option together with `--readable`:
+
+```shell
+php artisan env:encrypt --readable --incremental --key=3UVsEgGVK36XN82KKeyLFMhvosbZN1aF
+```
+
+Laravel compares the values in your `.env` file with the decrypted values from the existing `.env.encrypted` file. Unchanged values keep their existing ciphertext, while new or changed values are encrypted. Variables removed from `.env` are also removed from the encrypted file. For example, changing only `DB_PASSWORD` changes only that variable's encrypted entry, making pull request diffs easier to review.
+
+The `--incremental` option allows updating the encrypted file without `--force`. If the encrypted file does not exist, Laravel creates it normally. If no entries have changed, the existing file is left untouched.
+
+When updating an existing file, use the same encryption key and cipher that were used to create it. The file must be in readable format, and Laravel will abort without overwriting it if an encrypted entry cannot be decrypted. To re-encrypt all values, such as when changing the encryption key, use `--readable --force` without `--incremental`.
+
 <a name="decryption"></a>
 #### Decryption
 

--- a/configuration.md
+++ b/configuration.md
@@ -187,17 +187,17 @@ When decrypting environment files, Laravel automatically detects which format wa
 <a name="incremental-encryption"></a>
 #### Incremental Encryption
 
-To update a readable encrypted environment file without re-encrypting unchanged values, use the `--incremental` option together with `--readable`:
+To update a readable encrypted environment file without re-encrypting unchanged values, you may use the `--incremental` option. This option requires `--readable`:
 
 ```shell
 php artisan env:encrypt --readable --incremental --key=3UVsEgGVK36XN82KKeyLFMhvosbZN1aF
 ```
 
-Laravel compares the values in your `.env` file with the decrypted values from the existing `.env.encrypted` file. Unchanged values keep their existing ciphertext, while new or changed values are encrypted. Variables removed from `.env` are also removed from the encrypted file. For example, changing only `DB_PASSWORD` changes only that variable's encrypted entry, making pull request diffs easier to review.
+Laravel compares the values in your `.env` file with the decrypted values from the existing `.env.encrypted` file. Values that have not changed are left untouched, while new or changed values are encrypted. Variables removed from `.env` are also removed from the encrypted file. For example, changing only `DB_PASSWORD` changes only that variable's encrypted entry, making pull request diffs easier to review.
 
-The `--incremental` option allows updating the encrypted file without `--force`. If the encrypted file does not exist, Laravel creates it normally. If no entries have changed, the existing file is left untouched.
+The `--incremental` option updates the encrypted file without requiring `--force`. If the encrypted file does not exist, Laravel creates it. If the entries and their order have not changed, the existing file is left untouched.
 
-When updating an existing file, use the same encryption key and cipher that were used to create it. The file must be in readable format, and Laravel will abort without overwriting it if an encrypted entry cannot be decrypted. To re-encrypt all values, such as when changing the encryption key, use `--readable --force` without `--incremental`.
+When updating an existing file, use the same encryption key and cipher that were used to create it. The existing encrypted file must be in readable format, and Laravel will abort without overwriting it if a value cannot be decrypted. To re-encrypt all values, such as when changing the encryption key, use `--readable --force` without `--incremental`.
 
 <a name="decryption"></a>
 #### Decryption


### PR DESCRIPTION
Documents how `env:encrypt --readable` automatically preserves encrypted values that have not changed, making pull request diffs easier to review.

Explains updating existing readable files without `--force`, creating missing files, removing deleted variables, and using the existing encryption key and cipher. Also documents `--force` to encrypt all values again when changing the key or replacing an invalid encrypted file.

For https://github.com/laravel/framework/pull/61503.
