### PR TITLE
Fix billing table of contents spelling

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -38,7 +38,7 @@
     - [Usage Based Billing](#usage-based-billing)
     - [Subscription Taxes](#subscription-taxes)
     - [Subscription Anchor Date](#subscription-anchor-date)
-    - [Canceling Subscriptions](#cancelling-subscriptions)
+    - [Cancelling Subscriptions](#cancelling-subscriptions)
     - [Resuming Subscriptions](#resuming-subscriptions)
 - [Subscription Trials](#subscription-trials)
     - [With Payment Method Up Front](#with-payment-method-up-front)


### PR DESCRIPTION
The billing table of contents says ‘Canceling Subscriptions’, while the linked section is titled ‘Cancelling Subscriptions’. This updates the table of contents to match the section.